### PR TITLE
[iOS] Introduce TestWebKitAPI.app

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+// Copyright (C) 2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -23,7 +23,19 @@
 
 #include "TestWebKitAPIBase.xcconfig"
 
-PRODUCT_NAME = $(TARGET_NAME);
-PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.TestWebKitAPI;
+PRODUCT_NAME = TestWebKitAPI;
+PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.TestWebKitAPIApp;
 
-CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = *;
+SKIP_INSTALL[sdk=macosx*] = YES;
+
+GENERATE_INFOPLIST_FILE = YES;
+CURRENT_PROJECT_VERSION = 1;
+MARKETING_VERSION = 1.0;
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight;
+INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight;
+
+CLANG_ENABLE_OBJC_ARC = YES;

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
@@ -1,0 +1,162 @@
+// Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+
+GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) GTEST_API_=
+
+FRAMEWORK_SEARCH_PATHS = $(FRAMEWORK_SEARCH_PATHS_$(WK_COCOA_TOUCH));
+FRAMEWORK_SEARCH_PATHS_ = $(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks $(SYSTEM_LIBRARY_DIR)/Frameworks/WebKit.framework/Versions/A/Frameworks;
+FRAMEWORK_SEARCH_PATHS_cocoatouch = $(inherited);
+
+PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform $(SRCROOT)/../../Source/WebKit/Platform/IPC $(SRCROOT)/../../Source/WebKit/Platform/IPC/darwin $(SRCROOT)/../../Source/WebKit/Platform/IPC/cocoa $(SRCROOT)/../../Source/WebKit/Shared $(SRCROOT)/../../Source/WebKit/Shared/Cocoa $(SRCROOT)/../../Source/WebKit/Shared/cf $(SRCROOT)/../../Source/WebKit/Shared/API/C $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit $(inherited);
+
+WK_APPSERVERSUPPORT_LDFLAGS[sdk=iphone*] = -framework AppServerSupport
+WK_APPSERVERSUPPORT_LDFLAGS[sdk=xr*] = -framework AppServerSupport
+
+WK_AUTHKIT_LDFLAGS = $(WK_AUTHKIT_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_AUTHKIT_LDFLAGS_iphoneos = -framework AuthKit;
+WK_AUTHKIT_LDFLAGS_iphonesimulator = -framework AuthKit;
+WK_AUTHKIT_LDFLAGS_xros = -framework AuthKit;
+WK_AUTHKIT_LDFLAGS_xrsimulator = -framework AuthKit;
+WK_AUTHKIT_LDFLAGS_macosx = -framework AuthKit;
+
+WK_BROWSERENGINEKIT_LDFLAGS =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*] = -framework BrowserEngineKit
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.0*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.1*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.2*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.3*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=appletv*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=watch*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=xr*] =
+
+WK_REVEAL_LDFLAGS = $(WK_REVEAL_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_REVEAL_LDFLAGS_macosx = $(WK_REVEAL_LDFLAGS$(WK_MACOS_1015));
+WK_REVEAL_LDFLAGS_MACOS_SINCE_1015 = -framework Reveal;
+
+WK_HID_LDFLAGS = $(WK_HID_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_HID_LDFLAGS_macosx = $(WK_HID_LDFLAGS$(WK_MACOS_1015));
+WK_HID_LDFLAGS_MACOS_SINCE_1015 = -framework HID;
+
+WK_VISIONKITCORE_LDFLAGS = $(WK_VISIONKITCORE_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_VISIONKITCORE_LDFLAGS_iphoneos = -framework VisionKitCore;
+WK_VISIONKITCORE_LDFLAGS_iphonesimulator = -framework VisionKitCore;
+WK_VISIONKITCORE_LDFLAGS_xros = -framework VisionKitCore;
+WK_VISIONKITCORE_LDFLAGS_xrsimulator = -framework VisionKitCore;
+
+WK_OPENGL_LDFLAGS = $(WK_OPENGL_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_OPENGL_LDFLAGS_macosx = -framework OpenGL;
+WK_OPENGL_LDFLAGS_iphoneos = -framework OpenGLES;
+WK_OPENGL_LDFLAGS_iphonesimulator = -framework OpenGLES;
+WK_OPENGL_LDFLAGS_xros = -framework OpenGLES;
+WK_OPENGL_LDFLAGS_xrsimulator = -framework OpenGLES;
+
+WK_PDFKIT_LDFLAGS = $(WK_PDFKIT_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_PDFKIT_LDFLAGS_macosx = -framework PDFKit;
+WK_PDFKIT_LDFLAGS_maccatalyst = -framework PDFKit;
+WK_PDFKIT_LDFLAGS_iphoneos = -framework PDFKit;
+WK_PDFKIT_LDFLAGS_iphonesimulator = -framework PDFKit;
+WK_PDFKIT_LDFLAGS_xros = -framework PDFKit;
+WK_PDFKIT_LDFLAGS_xrsimulator = -framework PDFKit;
+
+WK_SYSTEM_LDFLAGS = $(WK_SYSTEM_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_SYSTEM_LDFLAGS_macosx = -framework System;
+WK_SYSTEM_LDFLAGS_iphoneos = $(WK_SYSTEM_LDFLAGS_$(WK_IOS_15));
+WK_SYSTEM_LDFLAGS_iphonesimulator = $(WK_SYSTEM_LDFLAGS_$(WK_IOS_15));
+WK_SYSTEM_LDFLAGS_IOS_SINCE_15 = -framework System;
+
+WK_UIKITMACHELPER_LDFLAGS = $(WK_UIKITMACHELPER_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_UIKITMACHELPER_LDFLAGS_maccatalyst = -framework UIKitMacHelper;
+
+WK_WEBCORE_LDFLAGS = $(WK_WEBCORE_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_WEBCORE_LDFLAGS_iphoneos = -framework WebCore
+WK_WEBCORE_LDFLAGS_iphonesimulator = -framework WebCore
+WK_WEBCORE_LDFLAGS_watchos = -framework WebCore
+WK_WEBCORE_LDFLAGS_watchsimulator = -framework WebCore
+
+WK_IMAGEIO_LDFLAGS = $(WK_IMAGEIO_LDFLAGS_$(WK_PLATFORM_NAME))
+WK_IMAGEIO_LDFLAGS_iphoneos = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_iphonesimulator = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_maccatalyst = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_macosx = $(WK_IMAGEIO_LDFLAGS$(WK_MACOS_1300));
+WK_IMAGEIO_LDFLAGS_MACOS_SINCE_1300 = -framework ImageIO;
+
+WK_WRITING_TOOLS_LDFLAGS = $(WK_WRITING_TOOLS_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_WRITING_TOOLS_LDFLAGS_iphoneos = $(WK_WRITING_TOOLS_LDFLAGS$(WK_IOS_18));
+WK_WRITING_TOOLS_LDFLAGS_iphonesimulator = $(WK_WRITING_TOOLS_LDFLAGS$(WK_IOS_18));
+WK_WRITING_TOOLS_LDFLAGS_IOS_SINCE_18 = -weak_framework WritingTools;
+WK_WRITING_TOOLS_LDFLAGS_maccatalyst = $(WK_WRITING_TOOLS_LDFLAGS_maccatalyst$(WK_MACOS_1500));
+WK_WRITING_TOOLS_LDFLAGS_maccatalyst_MACOS_SINCE_1500 = -weak_framework WritingTools;
+WK_WRITING_TOOLS_LDFLAGS_macosx = $(WK_WRITING_TOOLS_LDFLAGS$(WK_MACOS_1500));
+WK_WRITING_TOOLS_LDFLAGS_MACOS_SINCE_1500 = -weak_framework WritingTools;
+
+WK_WRITING_TOOLS_UI_LDFLAGS = $(WK_WRITING_TOOLS_UI_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_WRITING_TOOLS_UI_LDFLAGS_iphoneos = $(WK_WRITING_TOOLS_UI_LDFLAGS$(WK_IOS_18));
+WK_WRITING_TOOLS_UI_LDFLAGS_iphonesimulator = ;
+WK_WRITING_TOOLS_UI_LDFLAGS_IOS_SINCE_18 = -weak_framework WritingToolsUI;
+WK_WRITING_TOOLS_UI_LDFLAGS_maccatalyst = $(WK_WRITING_TOOLS_UI_LDFLAGS_maccatalyst$(WK_MACOS_1500));
+WK_WRITING_TOOLS_UI_LDFLAGS_maccatalyst_MACOS_SINCE_1500 = -weak_framework WritingToolsUI;
+WK_WRITING_TOOLS_UI_LDFLAGS_macosx = $(WK_WRITING_TOOLS_UI_LDFLAGS$(WK_MACOS_1500));
+WK_WRITING_TOOLS_UI_LDFLAGS_MACOS_SINCE_1500 = -weak_framework WritingToolsUI;
+
+OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
+
+OTHER_LDFLAGS = $(inherited) -lgtest -lxml2 -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices -framework CFNetwork -framework CoreGraphics -framework CoreLocation -framework CoreText -framework IOKit -lboringssl -licucore -lWebKitPlatform -framework LocalAuthentication -framework QuartzCore -framework Security $(WK_BROWSERENGINEKIT_LDFLAGS) $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(WK_WRITING_TOOLS_LDFLAGS) $(WK_WRITING_TOOLS_UI_LDFLAGS) $(OTHER_LDFLAGS_DELAY_INIT) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+
+OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
+OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=appletv*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=watch*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=xr*] = ;
+
+OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
+// FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.
+OTHER_LDFLAGS_PLATFORM_cocoatouch = -framework WebCore -framework UIKit -framework MobileCoreServices;
+
+LD_RUNPATH_SEARCH_PATHS = "@loader_path";
+
+MAC_CODE_SIGN_ENTITLEMENTS = $(MAC_CODE_SIGN_ENTITLEMENTS_$(USE_INTERNAL_SDK));
+MAC_CODE_SIGN_ENTITLEMENTS_ = Configurations/TestWebKitAPI-macOS.entitlements;
+MAC_CODE_SIGN_ENTITLEMENTS_YES = Configurations/TestWebKitAPI-macOS-internal.entitlements;
+
+CODE_SIGN_ENTITLEMENTS[sdk=embedded*] = Configurations/TestWebKitAPI-iOS.entitlements;
+CODE_SIGN_ENTITLEMENTS[sdk=macosx*] = $(MAC_CODE_SIGN_ENTITLEMENTS);
+
+STRIP_STYLE = debugging;
+
+CODE_SIGN_IDENTITY[sdk=macosx*] = $(CODE_SIGN_IDENTITY_$(CONFIGURATION));
+CODE_SIGN_IDENTITY_Debug = $(CODE_SIGN_IDENTITY_$(USE_INTERNAL_SDK));
+CODE_SIGN_IDENTITY_Release = $(CODE_SIGN_IDENTITY_$(USE_INTERNAL_SDK));
+CODE_SIGN_IDENTITY_ = -;
+CODE_SIGN_IDENTITY_YES = $(WK_ENGINEERING_CODE_SIGN_IDENTITY);
+CODE_SIGN_IDENTITY_Production = $(CODE_SIGN_IDENTITY_Production_$(USE_INTERNAL_SDK));
+CODE_SIGN_IDENTITY_Production_YES = -;
+
+INFOPLIST_FILE = $(SRCROOT)/Info.plist;
+
+ENTITLEMENTS_REQUIRED = $(ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_$(USE_INTERNAL_SDK))
+ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_ = NO;
+ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_NO = NO;
+ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_YES = $(ENTITLEMENTS_REQUIRED);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -39,6 +39,7 @@
 				3A5DDAFC28D3F2A7004DA950 /* PBXTargetDependency */,
 				7B9FC58828A26D83007570E7 /* PBXTargetDependency */,
 				7C83E0301D0A5E1B00FEBCF3 /* PBXTargetDependency */,
+				A17C58272C9AAAEE009DD0B5 /* PBXTargetDependency */,
 				7C83E0321D0A5E1D00FEBCF3 /* PBXTargetDependency */,
 			);
 			name = All;
@@ -1126,6 +1127,10 @@
 		A17C57ED2C9A53A0009DD0B5 /* TransformationMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AD3FE8D1D75FB8D00B169A4 /* TransformationMatrix.cpp */; };
 		A17C57EE2C9A53AD009DD0B5 /* WebTransportServer.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA8650322C7D01CA00117287 /* WebTransportServer.mm */; };
 		A17C57EF2C9A53B7009DD0B5 /* WKWebViewSpatialTrackingLabels.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD780E752BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm */; };
+		A17C58112C9AA132009DD0B5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A17C58102C9AA132009DD0B5 /* Assets.xcassets */; };
+		A17C58172C9AA132009DD0B5 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17C58162C9AA132009DD0B5 /* main.mm */; };
+		A17C58252C9AAA25009DD0B5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17C58242C9AAA25009DD0B5 /* UIKit.framework */; platformFilters = (ios, maccatalyst, tvos, ); };
+		A17C58282C9AAFA6009DD0B5 /* TestWebKitAPIResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */; };
 		A198D0A22BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */; };
 		A1AD382F2C3DA40B003499BE /* FullscreenLifecycle.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */; };
 		A1C142C224AA7B2E00444207 /* ContextMenuMouseEvents.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1C142C124AA7B2E00444207 /* ContextMenuMouseEvents.mm */; };
