### PR TITLE
[JSC] Add fast path for `array.concat()`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-concat-copy-double-and-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-concat-copy-double-and-int32.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1) {
+    return array1.concat();
+}
+noInline(test);
+
+var array1 = [2.1, 2.2, 2.3, 2.4, 4, 5, 6, 7];
+for (var i = 0; i < 1e4; ++i) {
+    var result = test(array1);
+    shouldBe(result[0], 2.1);
+    shouldBe(result[1], 2.2);
+    shouldBe(result[2], 2.3);
+    shouldBe(result[3], 2.4);
+    shouldBe(result[4], 4);
+    shouldBe(result[5], 5);
+    shouldBe(result[6], 6);
+    shouldBe(result[7], 7);
+    shouldBe(result.length, 8);
+}

--- a/JSTests/microbenchmarks/array-prototype-concat-copy-double.js
+++ b/JSTests/microbenchmarks/array-prototype-concat-copy-double.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1) {
+    return array1.concat();
+}
+noInline(test);
+
+var array1 = [2.1, 2.2, 2.3, 2.4];
+for (var i = 0; i < 1e4; ++i) {
+    var result = test(array1);
+    shouldBe(result[0], 2.1);
+    shouldBe(result[1], 2.2);
+    shouldBe(result[2], 2.3);
+    shouldBe(result[3], 2.4);
+    shouldBe(result.length, 4);
+}

--- a/JSTests/microbenchmarks/array-prototype-concat-copy-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-concat-copy-int32.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1) {
+    return array1.concat();
+}
+noInline(test);
+
+var array1 = [2, 3, 4, 5];
+for (var i = 0; i < 1e4; ++i) {
+    var result = test(array1);
+    shouldBe(result[0], 2);
+    shouldBe(result[1], 3);
+    shouldBe(result[2], 4);
+    shouldBe(result[3], 5);
+    shouldBe(result.length, 4);
+}

--- a/JSTests/microbenchmarks/array-prototype-concat-copy-obj.js
+++ b/JSTests/microbenchmarks/array-prototype-concat-copy-obj.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1) {
+    return array1.concat();
+}
+noInline(test);
+
+var obj1 = {}, obj2 = {}, obj3 = {}, obj4 = {};
+var array1 = [obj1, obj2, obj3, obj4];
+for (var i = 0; i < 1e4; ++i) {
+    var result = test(array1);
+    shouldBe(result[0], obj1);
+    shouldBe(result[1], obj2);
+    shouldBe(result[2], obj3);
+    shouldBe(result[3], obj4);
+    shouldBe(result.length, 4);
+}

--- a/JSTests/stress/array-prototype-concat-copy-empty.js
+++ b/JSTests/stress/array-prototype-concat-copy-empty.js
@@ -1,0 +1,109 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let source = new Array(0);
+    let result = source.concat();
+    shouldBe(result.length, 0);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42;
+    source[1] = 43;
+    let result = source.concat();
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 42);
+    shouldBe(result[1], 43);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42.195;
+    source[1] = 43.195;
+    let result = source.concat();
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 42.195);
+    shouldBe(result[1], 43.195);
+}
+
+{
+    let source = new Array(6);
+    let result = source.concat();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), false);
+        shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42;
+    let result = source.concat();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        if (i === 0) {
+            shouldBe(result.hasOwnProperty(i), true);
+            shouldBe(result[i], 42);
+        } else {
+            shouldBe(result.hasOwnProperty(i), false);
+            shouldBe(result[i], undefined);
+        }
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42.195;
+    let result = source.concat();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        if (i === 0) {
+            shouldBe(result.hasOwnProperty(i), true);
+            shouldBe(result[i], 42.195);
+        } else {
+            shouldBe(result.hasOwnProperty(i), false);
+            shouldBe(result[i], undefined);
+        }
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    let result = source.concat();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        if (i === 0) {
+            shouldBe(result.hasOwnProperty(i), true);
+            shouldBe(result[i], "string");
+        } else {
+            shouldBe(result.hasOwnProperty(i), false);
+            shouldBe(result[i], undefined);
+        }
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    $vm.ensureArrayStorage(source);
+    source[1000] = "Hello";
+    let result = source.concat();
+    shouldBe(result.length, 1001);
+    for (var i = 0; i < result.length; ++i) {
+        if (i === 0) {
+            shouldBe(result.hasOwnProperty(i), true);
+            shouldBe(result[i], "string");
+        } else if (i === 1000) {
+            shouldBe(result.hasOwnProperty(i), true);
+            shouldBe(result[i], "Hello");
+        } else {
+            shouldBe(result.hasOwnProperty(i), false);
+            shouldBe(result[i], undefined);
+        }
+    }
+}

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -53,7 +53,7 @@ function from(items /*, mapFn, thisArg */)
     var arrayLike = @toObject(items, "Array.from requires an array-like object - not null or undefined");
 
     if (!mapFn) {
-        var fastResult = @arrayFromFast(this, arrayLike);
+        var fastResult = @arrayFromFastFillWithUndefined(this, arrayLike);
         if (fastResult)
             return fastResult;
     }

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -400,6 +400,15 @@ function concat(first)
             return result;
     }
 
