### PR TITLE
Improve disassembly output

### DIFF
--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -1874,12 +1874,30 @@ const char* A64DOpcodeVectorDataProcessingLogical1Source::format()
 const char* A64DOpcodeVectorDataProcessingLogical1Source::opName()
 {
     switch (op10_15()) {
-    case 0b000111:
+    case 0b00111:
         return "ins";
-    case 0b001111:
+    case 0b01111:
         return "umov";
+    case 0b00110:
+        return "uzp1";
+    case 0b01010:
+        return "trn1";
+    case 0b01110:
+        return "zip1";
+    case 0b10110:
+        return "uzip2";
+    case 0b11010:
+        return "trn2";
+    case 0b11110:
+        return "zip2";
+    case 0b00011:
+        return "dup";
+    case 0b01011:
+        return "smov";
+    case 0b01000:
+        return "tbl";
     default:
-        dataLogLn("Dissassembler saw unknown simd one source instruction opcode ", op10_15());
+        dataLogLn("Dissassembler saw unknown simd 1 source instruction opcode ", op10_15());
         return "SIMDUK";
     }
 }
@@ -1887,7 +1905,7 @@ const char* A64DOpcodeVectorDataProcessingLogical1Source::opName()
 const char* A64DOpcodeVectorDataProcessingLogical2Source::format()
 {
     appendInstructionName(opName());
-    appendSIMDLaneType(q());
+    appendSIMDLaneType(q(), size());
     appendSeparator();
     appendCharacter('v');
     appendCharacter('/');
@@ -1909,6 +1927,10 @@ const char* A64DOpcodeVectorDataProcessingLogical2Source::opName()
     switch (op10_15()) {
     case 0b00111:
         return "orr";
+    case 0b11001:
+        return "smax";
+    case 0b10010:
+        return "bsl";
     default:
         dataLogLn("Dissassembler saw unknown simd 2 source instruction opcode ", op10_15());
         return "SIMDUK";


### PR DESCRIPTION
#### 347e26a214696b9a82d84b47967d39f438344892
<pre>
Improve disassembly output
<a href="https://bugs.webkit.org/show_bug.cgi?id=279861">https://bugs.webkit.org/show_bug.cgi?id=279861</a>

Reviewed by Justin Michaud.

This patch enhances the ARM64 disassembler to correctly handle and display
additional SIMD instructions, particularly those involving different vector
element sizes (.B, .H, .S, .D). This improvement allows for more accurate
representation of ARM SIMD instructions in the disassembled output.

* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::opName):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::format):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::opName):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h:
(JSC::ARM64Disassembler::A64DOpcode::appendSIMDLaneIndexAndType):
(JSC::ARM64Disassembler::A64DOpcode::appendSIMDLaneType):

Canonical link: <a href="https://commits.webkit.org/283855@main">https://commits.webkit.org/283855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba0bada2fc270a8f6a1fffca3c3e03e29139fe53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54082 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12474 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58382 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34544 "Found 2 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15786 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17004 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60624 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73256 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66754 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61528 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61590 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2979 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42693 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15609 "Found 7 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-bbq, wasm.yaml/wasm/fuzz/memory.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit, wasm.yaml/wasm/stress/tail-call.js.wasm-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->