@@ -1400,6 +1405,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = A17C46452C98E3430023F3C7;
 			remoteInfo = TestWebKitAPIResources;
+		};
+		A17C58262C9AAAEE009DD0B5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A17C58012C9AA12F009DD0B5;
+			remoteInfo = TestWebKitAPIApp;
 		};
 		BC575A95126E74E7006F0F12 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -3184,6 +3196,12 @@
 		A17C464A2C98E3640023F3C7 /* TestWebKitAPIResources.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestWebKitAPIResources.xcconfig; sourceTree = "<group>"; };
 		A17C48572C98FA3F0023F3C7 /* TestNSBundleExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestNSBundleExtras.h; sourceTree = "<group>"; };
 		A17C48582C98FA3F0023F3C7 /* TestNSBundleExtras.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestNSBundleExtras.m; sourceTree = "<group>"; };
+		A17C58022C9AA12F009DD0B5 /* TestWebKitAPI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestWebKitAPI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A17C58102C9AA132009DD0B5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A17C58162C9AA132009DD0B5 /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
+		A17C58222C9AA2B0009DD0B5 /* TestWebKitAPIApp.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestWebKitAPIApp.xcconfig; sourceTree = "<group>"; };
+		A17C58232C9AA491009DD0B5 /* TestWebKitAPI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestWebKitAPI.xcconfig; sourceTree = "<group>"; };
+		A17C58242C9AAA25009DD0B5 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		A17EAC542083056E0084B41B /* find.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; name = find.pdf; path = Tests/WebKit/find.pdf; sourceTree = SOURCE_ROOT; };
 		A180C0F91EE67DF000468F47 /* RunOpenPanel.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RunOpenPanel.mm; sourceTree = "<group>"; };
 		A18AA8CC1C3FA218009B2B97 /* ContentFiltering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentFiltering.h; sourceTree = "<group>"; };
@@ -3266,7 +3284,7 @@
 		BC90955C125548AA00083756 /* PlatformWebViewMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformWebViewMac.mm; sourceTree = "<group>"; };
 		BC90957E12554CF900083756 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		BC90957F12554CF900083756 /* DebugRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = DebugRelease.xcconfig; sourceTree = "<group>"; };
-		BC90958012554CF900083756 /* TestWebKitAPI.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TestWebKitAPI.xcconfig; sourceTree = "<group>"; };
+		BC90958012554CF900083756 /* TestWebKitAPIBase.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TestWebKitAPIBase.xcconfig; sourceTree = "<group>"; };
 		BC90964D1255620C00083756 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC909778125571AB00083756 /* simple.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = simple.html; sourceTree = "<group>"; };
 		BC909779125571AB00083756 /* PageLoadBasic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageLoadBasic.cpp; sourceTree = "<group>"; };
@@ -3859,6 +3877,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A17C57FF2C9AA12F009DD0B5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17C58252C9AAA25009DD0B5 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BC57597E126E74AF006F0F12 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -4056,6 +4082,7 @@
 				7C83DF681D0A590C00FEBCF3 /* libTestWTF.a */,
 				A13EBB491B87339E00097110 /* TestWebKitAPI.wkbundle */,
 				A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */,
