### PR TITLE
Provide option to "detach" a MediaSource element in a non-destructive fashion.

### DIFF
--- a/LayoutTests/media/media-source/media-detachablemse-append-expected.txt
+++ b/LayoutTests/media/media-source/media-detachablemse-append-expected.txt
@@ -1,0 +1,38 @@
+
+RUN(video.srcObject = source)
+RUN(video.muted = true)
+RUN(video.playsInline = true)
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+EXPECTED (source.detachable == 'true') OK
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(loadedmetadata)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+EXPECTED (video.videoTracks.length >= 1 == 'true') OK
+EXPECTED (video.audioTracks.length >= 1 == 'true') OK
+RUN(source.endOfStream())
+EVENT(sourceended)
+RUN(readyState = video.readyState)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+RUN(video.srcObject = null)
+EXPECTED (video.buffered.length == '0') OK
+EXPECTED (video.readyState == '0') OK
+EXPECTED (isNaN(video.duration) == 'true') OK
+EXPECTED (video.videoTracks.length == '0') OK
+EXPECTED (video.audioTracks.length == '0') OK
+RUN(video.srcObject = source)
+EVENT(sourceopen)
+EVENT(sourceended)
+EXPECTED (source.readyState == 'ended') OK
+EXPECTED (video.duration > 0 == 'true') OK
+EVENT(loadedmetadata)
+EVENT(loadeddata)
+EXPECTED (video.buffered.length == '1') OK
+EXPECTED (video.readyState == '4') OK
+EXPECTED (video.videoTracks.length >= 1 == 'true') OK
+EXPECTED (video.audioTracks.length >= 1 == 'true') OK
+RUN(video.play())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-detachablemse-append.html
+++ b/LayoutTests/media/media-source/media-detachablemse-append.html
@@ -1,0 +1,86 @@
+<!-- webkit-test-runner [ DetachableMediaSourceEnabled=true ] -->
+ <!DOCTYPE html>
+<html>
+<head>
+    <title>mediasource-detach-mse</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var readyState;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(loader);
+
+        source = new ManagedMediaSource({ detachable: true });
+        run('video.srcObject = source');
+        run('video.muted = true');
+        run('video.playsInline = true');
+        run('video.disableRemotePlayback = true');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        testExpected('source.detachable', true);
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        var loadedDataPromise = waitFor(video, 'loadeddata', true);
+        await Promise.all([ waitFor(video, 'loadedmetadata'), waitFor(sourceBuffer, 'update', true) ]);
+
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+        await waitFor(sourceBuffer, 'update');
+
+        testExpected('video.videoTracks.length >= 1', true);
+        testExpected('video.audioTracks.length >= 1', true);
+
+        run('source.endOfStream()');
+        waitFor(source, 'sourceended');
+        await loadedDataPromise;
+
+        run('readyState = video.readyState');
+
+        testExpected('sourceBuffer.buffered.length', 1);
+
+        run('video.srcObject = null');
+        testExpected('video.buffered.length', 0);
+        testExpected('video.readyState', 0);
+        testExpected('isNaN(video.duration)', true);
+        testExpected('video.videoTracks.length', 0);
+        testExpected('video.audioTracks.length', 0);
+
+        run('video.srcObject = source');
+        await Promise.all([waitFor(source, 'sourceopen'), waitFor(source, 'sourceended')]);
+        // Re-attaching an ended MediaSource go back to ended.
+        testExpected('source.readyState', "ended");
+        testExpected('video.duration > 0', true);
+        await Promise.all([waitFor(video, 'loadedmetadata'), waitFor(video, 'loadeddata')]);
+        testExpected('video.buffered.length', 1);
+        testExpected('video.readyState', readyState);
+
+        // Tracks are re-created.
+        testExpected('video.videoTracks.length >= 1', true);
+        testExpected('video.audioTracks.length >= 1', true);
+
+        // Re-attached MediaSource is playable.
+        run('video.play()');
+        await waitFor(video, 'ended', true);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1798,6 +1798,7 @@ webkit.org/b/256768 fast/mediastream/captureStream/canvas3d.html [ Failure Pass 
 webkit.org/b/249477 media/audioSession/audioSessionType.html [ Skip ]
 
 media/media-source/media-source-rendering-update-count.html [ Skip ]
+media/media-source/media-detachablemse-append.html [ Skip ]
 
 # Tests failing while still having the right values in expected related to the import in webkit.org/b/252516
 imported/w3c/web-platform-tests/css/css-tables/table-model-fixup-2.html [ Failure ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2379,6 +2379,21 @@ DeprecationReportingEnabled:
     WebCore:
       default: false
 
+DetachableMediaSourceEnabled:
+  type: bool
+  status: developer
+  category: media
+  humanReadableName: "Detachable Media Source"
+  humanReadableDescription: "Detachable Media Source API"
+  condition: ENABLE(MEDIA_SOURCE)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DetailsNameAttributeEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -442,6 +442,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediasource/ManagedSourceBuffer.idl
     Modules/mediasource/MediaSource.idl
     Modules/mediasource/MediaSourceHandle.idl
+    Modules/mediasource/MediaSourceInit.idl
     Modules/mediasource/SourceBuffer.idl
     Modules/mediasource/SourceBufferList.idl
     Modules/mediasource/TextTrack+MediaSource.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -572,6 +572,7 @@ $(PROJECT_DIR)/Modules/mediasource/ManagedMediaSource.idl
 $(PROJECT_DIR)/Modules/mediasource/ManagedSourceBuffer.idl
 $(PROJECT_DIR)/Modules/mediasource/MediaSource.idl
 $(PROJECT_DIR)/Modules/mediasource/MediaSourceHandle.idl
+$(PROJECT_DIR)/Modules/mediasource/MediaSourceInit.idl
 $(PROJECT_DIR)/Modules/mediasource/SourceBuffer.idl
 $(PROJECT_DIR)/Modules/mediasource/SourceBufferList.idl
 $(PROJECT_DIR)/Modules/mediasource/TextTrack+MediaSource.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1875,6 +1875,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSourceHandle.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSourceHandle.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSourceInit.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSourceInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStream.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStream.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamAudioDestinationNode.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -424,6 +424,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediasource/ManagedSourceBuffer.idl \
     $(WebCore)/Modules/mediasource/MediaSource.idl \
     $(WebCore)/Modules/mediasource/MediaSourceHandle.idl \
+    $(WebCore)/Modules/mediasource/MediaSourceInit.idl \
     $(WebCore)/Modules/mediasource/SourceBuffer.idl \
     $(WebCore)/Modules/mediasource/SourceBufferList.idl \
     $(WebCore)/Modules/mediasource/TextTrack+MediaSource.idl \

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -38,15 +38,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ManagedMediaSource);
 
-Ref<ManagedMediaSource> ManagedMediaSource::create(ScriptExecutionContext& context)
+Ref<ManagedMediaSource> ManagedMediaSource::create(ScriptExecutionContext& context, MediaSourceInit&& options)
 {
-    auto mediaSource = adoptRef(*new ManagedMediaSource(context));
+    auto mediaSource = adoptRef(*new ManagedMediaSource(context, WTFMove(options)));
     mediaSource->suspendIfNeeded();
     return mediaSource;
 }
 
-ManagedMediaSource::ManagedMediaSource(ScriptExecutionContext& context)
-    : MediaSource(context)
+ManagedMediaSource::ManagedMediaSource(ScriptExecutionContext& context, MediaSourceInit&& options)
+    : MediaSource(context, WTFMove(options))
     , m_streamingTimer(*this, &ManagedMediaSource::streamingTimerFired)
 {
 }
@@ -113,6 +113,8 @@ void ManagedMediaSource::monitorSourceBuffers()
         return;
     }
     auto currentTime = this->currentTime();
+    if (!currentTime.isValid())
+        return;
 
     ensurePrefsRead();
 

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class ManagedMediaSource final : public MediaSource {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ManagedMediaSource);
 public:
-    static Ref<ManagedMediaSource> create(ScriptExecutionContext&);
+    static Ref<ManagedMediaSource> create(ScriptExecutionContext&, MediaSourceInit&&);
     ~ManagedMediaSource();
 
     enum class PreferredQuality { Low, Medium, High };
@@ -50,7 +50,7 @@ public:
     bool isManaged() const final { return true; }
 
 private:
