### PR TITLE
Fallback to full-layout happens when more than 1 subtree layout is pending

### DIFF
--- a/PerformanceTests/Containment/multiple-changes-in-large-grid.html
+++ b/PerformanceTests/Containment/multiple-changes-in-large-grid.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="../resources/runner.js"></script>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<style>
+  html, body { height: 100%; }
+
+  #gridContainer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1px;
+  }
+
+  .gridItemContainStrict {
+      display: block;
+      width: 10px;
+      height: 10px;
+      background-color: #0F0;
+      contain: strict;
+      font-size: 6px;
+  }
+
+  .gridItemContainNone {
+      display: block;
+      width: 10px;
+      height: 10px;
+      background-color: #00F;
+      font-size: 6px;
+  }
+</style>
+
+</head>
+
+<body>
+    <pre id="log"></pre>
+
+    <div id="gridContainer">
+    </div>
+
+    <script>
+      var gridContainer = document.getElementById('gridContainer');
+
+      function makeid(length) {
+          let result = '';
+          const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+          const charactersLength = characters.length;
+          let counter = 0;
+          while (counter < length) {
+              result += characters.charAt(Math.floor(Math.random() * charactersLength));
+              counter += 1;
+          }
+          return result;
+      }
+
+      function createDivElement(className, htmlContent) {
+          let newElement = document.createElement('div');
+          newElement.className = className;
+          newElement.innerHTML = htmlContent;
+          return newElement;
+      }
+
+      function setup() {
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">qwertyui</span>'));
+          for (let i = 0; i < 5000; ++i) {
+              gridContainer.appendChild(createDivElement("gridItemContainNone", '<span>z</span>'));
+          }
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">asdfghjk</span>'));
+          for (let i = 0; i < 5000; ++i) {
+              gridContainer.appendChild(createDivElement("gridItemContainNone", '<span>z</span>'));
+          }
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">zxcvbnm,</span>'));
+      }
+
+      function test() {
+          for (element of document.getElementsByClassName("text")) {
+              element.innerText = makeid(8);
+          }
+          gridContainer.offsetHeight; // Force layout.
+      }
+
+      function done() {
+      }
+
+      setup();
+      PerfTestRunner.measureRunsPerSecond({
+          description: "Measures performance of getting offsetHeight of a large grid container.",
+          run: test,
+          done: done
+      });
+    </script>
+</body>
+
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2917,7 +2917,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
                 break;
             }
 
