### PR TITLE
REGRESSION(282648@main): RELEASE_ASSERT fires when inserting a slot element with dir=auto into the shadowRoot of a detached element

### DIFF
--- a/LayoutTests/fast/dom/HTMLElement/attr-dir-auto-slot-shadow-innerHTML-expected.txt
+++ b/LayoutTests/fast/dom/HTMLElement/attr-dir-auto-slot-shadow-innerHTML-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/dom/HTMLElement/attr-dir-auto-slot-shadow-innerHTML.html
+++ b/LayoutTests/fast/dom/HTMLElement/attr-dir-auto-slot-shadow-innerHTML.html
@@ -1,0 +1,19 @@
+<body>
+    <div id="root">
+        <slot name="x24">
+            <slot dir="auto"></slot>
+            <div id="child"></div>
+        </slot>
+    </div>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const child = document.getElementById("child");
+        child.replaceWith("This test passes if it does not crash.");
+
+        const innerHTML = root.innerHTML;
+        const shadow = child.attachShadow({ mode: "closed" });
+        shadow.innerHTML = innerHTML;
+    </script>
+</body>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2895,9 +2895,11 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
     } else if (!hasLanguageAttribute())
         updateEffectiveLangStateFromParent();
 
-    RefPtr parent = parentOrShadowHostElement();
-    if (UNLIKELY(selfOrPrecedingNodesAffectDirAuto() || (parent && parent->usesEffectiveTextDirection())))
-        updateEffectiveTextDirection();
+    if (!is<HTMLSlotElement>(*this)) {
+        RefPtr parent = parentOrShadowHostElement();
+        if (UNLIKELY(selfOrPrecedingNodesAffectDirAuto() || (parent && parent->usesEffectiveTextDirection())))
+            updateEffectiveTextDirection();
+    }
 
     return InsertedIntoAncestorResult::Done;
 }

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -65,11 +65,9 @@ HTMLSlotElement::InsertedIntoAncestorResult HTMLSlotElement::insertedIntoAncesto
     if (insertionType.treeScopeChanged && isInShadowTree()) {
         if (auto* shadowRoot = containingShadowRoot())
             shadowRoot->addSlotElementByName(attributeWithoutSynchronization(nameAttr), *this);
-
-        return Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback;
     }
 
-    return Node::InsertedIntoAncestorResult::Done;
+    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 
 void HTMLSlotElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)


### PR DESCRIPTION
#### cea37a7afdfcfb7858d60124a05e0c3b5186358d
<pre>
REGRESSION(282648@main): RELEASE_ASSERT fires when inserting a slot element with dir=auto into the shadowRoot of a detached element
<a href="https://bugs.webkit.org/show_bug.cgi?id=279834">https://bugs.webkit.org/show_bug.cgi?id=279834</a>
<a href="https://rdar.apple.com/135587710">rdar://135587710</a>

Reviewed by Ryosuke Niwa.

HTMLSlotElement needs to update the assignedNodes of its shadow root before it
computes its auto text directionality.

Make Element::insertedIntoAncestor() call updateEffectiveTextDirection() only
if the Element is not HTMLSlotElement.

HTMLSlotElement::insertedIntoAncestor() will return NeedsPostInsertionCallback
always. The callback HTMLSlotElement::didFinishInsertingNode() gets called
after updating the assignedNodes of the shadow root.

* LayoutTests/fast/dom/HTMLElement/attr-dir-auto-slot-shadow-innerHTML-expected.txt: Added.
* LayoutTests/fast/dom/HTMLElement/attr-dir-auto-slot-shadow-innerHTML.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::updateTextAttributes):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::insertedIntoAncestor):
(WebCore::HTMLSlotElement::didFinishInsertingNode): Deleted.
* Source/WebCore/html/HTMLSlotElement.h:

Canonical link: <a href="https://commits.webkit.org/283854@main">https://commits.webkit.org/283854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ec4a8982590a5dae450c9fa683ae0ccefa7de9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54092 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12489 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15807 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17025 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58471 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61598 "Found 1 new API test failure: /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14978 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2996 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42714 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->