-    explicit ManagedMediaSource(ScriptExecutionContext&);
+    ManagedMediaSource(ScriptExecutionContext&, MediaSourceInit&&);
     void monitorSourceBuffers() final;
     void elementDetached() final;
     void setStreaming(bool);

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
@@ -37,7 +37,7 @@ enum PreferredQuality {
     EnabledForContext,
     Exposed=(Window,DedicatedWorker)
 ] interface ManagedMediaSource : MediaSource {
-    [CallWith=CurrentScriptExecutionContext] constructor();
+    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaSourceInit init);
 
     readonly attribute PreferredQuality quality;
     attribute EventHandler onqualitychange;

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -38,6 +38,7 @@
 #include "HTMLMediaElement.h"
 #include "MediaPlayer.h"
 #include "MediaPromiseTypes.h"
+#include "MediaSourceInit.h"
 #include "MediaSourcePrivateClient.h"
 #include "URLRegistry.h"
 #include <optional>
@@ -83,7 +84,7 @@ public:
     static void setRegistry(URLRegistry*);
     static MediaSource* lookup(const String& url) { return s_registry ? static_cast<MediaSource*>(s_registry->lookup(url)) : nullptr; }
 
-    static Ref<MediaSource> create(ScriptExecutionContext&);
+    static Ref<MediaSource> create(ScriptExecutionContext&, MediaSourceInit&&);
     virtual ~MediaSource();
 
     using CanMakeWeakPtr<MediaSource>::weakPtrFactory;
@@ -133,6 +134,7 @@ public:
     static bool canConstructInDedicatedWorker(ScriptExecutionContext&);
     void registerTransferredHandle(MediaSourceHandle&);
 #endif
+    bool detachable() const { return m_detachable; }
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 
@@ -172,7 +174,7 @@ public:
     Ref<MediaSourcePrivateClient> client() const;
 
 protected:
-    explicit MediaSource(ScriptExecutionContext&);
+    MediaSource(ScriptExecutionContext&, MediaSourceInit&&);
 
     bool isBuffered(const PlatformTimeRanges&) const;
 
@@ -184,6 +186,7 @@ protected:
 
     RefPtr<MediaSourcePrivate> m_private;
     WeakPtr<HTMLMediaElement> m_mediaElement;
+    bool m_detachable { false };
 
 private:
     friend class MediaSourceClientImpl;
@@ -194,7 +197,13 @@ private:
 
     static bool isTypeSupported(ScriptExecutionContext&, const String& type, Vector<ContentType>&& contentTypesRequiringHardwareSupport);
 
+    void setPrivate(RefPtr<MediaSourcePrivate>&&);
     void setPrivateAndOpen(Ref<MediaSourcePrivate>&&);
+    void reOpen();
+    void open();
+
+    void removeSourceBufferWithOptionalDestruction(SourceBuffer&, bool withDestruction);
+
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
     Ref<MediaPromise> seekToTime(const MediaTime&);
     using RendererType = MediaSourcePrivateClient::RendererType;
@@ -231,6 +240,7 @@ private:
     bool m_openDeferred { false };
     bool m_sourceopenPending { false };
     bool m_isAttached { false };
+    std::optional<ReadyState> m_readyStateBeforeDetached;
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     RefPtr<MediaSourceHandle> m_handle;
 #endif

--- a/Source/WebCore/Modules/mediasource/MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSource.idl
@@ -49,7 +49,9 @@ enum ReadyState {
     EnabledForContext,
     Exposed=(Window,DedicatedWorker)
 ] interface MediaSource : EventTarget {
-    [CallWith=CurrentScriptExecutionContext] constructor();
+    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaSourceInit init = { });
+
+    [EnabledBySetting=DetachableMediaSourceEnabled] readonly attribute boolean detachable;
 
     [SameObject, Exposed=DedicatedWorker, Conditional=MEDIA_SOURCE_IN_WORKERS, EnabledBySetting=MediaSourceInWorkerEnabled]
     readonly attribute MediaSourceHandle handle;

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
@@ -75,9 +75,9 @@ public:
     const MediaSourceHandle::DispatcherType m_dispatcher;
 };
 
-Ref<MediaSourceHandle> MediaSourceHandle::create(MediaSource& mediaSource, MediaSourceHandle::DispatcherType&& dispatcher)
+Ref<MediaSourceHandle> MediaSourceHandle::create(MediaSource& mediaSource, MediaSourceHandle::DispatcherType&& dispatcher, bool detachable)
 {
-    return adoptRef(*new MediaSourceHandle(mediaSource, WTFMove(dispatcher)));
+    return adoptRef(*new MediaSourceHandle(mediaSource, WTFMove(dispatcher), detachable));
 }
 
 Ref<MediaSourceHandle> MediaSourceHandle::create(Ref<MediaSourceHandle>&& other)
@@ -86,13 +86,15 @@ Ref<MediaSourceHandle> MediaSourceHandle::create(Ref<MediaSourceHandle>&& other)
     return other;
 }
 
-MediaSourceHandle::MediaSourceHandle(MediaSource& mediaSource, MediaSourceHandle::DispatcherType&& dispatcher)
-    : m_private(MediaSourceHandle::SharedPrivate::create(mediaSource, WTFMove(dispatcher)))
+MediaSourceHandle::MediaSourceHandle(MediaSource& mediaSource, MediaSourceHandle::DispatcherType&& dispatcher, bool detachable)
+    : m_detachable(detachable)
+    , m_private(MediaSourceHandle::SharedPrivate::create(mediaSource, WTFMove(dispatcher)))
 {
 }
 
 MediaSourceHandle::MediaSourceHandle(MediaSourceHandle& other)
-    : m_private(other.m_private)
+    : m_detachable(other.m_detachable)
+    , m_private(other.m_private)
 {
     ASSERT(!other.m_detached);
     other.m_detached = true;

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
@@ -35,6 +35,7 @@
 namespace WebCore {
 
 class MediaSource;
+class MediaSource;
 class MediaSourcePrivate;
 class MediaSourcePrivateClient;
 
@@ -49,6 +50,7 @@ public:
 
     bool isDetached() const { return m_detached; }
     bool canDetach() const;
+    bool detachable() const { return m_detachable; }
 
     void setHasEverBeenAssignedAsSrcObject();
     bool hasEverBeenAssignedAsSrcObject() const;
@@ -66,12 +68,13 @@ private:
 
     using DispatcherType = Function<void(TaskType, bool)>;
 
-    static Ref<MediaSourceHandle> create(MediaSource&, DispatcherType&&);
-    MediaSourceHandle(MediaSource&, DispatcherType&&);
+    static Ref<MediaSourceHandle> create(MediaSource&, DispatcherType&&, bool);
+    MediaSourceHandle(MediaSource&, DispatcherType&&, bool);
     explicit MediaSourceHandle(MediaSourceHandle&);
     void mediaSourceDidOpen(MediaSourcePrivate&);
     void setDetached(bool value) { m_detached = value; }
 
+    const bool m_detachable;
     bool m_detached { false };
     Ref<SharedPrivate> m_private;
 };

--- a/Source/WebCore/Modules/mediasource/MediaSourceInit.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_SOURCE)
+
+namespace WebCore {
+
+struct MediaSourceInit {
+    bool detachable = false;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/mediasource/MediaSourceInit.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInit.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MEDIA_SOURCE
+] dictionary MediaSourceInit {
+    boolean detachable = false;
+};

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -108,6 +108,11 @@ void MediaSourceInterfaceMainThread::memoryPressure()
     m_mediaSource->memoryPressure();
 }
 
+bool MediaSourceInterfaceMainThread::detachable() const
+{
+    return m_mediaSource->detachable();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
@@ -51,6 +51,7 @@ private:
     bool isManaged() const final;
     void setAsSrcObject(bool) final;
     void memoryPressure() final;
+    bool detachable() const final;
 
     explicit MediaSourceInterfaceMainThread(Ref<MediaSource>&&);
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
@@ -58,6 +58,7 @@ public:
     virtual bool isManaged() const = 0;
     virtual void setAsSrcObject(bool) = 0;
     virtual void memoryPressure() = 0;
+    virtual bool detachable() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -138,6 +138,11 @@ void MediaSourceInterfaceWorker::memoryPressure()
     });
 }
 
+bool MediaSourceInterfaceWorker::detachable() const
+{
+    return m_handle->detachable();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE_IN_WORKERS)

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
@@ -51,6 +51,7 @@ private:
     bool isManaged() const final;
     void setAsSrcObject(bool) final;
     void memoryPressure() final;
+    bool detachable() const final;
 
     explicit MediaSourceInterfaceWorker(Ref<MediaSourceHandle>&&);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -148,6 +148,17 @@ public:
         });
     }
 
+    Ref<MediaPromise> sourceBufferPrivateDidAttach(InitializationSegment&& segment) final
+    {
+        MediaPromise::AutoRejectProducer producer(PlatformMediaError::BufferRemoved);
+        auto promise = producer.promise();
+
+        ensureWeakOnDispatcher([producer = WTFMove(producer), segment = WTFMove(segment)](SourceBuffer& parent) mutable {
+            parent.sourceBufferPrivateDidAttach(WTFMove(segment))->chainTo(WTFMove(producer));
+        });
+        return promise;
+    }
+
 private:
     explicit SourceBufferClientImpl(SourceBuffer& parent)
         : m_parent(parent)
