### PR TITLE
DATA LOSS: currentDatabaseSchemaVersion is incorrect for Web Extension storage.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-OBJC_CLASS _WKWebExtensionSQLiteDatabase;
+#import "_WKWebExtensionSQLiteDatabase.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,6 +48,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)close;
 
 - (void)deleteDatabaseWithCompletionHandler:(void (^)(NSString * _Nullable errorMessage))completionHandler;
+
+- (SchemaVersion)_migrateToCurrentSchemaVersionIfNeeded;
+
+- (SchemaVersion)_databaseSchemaVersion;
+- (DatabaseResult)_setDatabaseSchemaVersion:(SchemaVersion)newVersion;
 
 - (BOOL)_openDatabaseIfNecessaryReturningErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage;
 - (BOOL)_openDatabaseIfNecessaryReturningErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage createIfNecessary:(BOOL)createIfNecessary;


### PR DESCRIPTION
#### 4b61f0414c2c1b826c99bf95c74190a19ab4e926
<pre>
DATA LOSS: currentDatabaseSchemaVersion is incorrect for Web Extension storage.
<a href="https://webkit.org/b/279831">https://webkit.org/b/279831</a>
<a href="https://rdar.apple.com/problem/136159837">rdar://problem/136159837</a>

Reviewed by Brian Weinstein.

Safari shipped with a database schema version of 2, but when migrating to WebKit, the version was
incorrectly marked as 1. This mismatch was triggering a database schema reset, erasing all storage
data. However, since the schema for version 2 (Safari) and version 1 (WebKit) are identical, we simply
set the version and return the current version to avoid unnecessary data loss.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(currentDatabaseSchemaVersion): Set to 2, matching Safari.
(-[_WKWebExtensionSQLiteStore _migrateToCurrentSchemaVersionIfNeeded]): Use _databaseSchemaVersion.
(-[_WKWebExtensionSQLiteStore _databaseSchemaVersion]): Added.
(-[_WKWebExtensionSQLiteStore _setDatabaseSchemaVersion:]): Removed &quot;return 0;&quot; dead code.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm:
(-[_WKWebExtensionStorageSQLiteStore _migrateToCurrentSchemaVersionIfNeeded]): Added.

Canonical link: <a href="https://commits.webkit.org/283802@main">https://commits.webkit.org/283802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63dc95b53b87b16c6e349896b9e484cf409a758a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20065 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18361 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58329 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39655 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/16928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73180 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11392 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58397 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9315 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10241 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/44880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->