+				A17C58022C9AA12F009DD0B5 /* TestWebKitAPI.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4451,6 +4478,7 @@
 		2E9660DC16C07D7B00371B42 /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				A17C58032C9AA12F009DD0B5 /* app */,
 				F4D4F3B41E4E2BCB00BB2767 /* DragAndDropSimulatorIOS.mm */,
 				2E7765CC16C4D80A00BA2BB1 /* mainIOS.mm */,
 				F48D6C0F224B377000E3E2FB /* PreferredContentMode.mm */,
@@ -4786,6 +4814,7 @@
 				516281282325C45400BB7E42 /* PDFKit.framework */,
 				7A010BCC1D877C0D00EDE72A /* QuartzCore.framework */,
 				574F55D0204D471C002948C6 /* Security.framework */,
+				A17C58242C9AAA25009DD0B5 /* UIKit.framework */,
 				7B9FC5B628A52236007570E7 /* WebCore.framework */,
 				2B648DBA28C1C1F700791F2B /* WebKit.framework */,
 			);
@@ -5181,6 +5210,15 @@
 			path = spi;
 			sourceTree = "<group>";
 		};
+		A17C58032C9AA12F009DD0B5 /* app */ = {
+			isa = PBXGroup;
+			children = (
+				A17C58102C9AA132009DD0B5 /* Assets.xcassets */,
+				A17C58162C9AA132009DD0B5 /* main.mm */,
+			);
+			path = app;
+			sourceTree = "<group>";
+		};
 		A1C4FB6F1BACCEFA003742D0 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -5259,7 +5297,9 @@
 				5735F0251F3A4EA6000EE801 /* TestWebKitAPI-iOS.entitlements */,
 				51EB125324C66BCB000CB030 /* TestWebKitAPI-macOS-internal.entitlements */,
 				7AB0173923FB2BF0002F8366 /* TestWebKitAPI-macOS.entitlements */,