@@ -1517,6 +1528,92 @@ bool SourceBuffer::enabledForContext(ScriptExecutionContext& context)
 size_t SourceBuffer::evictableSize() const
 {
     return m_private->evictionData().evictableSize;
+}
+
+void SourceBuffer::detach()
+{
+    setActive(false);
+    m_private->detach();
+}
+
+void SourceBuffer::attach()
+{
+    m_private->attach();
+}
+
+Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivateClient::InitializationSegment&& segment)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    ASSERT(m_receivedFirstInitializationSegment);
+
+    // 3.2 Add the appropriate track descriptions from this initialization segment to each of the track buffers.
+    ASSERT(segment.audioTracks.size() == audioTracks().length());
+    for (auto& audioTrackInfo : segment.audioTracks) {
+        auto audioTrack = audioTracks().getTrackById(audioTrackInfo.track->id());
+        ASSERT(audioTrack);
+        audioTrack->setPrivate(*audioTrackInfo.track);
+        if (isMainThread())
+            m_source->addAudioTrackToElement(*audioTrack);
+        else {
+            // 11.5.7.7.9 If the parent media source was constructed in a DedicatedWorkerGlobalScope:
+            // Post an internal create track mirror message to [[port to main]] whose implicit handler in Window runs the following steps:
+            // Let mirrored audio track be a new AudioTrack object.
+            // Assign the same property values to mirrored audio track as were determined for new audio track.
+            // Add mirrored audio track to the audioTracks attribute on the HTMLMediaElement.
+            m_source->addAudioTrackMirrorToElement(*audioTrackInfo.track, audioTrack->enabled());
+        }
+    }
+
+    ASSERT(segment.videoTracks.size() == videoTracks().length());
+    for (auto& videoTrackInfo : segment.videoTracks) {
+        auto videoTrack = videoTracks().getTrackById(videoTrackInfo.track->id());
+        ASSERT(videoTrack);
+        videoTrack->setPrivate(*videoTrackInfo.track);
+        // 5.3.6 Add new video track to the videoTracks attribute on the HTMLMediaElement.
+        // 5.3.7 Queue a task to fire a trusted event named addtrack, that does not bubble and is
+        // not cancelable, and that uses the TrackEvent interface, at the VideoTrackList object
+        // referenced by the videoTracks attribute on the HTMLMediaElement.
+        if (isMainThread())
+            m_source->addVideoTrackToElement(*videoTrack);
+        else {
+            // 11.5.7.7.3.9 If the parent media source was constructed in a DedicatedWorkerGlobalScope:
+            // Post an internal create track mirror message to [[port to main]] whose implicit handler in Window runs the following steps:
+            // Let mirrored audio track be a new VideoTrack object.
+            // Assign the same property values to mirrored video track as were determined for new video track.
+            // Add mirrored video track to the videoTracks attribute on the HTMLMediaElement.
+            m_source->addVideoTrackMirrorToElement(*videoTrackInfo.track, videoTrack->selected());
+        }
+    }
+
+    ASSERT(segment.textTracks.size() == textTracks().length());
+    for (auto& textTrackInfo : segment.textTracks) {
+        auto textTrack = textTracks().getTrackById(textTrackInfo.track->id());
+        ASSERT(textTrack);
+        downcast<InbandTextTrack>(*textTrack).setPrivate(*textTrackInfo.track);
+        // 5.4.5 Add new text track to the textTracks attribute on the HTMLMediaElement.
+        // 5.4.6 Queue a task to fire a trusted event named addtrack, that does not bubble and is
+        // not cancelable, and that uses the TrackEvent interface, at the TextTrackList object
+        // referenced by the textTracks attribute on the HTMLMediaElement.
+        if (isMainThread())
+            m_source->addTextTrackToElement(*textTrack);
+        else {
+            // 11.5.7.7.4.10 If the parent media source was constructed in a DedicatedWorkerGlobalScope:
+            // Post an internal create track mirror message to [[port to main]] whose implicit handler in Window runs the following steps:
+            // Let mirrored text track be a new TextTrack object.
+            // Assign the same property values to mirrored text track as were determined for new text track.
+            // Add mirrored text track to the textTracks attribute on the HTMLMediaElement.
+            m_source->addTextTrackMirrorToElement(*textTrackInfo.track);
+        }
+    }
+
+    setActive(true);
+
+    // 6. If the HTMLMediaElement.readyState attribute is HAVE_NOTHING, then run the following steps:
+    m_source->sourceBufferReceivedFirstInitializationSegmentChanged();
+    m_source->monitorSourceBuffers();
+
+    return MediaPromise::createAndResolve();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -150,6 +150,10 @@ public:
     virtual bool isManaged() const { return false; }
     void memoryPressure();
 
+    // Detachable MSE methods.
+    void detach();
+    void attach();
+
 protected:
     SourceBuffer(Ref<SourceBufferPrivate>&&, MediaSource&);
 
@@ -168,6 +172,7 @@ private:
     Ref<MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime& duration);
     void sourceBufferPrivateDidDropSample();
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
+    Ref<MediaPromise> sourceBufferPrivateDidAttach(SourceBufferPrivateClient::InitializationSegment&&);
 
     // AudioTrackClient
     void audioTrackEnabledChanged(AudioTrack&) final;

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -82,7 +82,7 @@ void SourceBufferList::clear()
     scheduleEvent(eventNames().removesourcebufferEvent);
 }
 
-void SourceBufferList::swap(Vector<RefPtr<SourceBuffer>>& other)
+void SourceBufferList::replaceWith(Vector<RefPtr<SourceBuffer>>&& other)
 {
     int changeInSize = other.size() - m_list.size();
     int addedEntries = 0;
@@ -92,7 +92,7 @@ void SourceBufferList::swap(Vector<RefPtr<SourceBuffer>>& other)
     }
     int removedEntries = addedEntries - changeInSize;
 
-    m_list.swap(other);
+    m_list = WTFMove(other);
 
     if (addedEntries)
         scheduleEvent(eventNames().addsourcebufferEvent);

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -59,7 +59,7 @@ public:
     void remove(SourceBuffer&);
     bool contains(SourceBuffer& buffer) { return m_list.find(&buffer) != notFound; }
     void clear();
-    void swap(Vector<RefPtr<SourceBuffer>>&);
+    void replaceWith(Vector<RefPtr<SourceBuffer>>&&);
 
     auto begin() { return m_list.begin(); }
     auto end() { return m_list.end(); }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4046,6 +4046,7 @@ JSMediaSession.cpp
 JSMediaSettingsRange.cpp
 JSMediaSource.cpp
 JSMediaSourceHandle.cpp
+JSMediaSourceInit.cpp
 JSMediaStream.cpp
 JSMediaStreamAudioDestinationNode.cpp
 JSMediaStreamAudioSourceNode.cpp

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1882,6 +1882,11 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
 
         if (m_mediaSource) {
             ALWAYS_LOG(LOGIDENTIFIER, "loading MSE blob");
+            if (url.protocolIs(mediaSourceBlobProtocol) && m_mediaSource->detachable()) {
+                document().addConsoleMessage(MessageSource::MediaSource, MessageLevel::Error, makeString("Unable to attach detachable MediaSource via blob URL, use srcObject attribute"_s));
+                return mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
+            }
+
             if (!m_mediaSource->attachToElement(*this)) {
                 // Forget our reference to the MediaSource, so we leave it alone
                 // while processing remainder of load failure.

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -116,6 +116,8 @@ public:
 
     static Ref<NullMediaPlayerPrivate> create(MediaPlayer& player) { return adoptRef(*new NullMediaPlayerPrivate(player)); }
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::Null; }
+
     void load(const String&) final { }
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const ContentType&, MediaSourcePrivateClient&) final { }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -157,6 +157,21 @@ enum class MediaPlatformType {
     Remote
 };
 