-            if (currentRenderer == frameView->layoutContext().subtreeLayoutRoot())
+            if (frameView->layoutContext().hasSubtreeLayoutRoot(*currentRenderer))
                 break;
         }
     }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -536,12 +536,12 @@ void LocalFrameView::didRestoreFromBackForwardCache()
 void LocalFrameView::willDestroyRenderTree()
 {
     detachCustomScrollbars();
-    layoutContext().clearSubtreeLayoutRoot();
+    layoutContext().clearSubtreeLayoutRoots();
 }
 
 void LocalFrameView::didDestroyRenderTree()
 {
-    ASSERT(!layoutContext().subtreeLayoutRoot());
+    ASSERT(layoutContext().layoutType() != LocalFrameViewLayoutContext::LayoutType::SubtreeLayout);
     ASSERT(m_widgetsInRenderTree.isEmpty());
 
     ASSERT(!m_embeddedObjectsToUpdate || m_embeddedObjectsToUpdate->isEmpty());
@@ -717,7 +717,7 @@ void LocalFrameView::calculateScrollbarModesForLayout(ScrollbarMode& hMode, Scro
         vMode = ScrollbarMode::AlwaysOff;
     }
     
-    if (layoutContext().subtreeLayoutRoot())
+    if (layoutContext().layoutType() == LocalFrameViewLayoutContext::LayoutType::SubtreeLayout)
         return;
     
     auto* document = m_frame->document();
@@ -4000,7 +4000,7 @@ void LocalFrameView::autoSizeIfEnabled()
         return;
 
     SetForScope changeInAutoSize(m_inAutoSize, true);
-    if (layoutContext().subtreeLayoutRoot())
+    if (layoutContext().layoutType() == LocalFrameViewLayoutContext::LayoutType::SubtreeLayout)
         layoutContext().convertSubtreeLayoutToFullLayout();
 
     switch (m_autoSizeMode) {
@@ -5166,7 +5166,7 @@ void LocalFrameView::enableAutoSizeMode(bool enable, const IntSize& viewSize, Au
 
 void LocalFrameView::forceLayout(bool allowSubtreeLayout)
 {
-    if (!allowSubtreeLayout && layoutContext().subtreeLayoutRoot())
+    if (!allowSubtreeLayout && layoutContext().layoutType() == LocalFrameViewLayoutContext::LayoutType::SubtreeLayout)
         layoutContext().convertSubtreeLayoutToFullLayout();
     layoutContext().layout();
 }

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -70,6 +70,7 @@ static bool isObjectAncestorContainerOf(RenderElement& ancestor, RenderElement& 
 
 #ifndef NDEBUG
 class RenderTreeNeedsLayoutChecker {
+    WTF_MAKE_FAST_ALLOCATED;
 public :
     RenderTreeNeedsLayoutChecker(const RenderView& renderView)
         : m_renderView(renderView)
@@ -150,7 +151,7 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
 
     Ref protectedView(view());
 
-    performLayout(canDeferUpdateLayerPositions);
+    performLayouts(canDeferUpdateLayerPositions);
 
     if (view().hasOneRef())
         return;
@@ -162,14 +163,30 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
         if (!needsLayout())
             break;
 
-        performLayout(canDeferUpdateLayerPositions);
+        performLayouts(canDeferUpdateLayerPositions);
 
         if (view().hasOneRef())
             return;
     }
 }
 
-void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions)
+void LocalFrameViewLayoutContext::performLayouts(bool canDeferUpdateLayerPositions)
+{
+    if (layoutType() == LayoutType::SubtreeLayout) {
+        // When performing a subtree layout, we may need to perform layout for each subtree.
+        // The above might have been done in single pass, but calling performLayout() multiple times
+        // has some nice side-effects such as reporting "Layout" events in the inspector with specific subtree areas.
+        while (performLayout(canDeferUpdateLayerPositions, true) && m_subtreeLayoutRoots.size() > 0) { }
+#ifndef NDEBUG
+        // This function may be called recursively so let's do the checking when all the subtrees have been processed.
+        if (m_subtreeLayoutRoots.isEmpty())
+            RenderTreeNeedsLayoutChecker checker(*renderView());
+#endif
+    } else
+        performLayout(canDeferUpdateLayerPositions);
+}
+
+bool LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions, bool unchecked)
 {
     Ref frame = this->frame();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!document()->inRenderTreeUpdate());
@@ -181,13 +198,14 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         || document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
     if (!canPerformLayout()) {
         LOG(Layout, "  is not allowed, bailing");
-        return;
+        return false;
     }
 
     LayoutScope layoutScope(*this);
     TraceScope tracingScope(PerformLayoutStart, PerformLayoutEnd);
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     InspectorInstrumentation::willLayout(frame);
+    RenderElement* subtreeLayoutRoot;
     SingleThreadWeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
@@ -198,7 +216,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " elapsed time before first layout: " << document()->timeSinceDocumentCreation());
 #endif
 #if PLATFORM(IOS_FAMILY)
-    if (protectedView()->updateFixedPositionLayoutRect() && subtreeLayoutRoot())
+    if (protectedView()->updateFixedPositionLayoutRect() && layoutType() == LayoutType::SubtreeLayout)
         convertSubtreeLayoutToFullLayout();
 #endif
     {
@@ -213,16 +231,17 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         }
 
         if (view().hasOneRef())
-            return;
+            return false;
 
         protectedView()->autoSizeIfEnabled();
         if (!renderView())
-            return;
+            return false;
 
