### PR TITLE
[Script Telemetry] Deploy telemetry in document.(referrer|URL) and screen/window-related APIs

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6049,6 +6049,20 @@ ScriptTelemetryEnabled:
     WebKit:
       default: false
 
+ScriptTelemetryLoggingEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Script Telemetry Logging"
+  humanReadableDescription: "Script telemetry logging enabled"
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ScrollAnimatorEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -835,7 +835,7 @@ public:
 
     const URL& url() const final { return m_url; }
     void setURL(const URL&);
-    WEBCORE_EXPORT const URL& urlForBindings() const;
+    WEBCORE_EXPORT const URL& urlForBindings();
 
     URL adjustedURL() const;
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1269,7 +1269,7 @@ int LocalDOMWindow::outerHeight() const
     if (!page)
         return 0;
 
-    if (page->fingerprintingProtectionsEnabled())
+    if (page->shouldApplyScreenFingerprintingProtections(*protectedDocument()))
         return innerHeight();
 
 #if PLATFORM(IOS_FAMILY)
@@ -1297,7 +1297,7 @@ int LocalDOMWindow::outerWidth() const
     if (!page)
         return 0;
 
-    if (page->fingerprintingProtectionsEnabled())
+    if (page->shouldApplyScreenFingerprintingProtections(*protectedDocument()))
         return innerWidth();
 
 #if PLATFORM(IOS_FAMILY)
@@ -1362,7 +1362,7 @@ int LocalDOMWindow::screenX() const
         return 0;
 
     RefPtr page = frame->page();
-    if (!page || page->fingerprintingProtectionsEnabled())
+    if (!page || page->shouldApplyScreenFingerprintingProtections(*protectedDocument()))
         return 0;
 
     return static_cast<int>(page->chrome().windowRect().x());
@@ -1375,7 +1375,7 @@ int LocalDOMWindow::screenY() const
         return 0;
 
     RefPtr page = frame->page();
-    if (!page || page->fingerprintingProtectionsEnabled())
+    if (!page || page->shouldApplyScreenFingerprintingProtections(*protectedDocument()))
         return 0;
 
     return static_cast<int>(page->chrome().windowRect().y());

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1135,11 +1135,11 @@ FloatSize LocalFrame::screenSize() const
     if (!document)
         return defaultSize;
 
-    RefPtr loader = document->loader();
-    if (!loader || !loader->fingerprintingProtectionsEnabled())
+    RefPtr page = this->page();
+    if (!page)
         return defaultSize;
 
-    if (RefPtr page = this->page())
+    if (page->shouldApplyScreenFingerprintingProtections(*document))
         return page->chrome().client().screenSizeForFingerprintingProtections(*this, defaultSize);
 
     return defaultSize;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -41,6 +41,7 @@
 #include "RTCController.h"
 #include "Region.h"
 #include "RegistrableDomain.h"
+#include "ScriptTelemetryCategory.h"
 #include "ScrollTypes.h"
 #include "ShouldRelaxThirdPartyCookieBlocking.h"
 #include "Supplementable.h"
@@ -59,6 +60,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/URLHash.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -226,6 +228,7 @@ enum class MediaPlaybackTargetContextMockState : uint8_t;
 enum class MediaProducerMediaState : uint32_t;
 enum class MediaProducerMediaCaptureKind : uint8_t;
 enum class MediaProducerMutedState : uint8_t;
+enum class ScriptTelemetryCategory : uint8_t;
 enum class VisibilityState : bool;
 
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
@@ -398,7 +401,7 @@ public:
     void setCurrentKeyboardScrollingAnimator(KeyboardScrollingAnimator*);
     KeyboardScrollingAnimator* currentKeyboardScrollingAnimator() const { return m_currentKeyboardScrollingAnimator.get(); }
 
-    bool fingerprintingProtectionsEnabled() const;
+    bool shouldApplyScreenFingerprintingProtections(Document&) const;
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const;
 
@@ -1211,6 +1214,7 @@ public:
     WEBCORE_EXPORT bool isFullscreenManagerEnabled() const;
 #endif
 
