### PR TITLE
Add GPUCanvasConfiguration.toneMapping.mode

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8069,6 +8069,25 @@ WebGPUEnabled:
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
+WebGPUHDREnabled:
+  type: bool
+  status: internal
+  category: dom
+  humanReadableName: "WebGPU support for HDR"
+  humanReadableDescription: "WebGPU High Dynamic Range through canvas configuration tone mapping mode"
+  defaultValue:
+    WebKitLegacy:
+      "ENABLE(WEBGPU_BY_DEFAULT) && ENABLE(WEBGPU_HDR_BY_DEFAULT)": true
+      default: false
+    WebKit:
+      "ENABLE(WEBGPU_BY_DEFAULT) && ENABLE(WEBGPU_HDR_BY_DEFAULT)": true
+      default: false
+    WebCore:
+      "ENABLE(WEBGPU_BY_DEFAULT) && ENABLE(WEBGPU_HDR_BY_DEFAULT)": true
+      default: false
+  disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
+
 WebInspectorEngineeringSettingsAllowed:
   type: bool
   status: internal

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1796,6 +1796,8 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/WebGPU/GPUBufferUsage.idl
     Modules/WebGPU/GPUCanvasAlphaMode.idl
     Modules/WebGPU/GPUCanvasConfiguration.idl
+    Modules/WebGPU/GPUCanvasToneMapping.idl
+    Modules/WebGPU/GPUCanvasToneMappingMode.idl
     Modules/WebGPU/GPUColorDict.idl
     Modules/WebGPU/GPUColorTargetState.idl
     Modules/WebGPU/GPUColorWrite.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -67,6 +67,8 @@ $(PROJECT_DIR)/Modules/WebGPU/GPUBufferMapState.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUBufferUsage.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUCanvasAlphaMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUCanvasConfiguration.idl
+$(PROJECT_DIR)/Modules/WebGPU/GPUCanvasToneMapping.idl
+$(PROJECT_DIR)/Modules/WebGPU/GPUCanvasToneMappingMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUColorDict.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUColorTargetState.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUColorWrite.idl
@@ -216,6 +218,8 @@ $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUBufferMapState.idl
 $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUBufferUsage.idl
 $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUCanvasAlphaMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUCanvasConfiguration.idl
+$(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUCanvasToneMapping.idl
+$(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUCanvasToneMappingMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUColorDict.idl
 $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUColorTargetState.idl
 $(PROJECT_DIR)/Modules/WebGPU/WebExposedAPI/GPUColorWrite.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1151,6 +1151,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasAlphaMode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasAlphaMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasConfiguration.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasConfiguration.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasToneMapping.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasToneMapping.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasToneMappingMode.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasToneMappingMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasContext.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUCanvasContext.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUColorDict.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -80,6 +80,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/WebGPU/GPUBufferUsage.idl \
     $(WebCore)/Modules/WebGPU/GPUCanvasAlphaMode.idl \
     $(WebCore)/Modules/WebGPU/GPUCanvasConfiguration.idl \
+    $(WebCore)/Modules/WebGPU/GPUCanvasToneMapping.idl \
+    $(WebCore)/Modules/WebGPU/GPUCanvasToneMappingMode.idl \
     $(WebCore)/Modules/WebGPU/GPUColorDict.idl \
     $(WebCore)/Modules/WebGPU/GPUColorTargetState.idl \
     $(WebCore)/Modules/WebGPU/GPUColorWrite.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -35,6 +35,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/GPUBufferUsage.h
     Modules/WebGPU/GPUCanvasAlphaMode.h
     Modules/WebGPU/GPUCanvasConfiguration.h
+    Modules/WebGPU/GPUCanvasToneMapping.h
+    Modules/WebGPU/GPUCanvasToneMappingMode.h
     Modules/WebGPU/GPUColorDict.h
     Modules/WebGPU/GPUColorTargetState.h
     Modules/WebGPU/GPUColorWrite.h
@@ -197,6 +199,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/InternalAPI/WebGPUBufferUsage.h
     Modules/WebGPU/InternalAPI/WebGPUCanvasAlphaMode.h
     Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
+    Modules/WebGPU/InternalAPI/WebGPUCanvasToneMappingMode.h
     Modules/WebGPU/InternalAPI/WebGPUColor.h
     Modules/WebGPU/InternalAPI/WebGPUColorTargetState.h
     Modules/WebGPU/InternalAPI/WebGPUColorWrite.h

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GPUCanvasAlphaMode.h"
+#include "GPUCanvasToneMapping.h"
 #include "GPUDevice.h"
 #include "GPUPredefinedColorSpace.h"
 #include "GPUTextureFormat.h"
@@ -47,6 +48,7 @@ struct GPUCanvasConfiguration {
                 return WebCore::convertToBacking(viewFormat);
             }),
             WebCore::convertToBacking(colorSpace),
+            WebCore::convertToBacking(toneMapping.mode),
             WebCore::convertToBacking(alphaMode),
             reportValidationErrors,
         };
