### PR TITLE
[JSC] Add UnlinkedStringJumpTable min/max length

### DIFF
--- a/JSTests/stress/switch-string-oom.js
+++ b/JSTests/stress/switch-string-oom.js
@@ -18,8 +18,6 @@ function test(createOOMString)
         throw "Case \"three\", shouldn't get here";
         break;
     default:
-        if (createOOMString)
-            throw "Default case, shouldn't get here";
         break;
     }
 }

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -86,6 +86,8 @@ struct UnlinkedStringJumpTable {
 
     using StringOffsetTable = MemoryCompactLookupOnlyRobinHoodHashMap<RefPtr<StringImpl>, OffsetLocation>;
     StringOffsetTable m_offsetTable;
+    unsigned m_minLength { StringImpl::MaxLength };
+    unsigned m_maxLength { 0 };
 
     inline int32_t offsetForValue(StringImpl* value, int32_t defaultOffset) const
     {
@@ -102,6 +104,9 @@ struct UnlinkedStringJumpTable {
             return defaultIndex;
         return loc->value.m_indexInTable;
     }
+
+    unsigned minLength() const { return m_minLength; }
+    unsigned maxLength() const { return m_maxLength; }
 };
 
 struct UnlinkedSimpleJumpTable {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -4416,8 +4416,16 @@ static void prepareJumpTableForStringSwitch(UnlinkedStringJumpTable& jumpTable, 
         UniquedStringImpl* clause = static_cast<StringNode*>(nodes[i])->value().impl();
         ASSERT(clause->isAtom());
         auto result = jumpTable.m_offsetTable.add(clause, UnlinkedStringJumpTable::OffsetLocation { labels[i]->bind(switchAddress), 0 });
-        if (result.isNewEntry)
+        if (result.isNewEntry) {
             result.iterator->value.m_indexInTable = jumpTable.m_offsetTable.size() - 1;
+            jumpTable.m_minLength = std::min(jumpTable.m_minLength, clause->length());
+            jumpTable.m_maxLength = std::max(jumpTable.m_maxLength, clause->length());
+        }
+    }
+
+    if (jumpTable.m_offsetTable.isEmpty()) {
+        jumpTable.m_minLength = 0;
+        jumpTable.m_maxLength = 0;
     }
 }
 

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -717,6 +717,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSwitchStringAndGetIndex, unsigned, (J
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned length = string->length();
+    if (length < unlinkedTable->minLength() || length > unlinkedTable->maxLength())
+        return std::numeric_limits<unsigned>::max();
+
     auto str = string->value(globalObject);
 
     RETURN_IF_EXCEPTION(throwScope, 0);

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -900,15 +900,21 @@ public:
     void encode(Encoder& encoder, const UnlinkedStringJumpTable& jumpTable)
     {
         m_offsetTable.encode(encoder, jumpTable.m_offsetTable);
+        m_minLength = jumpTable.m_minLength;
+        m_maxLength = jumpTable.m_maxLength;
     }
 
     void decode(Decoder& decoder, UnlinkedStringJumpTable& jumpTable) const
     {
         m_offsetTable.decode(decoder, jumpTable.m_offsetTable);
+        jumpTable.m_minLength = m_minLength;
+        jumpTable.m_maxLength = m_maxLength;
     }
 
 private:
     CachedMemoryCompactLookupOnlyRobinHoodHashMap<CachedRefPtr<CachedStringImpl>, UnlinkedStringJumpTable::OffsetLocation> m_offsetTable;
+    unsigned m_minLength { 0 };
+    unsigned m_maxLength { 0 };
 };
 
 class CachedBitVector : public VariableLengthObject<BitVector> {


### PR DESCRIPTION
#### ff40245cb64a69f3fadde25fe840c44e36c74a1e
<pre>
[JSC] Add UnlinkedStringJumpTable min/max length
<a href="https://bugs.webkit.org/show_bug.cgi?id=279870">https://bugs.webkit.org/show_bug.cgi?id=279870</a>
<a href="https://rdar.apple.com/136202783">rdar://136202783</a>

Reviewed by Yijia Huang.

Let&apos;s avoid resolving strings and jumping to the default clause when we
know that jump table&apos;s strings min/max length are not fit to the given
string.

We also tweak the existing test since we no longer guarantee that rope
gets resolved when it is used for switch.

* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedStringJumpTable::minLength const):
(JSC::UnlinkedStringJumpTable::maxLength const):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::prepareJumpTableForStringSwitch):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedStringJumpTable::encode):
(JSC::CachedStringJumpTable::decode const):

Canonical link: <a href="https://commits.webkit.org/283848@main">https://commits.webkit.org/283848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfa6f68828105d3c349860261133578bc6cb5227

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18671 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54097 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12493 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17029 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60649 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73281 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66779 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11493 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15481 "Found 1 new test failure: fast/loader/stop-provisional-loads.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61539 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61603 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9388 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3001 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88548 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10269 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42718 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15620 "Found 10 new JSC stress test failures: wasm.yaml/wasm/function-tests/many-arguments-to-function.js.wasm-bbq, wasm.yaml/wasm/function-tests/many-arguments-to-function.js.wasm-eager-jettison, wasm.yaml/wasm/fuzz/export-function.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-to-wasm-i64-stack.js.default-wasm, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-simple.js.default-wasm, wasm.yaml/wasm/stress/tail-call.js.wasm-eager, wasm.yaml/wasm/stress/tail-call.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->