+enum class MediaPlayerType {
+    Null,
+    Mock,
+    MockMSE,
+    MediaFoundation,
+    AVFObjC,
+    AVFObjCMSE,
+    AVFObjCMediaStream,
+    CocoaWebM,
+    GStreamer,
+    GStreamerMSE,
+    HolePunch,
+    Remote
+};
+
 using TrackID = uint64_t;
 
 class MediaPlayerClient : public CanMakeWeakPtr<MediaPlayerClient> {

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -45,10 +45,15 @@ class VideoFrame;
 
 class MediaPlayerPrivateInterface {
 public:
+    // MediaPlayerPrivateInterface subclasses should be ref-counted, but each subclass may choose whether
+    // to be RefCounted or ThreadSafeRefCounted. Therefore, each subclass must implement a pair of
+    // virtual ref()/deref() methods. See NullMediaPlayerPrivate for an example.
     DECLARE_VIRTUAL_REFCOUNTED;
 
     WEBCORE_EXPORT MediaPlayerPrivateInterface();
     WEBCORE_EXPORT virtual ~MediaPlayerPrivateInterface();
+
+    virtual constexpr MediaPlayerType mediaPlayerType() const = 0;
 
     virtual void load(const String&) { }
     virtual void load(const URL& url, const ContentType&, const String&) { load(url.string()); }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -301,6 +301,10 @@ bool MediaSourcePrivate::timeIsProgressing() const
     return false;
 }
 
+void MediaSourcePrivate::shutdown()
+{
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -41,6 +41,7 @@
 namespace WebCore {
 
 class ContentType;
+class MediaPlayerPrivateInterface;
 class SourceBufferPrivate;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 class LegacyCDMSession;
@@ -72,6 +73,8 @@ public:
 
     RefPtr<MediaSourcePrivateClient> client() const;
     virtual RefPtr<MediaPlayerPrivateInterface> player() const = 0;
+    virtual void setPlayer(MediaPlayerPrivateInterface*) = 0;
+    virtual void shutdown();
 
     virtual constexpr MediaPlatformType platformType() const = 0;
     virtual AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) = 0;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -43,8 +43,10 @@ public:
     virtual ~MediaSourcePrivateClient() = default;
 
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
+    virtual void reOpen() = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
     virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;
+    virtual RefPtr<MediaSourcePrivate> mediaSourcePrivate() const = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual void setLogIdentifier(const void*) = 0;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -144,6 +144,10 @@ public:
     // Methods for ManagedSourceBuffer
     WEBCORE_EXPORT virtual void memoryPressure(const MediaTime& currentTime);
 
+    // Methods for Detachable MediaSource
+    virtual void detach() { }
+    WEBCORE_EXPORT virtual void attach();
+
     // Internals Utility methods
     using SamplesPromise = NativePromise<Vector<String>, PlatformMediaError>;
     WEBCORE_EXPORT virtual Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID);
@@ -275,6 +279,7 @@ private:
     MediaTime m_groupEndTimestamp { MediaTime::zeroTime() };
 
     bool m_isMediaSourceEnded { false };
+    std::optional<InitializationSegment> m_lastInitializationSegment;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -102,6 +102,7 @@ public:
     virtual void sourceBufferPrivateDidDropSample() = 0;
     virtual void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) = 0;
     virtual void sourceBufferPrivateEvictionDataChanged(const SourceBufferEvictionData&) { }
+    virtual Ref<MediaPromise> sourceBufferPrivateDidAttach(InitializationSegment&&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -55,6 +55,8 @@ class MediaPlayerPrivateAVFoundation
 public:
     virtual ~MediaPlayerPrivateAVFoundation();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::AVFObjC; }
+
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -75,6 +75,8 @@ public:
     explicit MediaPlayerPrivateMediaSourceAVFObjC(MediaPlayer*);
     virtual ~MediaPlayerPrivateMediaSourceAVFObjC();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::AVFObjCMSE; }
+
     static void registerMediaEngine(MediaEngineRegistrar);
 
     // MediaPlayer Factory Methods
@@ -434,5 +436,9 @@ struct LogArgument<WebCore::MediaPlayerPrivateMediaSourceAVFObjC::SeekState> {
 };
 
 } // namespace WTF
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaPlayerPrivateMediaSourceAVFObjC)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::AVFObjCMSE; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -310,7 +310,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const ContentType&, 
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
+    if (RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateAVFObjC>(client.mediaSourcePrivate())) {
+        mediaSourcePrivate->setPlayer(this);
+        m_mediaSourcePrivate = WTFMove(mediaSourcePrivate);
+        client.reOpen();
+    } else
+        m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
     m_mediaSourcePrivate->setResourceOwner(m_resourceOwner);
     m_mediaSourcePrivate->setVideoRenderer(layerOrVideoRenderer());
     m_mediaSourcePrivate->setDecompressionSession(m_decompressionSession.get());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -66,6 +66,8 @@ public:
     explicit MediaPlayerPrivateMediaStreamAVFObjC(MediaPlayer*);
     virtual ~MediaPlayerPrivateMediaStreamAVFObjC();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::AVFObjCMediaStream; }
+
     static void registerMediaEngine(MediaEngineRegistrar);
 
     using NativeImageCreator = RefPtr<NativeImage> (*)(const VideoFrame&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -67,6 +67,7 @@ public:
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::AVFObjC; }
 
     RefPtr<MediaPlayerPrivateInterface> player() const final;
+    void setPlayer(MediaPlayerPrivateInterface*) final;
 
     AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) final;
     void durationChanged(const MediaTime&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -73,6 +73,11 @@ MediaSourcePrivateAVFObjC::~MediaSourcePrivateAVFObjC()
     ALWAYS_LOG(LOGIDENTIFIER);
 }
 
+void MediaSourcePrivateAVFObjC::setPlayer(MediaPlayerPrivateInterface* player)
+{
+    m_player = downcast<MediaPlayerPrivateMediaSourceAVFObjC>(player);
+}
+
 MediaSourcePrivate::AddStatus MediaSourcePrivateAVFObjC::addSourceBuffer(const ContentType& contentType, bool webMParserEnabled, RefPtr<SourceBufferPrivate>& outPrivate)
 {
     DEBUG_LOG(LOGIDENTIFIER, contentType);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1381,7 +1381,7 @@ void SourceBufferPrivateAVFObjC::setDecompressionSession(WebCoreDecompressionSes
 RefPtr<MediaPlayerPrivateMediaSourceAVFObjC> SourceBufferPrivateAVFObjC::player() const
 {
     if (RefPtr mediaSource = m_mediaSource.get())
-        return static_cast<MediaPlayerPrivateMediaSourceAVFObjC*>(mediaSource->player().get());
+        return downcast<MediaPlayerPrivateMediaSourceAVFObjC>(mediaSource->player());
     return nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -83,6 +83,8 @@ public:
     MediaPlayerPrivateWebM(MediaPlayer*);
     ~MediaPlayerPrivateWebM();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::CocoaWebM; }
+
     void ref() const final { WebMResourceClientParent::ref(); }
     void deref() const final { WebMResourceClientParent::deref(); }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -107,6 +107,8 @@ public:
     MediaPlayerPrivateGStreamer(MediaPlayer*);
     virtual ~MediaPlayerPrivateGStreamer();
 
+    constexpr MediaPlayerType mediaPlayerType() const override { return MediaPlayerType::GStreamer; }
+
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
@@ -609,5 +611,10 @@ private:
     RefPtr<GStreamerQuirksManager> m_quirksManagerForTesting;
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaPlayerPrivateGStreamer)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::GStreamer; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -148,7 +148,12 @@ void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const ContentType&, Me
 {
     auto mseBlobURI = makeString("mediasource"_s, url.string().isEmpty() ? "blob://"_s : url.string());
     GST_DEBUG("Loading %s", mseBlobURI.ascii().data());
-    m_mediaSourcePrivate = MediaSourcePrivateGStreamer::open(mediaSource, *this);
+    if (RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateGStreamer>(mediaSource.mediaSourcePrivate())) {
+        mediaSourcePrivate->setPlayer(this);
+        m_mediaSourcePrivate = WTFMove(mediaSourcePrivate);
+        mediaSource.reOpen();
+    } else
+        m_mediaSourcePrivate = MediaSourcePrivateGStreamer::open(mediaSource, *this);
 
     MediaPlayerPrivateGStreamer::load(mseBlobURI);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -47,6 +47,8 @@ public:
 
     static void registerMediaEngine(MediaEngineRegistrar);
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::GStreamerMSE; }
+
     void load(const String&) override;
     void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
 
@@ -130,5 +132,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaPlayerPrivateGStreamerMSE)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::GStreamerMSE; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -88,7 +88,7 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     if (!SourceBufferPrivateGStreamer::isContentTypeSupported(contentType))
         return MediaSourcePrivateGStreamer::AddStatus::NotSupported;
 
-    m_sourceBuffers.append(SourceBufferPrivateGStreamer::create(*this, contentType, m_playerPrivate));
+    m_sourceBuffers.append(SourceBufferPrivateGStreamer::create(*this, contentType));
     sourceBufferPrivate = m_sourceBuffers.last();
     sourceBufferPrivate->setMediaSourceDuration(duration());
     return MediaSourcePrivateGStreamer::AddStatus::Ok;