+    bool reportScriptTelemetry(const URL&, ScriptTelemetryCategory);
     bool requiresScriptTelemetryForURL(const URL&) const;
 
 private:
@@ -1630,6 +1634,8 @@ private:
 #if ENABLE(WRITING_TOOLS)
     UniqueRef<WritingToolsController> m_writingToolsController;
 #endif
+
+    HashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;
 
     bool m_hasActiveNowPlayingSession { false };
     Timer m_activeNowPlayingSessionUpdateTimer;

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -55,9 +55,17 @@ Screen::Screen(LocalDOMWindow& window)
 
 Screen::~Screen() = default;
 
-static bool fingerprintingProtectionsEnabled(const LocalFrame& frame)
+static bool shouldApplyScreenFingerprintingProtections(const LocalFrame& frame)
 {
-    return frame.mainFrame().advancedPrivacyProtections().contains(AdvancedPrivacyProtections::FingerprintingProtections);
+    RefPtr page = frame.protectedPage();
+    if (!page)
+        return false;
+
+    RefPtr document = frame.document();
+    if (!document)
+        return false;
+
+    return page->shouldApplyScreenFingerprintingProtections(*document);
 }
 
 static bool shouldFlipScreenDimensions(const LocalFrame& frame)
@@ -113,7 +121,7 @@ int Screen::availLeft() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailLeft);
 
-    if (fingerprintingProtectionsEnabled(*frame))
+    if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
 
     return static_cast<int>(screenAvailableRect(frame->protectedView().get()).x());
@@ -128,7 +136,7 @@ int Screen::availTop() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailTop);
 
-    if (fingerprintingProtectionsEnabled(*frame))
+    if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
 
     return static_cast<int>(screenAvailableRect(frame->protectedView().get()).y());
@@ -143,7 +151,7 @@ int Screen::availHeight() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailHeight);
 
-    if (fingerprintingProtectionsEnabled(*frame))
+    if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().height());
 
     return static_cast<int>(screenAvailableRect(frame->protectedView().get()).height());
@@ -158,7 +166,7 @@ int Screen::availWidth() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailWidth);
 
-    if (fingerprintingProtectionsEnabled(*frame))
+    if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().width());
 
     return static_cast<int>(screenAvailableRect(frame->protectedView().get()).width());

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -237,6 +237,7 @@ Tests/WebKitCocoa/RunScriptAfterDocumentLoad.mm
 Tests/WebKitCocoa/SafeBrowsing.mm
 Tests/WebKitCocoa/SampledPageTopColor.mm
 Tests/WebKitCocoa/SchemeRegistry.mm
+Tests/WebKitCocoa/ScriptTelemetryTests.mm
 Tests/WebKitCocoa/ServiceWorkerBasic.mm
 Tests/WebKitCocoa/SessionStorage.mm
 Tests/WebKitCocoa/ShouldGoToBackForwardListItem.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3680,6 +3680,7 @@
 		F4A9202E1FEE34C800F59590 /* apple-data-url.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "apple-data-url.html"; sourceTree = "<group>"; };
 		F4AB57891F65164B00DB0DA1 /* custom-draggable-div.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "custom-draggable-div.html"; sourceTree = "<group>"; };
 		F4AD183725ED791500B1A19F /* FloatQuadTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FloatQuadTests.cpp; sourceTree = "<group>"; };
+		F4AF63B32C990A47001D782B /* ScriptTelemetryTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScriptTelemetryTests.mm; sourceTree = "<group>"; };
 		F4B0167F25AE02D600E445C4 /* DisableSpellcheckPlugIn.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisableSpellcheckPlugIn.mm; sourceTree = "<group>"; };
 		F4B0168225AE060F00E445C4 /* DisableSpellcheck.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisableSpellcheck.mm; sourceTree = "<group>"; };
 		F4B825D61EF4DBD4006E417F /* compressed-files.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "compressed-files.zip"; sourceTree = "<group>"; };
@@ -4299,6 +4300,7 @@
 				95095F1F262FFFA50000D920 /* SampledPageTopColor.mm */,
 				5CC8B16226A2527C00909603 /* SchemeChangingPlugIn.mm */,
 				CE0947362063223B003C9BA0 /* SchemeRegistry.mm */,
