### PR TITLE
[JSC] replace m_frozenValuesAreFinalized check with safepoint check

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1557,7 +1557,7 @@ void Graph::visitChildren(SlotVisitor& visitor) { visitChildrenImpl(visitor); }
 
 FrozenValue* Graph::freeze(JSValue value)
 {
-    RELEASE_ASSERT(!m_frozenValuesAreFinalized);
+    RELEASE_ASSERT(!m_plan.isInSafepoint());
     if (UNLIKELY(!value))
         return FrozenValue::emptySingleton();
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1294,7 +1294,6 @@ public:
     bool m_hasExceptionHandlers { false };
     bool m_isInSSAConversion { false };
     bool m_isValidating { false };
-    bool m_frozenValuesAreFinalized { false };
     std::optional<uint32_t> m_maxLocalsForCatchOSREntry;
     std::unique_ptr<FlowIndexing> m_indexingCache;
     std::unique_ptr<FlowMap<AbstractValue>> m_abstractValuesCache;

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -66,7 +66,6 @@ void compile(State& state, Safepoint::Result& safepointResult)
         graph.freeDFGIRAfterLowering();
 
     {
-        SetForScope disallowFreeze { state.graph.m_frozenValuesAreFinalized, true };
         GraphSafepoint safepoint(state.graph, safepointResult);
         B3::prepareForGeneration(*state.proc);
     }
@@ -128,7 +127,6 @@ void compile(State& state, Safepoint::Result& safepointResult)
 
     CCallHelpers jit(codeBlock);
     {
-        SetForScope disallowFreeze { state.graph.m_frozenValuesAreFinalized, true };
         GraphSafepoint safepoint(state.graph, safepointResult, true);
         B3::generate(*state.proc, jit);
     }

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -141,6 +141,11 @@ bool JITPlan::checkLivenessAndVisitChildren(AbstractSlotVisitor& visitor)
     return true;
 }
 
+bool JITPlan::isInSafepoint() const
+{
+    return m_thread && m_thread->safepoint();
+}
+
 bool JITPlan::safepointKeepsDependenciesLive() const
 {
     return m_thread && m_thread->safepoint() && m_thread->safepoint()->keepDependenciesLive();

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -96,6 +96,7 @@ public:
     virtual bool iterateCodeBlocksForGC(AbstractSlotVisitor&, const Function<void(CodeBlock*)>&);
     virtual bool checkLivenessAndVisitChildren(AbstractSlotVisitor&);
 
+    bool isInSafepoint() const;
     bool safepointKeepsDependenciesLive() const;
 
     template<typename Functor>


### PR DESCRIPTION
#### 27ffa956d3fb3be64eb9a67391109aa42d50e735
<pre>
[JSC] replace m_frozenValuesAreFinalized check with safepoint check
<a href="https://bugs.webkit.org/show_bug.cgi?id=279824">https://bugs.webkit.org/show_bug.cgi?id=279824</a>
<a href="https://rdar.apple.com/136150059">rdar://136150059</a>

Reviewed by Yusuke Suzuki.

Now that the plan knows whether the compiler is inside a GC safepoint
or not we can directly check that rather than having separate
state for this assertion. That will be more robust if we allow more
compilation to occur within a GC safepoint. Also, the name
m_frozenValuesAreFinalized was misleading since it is not a &quot;final&quot;
state.

* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::freeze):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::isInSafepoint const):
* Source/JavaScriptCore/jit/JITPlan.h:

Canonical link: <a href="https://commits.webkit.org/283789@main">https://commits.webkit.org/283789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/867ff93afd150e754b6774f1f3f6b053c1df5ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18500 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18291 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12405 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58273 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15673 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16858 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60478 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73110 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66608 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61455 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61514 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2877 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88377 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10230 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15578 "Found 5 new JSC stress test failures: wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/tail-call.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->