-        layoutRoot = subtreeLayoutRoot() ? subtreeLayoutRoot() : renderView();
+        subtreeLayoutRoot = layoutType() == LayoutType::SubtreeLayout ? *(m_subtreeLayoutRoots.begin()) : nullptr;
+        layoutRoot = subtreeLayoutRoot ?: renderView();
         m_needsFullRepaint = is<RenderView>(layoutRoot) && (m_firstLayout || renderView()->printing());
 
-        LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutIdentifier << " - subtree root " << subtreeLayoutRoot() << ", needsFullRepaint " << m_needsFullRepaint);
+        LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutIdentifier << " - subtree root " << subtreeLayoutRoot << ", needsFullRepaint " << m_needsFullRepaint);
 
         protectedView()->willDoLayout(layoutRoot);
         m_firstLayout = false;
@@ -233,17 +252,22 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         TraceScope tracingScope(RenderTreeLayoutStart, RenderTreeLayoutEnd);
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InRenderTreeLayout);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-        SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot());
+        SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot);
         RenderView::RepaintRegionAccumulator repaintRegionAccumulator(renderView());
 #ifndef NDEBUG
-        RenderTreeNeedsLayoutChecker checker(*renderView());
+        std::unique_ptr<RenderTreeNeedsLayoutChecker> checker;
+        if (!unchecked)
+            checker = WTF::makeUnique<RenderTreeNeedsLayoutChecker>(*renderView());
+#else
+        UNUSED_PARAM(unchecked);
 #endif
         ++m_layoutIdentifier;
         layoutRoot->layout();
 #if ENABLE(TEXT_AUTOSIZING)
         applyTextSizingIfNeeded(*layoutRoot.get());
 #endif
-        clearSubtreeLayoutRoot();
+        if (subtreeLayoutRoot)
+            removeSubtreeLayoutRoot(*subtreeLayoutRoot);
 
 #if !LOG_DISABLED && ENABLE(TREE_DEBUGGING)
         auto layoutLogEnabled = [] {
@@ -263,7 +287,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             // FIXME: Firing media query callbacks synchronously on nested frames could produced a detached FrameView here by
             // navigating away from the current document (see webkit.org/b/173329).
             if (view().hasOneRef())
-                return;
+                return true;
         }
     }
     {
@@ -276,6 +300,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
     }
     InspectorInstrumentation::didLayout(frame, *layoutRoot);
     DebugPageOverlays::didLayout(frame);
+    return true;
 }
 
 void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions)
@@ -323,7 +348,7 @@ void LocalFrameViewLayoutContext::flushPostLayoutTasks()
 void LocalFrameViewLayoutContext::reset()
 {
     m_layoutPhase = LayoutPhase::OutsideLayout;
-    clearSubtreeLayoutRoot();
+    clearSubtreeLayoutRoots();
     m_layoutSchedulingIsEnabled = true;
     m_layoutTimer.stop();
     m_firstLayout = true;
@@ -350,7 +375,7 @@ bool LocalFrameViewLayoutContext::needsLayoutInternal() const
     auto* renderView = this->renderView();
     return isLayoutPending()
         || (renderView && renderView->needsLayout())
-        || subtreeLayoutRoot()
+        || layoutType() == LayoutType::SubtreeLayout
         || (m_disableSetNeedsLayoutCount && m_setNeedsLayoutWasDeferred);
 }
 
@@ -388,7 +413,7 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     if (!document())
         return;
 
-    if (subtreeLayoutRoot())
+    if (layoutType() == LayoutType::SubtreeLayout)
         convertSubtreeLayoutToFullLayout();
 
     if (isLayoutPending())
@@ -433,49 +458,60 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     ASSERT(!renderView.renderTreeBeingDestroyed());
     ASSERT(frame().view() == &view());
 