+				F4AF63B32C990A47001D782B /* ScriptTelemetryTests.mm */,
 				51EB12931FDF050500A5A1BD /* ServiceWorkerBasic.mm */,
 				466AF38826FE393200CE2EB8 /* ServiceWorkerPagePlugIn.mm */,
 				460C2FC827039D7D0047EF11 /* ServiceWorkerPageProtocol.h */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTelemetryTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTelemetryTests.mm
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ScriptTelemetryTestsAdditions.mm>)
+#import <WebKitAdditions/ScriptTelemetryTestsAdditions.mm>
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -29,6 +29,7 @@
 
 #import "CGImagePixelReader.h"
 #import "PlatformUtilities.h"
+#import "Test.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebCore/ColorSerialization.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "TestCocoa.h"
+#import "WebExtensionUtilities.h"
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebExtensionCommand.h>
 #import <WebKit/WKWebExtensionContextPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -25,9 +25,13 @@
 
 #import "config.h"
 
+#import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestUIDelegate.h"
 #import "Utilities.h"
 #import "WebTransportServer.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/_WKInternalDebugFeature.h>
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### 822bd9c19a781cf9edd9bba79079f7fb0253c08a
<pre>
[Script Telemetry] Deploy telemetry in document.(referrer|URL) and screen/window-related APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=279845">https://bugs.webkit.org/show_bug.cgi?id=279845</a>
<a href="https://rdar.apple.com/136178559">rdar://136178559</a>

Reviewed by Abrar Rahman Protyasha.

Deploy script telemetry checks in a few contexts:

•   Various screen- and window-metrics APIs where existing fingerprinting protections in Private
    Browsing apply, such as `screen.width`, `screen.height`, and `outerWidth` / `outerHeight`.
•   `document.referrer`
•   `document.URL` (and other ways to programmatically request the full URL from bindings).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add a feature flag (off everywhere by default) to aid debugging and testing, by reporting script
telemetry observations. To avoid excessive console log, we also limit this to a single message per
script URL per telemetry category.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::urlForBindings):
(WebCore::Document::referrerForBindings):
(WebCore::Document::noiseInjectionPolicies const):
(WebCore::Document::urlForBindings const): Deleted.

This method becomes non-const, since it now calls into `requiresScriptExecutionTelemetry` which
may log a console message.

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::requiresScriptExecutionTelemetry):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::outerHeight const):
(WebCore::LocalDOMWindow::outerWidth const):
(WebCore::LocalDOMWindow::screenX const):
(WebCore::LocalDOMWindow::screenY const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::screenSize const):

Add telemetry in all the same places where we currently lock down access to fine-grained screen and
window-related metrics, which are not critical to page layout.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::shouldApplyScreenFingerprintingProtections const):

Rename `fingerprintingProtectionsEnabled` to `shouldApplyScreenFingerprintingProtections`, to better
reflect the fact that this is only used to guard screen-related fingerprinting protections.

(WebCore::Page::reportScriptTelemetry):
(WebCore::Page::fingerprintingProtectionsEnabled const): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/Screen.cpp:
(WebCore::shouldApplyScreenFingerprintingProtections):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
(WebCore::fingerprintingProtectionsEnabled): Deleted.
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTelemetryTests.mm: Added.

Add a new test suite, whose main implementation exists inside an additions file.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:

Apply several unified source build fixes to accommodate the new test source.

Canonical link: <a href="https://commits.webkit.org/283868@main">https://commits.webkit.org/283868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/113486b766c6ab5696988c90c391f367318d8d95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54063 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12450 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16941 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60561 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73193 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66691 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61500 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2941 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88460 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42630 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15600 "Found 4 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-eager-jettison, wasm.yaml/wasm/stress/tail-call.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->