### PR TITLE
Adopt more smart pointers in the UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -54,6 +54,9 @@ class PageClientImpl : public PageClient
 #endif
 {
     WTF_MAKE_TZONE_ALLOCATED(PageClientImpl);
+#if ENABLE(FULLSCREEN_API)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageClientImpl);
+#endif
 public:
     explicit PageClientImpl(GtkWidget*);
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/NotImplemented.h>
 #include <wpe/wpe.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(ATK)
 #include <atk/atk.h>
@@ -52,6 +53,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageClientImpl);
 
 PageClientImpl::PageClientImpl(WKWPE::View& view)
     : m_view(view)

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -27,6 +27,7 @@
 
 #include "PageClient.h"
 #include "WebFullScreenManagerProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 struct wpe_view_backend;
 typedef struct _AtkObject AtkObject;
@@ -53,6 +54,10 @@ class PageClientImpl final : public PageClient
     , public WebFullScreenManagerProxyClient
 #endif
 {
+    WTF_MAKE_TZONE_ALLOCATED(PageClientImpl);
+#if ENABLE(FULLSCREEN_API)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageClientImpl);
+#endif
 public:
     PageClientImpl(WKWPE::View&);
     virtual ~PageClientImpl();

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -393,7 +393,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    RetainPtr<UIViewController> presentingViewController = m_webPageProxy.uiClient().presentingViewController();
+    RetainPtr<UIViewController> presentingViewController = m_webPageProxy->uiClient().presentingViewController();
 
     if (!presentingViewController)
         return completionHandler();
@@ -408,7 +408,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", protectedThis->m_systemPreviewInfo.element.elementIdentifier ? protectedThis->m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
         auto request = WebCore::ResourceRequest(url);
         bool shouldRunAtForegroundPriority = false;
-        protectedThis->m_webPageProxy.dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
+        protectedThis->m_webPageProxy->dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
             if (!weakThis)
                 return completionHandler();
 
@@ -603,7 +603,7 @@ void SystemPreviewController::triggerSystemPreviewActionWithTargetForTesting(uin
         m_systemPreviewInfo.element.elementIdentifier = ObjectIdentifier<WebCore::ElementIdentifierType>(elementID);
     else
         m_systemPreviewInfo.element.elementIdentifier = std::nullopt;
-    m_systemPreviewInfo.element.documentIdentifier = { *uuid, m_webPageProxy.legacyMainFrameProcess().coreProcessIdentifier() };
+    m_systemPreviewInfo.element.documentIdentifier = { *uuid, m_webPageProxy->legacyMainFrameProcess().coreProcessIdentifier() };
     m_systemPreviewInfo.element.webPageIdentifier = ObjectIdentifier<WebCore::PageIdentifierType>(pageID);
     triggerSystemPreviewAction();
 }

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -77,7 +77,7 @@ public:
     void loadFailed();
     void end();
 
-    WebPageProxy& page() { return m_webPageProxy; }
+    WebPageProxy& page() { return m_webPageProxy.get(); }
     const WebCore::SystemPreviewInfo& previewInfo() const { return m_systemPreviewInfo; }
 
     void triggerSystemPreviewAction();
@@ -100,7 +100,7 @@ private:
 
     State m_state { State::Initial };
 
-    WebPageProxy& m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
     WebCore::SystemPreviewInfo m_systemPreviewInfo;
     URL m_downloadURL;
     URL m_localFileURL;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -475,8 +475,8 @@ private:
         float m_endProgress { 0 };
         bool m_cancelled { false };
 
-        ViewGestureController& m_viewGestureController;
-        WebPageProxy& m_webPageProxy;
+        CheckedRef<ViewGestureController> m_viewGestureController;
+        WeakRef<WebPageProxy> m_webPageProxy;
     };
 
     SwipeProgressTracker m_swipeProgressTracker;

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -57,6 +57,11 @@ WebBackForwardCacheEntry::~WebBackForwardCacheEntry()
     }
 }
 
