### PR TITLE
REGRESSION(283662@main): Web Extensions display strings are being returned unlocalized.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -108,6 +108,57 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 }
 
+TEST(WKWebExtension, DisplayStringParsingWithLocalization)
+{
+    NSMutableDictionary *testManifestDictionary = [@{
+        @"manifest_version": @2,
+        @"default_locale": @"en_US",
+
+        @"name": @"__MSG_default_name__",
+        @"short_name": @"__MSG_regional_name__",
+        @"version": @"1.0",
+        @"description": @"__MSG_default_description__"
+    } mutableCopy];
+
+    auto *defaultMessages = @{
+        @"default_name": @{
+            @"message": @"Default String",
+            @"description": @"The test name."
+        },
+        @"default_description": @{
+            @"message": @"Default Description",
+            @"description": @"The test description."
+        }
+    };
+
+    auto *regionalMessages = @{
+        @"regional_name": @{
+            @"message": @"Regional String",
+            @"description": @"The regional name."
+        }
+    };
+
+    auto *resources = @{
+        @"_locales/en/messages.json": defaultMessages,
+        @"_locales/en_US/messages.json": regionalMessages,
+    };
+
+    auto *extension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+
+    EXPECT_NS_EQUAL(extension.displayName, @"Default String");
+    EXPECT_NS_EQUAL(extension.displayShortName, @"Regional String");
+    EXPECT_NS_EQUAL(extension.displayVersion, @"1.0");
+    EXPECT_NS_EQUAL(extension.version, @"1.0");
+    EXPECT_NS_EQUAL(extension.displayDescription, @"Default Description");
+    EXPECT_NS_EQUAL(extension.errors, @[ ]);
+
+    testManifestDictionary[@"short_name"] = @"__MSG_default_name__";
+    extension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+
+    EXPECT_NS_EQUAL(extension.displayShortName, @"Default String");
+    EXPECT_NS_EQUAL(extension.errors, @[ ]);
+}
+
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 TEST(WKWebExtension, MultipleIconVariants)
 {


### PR DESCRIPTION
#### 056cae6be886c017d226ccd7de1a40e940febcd2
<pre>
REGRESSION(283662@main): Web Extensions display strings are being returned unlocalized.
<a href="https://webkit.org/b/279829">https://webkit.org/b/279829</a>
<a href="https://rdar.apple.com/136106148">rdar://136106148</a>

Reviewed by Brian Weinstein.

The regressed with <a href="https://commits.webkit.org/283662@main.">https://commits.webkit.org/283662@main.</a> We need to create the m_manifestJSON
object after localization so it has the localized strings.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseManifest): Create m_manifestJSON after localization.
(WebKit::WebExtension::manifest): Moved localization steps to parseManifest().
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, DisplayStringParsingWithLocalization)): Added.

Canonical link: <a href="https://commits.webkit.org/283788@main">https://commits.webkit.org/283788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e21079895af095d56c26ce57d05b9fe50dfa534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20020 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18316 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70455 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58293 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15693 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16034 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11347 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/73135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58358 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2896 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10229 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->