@@ -96,24 +96,42 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
 
 RefPtr<MediaPlayerPrivateInterface> MediaSourcePrivateGStreamer::player() const
 {
-    return &m_playerPrivate;
+    return m_playerPrivate.get();
+}
+
+void MediaSourcePrivateGStreamer::setPlayer(MediaPlayerPrivateInterface* player)
+{
+    m_playerPrivate = downcast<MediaPlayerPrivateGStreamerMSE>(player);
+}
+
+RefPtr<MediaPlayerPrivateGStreamerMSE> MediaSourcePrivateGStreamer::platformPlayer() const
+{
+    return m_playerPrivate.get();
 }
 
 void MediaSourcePrivateGStreamer::durationChanged(const MediaTime& duration)
 {
     ASSERT(isMainThread());
 
+    RefPtr player = platformPlayer();
+    if (!player)
+        return;
     MediaSourcePrivate::durationChanged(duration);
-    GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "Duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(toGstClockTime(duration)));
+    GST_TRACE_OBJECT(player->pipeline(), "Duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(toGstClockTime(duration)));
     if (!duration.isValid() || duration.isNegativeInfinite())
         return;
 
-    m_playerPrivate.durationChanged();
+    player->durationChanged();
 }
 
 void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamStatus)
 {
     ASSERT(isMainThread());
+
+    RefPtr player = platformPlayer();
+    if (!player)
+        return;
+
 #ifndef GST_DISABLE_GST_DEBUG
     const char* statusString = nullptr;
     switch (endOfStreamStatus) {
@@ -127,15 +145,15 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
         statusString = "network-error";
         break;
     }
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Marking EOS, status is %s", statusString);
+    GST_DEBUG_OBJECT(player->pipeline(), "Marking EOS, status is %s", statusString);
 #endif
     if (endOfStreamStatus == EndOfStreamStatus::NoError) {
-        m_playerPrivate.setNetworkState(MediaPlayer::NetworkState::Loaded);
+        player->setNetworkState(MediaPlayer::NetworkState::Loaded);
 
         auto bufferedRanges = buffered();
         if (!bufferedRanges.length()) {
             GST_DEBUG("EOS with no buffers");
-            m_playerPrivate.setEosWithNoBuffers(true);
+            player->setEosWithNoBuffers(true);
         }
     }
     MediaSourcePrivate::markEndOfStream(endOfStreamStatus);
@@ -144,22 +162,32 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
 void MediaSourcePrivateGStreamer::unmarkEndOfStream()
 {
     ASSERT(isMainThread());
-    m_playerPrivate.setEosWithNoBuffers(false);
+    RefPtr player = platformPlayer();
+    if (!player)
+        return;
+
+    player->setEosWithNoBuffers(false);
     MediaSourcePrivate::unmarkEndOfStream();
 }
 
 MediaPlayer::ReadyState MediaSourcePrivateGStreamer::mediaPlayerReadyState() const
 {
-    return m_playerPrivate.readyState();
+    RefPtr player = platformPlayer();
+    return player ? player->readyState() : MediaPlayer::ReadyState::HaveNothing;
 }
 
 void MediaSourcePrivateGStreamer::setMediaPlayerReadyState(MediaPlayer::ReadyState state)
 {
-    m_playerPrivate.setReadyState(state);
+    if (RefPtr player = platformPlayer())
+        player->setReadyState(state);
 }
 
 void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
 {
+    RefPtr player = platformPlayer();
+    if (!player)
+        return;
+
     if (m_hasAllTracks) {
         // Already started, nothing to do.
         return;
@@ -167,12 +195,12 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
 
     for (auto& sourceBuffer : m_sourceBuffers) {
         if (!sourceBuffer->hasReceivedFirstInitializationSegment()) {
-            GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "There are still SourceBuffers without an initialization segment, not starting source yet.");
+            GST_DEBUG_OBJECT(player->pipeline(), "There are still SourceBuffers without an initialization segment, not starting source yet.");
             return;
         }
     }
 
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "All SourceBuffers have an initialization segment, starting source.");
+    GST_DEBUG_OBJECT(player->pipeline(), "All SourceBuffers have an initialization segment, starting source.");
     m_hasAllTracks = true;
 
     Vector<RefPtr<MediaSourceTrackGStreamer>> tracks;
@@ -181,12 +209,18 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
         for (auto& [_, track] : sourceBuffer->tracks())
             tracks.append(track);
     }
-    m_playerPrivate.startSource(tracks);
+    player->startSource(tracks);
 }
 
 void MediaSourcePrivateGStreamer::notifyActiveSourceBuffersChanged()
 {
-    m_playerPrivate.notifyActiveSourceBuffersChanged();
+    if (RefPtr player = platformPlayer())
+        player->notifyActiveSourceBuffersChanged();
+}
+
+void MediaSourcePrivateGStreamer::detach()
+{
+    m_hasAllTracks = false;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -56,6 +56,7 @@ public:
     static Ref<MediaSourcePrivateGStreamer> open(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
     virtual ~MediaSourcePrivateGStreamer();
 
+    void setPlayer(MediaPlayerPrivateInterface*) final;
     RefPtr<MediaPlayerPrivateInterface> player() const final;
 
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::GStreamer; }
@@ -74,6 +75,8 @@ public:
     void startPlaybackIfHasAllTracks();
     bool hasAllTracks() const { return m_hasAllTracks; }
 
+    void detach();
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }
@@ -85,8 +88,9 @@ public:
 
 private:
     MediaSourcePrivateGStreamer(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
+    RefPtr<MediaPlayerPrivateGStreamerMSE> platformPlayer() const;
 
-    MediaPlayerPrivateGStreamerMSE& m_playerPrivate;
+    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamerMSE> m_playerPrivate;
     bool m_hasAllTracks { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -64,16 +64,15 @@ bool SourceBufferPrivateGStreamer::isContentTypeSupported(const ContentType& typ
     return containerType == "audio/mpeg"_s || containerType.endsWith("mp4"_s) || containerType.endsWith("aac"_s) || containerType.endsWith("webm"_s);
 }
 
-Ref<SourceBufferPrivateGStreamer> SourceBufferPrivateGStreamer::create(MediaSourcePrivateGStreamer& mediaSource, const ContentType& contentType, MediaPlayerPrivateGStreamerMSE& playerPrivate)
+Ref<SourceBufferPrivateGStreamer> SourceBufferPrivateGStreamer::create(MediaSourcePrivateGStreamer& mediaSource, const ContentType& contentType)
 {
-    return adoptRef(*new SourceBufferPrivateGStreamer(mediaSource, contentType, playerPrivate));
+    return adoptRef(*new SourceBufferPrivateGStreamer(mediaSource, contentType));
 }
 
-SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer& mediaSource, const ContentType& contentType, MediaPlayerPrivateGStreamerMSE& playerPrivate)
+SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer& mediaSource, const ContentType& contentType)
     : SourceBufferPrivate(mediaSource)
     , m_type(contentType)
-    , m_playerPrivate(playerPrivate)
-    , m_appendPipeline(makeUnique<AppendPipeline>(*this, playerPrivate))
+    , m_appendPipeline(makeUnique<AppendPipeline>(*this, *player()))
 #if !RELEASE_LOG_DISABLED
     , m_logger(mediaSource.logger())
     , m_logIdentifier(mediaSource.nextSourceBufferLogIdentifier())
@@ -94,7 +93,8 @@ Ref<MediaPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>
 {
     ASSERT(isMainThread());
 
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Appending %zu bytes", data->size());
+    if (RefPtr player = this->player())
+        GST_DEBUG_OBJECT(player->pipeline(), "Appending %zu bytes", data->size());
 
     ASSERT(!m_appendPromise);
     m_appendPromise.emplace();
@@ -116,7 +116,8 @@ void SourceBufferPrivateGStreamer::resetParserStateInternal()
     if (!m_appendPipeline)
         return;
 
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "resetting parser state");
+    if (RefPtr player = this->player())
+        GST_DEBUG_OBJECT(player->pipeline(), "resetting parser state");
     m_appendPipeline->resetParserState();
 }
 
@@ -149,16 +150,21 @@ void SourceBufferPrivateGStreamer::flush(TrackID trackId)
     if (!mediaSource)
         return;
 