-    if (renderView.needsLayout() && !subtreeLayoutRoot()) {
+    if (renderView.needsLayout() && layoutType() != LayoutType::SubtreeLayout) {
         layoutRoot.markContainingBlocksForLayout(&renderView);
         return;
     }
 
     if (!isLayoutPending() && isLayoutSchedulingEnabled()) {
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        setSubtreeLayoutRoot(layoutRoot);
+        addSubtreeLayoutRoot(layoutRoot); // WARNING
         InspectorInstrumentation::didInvalidateLayout(protectedFrame());
         m_layoutTimer.startOneShot(0_s);
         return;
     }
 
-    auto* subtreeLayoutRoot = this->subtreeLayoutRoot();
-    if (subtreeLayoutRoot == &layoutRoot)
+    if (hasSubtreeLayoutRoot(layoutRoot))
         return;
 
-    if (!subtreeLayoutRoot) {
+    if (layoutType() != LayoutType::SubtreeLayout) {
         // We already have a pending (full) layout. Just mark the subtree for layout.
         layoutRoot.markContainingBlocksForLayout(&renderView);
         InspectorInstrumentation::didInvalidateLayout(protectedFrame());
         return;
     }
 
-    if (isObjectAncestorContainerOf(*subtreeLayoutRoot, layoutRoot)) {
-        // Keep the current root.
-        layoutRoot.markContainingBlocksForLayout(subtreeLayoutRoot);
-        ASSERT(!subtreeLayoutRoot->container() || is<RenderView>(subtreeLayoutRoot->container()) || !subtreeLayoutRoot->container()->needsLayout());
-        return;
+    // Combine new subtree with existing ones to make sure we store only independent subtrees.
+    for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots) {
+        if (isObjectAncestorContainerOf(*subtreeLayoutRoot, layoutRoot)) {
+            // New subtree is a subtree of existing subtree.
+            layoutRoot.markContainingBlocksForLayout(subtreeLayoutRoot);
+            ASSERT(!subtreeLayoutRoot->container() || is<RenderView>(subtreeLayoutRoot->container()) || !subtreeLayoutRoot->container()->needsLayout());
+            return;
+        }
+        if (isObjectAncestorContainerOf(layoutRoot, *subtreeLayoutRoot)) {
+            // Existing subtree is a subtree of new subtree.
+            subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
+            ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
+            InspectorInstrumentation::didInvalidateLayout(protectedFrame());
+            removeSubtreeLayoutRoot(*subtreeLayoutRoot);
+            addSubtreeLayoutRoot(layoutRoot);
+            return;
+        }
     }
 
-    if (isObjectAncestorContainerOf(layoutRoot, *subtreeLayoutRoot)) {
-        // Re-root at newRelayoutRoot.
-        subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
-        setSubtreeLayoutRoot(layoutRoot);
-        ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        InspectorInstrumentation::didInvalidateLayout(protectedFrame());
-        return;
-    }
-    // Two disjoint subtrees need layout. Mark both of them and issue a full layout instead.
-    convertSubtreeLayoutToFullLayout();
-    layoutRoot.markContainingBlocksForLayout(&renderView);
+    // We already have a pending subtree layout. Just add new subtree to collection.
+    addSubtreeLayoutRoot(layoutRoot);
     InspectorInstrumentation::didInvalidateLayout(protectedFrame());
+}
+
+LocalFrameViewLayoutContext::LayoutType LocalFrameViewLayoutContext::layoutType() const
+{
+    if (!m_subtreeLayoutRoots.isEmpty())
+        return LayoutType::SubtreeLayout;
+    // if (auto* renderView = this->renderView(); renderView && renderView->needsLayout())
+    //     return LayoutType::FullLayout;
+    return LayoutType::NoLayout;
 }
 
 void LocalFrameViewLayoutContext::layoutTimerFired()
@@ -487,21 +523,32 @@ void LocalFrameViewLayoutContext::layoutTimerFired()
     layout();
 }
 
