### PR TITLE
[UnifiedPDF] [iOS] No way to unlock encrypted PDF document

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #include <WebCore/EventListener.h>
 #include <wtf/CheckedPtr.h>
@@ -112,4 +112,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -26,10 +26,9 @@
 #import "config.h"
 #import "PDFPluginAnnotation.h"
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #import "PDFAnnotationTypeHelpers.h"
-#import "PDFLayerControllerSPI.h"
 #import "PDFPlugin.h"
 #import "PDFPluginBase.h"
 #import "PDFPluginChoiceAnnotation.h"
@@ -39,7 +38,6 @@
 #import <WebCore/AddEventListenerOptions.h>
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
-#import <WebCore/ColorMac.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventLoop.h>
 #import <WebCore/EventNames.h>
@@ -61,8 +59,10 @@ RefPtr<PDFPluginAnnotation> PDFPluginAnnotation::create(PDFAnnotation *annotatio
 {
     if (annotationIsWidgetOfType(annotation, WidgetType::Text))
         return PDFPluginTextAnnotation::create(annotation, plugin);
+#if PLATFORM(MAC)
     if (annotationIsWidgetOfType(annotation, WidgetType::Choice))
         return PDFPluginChoiceAnnotation::create(annotation, plugin);
+#endif
 
     return nullptr;
 }
@@ -99,7 +99,7 @@ PDFPluginAnnotation::~PDFPluginAnnotation()
     m_element->removeEventListener(eventNames().changeEvent, *m_eventListener, false);
     m_element->removeEventListener(eventNames().blurEvent, *m_eventListener, false);
 
-    m_eventListener->setAnnotation(0);
+    m_eventListener->setAnnotation(nullptr);
 
     m_element->document().eventLoop().queueTask(TaskSource::InternalAsyncTask, [ weakElement = WeakPtr<Node, WeakPtrImplWithEventTargetData> { element() } ]() {
         if (RefPtr element = weakElement.get())
@@ -136,4 +136,4 @@ void PDFPluginAnnotation::PDFPluginAnnotationEventListener::handleEvent(ScriptEx
 
 } // namespace WebKit
 
-#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #include "PDFPluginTextAnnotation.h"
 
@@ -53,4 +53,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -26,11 +26,10 @@
 #import "config.h"
 #import "PDFPluginPasswordField.h"
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #import "PDFLayerControllerSPI.h"
 #import "PDFPlugin.h"
-#import <Quartz/Quartz.h>
 #import <WebCore/AddEventListenerOptions.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
@@ -84,4 +83,4 @@ void PDFPluginPasswordField::resetField()
     
 } // namespace WebKit
 
-#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #include "PDFPluginAnnotation.h"
 
@@ -55,4 +55,4 @@ private:
 
 } // namespace WebKit
 
-#endif // PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "PDFPluginPasswordForm.h"
 
-#if PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #import <WebCore/ElementInlines.h>
 #import <WebCore/HTMLElement.h>
@@ -88,4 +88,4 @@ void PDFPluginPasswordForm::updateGeometry()
 
 } // namespace WebKit
 
-#endif // PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #include "PDFPluginAnnotation.h"
 
@@ -64,4 +64,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -26,17 +26,14 @@
 #import "config.h"
 #import "PDFPluginTextAnnotation.h"
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
 
 #import "PDFAnnotationTypeHelpers.h"
 #import "PDFKitSPI.h"
-#import "PDFLayerControllerSPI.h"
-#import "PDFPlugin.h"
-#import <Quartz/Quartz.h>
 #import <WebCore/AddEventListenerOptions.h>
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
-#import <WebCore/ColorMac.h>
+#import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
@@ -153,4 +150,4 @@ bool PDFPluginTextAnnotation::handleEvent(Event& event)
 
 } // namespace WebKit
 
-#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -551,9 +551,7 @@ private:
 
     float scaleForPagePreviews() const;
 
-#if PLATFORM(MAC)
     void createPasswordEntryForm();
-#endif
 
     bool isInDiscreteDisplayMode() const;
     bool isShowingTwoPages() const;
@@ -614,10 +612,10 @@ private:
 
     RetainPtr<WKPDFFormMutationObserver> m_pdfMutationObserver;
 
-#if PLATFORM(MAC)
     RefPtr<PDFPluginPasswordField> m_passwordField;
     RefPtr<PDFPluginPasswordForm> m_passwordForm;
 
+#if PLATFORM(MAC)
     bool m_isScrollingWithAnimationToPageExtent { false };
     std::optional<WebCore::ScrollDirection> m_animatedKeyboardScrollingDirection;
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -269,10 +269,8 @@ void UnifiedPDFPlugin::installPDFDocument()
     updateHUDVisibility();
 #endif
 
-#if PLATFORM(MAC)
     if (isLocked())
         createPasswordEntryForm();
-#endif
 
     if (m_view)
         m_view->layerHostingStrategyDidChange();
@@ -345,8 +343,6 @@ void UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects()
 
 #endif
 
-#if PLATFORM(MAC)
-
 void UnifiedPDFPlugin::createPasswordEntryForm()
 {
     if (!supportsForms())
@@ -361,8 +357,6 @@ void UnifiedPDFPlugin::createPasswordEntryForm()
     passwordField->attach(m_annotationContainer.get());
 }
 
-#endif
-
 void UnifiedPDFPlugin::attemptToUnlockPDF(const String& password)
 {
     std::optional<ShouldUpdateAutoSizeScale> shouldUpdateAutoSizeScaleOverride;
@@ -370,17 +364,13 @@ void UnifiedPDFPlugin::attemptToUnlockPDF(const String& password)
         shouldUpdateAutoSizeScaleOverride = ShouldUpdateAutoSizeScale::Yes;
 
     if (![m_pdfDocument unlockWithPassword:password]) {
-#if PLATFORM(MAC)
         m_passwordField->resetField();
         m_passwordForm->unlockFailed();
-#endif
         return;
     }
 
-#if PLATFORM(MAC)
     m_passwordForm = nullptr;
     m_passwordField = nullptr;
-#endif
 
     updateLayout(AdjustScaleAfterLayout::Yes, shouldUpdateAutoSizeScaleOverride);
 


### PR DESCRIPTION
#### f4b563ff60d53280484116a73e54fa9a96a7d1ad
<pre>
[UnifiedPDF] [iOS] No way to unlock encrypted PDF document
<a href="https://bugs.webkit.org/show_bug.cgi?id=279825">https://bugs.webkit.org/show_bug.cgi?id=279825</a>
<a href="https://rdar.apple.com/136133554">rdar://136133554</a>

Reviewed by Aditya Keerthi.

Currently, on iOS, with Unified PDF enabled, we do not present any UI to
unlock an encrypted PDF document.

This patch builds on bug 279807 and makes PDFPluginPassword[Field|Form]
available on the iOS family. We also make the presentment of the
password unlock annotations platform agnostic, so that there is some way
to view encrypted documents.

We will likely iterate on the existing design here because the password
unlock flow is not up to parity with PDFHVC (smaller labels, less convenient
software keyboard, etc.) but this is a first pass.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::create):
(WebKit::PDFPluginAnnotation::~PDFPluginAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):

Canonical link: <a href="https://commits.webkit.org/283821@main">https://commits.webkit.org/283821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5a4a3f2c76796fd907023e1a700a429c19924f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71498 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18587 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39670 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15407 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58413 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2946 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10252 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->