### PR TITLE
Clean up state in PageLoadTimingFrameLoadStateObserver better when running PLT with site isolation

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -57,7 +57,7 @@ private:
     void beforeStart() final;
 
     // FrameLoadStateObserver
-    void didFinishLoad() final;
+    void didFinishLoad(const URL&) final;
 
     void appendRequestToLoad(URL&&, Supplement&&);
     void loadRequestToFrame();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -105,7 +105,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(span8(soAuthorizationPostDidStartMessageToParent)));
 }
 
-void SubFrameSOAuthorizationSession::didFinishLoad()
+void SubFrameSOAuthorizationSession::didFinishLoad(const URL&)
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("didFinishLoad");
     RefPtr frame = WebFrameProxy::webFrame(m_frameID);

--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -53,6 +53,7 @@ void FrameLoadState::didStartProvisionalLoad(const URL& url)
 
     m_observers.forEach([&url](FrameLoadStateObserver& observer) {
         observer.didReceiveProvisionalURL(url);
+        observer.didStartProvisionalLoad(url);
     });
 }
 
@@ -94,6 +95,7 @@ void FrameLoadState::didFailProvisionalLoad()
 
     m_observers.forEach([](FrameLoadStateObserver& observer) {
         observer.didCancelProvisionalLoad();
+        observer.didFailProvisionalLoad();
     });
 }
 
@@ -106,8 +108,9 @@ void FrameLoadState::didCommitLoad()
     m_url = m_provisionalURL.isNull() ? aboutBlankURL() : m_provisionalURL;
     m_provisionalURL = { };
 