+    if (@argumentCount() === 0
+        && @isJSArray(this)
+        && @tryGetByIdWithWellKnownSymbol(this, "isConcatSpreadable") === @undefined) {
+
+        var result = @arrayFromFastFillWithEmpty(@Array, this);
+        if (result)
+            return result;
+    }
+
     return @tailCallForwardArguments(@concatSlowPath, this);
 }
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -202,7 +202,8 @@ namespace JSC {
     macro(sentinelString) \
     macro(createRemoteFunction) \
     macro(isRemoteFunction) \
-    macro(arrayFromFast) \
+    macro(arrayFromFastFillWithUndefined) \
+    macro(arrayFromFastFillWithEmpty) \
     macro(arraySort) \
     macro(jsonParse) \
     macro(jsonStringify) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -132,7 +132,8 @@ class JSGlobalObject;
     v(sentinelString, nullptr) \
     v(createRemoteFunction, nullptr) \
     v(isRemoteFunction, nullptr) \
-    v(arrayFromFast, nullptr) \
+    v(arrayFromFastFillWithUndefined, nullptr) \
+    v(arrayFromFastFillWithEmpty, nullptr) \
     v(arraySort, nullptr) \
     v(jsonParse, nullptr) \
     v(jsonStringify, nullptr) \

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1725,7 +1725,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncAppendMemcpy, (JSGlobalObject* glo
     return JSValue::encode(jsUndefined());
 }
 
-JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFast, (JSGlobalObject* globalObject, CallFrame* callFrame))
+JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithUndefined, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1738,7 +1738,28 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFast, (JSGlobalObject* globalO
     if (UNLIKELY(!isJSArray(arrayValue)))
         return JSValue::encode(jsUndefined());
 
-    JSArray* array = tryCloneArrayFromFast(globalObject, arrayValue);
+    JSArray* array = tryCloneArrayFromFast<ArrayFillMode::Undefined>(globalObject, arrayValue);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (array)
+        return JSValue::encode(array);
+
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithEmpty, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue constructor = callFrame->uncheckedArgument(0);
+    if (UNLIKELY(constructor != globalObject->arrayConstructor() && constructor.isObject()))
+        return JSValue::encode(jsUndefined());
+
+    JSValue arrayValue = callFrame->uncheckedArgument(1);
+    if (UNLIKELY(!isJSArray(arrayValue)))
+        return JSValue::encode(jsUndefined());
+
+    JSArray* array = tryCloneArrayFromFast<ArrayFillMode::Empty>(globalObject, arrayValue);
     RETURN_IF_EXCEPTION(scope, { });
     if (array)
         return JSValue::encode(array);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.h
@@ -50,6 +50,7 @@ JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToString);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncValues);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncConcatMemcpy);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncAppendMemcpy);
-JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncFromFast);
+JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithUndefined);
+JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithEmpty);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1508,6 +1508,7 @@ void clearElement(double& element)
     element = PNaN;
 }
 
+template<ArrayFillMode fillMode>
 JSArray* tryCloneArrayFromFast(JSGlobalObject* globalObject, JSValue arrayValue)
 {
     ASSERT(isJSArray(arrayValue));
@@ -1531,7 +1532,7 @@ JSArray* tryCloneArrayFromFast(JSGlobalObject* globalObject, JSValue arrayValue)
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
-        moveArrayElements<ArrayFillMode::Undefined>(globalObject, vm, result, 0, array, resultSize);
+        moveArrayElements<fillMode>(globalObject, vm, result, 0, array, resultSize);
         return result;
     }
 
@@ -1588,10 +1589,13 @@ JSArray* tryCloneArrayFromFast(JSGlobalObject* globalObject, JSValue arrayValue)
     ASSERT(resultType == ArrayWithContiguous);
     auto* buffer = result->butterfly()->contiguous().data();
     if (sourceType == ArrayWithDouble)