-				BC90958012554CF900083756 /* TestWebKitAPI.xcconfig */,
+				A17C58232C9AA491009DD0B5 /* TestWebKitAPI.xcconfig */,
+				A17C58222C9AA2B0009DD0B5 /* TestWebKitAPIApp.xcconfig */,
+				BC90958012554CF900083756 /* TestWebKitAPIBase.xcconfig */,
 				7CCE7EA31A4115CB00447C4C /* TestWebKitAPILibrary.xcconfig */,
 				A17C464A2C98E3640023F3C7 /* TestWebKitAPIResources.xcconfig */,
 				3A5DDADB28D15328004DA950 /* TestWGSL.xcconfig */,
@@ -6167,6 +6207,23 @@
 			productReference = A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		A17C58012C9AA12F009DD0B5 /* TestWebKitAPIApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A17C58212C9AA132009DD0B5 /* Build configuration list for PBXNativeTarget "TestWebKitAPIApp" */;
+			buildPhases = (
+				A17C57FE2C9AA12F009DD0B5 /* Sources */,
+				A17C57FF2C9AA12F009DD0B5 /* Frameworks */,
+				A17C58002C9AA12F009DD0B5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestWebKitAPIApp;
+			productName = TestWebKitAPIApp;
+			productReference = A17C58022C9AA12F009DD0B5 /* TestWebKitAPI.app */;
+			productType = "com.apple.product-type.application";
+		};
 		BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BC575986126E74AF006F0F12 /* Build configuration list for PBXNativeTarget "InjectedBundleTestWebKitAPI" */;