-    m_observers.forEach([](FrameLoadStateObserver& observer) {
+    m_observers.forEach([&](FrameLoadStateObserver& observer) {
         observer.didCommitProvisionalLoad();
+        observer.didCommitProvisionalLoad(m_isMainFrame);
     });
 }
 
@@ -118,8 +121,8 @@ void FrameLoadState::didFinishLoad()
 
     m_state = State::Finished;
 
-    m_observers.forEach([](FrameLoadStateObserver& observer) {
-        observer.didFinishLoad();
+    m_observers.forEach([&](FrameLoadStateObserver& observer) {
+        observer.didFinishLoad(m_url);
     });
 }
 

--- a/Source/WebKit/UIProcess/FrameLoadState.h
+++ b/Source/WebKit/UIProcess/FrameLoadState.h
@@ -39,17 +39,25 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::FrameLoadStat
 
 namespace WebKit {
 
+enum class IsMainFrame : bool;
+
 class FrameLoadStateObserver : public CanMakeWeakPtr<FrameLoadStateObserver> {
 public:
     virtual ~FrameLoadStateObserver() = default;
     virtual void didReceiveProvisionalURL(const URL&) { }
+    virtual void didStartProvisionalLoad(const URL&) { }
+    virtual void didFailProvisionalLoad() { }
     virtual void didCancelProvisionalLoad() { }
     virtual void didCommitProvisionalLoad() { }
-    virtual void didFinishLoad() { }
+    virtual void didCommitProvisionalLoad(IsMainFrame) { }
+    virtual void didFinishLoad(const URL&) { }
 };
 
 class FrameLoadState {
 public:
+    FrameLoadState(IsMainFrame isMainFrame)
+        : m_isMainFrame(isMainFrame) { }
+
     ~FrameLoadState();
 
     enum class State {
@@ -81,7 +89,9 @@ public:
     void setUnreachableURL(const URL&);
     const URL& unreachableURL() const { return m_unreachableURL; }
 
+    IsMainFrame isMainFrame() const { return m_isMainFrame; }
 private:
+    const IsMainFrame m_isMainFrame;
     State m_state { State::Finished };
     URL m_url;
     URL m_provisionalURL;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -117,7 +117,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     } else if (m_page->preferences().siteIsolationEnabled())
         m_mainFrame = m_page->mainFrame();
     else {
-        m_mainFrame = WebFrameProxy::create(protectedPage(), m_frameProcess, FrameIdentifier::generate(), previousMainFrame->effectiveSandboxFlags(), WebFrameProxy::IsMainFrame::Yes);
+        m_mainFrame = WebFrameProxy::create(protectedPage(), m_frameProcess, FrameIdentifier::generate(), previousMainFrame->effectiveSandboxFlags(), IsMainFrame::Yes);
 
         // Restore the main frame's committed URL as some clients may rely on it until the next load is committed.
         m_mainFrame->frameLoadState().setURL(previousMainFrame->url());

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -90,9 +90,9 @@ bool WebFrameProxy::canCreateFrame(FrameIdentifier frameID)
 WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIdentifier frameID, SandboxFlags effectiveSandboxFlags, IsMainFrame isMainFrame)
     : m_page(page)
     , m_frameProcess(process)
+    , m_frameLoadState(isMainFrame)
     , m_frameID(frameID)
     , m_layerHostingContextIdentifier(LayerHostingContextIdentifier::generate())
-    , m_isMainFrame(isMainFrame)
     , m_effectiveSandboxFlags(effectiveSandboxFlags)
 {
     ASSERT(!allFrames().contains(frameID));
@@ -410,7 +410,7 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, const St
     MESSAGE_CHECK(WebFrameProxy::canCreateFrame(frameID));
     MESSAGE_CHECK(frameID.processIdentifier() == process().coreProcessIdentifier());
 
-    Ref child = WebFrameProxy::create(*page, m_frameProcess, frameID, effectiveSandboxFlags, WebFrameProxy::IsMainFrame::No);
+    Ref child = WebFrameProxy::create(*page, m_frameProcess, frameID, effectiveSandboxFlags, IsMainFrame::No);
     child->m_parentFrame = *this;
     child->m_frameName = frameName;
     page->observeAndCreateRemoteSubframesInOtherProcesses(child, frameName);
@@ -668,6 +668,11 @@ WebFrameProxy& WebFrameProxy::rootFrame()
     while (rootFrame->m_parentFrame && rootFrame->m_parentFrame->process().coreProcessIdentifier() == process().coreProcessIdentifier())
         rootFrame = *rootFrame->m_parentFrame;
     return rootFrame;
+}
+
+bool WebFrameProxy::isMainFrame() const
+{
+    return m_frameLoadState.isMainFrame() == IsMainFrame::Yes;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -71,6 +71,7 @@ class WebsiteDataStore;
 
 enum class CanWrap : bool { No, Yes };
 enum class DidWrap : bool { No, Yes };
+enum class IsMainFrame : bool { No, Yes };
 enum class ShouldExpectSafeBrowsingResult : bool;
 enum class ProcessSwapRequestedByClient : bool;
 
@@ -81,7 +82,6 @@ struct WebsitePoliciesData;
 
 class WebFrameProxy : public API::ObjectImpl<API::Object::Type::Frame>, public CanMakeWeakPtr<WebFrameProxy> {
 public:
-    enum class IsMainFrame : bool { No, Yes };
     static Ref<WebFrameProxy> create(WebPageProxy& page, FrameProcess& process, WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags, IsMainFrame isMainFrame)
     {
         return adoptRef(*new WebFrameProxy(page, process, frameID, sandboxFlags, isMainFrame));
@@ -100,7 +100,7 @@ public:
 
     void webProcessWillShutDown();
 
-    bool isMainFrame() const { return m_isMainFrame == IsMainFrame::Yes; }
+    bool isMainFrame() const;
 
     FrameLoadState& frameLoadState() { return m_frameLoadState; }
 
@@ -236,7 +236,6 @@ private:
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)> m_navigateCallback;
     const WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
     bool m_hasPendingBackForwardItem { false };
-    const IsMainFrame m_isMainFrame;
     std::optional<WebCore::IntSize> m_remoteFrameSize;
     WebCore::SandboxFlags m_effectiveSandboxFlags;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1596,7 +1596,7 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     m_pageToCloneSessionStorageFrom = nullptr;
 
     Ref process = m_legacyMainFrameProcess;
-    m_mainFrame = WebFrameProxy::create(*this, m_browsingContextGroup->ensureProcessForSite(site, process, preferences()), FrameIdentifier::generate(), effectiveSandboxFlags, WebFrameProxy::IsMainFrame::Yes);
+    m_mainFrame = WebFrameProxy::create(*this, m_browsingContextGroup->ensureProcessForSite(site, process, preferences()), FrameIdentifier::generate(), effectiveSandboxFlags, IsMainFrame::Yes);
     if (m_preferences->siteIsolationEnabled())
         m_browsingContextGroup->addPage(*this);
     legacyMainFrameProcess().send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *m_drawingArea, m_mainFrame->frameID(), std::nullopt)), 0);
@@ -6648,6 +6648,7 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame()) {
         internals().pageLoadState.didCommitLoad(transaction, certificateInfo, markPageInsecure, usedLegacyTLS, wasPrivateRelayed, frameInfo.securityOrigin);
         m_shouldSuppressNextAutomaticNavigationSnapshot = false;
+        m_framesWithSubresourceLoadingForPageLoadTiming.clear();
     } else if (markPageInsecure)
         internals().pageLoadState.didDisplayOrRunInsecureContent(transaction);
 


### PR DESCRIPTION
#### ccc524ab96943311a538cbdeb97faa8e6072ae71
<pre>
Clean up state in PageLoadTimingFrameLoadStateObserver better when running PLT with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=279858">https://bugs.webkit.org/show_bug.cgi?id=279858</a>

Reviewed by Ryosuke Niwa.

When running PLT with site isolation on, the state in PageLoadTimingFrameLoadStateObserver
and other state used by WebPageProxy::generatePageLoadingTimingSoon gets confused.

Firstly, one of the subtests has an onload that creates a few iframes after the page load
timing for that page is complete.  This causes m_loadingFrameCount to be incremented a few
times and it is not reset when the main frame commits the next load and the frames and frame
processes are discarded without waiting for the didFailProvisionalLoad calls from those frames.

Similarly, several tests start loading some subresources after the page load is &quot;complete&quot;,
which causes m_framesWithSubresourceLoadingForPageLoadTiming to be non-empty, and we
don&apos;t get a WebPageProxy::didDestroyFrame message for each frame, so we need a call to
m_framesWithSubresourceLoadingForPageLoadTiming.clear() when the main frame commits a new load.

In order to make the FrameLoadStateObserver callbacks able to be used to track state for
loads like this, I needed to add a few new ones and add an IsMainFrame parameter to only
reset when the main frame commits a load.  The existing callbacks are currently mostly used
to aggressively gather lists of URLs and not to precisely track entering and exiting loading
state.  For example, if FrameLoadState::setURL is called and we hadn&apos;t already started a
provisional load, we would get a call to didCancelProvisionalLoad without a corresponding
start call.

This makes PLT run most tests to completion immediately.  There is still a subtest that
has an iframe do a cross-site redirect to a load fail.  That needs separate investigation.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::didFinishLoad):
* Source/WebKit/UIProcess/FrameLoadState.cpp:
(WebKit::FrameLoadState::didStartProvisionalLoad):
(WebKit::FrameLoadState::didFailProvisionalLoad):
(WebKit::FrameLoadState::didCommitLoad):
(WebKit::FrameLoadState::didFinishLoad):
* Source/WebKit/UIProcess/FrameLoadState.h:
(WebKit::FrameLoadStateObserver::didStartProvisionalLoad):
(WebKit::FrameLoadStateObserver::didFailProvisionalLoad):
(WebKit::FrameLoadStateObserver::didCommitProvisionalLoad):
(WebKit::FrameLoadStateObserver::didFinishLoad):
(WebKit::FrameLoadState::FrameLoadState):
(WebKit::FrameLoadState::isMainFrame const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::didCreateSubframe):
(WebKit::WebFrameProxy::isMainFrame const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::isMainFrame const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/283819@main">https://commits.webkit.org/283819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/340497ffc56969d646721c46fe793673eeacdc38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18635 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18426 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58378 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39700 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16993 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73245 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11457 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58446 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9361 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10251 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43500 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->