-RenderElement* LocalFrameViewLayoutContext::subtreeLayoutRoot() const
+bool LocalFrameViewLayoutContext::hasSubtreeLayoutRoot(const RenderElement& subtreeLayoutRoot) const
 {
-    return m_subtreeLayoutRoot.get();
+    return m_subtreeLayoutRoots.contains(const_cast<RenderElement*>(&subtreeLayoutRoot));
+}
+
+void LocalFrameViewLayoutContext::clearSubtreeLayoutRoots()
+{
+    m_subtreeLayoutRoots.clear();
 }
 
 void LocalFrameViewLayoutContext::convertSubtreeLayoutToFullLayout()
 {
-    ASSERT(subtreeLayoutRoot());
-    subtreeLayoutRoot()->markContainingBlocksForLayout(renderView());
-    clearSubtreeLayoutRoot();
+    ASSERT(!m_subtreeLayoutRoots.isEmpty());
+    for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots)
+        subtreeLayoutRoot->markContainingBlocksForLayout(renderView());
+    clearSubtreeLayoutRoots();
 }
 
-void LocalFrameViewLayoutContext::setSubtreeLayoutRoot(RenderElement& layoutRoot)
+void LocalFrameViewLayoutContext::addSubtreeLayoutRoot(RenderElement& subtreeLayoutRoot)
 {
-    m_subtreeLayoutRoot = layoutRoot;
+    m_subtreeLayoutRoots.add(&subtreeLayoutRoot);
+}
+
+void LocalFrameViewLayoutContext::removeSubtreeLayoutRoot(const RenderElement& subtreeLayoutRoot)
+{
+    m_subtreeLayoutRoots.remove(const_cast<RenderElement*>(&subtreeLayoutRoot));
 }
 
 bool LocalFrameViewLayoutContext::canPerformLayout() const
@@ -512,7 +559,7 @@ bool LocalFrameViewLayoutContext::canPerformLayout() const
     if (view().isPainting())
         return false;
 
-    if (!subtreeLayoutRoot() && !document()->renderView())
+    if (layoutType() != LayoutType::SubtreeLayout && !document()->renderView())
         return false;
 
     return true;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -81,6 +81,12 @@ public:
     void disableSetNeedsLayout();
     void enableSetNeedsLayout();
 
+    enum class LayoutType : uint8_t {
+        NoLayout,
+        FullLayout,
+        SubtreeLayout,
+    };
+    LayoutType layoutType() const;
     enum class LayoutPhase : uint8_t {
         OutsideLayout,
         InPreLayout,
@@ -98,8 +104,9 @@ public:
     bool needsSkippedContentLayout() const { return m_needsSkippedContentLayout; }
     void setNeedsSkippedContentLayout(bool needsSkippedContentLayout) { m_needsSkippedContentLayout = needsSkippedContentLayout; }
 
-    RenderElement* subtreeLayoutRoot() const;
-    void clearSubtreeLayoutRoot() { m_subtreeLayoutRoot.clear(); }
+    bool hasSubtreeLayoutRoot(const RenderElement&) const;
+    void removeSubtreeLayoutRoot(const RenderElement&);
+    void clearSubtreeLayoutRoots();
     void convertSubtreeLayoutToFullLayout();
 
     void reset();
@@ -144,7 +151,8 @@ private:
 
     bool needsLayoutInternal() const;
 
-    void performLayout(bool canDeferUpdateLayerPositions);
+    void performLayouts(bool canDeferUpdateLayerPositions);
+    bool performLayout(bool canDeferUpdateLayerPositions, bool unchecked = false);
     bool canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
@@ -153,7 +161,7 @@ private:
     void runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions);
     bool inAsynchronousTasks() const { return m_inAsynchronousTasks; }
 
-    void setSubtreeLayoutRoot(RenderElement&);
+    void addSubtreeLayoutRoot(RenderElement&);
 
 #if ENABLE(TEXT_AUTOSIZING)
     void applyTextSizingIfNeeded(RenderElement& layoutRoot);
@@ -184,7 +192,7 @@ private:
     SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;
     Timer m_postLayoutTaskTimer;