-        copyArrayElements<ArrayFillMode::Undefined>(buffer, 0, butterfly->contiguousDouble().data(), resultSize, ArrayWithDouble);
+        copyArrayElements<fillMode>(buffer, 0, butterfly->contiguousDouble().data(), resultSize, ArrayWithDouble);
     else
-        copyArrayElements<ArrayFillMode::Undefined>(buffer, 0, butterfly->contiguous().data(), resultSize, sourceType);
+        copyArrayElements<fillMode>(buffer, 0, butterfly->contiguous().data(), resultSize, sourceType);
     return result;
 }
+
+template JSArray* tryCloneArrayFromFast<ArrayFillMode::Undefined>(JSGlobalObject*, JSValue);
+template JSArray* tryCloneArrayFromFast<ArrayFillMode::Empty>(JSGlobalObject*, JSValue);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -403,6 +403,7 @@ JS_EXPORT_PRIVATE JSArray* constructArrayNegativeIndexed(JSGlobalObject*, Struct
 
 ALWAYS_INLINE uint64_t toLength(JSGlobalObject*, JSObject*);
 
+template<ArrayFillMode fillMode>
 JSArray* tryCloneArrayFromFast(JSGlobalObject*, JSValue arrayValue);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1652,9 +1652,12 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayFromFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "typedArrayViewTypedArrayFromFast"_s, typedArrayViewPrivateFuncTypedArrayFromFast, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFast"_s, arrayProtoPrivateFuncFromFast, ImplementationVisibility::Private));
-        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFastFillWithUndefined)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFastFillWithUndefined"_s, arrayProtoPrivateFuncFromFastFillWithUndefined, ImplementationVisibility::Private));
+    });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFastFillWithEmpty)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFastFillWithEmpty"_s, arrayProtoPrivateFuncFromFastFillWithEmpty, ImplementationVisibility::Private));
+    });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isDetached)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsDetached"_s, typedArrayViewPrivateFuncIsDetached, ImplementationVisibility::Private));
         });


### PR DESCRIPTION
#### 21359545c81d7899938c4b2e0e15c327586dcb89
<pre>
[JSC] Add fast path for `array.concat()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279862">https://bugs.webkit.org/show_bug.cgi?id=279862</a>

Reviewed by Yusuke Suzuki.

This patch adds fast path for `array.concat()` using same way as `Array.from(array)`.

`Array.from()` fills any empty slots in the array with `undefined`. On the other hand,
`Array.prototype.concat` preserves empty slots. So, this patch tweaks `tryCloneArrayFromFast`.

According to microbench it is 1.5~6x faster.

                                                 TipOfTree                  Patched

array-prototype-concat-copy-obj                 1.5540+-0.0570     ^      0.9991+-0.0218        ^ definitely 1.5554x faster
array-prototype-concat-copy-double-and-int32
                                                1.9665+-0.4020     ^      1.1984+-0.0770        ^ definitely 1.6409x faster
array-prototype-concat-copy-double              1.5371+-0.1052     ^      0.9618+-0.0419        ^ definitely 1.5982x faster
array-prototype-concat-copy-int32               1.5674+-0.1159     ^      0.9719+-0.0541        ^ definitely 1.6127x faster

&lt;geometric&gt;                                     1.6457+-0.1324     ^      1.0283+-0.0293        ^ definitely 1.6004x faster

Exist benchmarks of Arrray.prototype.concat show no performance regressions.

* JSTests/microbenchmarks/array-prototype-concat-copy-double-and-int32.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/array-prototype-concat-copy-double.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/array-prototype-concat-copy-int32.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/array-prototype-concat-copy-obj.js: Added.
(shouldBe):
(test):
* JSTests/stress/array-prototype-concat-copy-empty.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/builtins/ArrayConstructor.js:
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(concat):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayPrototype.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::tryCloneArrayFromFast):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/284060@main">https://commits.webkit.org/284060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ecdde589fbd0ce60e2ee1243891efd53847a61c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68386 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19531 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19347 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35064 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40354 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17888 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61504 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74145 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67634 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62052 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62073 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3612 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43579 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15823 "Found 10 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-bbq, wasm.yaml/wasm/stress/tail-call.js.wasm-eager-jettison, wasm.yaml/wasm/stress/throw-null-ref.js.wasm-eager, wasm.yaml/wasm/stress/throw-null-ref.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->