### PR TITLE
Add RAMification support to compare-results

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -66,6 +66,7 @@ MotionMark1_1 = "MotionMark-1.1"
 MotionMark1_1_1 = "MotionMark-1.1.1"
 MotionMark1_2 = "MotionMark-1.2"
 MotionMark1_3 = "MotionMark-1.3"
+RAMification = "RAMification"
 
 unitMarker = "__unit__"
 
@@ -260,6 +261,23 @@ def plum3Breakdown(jsonObject):
     result[unitMarker] = "B"
     for test in breakdown._results["PLUM3-PhysFootprint"]["tests"].keys():
         result[test] = breakdown._results["PLUM3-PhysFootprint"]["tests"][test]["metrics"]["Allocations"]["Geometric"]["current"]
+    return result
+
+def ramificationBreakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "B"
+    for test in breakdown._results["RAMification"]["tests"].keys():
+        result[test] = breakdown._results["RAMification"]["tests"][test]["metrics"]["Allocations"]["Geometric"]["current"]
+    return result
+
+def detailedRAMificationBreakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "B"
+    for test in breakdown._results["RAMification"]["tests"].keys():
+        for subtest in breakdown._results["RAMification"]["tests"][test]["tests"]:
+            result[test + "-" + subtest] = breakdown._results["RAMification"]["tests"][test]["tests"][subtest]["metrics"]["Allocations"]["Geometric"]["current"]
     return result
 
 def displayStr(value):
@@ -542,7 +560,6 @@ def detectMotionMark1_2(payload):
 def detectMotionMark1_3(payload):
     return "MotionMark-1.3" in payload
 
-
 def motionMarkResults(payload):
     assert any(validMotionMarkDetector(payload) for validMotionMarkDetector in [detectMotionMark, detectMotionMark1_1, detectMotionMark1_1_1, detectMotionMark1_2, detectMotionMark1_3])
     if detectMotionMark(payload):
@@ -565,6 +582,14 @@ def motionMarkResults(payload):
         results.append(stats.gmean(scores))
 
     return results
+
+def detectRAMification(payload):
+    return "RAMification" in payload
+
+def RAMificationResults(payload):
+    assert detectRAMification(payload)
+    breakdown = BenchmarkResults(payload)
+    return breakdown._results["RAMification"]["metrics"]["Allocations"][None]["current"]
 
 def detectBenchmark(payload):
     if detectJetStream3(payload):
@@ -591,12 +616,14 @@ def detectBenchmark(payload):
         return MotionMark1_2
     if detectMotionMark1_3(payload):
         return MotionMark1_3
+    if detectRAMification(payload):
+        return RAMification
     return None
 
 def biggerIsBetter(benchmarkType):
     if benchmarkType in [JetStream2, JetStream3, Speedometer2, Speedometer3, MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3]:
         return True
-    elif benchmarkType in [PLT5, CompetitivePLT, PLUM3]:
+    elif benchmarkType in [PLT5, CompetitivePLT, PLUM3, RAMification]:
         return False
     else:
         raise Exception('An unknown benchmark type was passed into biggerIsBetter: {}. It should not be possible to hit this.'.format(benchmarkType))
@@ -761,6 +788,16 @@ def main():
 
         if args.csv:
             writeCSV(plum3Breakdown(a), plum3Breakdown(b), args.csv)
+    elif typeA == RAMification:
+        if args.detailed_breakdown:
+            dumpBreakdowns(detailedRAMificationBreakdown(a), detailedRAMificationBreakdown(b))
+        if args.breakdown:
+            dumpBreakdowns(ramificationBreakdown(a), ramificationBreakdown(b))
+
+        ttest(typeA, RAMificationResults(a), RAMificationResults(b))
+
+        if args.csv:
+            writeCSV(ramificationBreakdown(a), ramificationBreakdown(b), args.csv)
     else:
         print("Unknown benchmark type")
         sys.exit(1)


### PR DESCRIPTION
#### 5ed69108c1aedfa13068564abcddb567bd35d6db
<pre>
Add RAMification support to compare-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=279823">https://bugs.webkit.org/show_bug.cgi?id=279823</a>
<a href="https://rdar.apple.com/136149604">rdar://136149604</a>

Reviewed by Yusuke Suzuki.

Add support for results, breakdown and detailed-breakdown
for RAMification json output.

* Tools/Scripts/compare-results:
(plum3Breakdown):
(ramificationBreakdown):
(detailedRAMificationBreakdown):
(detectMotionMark1_3):
(motionMarkResults):
(detectRAMification):
(RAMificationResults):
(detectBenchmark):
(biggerIsBetter):
(main):

Canonical link: <a href="https://commits.webkit.org/283791@main">https://commits.webkit.org/283791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e06357c7408f1fa7e024ab3e2fb6559316b8698

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54019 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58269 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39605 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15669 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/alignment-in-subgridded-axes-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61454 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61512 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2873 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10232 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->