@@ -6216,6 +6273,9 @@
 					A17C46452C98E3430023F3C7 = {
 						CreatedOnToolsVersion = 16.0;
 					};
+					A17C58012C9AA12F009DD0B5 = {
+						CreatedOnToolsVersion = 16.0;
+					};
 					BC57597F126E74AF006F0F12 = {
 						ProvisioningStyle = Manual;
 					};
@@ -6245,6 +6305,7 @@
 				7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */,
 				7B9FC39428A26137007570E7 /* TestIPC */,
 				8DD76F960486AA7600D96B5E /* TestWebKitAPI */,
+				A17C58012C9AA12F009DD0B5 /* TestWebKitAPIApp */,
 				A17C46452C98E3430023F3C7 /* TestWebKitAPIResources */,
 				3A15783C28D1505B00142DB1 /* TestWGSL */,
 				7C83DF951D0A5AE400FEBCF3 /* TestWTF */,
@@ -6308,6 +6369,15 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		A17C58002C9AA12F009DD0B5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17C58112C9AA132009DD0B5 /* Assets.xcassets in Resources */,
+				A17C58282C9AAFA6009DD0B5 /* TestWebKitAPIResources.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BC57597C126E74AF006F0F12 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -7126,6 +7196,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A17C57FE2C9AA12F009DD0B5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A17C58172C9AA132009DD0B5 /* main.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BC57597D126E74AF006F0F12 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -7235,6 +7313,11 @@
 			target = A17C46452C98E3430023F3C7 /* TestWebKitAPIResources */;
 			targetProxy = A17C48552C98EBF50023F3C7 /* PBXContainerItemProxy */;
 		};
