### PR TITLE
[GStreamer][DMABuf] Disable DMABuf video sink by default

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -175,22 +175,22 @@ static void webkit_dmabuf_video_sink_class_init(WebKitDMABufVideoSinkClass* klas
 
 bool webKitDMABufVideoSinkIsEnabled()
 {
-    static bool s_disabled = false;
+    static bool s_enabled = false;
 #if USE(GBM)
     static std::once_flag s_flag;
     std::call_once(s_flag, [&] {
-        const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED");
+        const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_ENABLED");
         auto valueSpan = span(value);
-        s_disabled = value && (equalLettersIgnoringASCIICase(valueSpan, "true"_s) || equalLettersIgnoringASCIICase(valueSpan, "1"_s));
-        if (!s_disabled && !DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render)) {
+        s_enabled = value && (equalLettersIgnoringASCIICase(valueSpan, "true"_s) || equalLettersIgnoringASCIICase(valueSpan, "1"_s));
+        if (s_enabled && !DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render)) {
             WTFLogAlways("Unable to access the GBM device, disabling DMABuf video sink.");
-            s_disabled = true;
+            s_enabled = false;
         }
     });
 #else
-    s_disabled = true;
+    s_enabled = false;
 #endif
-    return !s_disabled;
+    return s_enabled;
 }
 
 bool webKitDMABufVideoSinkProbePlatform()

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -92,7 +92,7 @@ class GLibPort(Port):
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_DISABLE_GL_SINK')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_DMABUF_SINK_DISABLED')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_DMABUF_SINK_ENABLED')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_HARNESS_DUMP_DIR')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_HOLE_PUNCH_QUIRK')


### PR DESCRIPTION
#### 8a57ce9951630763ce4616d88e4a37016260a38b
<pre>
[GStreamer][DMABuf] Disable DMABuf video sink by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=279819">https://bugs.webkit.org/show_bug.cgi?id=279819</a>

Reviewed by Xabier Rodriguez-Calvar.

In its current form this sink and the associated rendering logic in the TextureMapper are prone to
memory leaks and increased file descriptors usage. There is a plan to rework this but it was too
late for the 2.46 release.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkIsEnabled):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/283833@main">https://commits.webkit.org/283833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8a23d63ef45561d328b07698ad12d56c75a2ec2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71594 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18683 "Failed to checkout and rebase branch from PR 33765") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18481 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/18683 "Failed to checkout and rebase branch from PR 33765") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/67058 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39738 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/15823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17041 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73293 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11505 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58487 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9397 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->