+    RefPtr player = this->player();
+
     ASSERT(m_tracks.contains(trackId));
     auto track = m_tracks[trackId];
     if (!downcast<MediaSourcePrivateGStreamer>(mediaSource)->hasAllTracks()) {
-        GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", track->stringId().string().utf8().data());
+        if (player)
+            GST_DEBUG_OBJECT(player->pipeline(), "Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", track->stringId().string().utf8().data());
         track->clearQueue();
         return;
     }
 
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%s'", track->stringId().string().utf8().data());
-    webKitMediaSrcFlush(m_playerPrivate.webKitMediaSrc(), track->stringId());
+    if (!player)
+        return;
+    GST_DEBUG_OBJECT(player->pipeline(), "Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%s'", track->stringId().string().utf8().data());
+    webKitMediaSrcFlush(player->webKitMediaSrc(), track->stringId());
 }
 
 void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, TrackID trackId)
@@ -169,11 +175,12 @@ void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, Trac
     ASSERT(gstSample);
     ASSERT(gst_sample_get_buffer(gstSample.get()));
 
-    GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "enqueing sample trackId=%" PRIu64 " presentationSize=%.0fx%.0f at PTS %" GST_TIME_FORMAT " duration: %" GST_TIME_FORMAT,
-        trackId, sample->presentationSize().width(), sample->presentationSize().height(),
-        GST_TIME_ARGS(WebCore::toGstClockTime(sample->presentationTime())),
-        GST_TIME_ARGS(WebCore::toGstClockTime(sample->duration())));
-
+    if (RefPtr player = this->player()) {
+        GST_TRACE_OBJECT(player->pipeline(), "enqueing sample trackId=%" PRIu64 " presentationSize=%.0fx%.0f at PTS %" GST_TIME_FORMAT " duration: %" GST_TIME_FORMAT,
+            trackId, sample->presentationSize().width(), sample->presentationSize().height(),
+            GST_TIME_ARGS(WebCore::toGstClockTime(sample->presentationTime())),
+            GST_TIME_ARGS(WebCore::toGstClockTime(sample->duration())));
+    }
     ASSERT(m_tracks.contains(trackId));
     auto track = m_tracks[trackId];
     track->enqueueObject(adoptGRef(GST_MINI_OBJECT(gstSample.leakRef())));
@@ -185,7 +192,8 @@ bool SourceBufferPrivateGStreamer::isReadyForMoreSamples(TrackID trackId)
     ASSERT(m_tracks.contains(trackId));
     auto track = m_tracks[trackId];
     bool ret = track->isReadyForMoreSamples();
-    GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "isReadyForMoreSamples: %s", boolForPrinting(ret));
+    if (RefPtr player = this->player())
+        GST_TRACE_OBJECT(player->pipeline(), "isReadyForMoreSamples: %s", boolForPrinting(ret));
     return ret;
 }
 
@@ -209,7 +217,8 @@ void SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued(TrackID trackId)
     ASSERT(isMainThread());
     ASSERT(m_tracks.contains(trackId));
     auto track = m_tracks[trackId];
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Enqueueing EOS for track '%s'", track->stringId().string().utf8().data());
+    if (RefPtr player = this->player())
+        GST_DEBUG_OBJECT(player->pipeline(), "Enqueueing EOS for track '%s'", track->stringId().string().utf8().data());
     track->enqueueObject(adoptGRef(GST_MINI_OBJECT(gst_event_new_eos())));
 }
 
@@ -243,7 +252,7 @@ bool SourceBufferPrivateGStreamer::precheckInitializationSegment(const Initializ
 void SourceBufferPrivateGStreamer::processInitializationSegment(std::optional<InitializationSegment>&& segment)
 {
     if (RefPtr mediaSource = m_mediaSource.get(); mediaSource && segment)
-        static_cast<MediaSourcePrivateGStreamer*>(mediaSource.get())->startPlaybackIfHasAllTracks();
+        downcast<MediaSourcePrivateGStreamer>(mediaSource)->startPlaybackIfHasAllTracks();
 }
 
 void SourceBufferPrivateGStreamer::didReceiveAllPendingSamples()
@@ -379,6 +388,22 @@ size_t SourceBufferPrivateGStreamer::platformEvictionThreshold() const
             evictionThreshold = parseInteger<size_t>(stringView, 10).value_or(0);
     });
     return evictionThreshold;
+}
+
+RefPtr<MediaPlayerPrivateGStreamerMSE> SourceBufferPrivateGStreamer::player() const
+{
+    if (RefPtr mediaSource = m_mediaSource.get())
+        return downcast<MediaPlayerPrivateGStreamerMSE>(mediaSource->player());
+    return nullptr;
+}
+
+void SourceBufferPrivateGStreamer::detach()
+{
+    for (auto& track : m_tracks)
+        flush(track.first);
+
+    if (RefPtr mediaSource = m_mediaSource.get())
+        downcast<MediaSourcePrivateGStreamer>(mediaSource)->detach();
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -57,7 +57,7 @@ class MediaSourcePrivateGStreamer;
 class SourceBufferPrivateGStreamer final : public SourceBufferPrivate, public CanMakeWeakPtr<SourceBufferPrivateGStreamer> {
 public:
     static bool isContentTypeSupported(const ContentType&);
-    static Ref<SourceBufferPrivateGStreamer> create(MediaSourcePrivateGStreamer&, const ContentType&, MediaPlayerPrivateGStreamerMSE&);
+    static Ref<SourceBufferPrivateGStreamer> create(MediaSourcePrivateGStreamer&, const ContentType&);
     ~SourceBufferPrivateGStreamer();
 
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::GStreamer; }
@@ -96,13 +96,15 @@ public:
 private:
     friend class AppendPipeline;
 
-    SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer&, const ContentType&, MediaPlayerPrivateGStreamerMSE&);
+    SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer&, const ContentType&);
+    RefPtr<MediaPlayerPrivateGStreamerMSE> player() const;
 
     void notifyClientWhenReadyForMoreSamples(TrackID) override;
 
+    void detach() final;
+
     bool m_hasBeenRemovedFromMediaSource { false };
     ContentType m_type;
-    MediaPlayerPrivateGStreamerMSE& m_playerPrivate;
     std::unique_ptr<AppendPipeline> m_appendPipeline;
     StdUnorderedMap<TrackID, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
     std::optional<MediaPromise::Producer> m_appendPromise;

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -45,6 +45,8 @@ public:
     MediaPlayerPrivateHolePunch(MediaPlayer*);
     ~MediaPlayerPrivateHolePunch();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::HolePunch; }
+
     static void registerMediaEngine(MediaEngineRegistrar);
 
     void load(const String&) final;

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -61,6 +61,8 @@ public:
     explicit MediaPlayerPrivateMediaFoundation(MediaPlayer*);
     ~MediaPlayerPrivateMediaFoundation();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::MediaFoundation; }
+
     static void registerMediaEngine(MediaEngineRegistrar);
 
     static void getSupportedTypes(HashSet<String>& types);

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -113,7 +113,12 @@ void MockMediaPlayerMediaSource::load(const String&)
 
 void MockMediaPlayerMediaSource::load(const URL&, const ContentType&, MediaSourcePrivateClient& source)
 {
-    m_mediaSourcePrivate = MockMediaSourcePrivate::create(*this, source);
+    if (RefPtr mediaSourcePrivate = downcast<MockMediaSourcePrivate>(source.mediaSourcePrivate())) {
+        mediaSourcePrivate->setPlayer(this);
+        m_mediaSourcePrivate = WTFMove(mediaSourcePrivate);
+        source.reOpen();
+    } else
+        m_mediaSourcePrivate = MockMediaSourcePrivate::create(*this, source);
 }
 
 void MockMediaPlayerMediaSource::cancelLoad()

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -55,6 +55,8 @@ public:
 
     virtual ~MockMediaPlayerMediaSource();
 
+    constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::MockMSE; }
+
     void advanceCurrentTime();
     MediaTime currentTime() const override;
     bool timeIsProgressing() const override;
@@ -109,6 +111,10 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MockMediaPlayerMediaSource)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::MockMSE; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_SOURCE)
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -78,6 +78,11 @@ RefPtr<MediaPlayerPrivateInterface> MockMediaSourcePrivate::player() const
     return m_player.get();
 }
 
+void MockMediaSourcePrivate::setPlayer(MediaPlayerPrivateInterface* player)
+{
+    m_player = downcast<MockMediaPlayerMediaSource>(player);
+}
+
 void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
 {
     MediaSourcePrivate::durationChanged(duration);

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -49,6 +49,7 @@ public:
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::Mock; }
 
     RefPtr<MediaPlayerPrivateInterface> player() const final;
+    void setPlayer(WebCore::MediaPlayerPrivateInterface*) final;
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -71,6 +71,10 @@ void RemoteMediaPlayerManagerProxy::clear()
 
     for (auto& proxy : proxies.values())
         proxy->invalidate();