+		A17C58272C9AAAEE009DD0B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A17C58012C9AA12F009DD0B5 /* TestWebKitAPIApp */;
+			targetProxy = A17C58262C9AAAEE009DD0B5 /* PBXContainerItemProxy */;
+		};
 		BC575A96126E74E7006F0F12 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */;
@@ -7260,14 +7343,14 @@
 /* Begin XCBuildConfiguration section */
 		1DEB927508733DD40010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BC90958012554CF900083756 /* TestWebKitAPI.xcconfig */;
+			baseConfigurationReference = A17C58232C9AA491009DD0B5 /* TestWebKitAPI.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
 		1DEB927608733DD40010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BC90958012554CF900083756 /* TestWebKitAPI.xcconfig */;
+			baseConfigurationReference = A17C58232C9AA491009DD0B5 /* TestWebKitAPI.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
@@ -7428,6 +7511,20 @@
 			};
 			name = Release;
 		};
+		A17C58182C9AA132009DD0B5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A17C58222C9AA2B0009DD0B5 /* TestWebKitAPIApp.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		A17C58192C9AA132009DD0B5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A17C58222C9AA2B0009DD0B5 /* TestWebKitAPIApp.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		BC575984126E74AF006F0F12 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC575AE2126E88B1006F0F12 /* InjectedBundle.xcconfig */;
@@ -7549,6 +7646,15 @@
 			buildConfigurations = (
 				A17C46482C98E3440023F3C7 /* Debug */,
 				A17C46492C98E3440023F3C7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A17C58212C9AA132009DD0B5 /* Build configuration list for PBXNativeTarget "TestWebKitAPIApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A17C58182C9AA132009DD0B5 /* Debug */,
+				A17C58192C9AA132009DD0B5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tools/TestWebKitAPI/ios/app/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tools/TestWebKitAPI/ios/app/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tools/TestWebKitAPI/ios/app/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tools/TestWebKitAPI/ios/app/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tools/TestWebKitAPI/ios/app/Assets.xcassets/Contents.json
+++ b/Tools/TestWebKitAPI/ios/app/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tools/TestWebKitAPI/ios/app/main.mm
+++ b/Tools/TestWebKitAPI/ios/app/main.mm
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <UIKit/UIKit.h>
+
+#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
+#import <WebKit/WKProcessPoolPrivate.h>
+#endif
+
+static NSString * const sceneConfigurationName = @"Default Configuration";
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@end
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+@property (nonatomic, strong) UIWindow *window;
+@end
+
+@implementation AppDelegate
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options
+{
+    UISceneConfiguration *configuration = [[UISceneConfiguration alloc] initWithName:sceneConfigurationName sessionRole:connectingSceneSession.role];
+    configuration.delegateClass = SceneDelegate.class;
+    return configuration;
+}
+
+@end
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    UIWindow *window = [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
+    window.rootViewController = [[UIViewController alloc] init];
+    [window makeKeyAndVisible];
+
+    self.window = window;
+}
+
+@end
+
+int main(int argc, char * argv[])
+{
+    NSString *appDelegateClassName;
+
+    @autoreleasepool {
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+
+        [NSUserDefaults.standardUserDefaults removePersistentDomainForName:@"TestWebKitAPI"];
+
+        // Set up user defaults.
+        NSMutableDictionary *argumentDomain = [[NSUserDefaults.standardUserDefaults volatileDomainForName:NSArgumentDomain] mutableCopy];
+        if (!argumentDomain)
+            argumentDomain = [[NSMutableDictionary alloc] init];
+
+        [NSUserDefaults.standardUserDefaults setVolatileDomain:argumentDomain forName:NSArgumentDomain];
+
+#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
+        [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
+#endif
+    }
+
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}


### PR DESCRIPTION
#### 806c44b2b76db4a49e74813fcae61c257898b7a6
<pre>
[iOS] Introduce TestWebKitAPI.app
<a href="https://bugs.webkit.org/show_bug.cgi?id=279871">https://bugs.webkit.org/show_bug.cgi?id=279871</a>
<a href="https://rdar.apple.com/136204656">rdar://136204656</a>

Reviewed by Jer Noble.

Introduced TestWebKitAPI.app on iOS. This serves the same purpose as TestWebKitAPI, but unlike the
command-line tool it runs as a foreground application with a UIWindowScene. This will allow us to
test WKWebView APIs in ways we were unable to previously.

This commit merely introduces the app. In future commits we will teach run-api-tests to use it.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:
* Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig: Added.
* Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig: Copied from Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/ios/app/Assets.xcassets/AccentColor.colorset/Contents.json: Added.
* Tools/TestWebKitAPI/ios/app/Assets.xcassets/AppIcon.appiconset/Contents.json: Added.
* Tools/TestWebKitAPI/ios/app/Assets.xcassets/Contents.json: Added.
* Tools/TestWebKitAPI/ios/app/main.mm: Added.
(-[AppDelegate application:configurationForConnectingSceneSession:options:]):
(-[SceneDelegate scene:willConnectToSession:options:]):
(main):

Canonical link: <a href="https://commits.webkit.org/283902@main">https://commits.webkit.org/283902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4f4373dfb5c6ccb808b0ba4b69ca3502fe08d0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71779 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54190 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34657 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15963 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73476 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58626 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3146 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42913 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->