### PR TITLE
Remove workarounds for no conversion data calc resolution

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
@@ -277,8 +277,6 @@ Tree fromCalculationValue(const CalculationValue& calculationValue, const Render
             .conversionData = std::nullopt,
             .symbolTable = { },
             .allowZeroValueLengthRemovalFromSum = true,
-            .allowUnresolvedUnits = false,
-            .allowNonMatchingUnits = false
         },
         .style = style,
     };
@@ -308,8 +306,6 @@ Ref<CalculationValue> toCalculationValue(const Tree& tree, const EvaluationOptio
         .conversionData = options.conversionData,
         .symbolTable = options.symbolTable,
         .allowZeroValueLengthRemovalFromSum = true,
-        .allowUnresolvedUnits = false,
-        .allowNonMatchingUnits = false
     };
     auto simplifiedTree = copyAndSimplify(tree, simplificationOptions);
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -124,10 +124,6 @@ std::optional<double> evaluate(const NonCanonicalDimension& root, const Evaluati
     if (auto canonical = canonicalize(root, options.conversionData))
         return evaluate(*canonical, options);
 
-    // FIXME: This is only needed while CSSToLengthConversionData is optional. Once all callers pass one in, this will go away.
-    if (options.allowUnresolvedUnits)
-        return root.value;
-
     return std::nullopt;
 }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
@@ -41,12 +41,6 @@ struct EvaluationOptions {
 
     // `symbolTable` contains information needed to convert unresolved symbols into numeric values.
     const CSSCalcSymbolTable& symbolTable;
-
-    // `allowUnresolvedUnits` allows math operations to be evaluated even if the unit is not fully canonicalized. Only meaningful if `conversionData` cannot be supplied.
-    bool allowUnresolvedUnits = false;
-
-    // `allowNonMatchingUnits` allows math operations to be evaluated even if the units of its arguments don't match. Only meaningful if `conversionData` cannot be supplied.
-    bool allowNonMatchingUnits = false;
 };
 
 std::optional<double> evaluateDouble(const Tree&, const EvaluationOptions&);

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -90,9 +90,9 @@ static bool unitsMatch(const CanonicalDimension& a, const CanonicalDimension& b,
     return a.dimension == b.dimension;
 }
 
-static bool unitsMatch(const NonCanonicalDimension& a, const NonCanonicalDimension& b, const SimplificationOptions& options)
+static bool unitsMatch(const NonCanonicalDimension& a, const NonCanonicalDimension& b, const SimplificationOptions&)
 {
-    return a.unit == b.unit || options.allowNonMatchingUnits;
+    return a.unit == b.unit;
 }
 
 // MARK: Predicate: magnitudeComparable
@@ -134,9 +134,9 @@ constexpr bool fullyResolved(const CanonicalDimension&, const SimplificationOpti
     return true;
 }
 
-constexpr bool fullyResolved(const NonCanonicalDimension&, const SimplificationOptions& options)
+constexpr bool fullyResolved(const NonCanonicalDimension&, const SimplificationOptions&)
 {
-    return options.allowUnresolvedUnits;
+    return false;
 }
 
 std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const std::optional<CSSToLengthConversionData>& conversionData)

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -50,12 +50,6 @@ struct SimplificationOptions {
 
     // `allowZeroValueLengthRemovalFromSum` allows removal of 0 value lengths (px, em, etc.) from Sum operations.
     bool allowZeroValueLengthRemovalFromSum = false;
-
-    // `allowUnresolvedUnits` allows math operations to be evaluated even if the unit is not fully canonicalized. Only meaningful if `conversionData` cannot be supplied.
-    bool allowUnresolvedUnits = false;
-
-    // `allowNonMatchingUnits` allows math operations to be evaluated even if the units of its arguments don't match. Only meaningful if `conversionData` cannot be supplied.
-    bool allowNonMatchingUnits = false;
 };
 
 // MARK: Copy & Simplify

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -469,8 +469,6 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::parse(String&& cssText)
                 .conversionData = std::nullopt,
                 .symbolTable = { },
                 .allowZeroValueLengthRemovalFromSum = false,
-                .allowUnresolvedUnits = false,
-                .allowNonMatchingUnits = false
             };
             auto tree = CSSCalc::parseAndSimplify(CSSPropertyParserHelpers::consumeFunction(componentValueRange), functionID, parserOptions, simplificationOptions);
             if (!tree)


### PR DESCRIPTION
#### 8a49ef7b905fdfe7456c0843bc2f23798e39ade9
<pre>
Remove workarounds for no conversion data calc resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=279860">https://bugs.webkit.org/show_bug.cgi?id=279860</a>

Reviewed by NOBODY (OOPS!).

WIP - DRAFT

* Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp:
(WebCore::CSSCalc::fromCalculationValue):
(WebCore::CSSCalc::toCalculationValue):
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.h:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::unitsMatch):
(WebCore::CSSCalc::fullyResolved):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::parse):
(WebCore::CSSCalcValue::copySimplified const):
(WebCore::CSSCalcValue::doubleValueNoConversionDataRequired const):
(WebCore::CSSCalcValue::doubleValueDeprecated const):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::parse):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a49ef7b905fdfe7456c0843bc2f23798e39ade9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54078 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15785 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61522 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61583 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2978 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->