@@ -57,6 +59,7 @@ struct GPUCanvasConfiguration {
     GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
     Vector<GPUTextureFormat> viewFormats;
     GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
+    GPUCanvasToneMapping toneMapping;
     GPUCanvasAlphaMode alphaMode { GPUCanvasAlphaMode::Opaque };
 };
 

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
@@ -37,5 +37,6 @@ dictionary GPUCanvasConfiguration {
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     sequence<GPUTextureFormat> viewFormats = [];
     GPUPredefinedColorSpace colorSpace = "srgb";
+    [EnabledBySetting=WebGPUHDREnabled] GPUCanvasToneMapping toneMapping = {};
     GPUCanvasAlphaMode alphaMode = "opaque";
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,26 +25,12 @@
 
 #pragma once
 
-#include "WebGPUCanvasAlphaMode.h"
-#include "WebGPUCanvasToneMappingMode.h"
-#include "WebGPUDevice.h"
-#include "WebGPUPredefinedColorSpace.h"
-#include "WebGPUTextureFormat.h"
-#include "WebGPUTextureUsage.h"
-#include <wtf/Vector.h>
-#include <wtf/WeakRef.h>
+#include "GPUCanvasToneMappingMode.h"
 
-namespace WebCore::WebGPU {
+namespace WebCore {
 
-struct CanvasConfiguration {
-    WeakRef<Device> device;
-    TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage { TextureUsage::RenderAttachment };
-    Vector<TextureFormat> viewFormats;
-    PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
-    CanvasToneMappingMode toneMappingMode { CanvasToneMappingMode::Standard };
-    CanvasAlphaMode compositingAlphaMode { CanvasAlphaMode::Opaque };
-    bool reportValidationErrors { true };
+struct GPUCanvasToneMapping {
+    GPUCanvasToneMappingMode mode { GPUCanvasToneMappingMode::Standard };
 };
 
-} // namespace WebCore::WebGPU
+}

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+// https://gpuweb.github.io/gpuweb/#dictdef-gpucanvastonemapping
 
-#include "WebGPUCanvasAlphaMode.h"
-#include "WebGPUCanvasToneMappingMode.h"
-#include "WebGPUDevice.h"
-#include "WebGPUPredefinedColorSpace.h"
-#include "WebGPUTextureFormat.h"
-#include "WebGPUTextureUsage.h"
-#include <wtf/Vector.h>
-#include <wtf/WeakRef.h>
-
-namespace WebCore::WebGPU {
-
-struct CanvasConfiguration {
-    WeakRef<Device> device;
-    TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage { TextureUsage::RenderAttachment };
-    Vector<TextureFormat> viewFormats;
-    PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
-    CanvasToneMappingMode toneMappingMode { CanvasToneMappingMode::Standard };
-    CanvasAlphaMode compositingAlphaMode { CanvasAlphaMode::Opaque };
-    bool reportValidationErrors { true };
+[
+    EnabledBySetting=WebGPUEnabled&WebGPUHDREnabled
+]
+dictionary GPUCanvasToneMapping {
+  GPUCanvasToneMappingMode mode = "standard";
 };
-
-} // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,26 +25,24 @@
 
 #pragma once
 
-#include "WebGPUCanvasAlphaMode.h"
 #include "WebGPUCanvasToneMappingMode.h"
-#include "WebGPUDevice.h"
-#include "WebGPUPredefinedColorSpace.h"
-#include "WebGPUTextureFormat.h"
-#include "WebGPUTextureUsage.h"
-#include <wtf/Vector.h>
-#include <wtf/WeakRef.h>
 
-namespace WebCore::WebGPU {
+namespace WebCore {
 
-struct CanvasConfiguration {
-    WeakRef<Device> device;
-    TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage { TextureUsage::RenderAttachment };
-    Vector<TextureFormat> viewFormats;
-    PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
-    CanvasToneMappingMode toneMappingMode { CanvasToneMappingMode::Standard };
-    CanvasAlphaMode compositingAlphaMode { CanvasAlphaMode::Opaque };
-    bool reportValidationErrors { true };
+enum class GPUCanvasToneMappingMode : uint8_t {
+    Standard,
+    Extended,
 };
 
-} // namespace WebCore::WebGPU
+inline constexpr WebGPU::CanvasToneMappingMode convertToBacking(GPUCanvasToneMappingMode canvasToneMappingMode)
+{
+    switch (canvasToneMappingMode) {
+    case GPUCanvasToneMappingMode::Standard:
+        return WebGPU::CanvasToneMappingMode::Standard;
+    case GPUCanvasToneMappingMode::Extended:
+        return WebGPU::CanvasToneMappingMode::Extended;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+// FIXME: Link below doesn't exist, specs should be fixed!
+// https://gpuweb.github.io/gpuweb/#dictdef-gpucanvastonemappingmode
 
-#include "WebGPUCanvasAlphaMode.h"
-#include "WebGPUCanvasToneMappingMode.h"
-#include "WebGPUDevice.h"
-#include "WebGPUPredefinedColorSpace.h"
-#include "WebGPUTextureFormat.h"
-#include "WebGPUTextureUsage.h"
-#include <wtf/Vector.h>
-#include <wtf/WeakRef.h>
-
-namespace WebCore::WebGPU {
-
-struct CanvasConfiguration {
-    WeakRef<Device> device;
-    TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage { TextureUsage::RenderAttachment };
-    Vector<TextureFormat> viewFormats;
-    PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
-    CanvasToneMappingMode toneMappingMode { CanvasToneMappingMode::Standard };
-    CanvasAlphaMode compositingAlphaMode { CanvasAlphaMode::Opaque };
-    bool reportValidationErrors { true };
+[
+    EnabledBySetting=WebGPUEnabled&WebGPUHDREnabled
+]
+enum GPUCanvasToneMappingMode {
+    "standard",
+    "extended",
 };
-
-} // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -58,6 +58,19 @@ void PresentationContextImpl::setSize(uint32_t width, uint32_t height)
     m_height = height;
 }
 
+static WGPUToneMappingMode convertToToneMappingMode(WebCore::WebGPU::CanvasToneMappingMode toneMappingMode)
+{
+    switch (toneMappingMode) {
+    case WebCore::WebGPU::CanvasToneMappingMode::Standard:
+        return WGPUToneMappingMode_Standard;
+    case WebCore::WebGPU::CanvasToneMappingMode::Extended:
+        return WGPUToneMappingMode_Extended;
+    }
+
+    ASSERT_NOT_REACHED();
+    return WGPUToneMappingMode_Extended;
+}
+
 static WGPUCompositeAlphaMode convertToAlphaMode(WebCore::WebGPU::CanvasAlphaMode compositingAlphaMode)
 {
     switch (compositingAlphaMode) {
@@ -89,6 +102,7 @@ bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfigu
             return convertToBackingContext.convertToBacking(colorFormat);
         }),
         .colorSpace = canvasConfiguration.colorSpace == WebCore::WebGPU::PredefinedColorSpace::SRGB ? WGPUColorSpace::SRGB : WGPUColorSpace::DisplayP3,
+        .toneMappingMode = convertToToneMappingMode(canvasConfiguration.toneMappingMode),
         .compositeAlphaMode = convertToAlphaMode(canvasConfiguration.compositingAlphaMode),
         .reportValidationErrors = canvasConfiguration.reportValidationErrors
     };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -91,6 +91,12 @@ enum class WebCore::WebGPU::BlendOperation : uint8_t {
     Max,
 };
 
+header: <WebCore/WebGPUCanvasToneMappingMode.h>
+enum class WebCore::WebGPU::CanvasToneMappingMode : uint8_t {
+    Standard,
+    Extended,
+};
+
 header: <WebCore/WebGPUCanvasAlphaMode.h>
 enum class WebCore::WebGPU::CanvasAlphaMode : uint8_t {
     Opaque,

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3717,6 +3717,8 @@ JSGPUBufferUsage.cpp
 JSGPUCanvasAlphaMode.cpp
 JSGPUCanvasConfiguration.cpp
 JSGPUCanvasContext.cpp
+JSGPUCanvasToneMapping.cpp
+JSGPUCanvasToneMappingMode.cpp
 JSGPUColorDict.cpp
 JSGPUColorTargetState.cpp
 JSGPUColorWrite.cpp

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -96,6 +96,7 @@ private:
         GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
         Vector<GPUTextureFormat> viewFormats;
         GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
+        GPUCanvasToneMapping toneMapping;
         GPUCanvasAlphaMode compositingAlphaMode { GPUCanvasAlphaMode::Opaque };
         Vector<MachSendRight> renderBuffers;
         unsigned frameCount { 0 };

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -171,6 +171,7 @@ void GPUCanvasContextCocoa::reshape()
             configuration->usage,
             configuration->viewFormats,
             configuration->colorSpace,
+            configuration->toneMapping,
             configuration->compositingAlphaMode,
         };
         configure(WTFMove(canvasConfiguration), true);
@@ -276,6 +277,7 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
         configuration.usage,
         configuration.viewFormats,
         configuration.colorSpace,
+        configuration.toneMapping,
         configuration.alphaMode,
         WTFMove(renderBuffers),
         0,

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -75,6 +75,7 @@ private:
     std::optional<const MachSendRight> m_webProcessID;
 #endif
     WGPUColorSpace m_colorSpace { WGPUColorSpace::SRGB };
+    WGPUToneMappingMode m_toneMappingMode { WGPUToneMappingMode_Standard };
     WGPUCompositeAlphaMode m_alphaMode { WGPUCompositeAlphaMode_Premultiplied };
 };
 

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -190,6 +190,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
         descriptor.viewFormats.size() ? &descriptor.viewFormats[0] : &effectiveFormat,
     };
     m_colorSpace = descriptor.colorSpace;
+    m_toneMappingMode = descriptor.toneMappingMode;
     m_alphaMode = descriptor.compositeAlphaMode;
     MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:Texture::pixelFormat(effectiveFormat) width:width height:height mipmapped:NO];
     textureDescriptor.usage = Texture::usage(descriptor.usage, effectiveFormat);

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -299,6 +299,11 @@ typedef enum WGPUCompilationMessageType {
     WGPUCompilationMessageType_Force32 = 0x7FFFFFFF
 } WGPUCompilationMessageType WGPU_ENUM_ATTRIBUTE;
 
+typedef enum WGPUToneMappingMode {
+    WGPUToneMappingMode_Standard = 0x00000000,
+    WGPUToneMappingMode_Extended = 0x00000001,
+} WGPUToneMappingMode WGPU_ENUM_ATTRIBUTE;
+
 typedef enum WGPUCompositeAlphaMode {
     WGPUCompositeAlphaMode_Auto = 0x00000000,
     WGPUCompositeAlphaMode_Opaque = 0x00000001,
@@ -1109,6 +1114,7 @@ typedef struct WGPUSwapChainDescriptor {
     Vector<WGPUTextureFormat> viewFormats;
 #endif
     WGPUColorSpace colorSpace;
+    WGPUToneMappingMode toneMappingMode;
     WGPUCompositeAlphaMode compositeAlphaMode;
     WGPUBool reportValidationErrors;
 } WGPUSwapChainDescriptor WGPU_STRUCTURE_ATTRIBUTE;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1052,6 +1052,7 @@ def headers_for_type(type):
         'WebCore::WebGPU::BufferDynamicOffset': ['<WebCore/WebGPUIntegralTypes.h>'],
         'WebCore::WebGPU::BufferUsageFlags': ['<WebCore/WebGPUBufferUsage.h>'],
         'WebCore::WebGPU::CanvasAlphaMode': ['<WebCore/WebGPUCanvasAlphaMode.h>'],
+        'WebCore::WebGPU::CanvasToneMappingMode': ['<WebCore/WebGPUCanvasToneMappingMode.h>'],
         'WebCore::WebGPU::ColorWriteFlags': ['<WebCore/WebGPUColorWrite.h>'],
         'WebCore::WebGPU::CompareFunction': ['<WebCore/WebGPUCompareFunction.h>'],
         'WebCore::WebGPU::CompilationMessageType': ['<WebCore/WebGPUCompilationMessageType.h>'],

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
@@ -41,7 +41,7 @@ std::optional<CanvasConfiguration> ConvertToBackingContext::convertToBacking(con
     if (!device)
         return std::nullopt;
 
-    return { { device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.compositingAlphaMode, canvasConfiguration.reportValidationErrors } };
+    return { { device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.toneMappingMode, canvasConfiguration.compositingAlphaMode, canvasConfiguration.reportValidationErrors } };
 }
 
 std::optional<WebCore::WebGPU::CanvasConfiguration> ConvertFromBackingContext::convertFromBacking(const CanvasConfiguration& canvasConfiguration)
@@ -50,7 +50,7 @@ std::optional<WebCore::WebGPU::CanvasConfiguration> ConvertFromBackingContext::c
     if (!device)
         return std::nullopt;
 
-    return { { *device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.compositingAlphaMode, canvasConfiguration.reportValidationErrors } };
+    return { { *device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.toneMappingMode, canvasConfiguration.compositingAlphaMode, canvasConfiguration.reportValidationErrors } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.h
@@ -29,6 +29,7 @@
 
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCanvasAlphaMode.h>
+#include <WebCore/WebGPUCanvasToneMappingMode.h>
 #include <WebCore/WebGPUPredefinedColorSpace.h>
 #include <WebCore/WebGPUTextureFormat.h>
 #include <WebCore/WebGPUTextureUsage.h>
@@ -45,6 +46,7 @@ struct CanvasConfiguration {
     WebCore::WebGPU::TextureUsageFlags usage { WebCore::WebGPU::TextureUsage::RenderAttachment };
     Vector<WebCore::WebGPU::TextureFormat> viewFormats;
     WebCore::WebGPU::PredefinedColorSpace colorSpace { WebCore::WebGPU::PredefinedColorSpace::SRGB };
+    WebCore::WebGPU::CanvasToneMappingMode toneMappingMode { WebCore::WebGPU::CanvasToneMappingMode::Standard };
     WebCore::WebGPU::CanvasAlphaMode compositingAlphaMode { WebCore::WebGPU::CanvasAlphaMode::Opaque };
     bool reportValidationErrors { true };
 };

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.serialization.in
@@ -27,6 +27,7 @@
     WebCore::WebGPU::TextureUsageFlags usage
     Vector<WebCore::WebGPU::TextureFormat> viewFormats
     WebCore::WebGPU::PredefinedColorSpace colorSpace
+    WebCore::WebGPU::CanvasToneMappingMode toneMappingMode
     WebCore::WebGPU::CanvasAlphaMode compositingAlphaMode
     bool reportValidationErrors
 }


### PR DESCRIPTION
#### 60fafaadcbdbefd62d08ae90415f43b3e01ccf89
<pre>
Add GPUCanvasConfiguration.toneMapping.mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=279816">https://bugs.webkit.org/show_bug.cgi?id=279816</a>
<a href="https://rdar.apple.com/136139263">rdar://136139263</a>

Reviewed by Mike Wyrzykowski.

- Add WebGPUHDREnabled internal preference, false by default.
- Implement GPUCanvasToneMapping and GPUCanvasToneMappingMode idl&apos;s (if
  WebGPUHDREnabled), headers and serializations.
- Add GPUCanvasToneMapping to GPUCanvasConfiguration (if WebGPUHDREnabled).
- Transmit tone mapping mode wherever GPUCanvasConfiguration or equivalent
  is used.

If WebGPUHDREnabled is false, the tone mapping mode will just be stuck at
&quot;standard&quot;, so future changes that start using it will not produce any HDR
content.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h:
(WebCore::GPUCanvasConfiguration::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl:
* Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.h: Copied from Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl.
* Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl: Copied from Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl.
* Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.h: Copied from Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl.
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.idl: Copied from Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::convertToToneMappingMode):
(WebCore::WebGPU::PresentationContextImpl::configure):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::reshape):
(WebCore::GPUCanvasContextCocoa::configure):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.h:
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.serialization.in:

Canonical link: <a href="https://commits.webkit.org/283803@main">https://commits.webkit.org/283803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64d3c42f5a1635bdcbed370daf87909daf3a296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53971 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58256 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34470 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/66855 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16838 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60458 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61551 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15997 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Skipped layout-tests; 14 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73090 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66588 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2860 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88357 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42527 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15576 "Found 10 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-bbq, wasm.yaml/wasm/stress/cc-i32-kitchen-sink.js.wasm-eager, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-bbq, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-simple.js.default-wasm, wasm.yaml/wasm/stress/tail-call.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->