+WebBackForwardCache& WebBackForwardCacheEntry::backForwardCache() const
+{
+    return m_backForwardCache.get();
+}
+
 std::unique_ptr<SuspendedPageProxy> WebBackForwardCacheEntry::takeSuspendedPage()
 {
     ASSERT(m_suspendedPage);
@@ -79,7 +84,7 @@ void WebBackForwardCacheEntry::expirationTimerFired()
     ASSERT(m_backForwardItemID);
     auto* item = WebBackForwardListItem::itemForID(m_backForwardItemID);
     ASSERT(item);
-    m_backForwardCache.removeEntry(*item); // Will destroy |this|.
+    m_backForwardCache->removeEntry(*item); // Will destroy |this|.
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
@@ -43,7 +44,7 @@ public:
     WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
     ~WebBackForwardCacheEntry();
 
-    WebBackForwardCache& backForwardCache() const { return m_backForwardCache; }
+    WebBackForwardCache& backForwardCache() const;
 
     SuspendedPageProxy* suspendedPage() const { return m_suspendedPage.get(); }
     std::unique_ptr<SuspendedPageProxy> takeSuspendedPage();
@@ -53,7 +54,7 @@ public:
 private:
     void expirationTimerFired();
 
-    WebBackForwardCache& m_backForwardCache;
+    CheckedRef<WebBackForwardCache> m_backForwardCache;
     WebCore::ProcessIdentifier m_processIdentifier;
     WebCore::BackForwardItemIdentifier m_backForwardItemID;
     std::unique_ptr<SuspendedPageProxy> m_suspendedPage;

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -73,7 +73,7 @@ WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 {
     Ref webPageProxy = m_page.get();
     webPageProxy->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), webPageProxy->webPageIDInMainFrameProcess());
-    m_client.closeFullScreenManager();
+    m_client->closeFullScreenManager();
     callCloseCompletionHandlers();
 }
 
@@ -203,12 +203,12 @@ void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
 
 void WebFullScreenManagerProxy::close()
 {
-    m_client.closeFullScreenManager();
+    m_client->closeFullScreenManager();
 }
 
 bool WebFullScreenManagerProxy::isFullScreen()
 {
-    return m_client.isFullScreen();
+    return m_client->isFullScreen();
 }
 
 bool WebFullScreenManagerProxy::blocksReturnToFullscreenFromPictureInPicture() const
@@ -234,10 +234,10 @@ void WebFullScreenManagerProxy::enterFullScreen(bool blocksReturnToFullscreenFro
 #endif // QUICKLOOK_FULLSCREEN
 
     auto mediaDimensions = mediaDetails.mediaDimensions;
-    m_client.enterFullScreen(mediaDimensions);
+    m_client->enterFullScreen(mediaDimensions);
 #else
     UNUSED_PARAM(mediaDetails);
-    m_client.enterFullScreen();
+    m_client->enterFullScreen();
 #endif
 }
 
@@ -246,7 +246,7 @@ void WebFullScreenManagerProxy::exitFullScreen()
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     m_imageBuffer = nullptr;
 #endif
