### PR TITLE
Adopt more smart pointers in RemoteCDMInstanceSessionProxy, RemoteAudioSessionProxyManager, and RemoteAudioSessionProxy

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -37,7 +37,7 @@
 #include <WebCore/AudioSession.h>
 #include <wtf/TZoneMalloc.h>
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, protectedConnection().get())
 
 namespace WebKit {
 
@@ -129,19 +129,19 @@ void RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride(std::optional<bool
 
 void RemoteAudioSessionProxy::configurationChanged()
 {
-    connection().send(Messages::RemoteAudioSession::ConfigurationChanged(configuration()), { });
+    protectedConnection()->send(Messages::RemoteAudioSession::ConfigurationChanged(configuration()), { });
 }
 
 void RemoteAudioSessionProxy::beginInterruption()
 {
     m_isInterrupted = true;
-    connection().send(Messages::RemoteAudioSession::BeginInterruptionRemote(), { });
+    protectedConnection()->send(Messages::RemoteAudioSession::BeginInterruptionRemote(), { });
 }
 
 void RemoteAudioSessionProxy::endInterruption(AudioSession::MayResume mayResume)
 {
     m_isInterrupted = false;
-    connection().send(Messages::RemoteAudioSession::EndInterruptionRemote(mayResume), { });
+    protectedConnection()->send(Messages::RemoteAudioSession::EndInterruptionRemote(mayResume), { });
 }
 
 void RemoteAudioSessionProxy::beginInterruptionRemote()
@@ -178,9 +178,9 @@ bool RemoteAudioSessionProxy::allowTestOnlyIPC()
     return false;
 }
 
-IPC::Connection& RemoteAudioSessionProxy::connection()
+Ref<IPC::Connection> RemoteAudioSessionProxy::protectedConnection() const
 {
-    return m_gpuConnection.get()->connection();
+    return m_gpuConnection.get()->protectedConnection();
 }
 
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -106,7 +106,7 @@ private:
     bool allowTestOnlyIPC();
 
     RemoteAudioSessionProxyManager& audioSessionManager();
-    IPC::Connection& connection();
+    Ref<IPC::Connection> protectedConnection() const;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -235,7 +235,7 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
 
     Vector<audit_token_t> presentingProcesses;
 
-    if (auto token = m_gpuProcess->parentProcessConnection()->getAuditToken())
+    if (auto token = m_gpuProcess->protectedParentProcessConnection()->getAuditToken())
         presentingProcesses.append(*token);
 
     // AVAudioSession will take out an assertion on all the "presenting applications"

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -147,7 +147,7 @@ void RemoteCDMInstanceSessionProxy::updateKeyStatuses(KeyStatusVector&& keyStatu
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::UpdateKeyStatuses(WTFMove(keyStatuses)), m_identifier);
+    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::UpdateKeyStatuses(WTFMove(keyStatuses)), m_identifier);
 }
 
 void RemoteCDMInstanceSessionProxy::sendMessage(CDMMessageType type, Ref<SharedBuffer>&& message)
@@ -162,7 +162,7 @@ void RemoteCDMInstanceSessionProxy::sendMessage(CDMMessageType type, Ref<SharedB
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::SendMessage(type, WTFMove(message)), m_identifier);
+    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::SendMessage(type, WTFMove(message)), m_identifier);
 }
 
 void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)
@@ -178,7 +178,7 @@ void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)
     if (!gpuConnectionToWebProcess)
         return;
 
-    gpuConnectionToWebProcess->connection().send(Messages::RemoteCDMInstanceSession::SessionIdChanged(sessionId), m_identifier);
+    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::SessionIdChanged(sessionId), m_identifier);
 }
 
 }


### PR DESCRIPTION
#### 9b1ffca8bc3f2d8fd1e83a3c6d06e1eb0965a33d
<pre>
Adopt more smart pointers in RemoteCDMInstanceSessionProxy, RemoteAudioSessionProxyManager, and RemoteAudioSessionProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=279877">https://bugs.webkit.org/show_bug.cgi?id=279877</a>
<a href="https://rdar.apple.com/136208358">rdar://136208358</a>

Reviewed by Youenn Fablet.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::configurationChanged):
(WebKit::RemoteAudioSessionProxy::beginInterruption):
(WebKit::RemoteAudioSessionProxy::endInterruption):
(WebKit::RemoteAudioSessionProxy::protectedConnection const):
(WebKit::RemoteAudioSessionProxy::connection): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updatePresentingProcesses):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::updateKeyStatuses):
(WebKit::RemoteCDMInstanceSessionProxy::sendMessage):
(WebKit::RemoteCDMInstanceSessionProxy::sessionIdChanged):

Canonical link: <a href="https://commits.webkit.org/283890@main">https://commits.webkit.org/283890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/718df95df2f1043b484d50ecf4bfdf1283746910

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71708 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18598 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54161 "Found 1 new test failure: media/media-vp8-webm-seek-to-start.html (failure)") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70721 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43151 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34630 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39825 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61609 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58571 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3093 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10290 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42839 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->