+
+#if ENABLE(MEDIA_SOURCE)
+    m_pendingMediaSources.clear();
+#endif
 }
 
 void RemoteMediaPlayerManagerProxy::createMediaPlayer(MediaPlayerIdentifier identifier, MediaPlayerClientIdentifier clientIdentifier, MediaPlayerEnums::MediaEngineIdentifier engineIdentifier, RemoteMediaPlayerProxyConfiguration&& proxyConfiguration)
@@ -206,6 +210,34 @@ std::optional<ShareableBitmap::Handle> RemoteMediaPlayerManagerProxy::bitmapImag
 
     return bitmap->createHandle();
 }
+
+#if ENABLE(MEDIA_SOURCE)
+void RemoteMediaPlayerManagerProxy::registerMediaSource(RemoteMediaSourceIdentifier identifier, RemoteMediaSourceProxy& mediaSource)
+{
+    ASSERT(RunLoop::isMain());
+
+    ASSERT(!m_pendingMediaSources.contains(identifier));
+    m_pendingMediaSources.add(identifier, &mediaSource);
+}
+
+void RemoteMediaPlayerManagerProxy::invalidateMediaSource(RemoteMediaSourceIdentifier identifier)
+{
+    ASSERT(RunLoop::isMain());
+
+    ASSERT(m_pendingMediaSources.contains(identifier));
+    m_pendingMediaSources.remove(identifier);
+}
+
+RefPtr<RemoteMediaSourceProxy> RemoteMediaPlayerManagerProxy::pendingMediaSource(RemoteMediaSourceIdentifier identifier)
+{
+    ASSERT(RunLoop::isMain());
+
+    auto iterator = m_pendingMediaSources.find(identifier);
+    if (iterator == m_pendingMediaSources.end())
+        return nullptr;
+    return iterator->value;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -45,6 +45,9 @@
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 #include <WebCore/VideoReceiverEndpoint.h>
 #endif
+#if ENABLE(MEDIA_SOURCE)
+#include "RemoteMediaSourceIdentifier.h"
+#endif
 
 namespace WebKit {
 class VideoReceiverEndpointMessage;
@@ -55,6 +58,8 @@ namespace WebKit {
 class RemoteMediaPlayerProxy;
 struct RemoteMediaPlayerConfiguration;
 struct RemoteMediaPlayerProxyConfiguration;
+class RemoteMediaSourceProxy;
+class VideoReceiverEndpointMessage;
 
 class RemoteMediaPlayerManagerProxy
     : public RefCounted<RemoteMediaPlayerManagerProxy>, public IPC::MessageReceiver
@@ -89,6 +94,12 @@ public:
     void handleVideoReceiverEndpointMessage(const VideoReceiverEndpointMessage&);
 #endif
 
+#if ENABLE(MEDIA_SOURCE)
+    RefPtr<RemoteMediaSourceProxy> pendingMediaSource(RemoteMediaSourceIdentifier);
+    void registerMediaSource(RemoteMediaSourceIdentifier, RemoteMediaSourceProxy&);
+    void invalidateMediaSource(RemoteMediaSourceIdentifier);
+#endif
+
 private:
     explicit RemoteMediaPlayerManagerProxy(GPUConnectionToWebProcess&);
 
@@ -114,6 +125,10 @@ private:
         WebCore::PlatformVideoTarget videoTarget;
     };
     HashMap<WebCore::HTMLMediaElementIdentifier, VideoRecevierEndpointCacheEntry> m_videoReceiverEndpointCache;
+#endif
+
+#if ENABLE(MEDIA_SOURCE)
+    HashMap<RemoteMediaSourceIdentifier, RefPtr<RemoteMediaSourceProxy>> m_pendingMediaSources;
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -34,6 +34,7 @@ messages -> RemoteMediaSourceProxy NotRefCounted {
     SetTimeFudgeFactor(MediaTime fudgeFactor)
     MarkEndOfStream(enum:uint8_t WebCore::MediaSourcePrivateEndOfStreamStatus status)
     UnmarkEndOfStream()
+    Shutdown()
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -63,7 +63,8 @@ public:
     static Ref<RemoteSourceBufferProxy> create(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
     virtual ~RemoteSourceBufferProxy();
 
-    void shutdown();
+    void setMediaPlayer(RemoteMediaPlayerProxy&);
+
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
 private:
@@ -79,6 +80,7 @@ private:
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
     void sourceBufferPrivateEvictionDataChanged(const WebCore::SourceBufferEvictionData&) final;
+    Ref<WebCore::MediaPromise> sourceBufferPrivateDidAttach(InitializationSegment&&) final;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -117,7 +119,10 @@ private:
     void memoryPressure(const MediaTime& currentTime);
     void minimumUpcomingPresentationTimeForTrackID(TrackID, CompletionHandler<void(MediaTime)>&&);
     void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
+    void detach();
+    void attach();
     void disconnect();
+    std::optional<InitializationSegmentInfo> createInitializationSegmentInfo(InitializationSegment&&);
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     RemoteSourceBufferIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -58,6 +58,8 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     BufferedSamplesForTrackId(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     EnqueuedSamplesForTrackID(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     MemoryPressure(MediaTime currentTime)
+    Detach()
+    Attach()
     SetMaximumQueueDepthForTrackID(WebCore::TrackID trackID, uint64_t depth)
     MinimumUpcomingPresentationTimeForTrackID(WebCore::TrackID trackID) -> (MediaTime time) Synchronous
 }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -96,6 +96,8 @@ public:
     MediaPlayerPrivateRemote(WebCore::MediaPlayer*, WebCore::MediaPlayerEnums::MediaEngineIdentifier, WebCore::MediaPlayerIdentifier, RemoteMediaPlayerManager&);
     ~MediaPlayerPrivateRemote();
 
+    constexpr WebCore::MediaPlayerType mediaPlayerType() const final { return WebCore::MediaPlayerType::Remote; }
+
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
@@ -538,5 +540,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::MediaPlayerPrivateRemote)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::Remote; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -72,8 +72,12 @@ public:
     void unmarkEndOfStream() final;
     WebCore::MediaPlayer::ReadyState mediaPlayerReadyState() const final;
     void setMediaPlayerReadyState(WebCore::MediaPlayer::ReadyState) final;
+    void setPlayer(WebCore::MediaPlayerPrivateInterface*) final;
+    void shutdown() final;
 
     void setTimeFudgeFactor(const MediaTime&) final;
+
+    RemoteMediaSourceIdentifier identifier() const { return m_identifier; }
 
     static WorkQueue& queue();
 
@@ -94,7 +98,6 @@ public:
         void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
         void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
         void proxySeekToTime(const MediaTime&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
-        void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
 
         RefPtr<WebCore::MediaSourcePrivateClient> client() const;
         ThreadSafeWeakPtr<MediaSourcePrivateRemote> m_parent;
@@ -129,5 +132,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::MediaSourcePrivateRemote)
+static bool isType(const WebCore::MediaSourcePrivate& mediaSource) { return mediaSource.platformType() == WebCore::MediaPlatformType::Remote; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
@@ -28,7 +28,6 @@
 messages -> MediaSourcePrivateRemoteMessageReceiver NotRefCounted {
     ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime);
     ProxySeekToTime(MediaTime time) -> (Expected<void, WebCore::PlatformMediaError> result);
-    MediaSourcePrivateShuttingDown() -> ();
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -63,7 +63,7 @@ class SourceBufferPrivateRemote final
 {
     WTF_MAKE_TZONE_ALLOCATED(SourceBufferPrivateRemote);
 public:
-    static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
+    static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&);
     virtual ~SourceBufferPrivateRemote();
 
     constexpr WebCore::MediaPlatformType platformType() const final { return WebCore::MediaPlatformType::Remote; }
@@ -88,13 +88,14 @@ public:
         void sourceBufferPrivateDidDropSample();
         void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
         void sourceBufferPrivateEvictionDataChanged(WebCore::SourceBufferEvictionData&&);
-        void sourceBufferPrivateShuttingDown(CompletionHandler<void()>&&);
+        void sourceBufferPrivateDidAttach(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
         RefPtr<WebCore::SourceBufferPrivateClient> client() const;
+        WebCore::SourceBufferPrivateClient::InitializationSegment createInitializationSegment(MediaPlayerPrivateRemote&, InitializationSegmentInfo&&) const;
         ThreadSafeWeakPtr<SourceBufferPrivateRemote> m_parent;
     };
 
 private:
-    SourceBufferPrivateRemote(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
+    SourceBufferPrivateRemote(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&);
 
     // SourceBufferPrivate overrides
     void setActive(bool) final;
@@ -136,6 +137,9 @@ private:
 
     void memoryPressure(const MediaTime& currentTime) final;
 
+    void detach() final;
+    void attach() final;
+
     // Internals Utility methods
     Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID) final;
     Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID) final;
@@ -144,6 +148,8 @@ private:
 
     void ensureOnDispatcherSync(Function<void()>&&);
     void ensureWeakOnDispatcher(Function<void()>&&);
+
+    RefPtr<MediaPlayerPrivateRemote> player() const;
 
     template<typename PC = IPC::Connection::NoOpPromiseConverter, typename T>
     auto sendWithPromisedReply(T&& message)
@@ -155,12 +161,10 @@ private:
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     Ref<MessageReceiver> m_receiver;
     const RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
-    ThreadSafeWeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
 
     std::atomic<uint64_t> m_totalTrackBufferSizeInBytes = { 0 };
 
-    bool isGPURunning() const { return !m_shutdown && !m_removed; }
-    std::atomic<bool> m_shutdown { false };
+    bool isGPURunning() const { return !m_removed; }
     std::atomic<bool> m_removed { false };
 
     mutable Lock m_lock;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
@@ -34,7 +34,7 @@ messages -> SourceBufferPrivateRemoteMessageReceiver NotRefCounted {
     SourceBufferPrivateDidDropSample()
     SourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
     SourceBufferPrivateEvictionDataChanged(struct WebCore::SourceBufferEvictionData evictionData)
-    SourceBufferPrivateShuttingDown() -> ()
+    SourceBufferPrivateDidAttach(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (Expected<void, WebCore::PlatformMediaError> result)
 }
 
 #endif


### PR DESCRIPTION
#### 2ee9927bd954263ac537fd27463d167c87de05e3
<pre>
Provide option to &quot;detach&quot; a MediaSource element in a non-destructive fashion.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279875">https://bugs.webkit.org/show_bug.cgi?id=279875</a>
<a href="https://rdar.apple.com/129298010">rdar://129298010</a>

Reviewed by Jer Noble.

A MediaSource object is attached to a media element. When this MediaSource is detached from the media element (such as when the src or srcObject attribute is cleared or set to another object), the “3.15.2 Detaching from a media element” algorithm is to be run which will clear all its source buffers and their content and change the readyState of the MediaSource object to “close”

Discussion with users has show interests on having the ability to detach a MediaSource from a media element temporarily to re-attach it again later so that a new MediaSource doesn’t need to be created and having to reload all the original content again.

We add a construction parameter allowing to construct a MediaSource or ManagedMediaSource that is detachable.

If detached from the media element, a detachable MediaSource&apos;s content will not be destructed and can later be re-attached to the same media element (or another).
This option is disabled by default and change isn&apos;t observable.
Added test and covered by other tests.

* LayoutTests/media/media-source/media-detachablemse-append-expected.txt: Added.
* LayoutTests/media/media-source/media-detachablemse-append.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::create):
(WebCore::ManagedMediaSource::ManagedMediaSource):
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.idl:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::create):
(WebCore::MediaSource::MediaSource):
(WebCore::MediaSource::~MediaSource):
(WebCore::MediaSource::setPrivate):
(WebCore::MediaSource::setPrivateAndOpen):
(WebCore::MediaSource::reOpen):
(WebCore::MediaSource::open):
(WebCore::MediaSource::duration const):
(WebCore::MediaSource::setReadyState):
(WebCore::MediaSource::detachFromElement):
(WebCore::MediaSource::openIfDeferredOpen):
(WebCore::MediaSource::stop):
(WebCore::MediaSource::onReadyStateChange):
(WebCore::MediaSource::regenerateActiveSourceBuffers):
(WebCore::MediaSource::handle):
* Source/WebCore/Modules/mediasource/MediaSource.h:
(WebCore::MediaSource::detachable const):
* Source/WebCore/Modules/mediasource/MediaSource.idl:
* Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp:
(WebCore::MediaSourceHandle::create):
(WebCore::MediaSourceHandle::MediaSourceHandle):
* Source/WebCore/Modules/mediasource/MediaSourceHandle.h:
(WebCore::MediaSourceHandle::detachable const):
* Source/WebCore/Modules/mediasource/MediaSourceInit.h: Copied from Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in.
* Source/WebCore/Modules/mediasource/MediaSourceInit.idl: Copied from Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in.
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp:
(WebCore::MediaSourceInterfaceMainThread::detachable const):
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp:
(WebCore::MediaSourceInterfaceWorker::detachable const):
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::detached):
(WebCore::SourceBuffer::attached):
(WebCore::SourceBuffer::sourceBufferPrivateDidAttach):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.cpp:
(WebCore::SourceBufferList::replaceWith):
(WebCore::SourceBufferList::swap): Deleted.
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::shutdown):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::attached):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::setPlayer):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::player const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
(isType):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::load):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
(isType):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::addSourceBuffer):
(WebCore::MediaSourcePrivateGStreamer::player const):
(WebCore::MediaSourcePrivateGStreamer::setPlayer):
(WebCore::MediaSourcePrivateGStreamer::durationChanged):
(WebCore::MediaSourcePrivateGStreamer::markEndOfStream):
(WebCore::MediaSourcePrivateGStreamer::unmarkEndOfStream):
(WebCore::MediaSourcePrivateGStreamer::mediaPlayerReadyState const):
(WebCore::MediaSourcePrivateGStreamer::setMediaPlayerReadyState):
(WebCore::MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks):
(WebCore::MediaSourcePrivateGStreamer::notifyActiveSourceBuffersChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:  Don&apos;t store a reference to the MediaPlayerPrivate as it will be deleted.
Instead we use ThreadSafeWeakPtr and provide a fallible method to check if the player is still present.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::create):
(WebCore::SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::appendInternal):
(WebCore::SourceBufferPrivateGStreamer::resetParserStateInternal):
(WebCore::SourceBufferPrivateGStreamer::flush):
(WebCore::SourceBufferPrivateGStreamer::enqueueSample):
(WebCore::SourceBufferPrivateGStreamer::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued):
(WebCore::SourceBufferPrivateGStreamer::player const):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:  No longer store a reference to the MediaPlayerPrivate as
it will be deleted when the mediasource is detached from the media element.
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::load):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
(isType):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::setPlayer):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::clear):
(WebKit::RemoteMediaPlayerManagerProxy::registerMediaSource):
(WebKit::RemoteMediaPlayerManagerProxy::invalidateMediaSource):
(WebKit::RemoteMediaPlayerManagerProxy::pendingMediaSource):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy):
(WebKit::RemoteMediaPlayerProxy::loadMediaSource):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::RemoteMediaSourceProxy):
(WebKit::RemoteMediaSourceProxy::setMediaPlayers):
(WebKit::RemoteMediaSourceProxy::disconnect):
(WebKit::RemoteMediaSourceProxy::reOpen):
(WebKit::RemoteMediaSourceProxy::waitForTarget):
(WebKit::RemoteMediaSourceProxy::seekToTime):
(WebKit::RemoteMediaSourceProxy::addSourceBuffer):
(WebKit::RemoteMediaSourceProxy::attached):
(WebKit::RemoteMediaSourceProxy::shutdown):
(WebKit::RemoteMediaSourceProxy::connectionToWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::setMediaPlayer):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::RemoteSourceBufferProxy::attached):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidAttach):
(WebKit::RemoteSourceBufferProxy::createInitializationSegmentInfo):
(WebKit::RemoteSourceBufferProxy::shutdown): Deleted.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
(isType):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::addSourceBuffer):
(WebKit::MediaSourcePrivateRemote::setPlayer):
(WebKit::MediaSourcePrivateRemote::shutdown):
(WebKit::MediaSourcePrivateRemote::MessageReceiver::mediaSourcePrivateShuttingDown): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
(isType):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::create):
(WebKit::SourceBufferPrivateRemote::SourceBufferPrivateRemote):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDidAttach):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::createInitializationSegment const):
(WebKit::SourceBufferPrivateRemote::totalTrackBufferSizeInBytes const):
(WebKit::SourceBufferPrivateRemote::player const):
(WebKit::SourceBufferPrivateRemote::attached):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateShuttingDown): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in:

Canonical link: <a href="https://commits.webkit.org/284032@main">https://commits.webkit.org/284032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0ae3018dde689d377216e2cf1b2433406ae9ff6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19144 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12864 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16324 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17685 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/61301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73942 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67431 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61928 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3467 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43376 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15754 "Found 9 new JSC stress test failures: stress/sampling-profiler-display-name.js.dfg-eager, wasm.yaml/wasm/function-tests/many-arguments-to-function.js.wasm-no-cjit, wasm.yaml/wasm/function-tests/many-arguments-to-function.js.wasm-slow-memory, wasm.yaml/wasm/fuzz/export-function.js.wasm-bbq, wasm.yaml/wasm/gc/bug250613.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->