-    m_client.exitFullScreen();
+    m_client->exitFullScreen();
 }
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
@@ -275,23 +275,23 @@ void WebFullScreenManagerProxy::beganEnterFullScreen(const IntRect& initialFrame
 {
     protectedPage()->callAfterNextPresentationUpdate([weakThis = WeakPtr { *this }, initialFrame = initialFrame, finalFrame = finalFrame] {
         if (weakThis)
-            weakThis->m_client.beganEnterFullScreen(initialFrame, finalFrame);
+            weakThis->m_client->beganEnterFullScreen(initialFrame, finalFrame);
     });
 }
 
 void WebFullScreenManagerProxy::beganExitFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)
 {
-    m_client.beganExitFullScreen(initialFrame, finalFrame);
+    m_client->beganExitFullScreen(initialFrame, finalFrame);
 }
 
 bool WebFullScreenManagerProxy::lockFullscreenOrientation(WebCore::ScreenOrientationType orientation)
 {
-    return m_client.lockFullscreenOrientation(orientation);
+    return m_client->lockFullscreenOrientation(orientation);
 }
 
 void WebFullScreenManagerProxy::unlockFullscreenOrientation()
 {
-    m_client.unlockFullscreenOrientation();
+    m_client->unlockFullscreenOrientation();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -58,7 +58,9 @@ namespace WebKit {
 class WebPageProxy;
 struct SharedPreferencesForWebProcess;
 
-class WebFullScreenManagerProxyClient {
+class WebFullScreenManagerProxyClient : public CanMakeCheckedPtr<WebFullScreenManagerProxyClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebFullScreenManagerProxyClient);
 public:
     virtual ~WebFullScreenManagerProxyClient() { }
 
@@ -140,7 +142,7 @@ private:
 #endif
 
     WeakRef<WebPageProxy> m_page;
-    WebFullScreenManagerProxyClient& m_client;
+    CheckedRef<WebFullScreenManagerProxyClient> m_client;
     FullscreenState m_fullscreenState { FullscreenState::NotInFullscreen };
     bool m_blocksReturnToFullscreenFromPictureInPicture { false };
 #if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -55,6 +55,10 @@ class PageClientImpl final : public PageClientImplCocoa
     , public WebFullScreenManagerProxyClient
 #endif
     {
+    WTF_MAKE_FAST_ALLOCATED;
+#if ENABLE(FULLSCREEN_API)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageClientImpl);
+#endif
 public:
     PageClientImpl(WKContentView *, WKWebView *);
     virtual ~PageClientImpl();

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -53,6 +53,10 @@ class PageClientImpl final : public PageClientImplCocoa
     , public WebFullScreenManagerProxyClient
 #endif
     {
+    WTF_MAKE_FAST_ALLOCATED;
+#if ENABLE(FULLSCREEN_API)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageClientImpl);
+#endif
 public:
     PageClientImpl(NSView *, WKWebView *);
     virtual ~PageClientImpl();

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -42,6 +42,9 @@ class PageClientImpl final : public PageClient
 #endif
 {
     WTF_MAKE_TZONE_ALLOCATED(PageClientImpl);
+#if ENABLE(FULLSCREEN_API)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageClientImpl);
+#endif
 public:
     PageClientImpl(PlayStationWebView&);
 

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -52,6 +52,10 @@ class PageClientImpl : public PageClient
     , public WebFullScreenManagerProxyClient
 #endif
 {
+    WTF_MAKE_FAST_ALLOCATED;
+#if ENABLE(FULLSCREEN_API)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageClientImpl);
+#endif
 public:
     PageClientImpl(WebView&);
 


### PR DESCRIPTION
#### 7d77116300b1fc054347b1303f3ecbfcdf9fca45
<pre>
Adopt more smart pointers in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279808">https://bugs.webkit.org/show_bug.cgi?id=279808</a>

Reviewed by Per Arne Vollan.

* Source/WebKit/UIProcess/SystemPreviewController.h:
(WebKit::SystemPreviewController::page):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::backForwardCache const):
(WebKit::WebBackForwardCacheEntry::expirationTimerFired):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
(WebKit::WebBackForwardCacheEntry::backForwardCache const): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::~WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::close):
(WebKit::WebFullScreenManagerProxy::isFullScreen):
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::exitFullScreen):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
(WebKit::WebFullScreenManagerProxy::lockFullscreenOrientation):
(WebKit::WebFullScreenManagerProxy::unlockFullscreenOrientation):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/win/PageClientImpl.h:

Canonical link: <a href="https://commits.webkit.org/283846@main">https://commits.webkit.org/283846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3a6fc68b3b2b56bc23baa91beb3519b266ab4eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54050 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39652 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15390 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61488 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/block-with-overflowing-text.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-root.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-element-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-has-scrollbars.html imported/w3c/web-platform-tests/css/css-view-transitions/old-root-vertical-writing-mode.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61547 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2919 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42610 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->