### PR TITLE
Sort gb180302022Encode cases

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -902,14 +902,6 @@ static const GB18030EncodeIndex& gb18030EncodeIndex()
 static std::optional<uint32_t> gb180302022Encode(char32_t codePoint)
 {
     switch (codePoint) {
-    case 0xE81E: return 0xFE59;
-    case 0xE826: return 0xFE61;
-    case 0xE82B: return 0xFE66;
-    case 0xE82C: return 0xFE67;
-    case 0xE832: return 0xFE6D;
-    case 0xE843: return 0xFE7E;
-    case 0xE854: return 0xFE90;
-    case 0xE864: return 0xFEA0;
     case 0xE78D: return 0xA6D9;
     case 0xE78F: return 0xA6DB;
     case 0xE78E: return 0xA6DA;
@@ -920,6 +912,14 @@ static std::optional<uint32_t> gb180302022Encode(char32_t codePoint)
     case 0xE794: return 0xA6EC;
     case 0xE795: return 0xA6ED;
     case 0xE796: return 0xA6F3;
+    case 0xE81E: return 0xFE59;
+    case 0xE826: return 0xFE61;
+    case 0xE82B: return 0xFE66;
+    case 0xE82C: return 0xFE67;
+    case 0xE832: return 0xFE6D;
+    case 0xE843: return 0xFE7E;
+    case 0xE854: return 0xFE90;
+    case 0xE864: return 0xFEA0;
     }
     return std::nullopt;
 }


### PR DESCRIPTION
#### 340983b6ceab3dbdeb973daa7b9d9ab0f252b983
<pre>
Sort gb180302022Encode cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=279814">https://bugs.webkit.org/show_bug.cgi?id=279814</a>
<a href="https://rdar.apple.com/136134964">rdar://136134964</a>

Reviewed by NOBODY (OOPS!).

Sorting cases in ascending order improves readability.

* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::gb180302022Encode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/340983b6ceab3dbdeb973daa7b9d9ab0f252b983

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53927 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12381 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16831 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15319 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61410 "Found 4 new test failures: fast/editing/document-leak-altered-text-field.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_block_downloads.tentative.html imported/w3c/web-platform-tests/scroll-to-text-fragment/find-range-from-text-directive.html webgl/2.0.0/conformance/canvas/rapid-resizing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61496 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2850 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42520 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43597 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->