### PR TITLE
[Static Analyzer CI] Run smart pointer static analysis with release config

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -198,7 +198,7 @@ testing t: force
 	@$(call invoke_xcode,,)
 
 analyze:
-	@$(call set_webkit_configuration,--debug)
+	@$(call set_webkit_configuration,)
 	@$(call invoke_xcode,analyze,$(ANALYZER_XCODE_SETTINGS)) || true
 	@for dir in $$(ls -d $(ANALYZER_OUTPUT)/StaticAnalyzer/*); do \
 		mkdir -p $$dir/StaticAnalyzerReports; \

--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -232,7 +232,7 @@
                   },
                   {
                   "name": "Apple-Sonoma-Smart-Pointer-Static-Analyzer-Build", "factory": "SmartPointerStaticAnalyzerFactory",
-                  "platform": "mac-sonoma", "configuration": "debug", "architectures": ["arm64"],
+                  "platform": "mac-sonoma", "configuration": "release", "architectures": ["arm64"],
                   "workernames": ["bot600"]
                   },
                   { "name": "Apple-Ventura-Release-Build", "factory": "BuildFactory",

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1617,7 +1617,7 @@ class ScanBuildSmartPointer(steps.ShellSequence, ShellMixin):
     @defer.inlineCallbacks
     def run(self):
         self.commands = []
-        build_command = f"Tools/Scripts/build-and-analyze --output-dir {os.path.join(self.getProperty('builddir'), f'build/{SCAN_BUILD_OUTPUT_DIR}')} "
+        build_command = f"Tools/Scripts/build-and-analyze --output-dir {os.path.join(self.getProperty('builddir'), f'build/{SCAN_BUILD_OUTPUT_DIR}')} --configuration {self.build.getProperty('configuration')} "
         build_command += f"--only-smart-pointers --analyzer-path={os.path.join(self.getProperty('builddir'), 'llvm-project/build/bin/clang')} "
         build_command += '--scan-build-path=../llvm-project/clang/tools/scan-build/bin/scan-build --sdkroot=macosx --preprocessor-additions=CLANG_WEBKIT_BRANCH=1 '
         build_command += '2>&1 | python3 Tools/Scripts/filter-test-logs scan-build --output build-log.txt'

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1831,7 +1831,7 @@ exit 1''')
 
 class TestScanBuildSmartPointer(BuildStepMixinAdditions, unittest.TestCase):
     WORK_DIR = 'wkdir'
-    EXPECTED_BUILD_COMMAND = ['/bin/sh', '-c', f'Tools/Scripts/build-and-analyze --output-dir wkdir/build/{SCAN_BUILD_OUTPUT_DIR} --only-smart-pointers --analyzer-path=wkdir/llvm-project/build/bin/clang --scan-build-path=../llvm-project/clang/tools/scan-build/bin/scan-build --sdkroot=macosx --preprocessor-additions=CLANG_WEBKIT_BRANCH=1 2>&1 | python3 Tools/Scripts/filter-test-logs scan-build --output build-log.txt']
+    EXPECTED_BUILD_COMMAND = ['/bin/sh', '-c', f'Tools/Scripts/build-and-analyze --output-dir wkdir/build/{SCAN_BUILD_OUTPUT_DIR} --configuration release --only-smart-pointers --analyzer-path=wkdir/llvm-project/build/bin/clang --scan-build-path=../llvm-project/clang/tools/scan-build/bin/scan-build --sdkroot=macosx --preprocessor-additions=CLANG_WEBKIT_BRANCH=1 2>&1 | python3 Tools/Scripts/filter-test-logs scan-build --output build-log.txt']
 
     def setUp(self):
         return self.setUpBuildStep()
@@ -1845,6 +1845,7 @@ class TestScanBuildSmartPointer(BuildStepMixinAdditions, unittest.TestCase):
     def test_failure(self):
         self.configureStep()
         self.setProperty('builddir', self.WORK_DIR)
+        self.setProperty('configuration', 'release')
 
         self.expectRemoteCommands(
             ExpectShell(workdir=self.WORK_DIR,
@@ -1862,6 +1863,7 @@ class TestScanBuildSmartPointer(BuildStepMixinAdditions, unittest.TestCase):
     def test_success(self):
         self.configureStep()
         self.setProperty('builddir', self.WORK_DIR)
+        self.setProperty('configuration', 'release')
 
         self.expectRemoteCommands(
             ExpectShell(workdir=self.WORK_DIR,
@@ -1880,6 +1882,7 @@ class TestScanBuildSmartPointer(BuildStepMixinAdditions, unittest.TestCase):
     def test_success_with_issues(self):
         self.configureStep()
         self.setProperty('builddir', self.WORK_DIR)
+        self.setProperty('configuration', 'release')
 
         self.expectRemoteCommands(
             ExpectShell(workdir=self.WORK_DIR,

--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -142,6 +142,9 @@ def main(args):
     generate_static_analysis_archive_path = os.path.realpath(
         os.path.join(os.path.dirname(__file__), 'generate-static-analysis-archive'))
 
+    set_webkit_config_path = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), 'set-webkit-configuration'))
+
     make_command = ['make', 'analyze', 'SDKROOT={}'.format(args.sdkroot)]
     if args.analyzer_path:
         make_command.extend(['CC={}'.format(analyzer_path), 'CPLUSPLUS={}'.format(analyzer_path)])
@@ -149,6 +152,7 @@ def main(args):
         make_command.extend(['GCC_PREPROCESSOR_ADDITIONS={}'.format(args.preprocessor_additions)])
 
     commands = [
+        [set_webkit_config_path, '--{}'.format(args.configuration)],
         make_command,
         [generate_static_analysis_archive_path, '--count', '--output-root', output_dir, '--id-string', 'WebKit Build'],
     ]
@@ -195,6 +199,7 @@ def parse_args():
                         help='Additional preprocessor macros.')
     parser.add_argument('--dry-run', default=False,
                         action='store_true', help='Output the command instead of executing it.')
+    parser.add_argument('--configuration', default='debug', choices=['debug', 'release'], dest='configuration', help='Set the build configuration (default: debug).')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
#### 2e5790b1d728501d4958b8c9bb6d3c91df5e45e3
<pre>
[Static Analyzer CI] Run smart pointer static analysis with release config
<a href="https://bugs.webkit.org/show_bug.cgi?id=279856">https://bugs.webkit.org/show_bug.cgi?id=279856</a>
<a href="https://rdar.apple.com/136183334">rdar://136183334</a>

Reviewed by Ryosuke Niwa.

Change the build config for Apple-Sonoma-Smart-Pointer-Static-Analyzer-Build to release and
invoke build-and-analyze with release config.

This will allow the configuration of make analyze to be changed using set-webkit-configuration and
default to whatever configuration was last set, similar to how local builds work.

* Makefile.shared: Remove debug-only config.
* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/steps.py:
(ScanBuildSmartPointer.run): Add --configuration release to build-and-analyze invocation.
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/Scripts/build-and-analyze:
(main): Run set-webkit-configuration before make analyze.
(parse_args): Add --configuration argument (default: debug).

Canonical link: <a href="https://commits.webkit.org/283850@main">https://commits.webkit.org/283850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd4144e34e16f95e9c95334bedc37468d305eefd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54073 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16976 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60596 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73228 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66726 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61519 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/67161 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61580 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2963 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88495 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42665 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15603 "Found 4 new JSC stress test failures: wasm.yaml/wasm/function-tests/many-arguments-to-function.js.wasm-eager, wasm.yaml/wasm/fuzz/memory.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->