-    SingleThreadWeakPtr<RenderElement> m_subtreeLayoutRoot;
+    HashSet<RenderElement*> m_subtreeLayoutRoots;
     // Note that arithmetic overflow is perfectly acceptable as long as we use this only for repaint optimization.
     RenderElement::LayoutIdentifier m_layoutIdentifier : 12 { 0 };
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5824,7 +5824,7 @@ void RenderBox::updateFloatPainterAfterSelfPaintingLayerChange()
     // Find the ancestor renderer that is supposed to paint this float now that it is not self painting anymore.
     auto floatingObjectForFloatPainting = [&]() -> FloatingObject* {
         auto& layoutContext = view().frameView().layoutContext();
-        if (!layoutContext.isInLayout() || layoutContext.subtreeLayoutRoot() != this)
+        if (!layoutContext.isInLayout() || !layoutContext.hasSubtreeLayoutRoot(*this))
             return nullptr;
 
         FloatingObject* floatPainter = nullptr;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1117,7 +1117,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     if (renderTreeBeingDestroyed())
         return;
 
-    if (view().frameView().layoutContext().subtreeLayoutRoot() != this)
+    if (!view().frameView().layoutContext().hasSubtreeLayoutRoot(*this))
         return;
 
     // Normally when a renderer is detached from the tree, the appropriate dirty bits get set
@@ -1127,7 +1127,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     // This indicates a failure to layout the child, which is why
     // the layout root is still set to |this|. Make sure to clear it
     // since we are getting destroyed.
-    view().protectedFrameView()->layoutContext().clearSubtreeLayoutRoot();
+    view().protectedFrameView()->layoutContext().removeSubtreeLayoutRoot(*this);
 }
 
 void RenderElement::willBeDestroyed()


### PR DESCRIPTION
#### 0dc91df01eb4941f326e8661743e2a8992c5c390
<pre>
Fallback to full-layout happens when more than 1 subtree layout is pending
<a href="https://bugs.webkit.org/show_bug.cgi?id=275394">https://bugs.webkit.org/show_bug.cgi?id=275394</a>

Reviewed by NOBODY (OOPS!).

Originally, subtree layout was designed to work with a single subtree. However,
there are use-cases which require subtree layout to support multiple subtrees at once
so that no fallback to &quot;full&quot; layout is done.

One of such use-cases is CSS containment, which (under certain conditions)
allows one to isolate parts of DOM tree so that in case of internal changes they can
be laid out without layouting full tree. With CSS containment, it&apos;s fairly common that
such internal subtree changes will happen at once thus leading to multiple subtree layouts
being scheduled. Unfortunately, currenly such situation leads to fallback to &quot;full&quot; layout
as only single subtree layout is supported. Fortunately, currently it&apos;s possible (although
not ideal) to workaround that problem by forcing layout after each subtree change using
position queries such as document.body.offsetLeft etc.

This PR adds support for layouting multiple subtrees at once. This is achived
by collecting pending subtrees and eventually layouting them one by one.

* PerformanceTests/Containment/multiple-changes-in-large-grid.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willDestroyRenderTree):
(WebCore::LocalFrameView::didDestroyRenderTree):
(WebCore::LocalFrameView::calculateScrollbarModesForLayout):
(WebCore::LocalFrameView::autoSizeIfEnabled):
(WebCore::LocalFrameView::forceLayout):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
(WebCore::LocalFrameViewLayoutContext::performLayouts):
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::reset):
(WebCore::LocalFrameViewLayoutContext::needsLayoutInternal const):
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::scheduleSubtreeLayout):
(WebCore::LocalFrameViewLayoutContext::hasSubtreeLayoutRoot const):
(WebCore::LocalFrameViewLayoutContext::clearSubtreeLayoutRoots):
(WebCore::LocalFrameViewLayoutContext::convertSubtreeLayoutToFullLayout):
(WebCore::LocalFrameViewLayoutContext::addSubtreeLayoutRoot):
(WebCore::LocalFrameViewLayoutContext::removeSubtreeLayoutRoot):
(WebCore::LocalFrameViewLayoutContext::canPerformLayout const):
(WebCore::LocalFrameViewLayoutContext::subtreeLayoutRoot const): Deleted.
(WebCore::LocalFrameViewLayoutContext::setSubtreeLayoutRoot): Deleted.
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::updateFloatPainterAfterSelfPaintingLayerChange):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::clearSubtreeLayoutRootIfNeeded const):
</pre>