### PR TITLE
mediaSession.setCameraActive/setMicrophoneActive callback is executed after WebPage is notified of muted state

### DIFF
--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -100,6 +100,8 @@ public:
 #endif
 
     CompletionHandler<void(bool)> decisionCompletionHandler() { return std::exchange(m_decisionCompletionHandler, { }); }
+    void setBeforeStartingCaptureCallback(Function<void()>&& callback) { m_beforeStartingCaptureCallback = WTFMove(callback); }
+    Function<void()> beforeStartingCaptureCallback() { return std::exchange(m_beforeStartingCaptureCallback, { }); }
 
 protected:
     UserMediaPermissionRequestProxy(UserMediaPermissionRequestManagerProxy&, WebCore::UserMediaRequestIdentifier, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& userMediaDocumentOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, Vector<WebCore::CaptureDevice>&& audioDevices, Vector<WebCore::CaptureDevice>&& videoDevices, WebCore::MediaStreamRequest&&, CompletionHandler<void(bool)>&&);
@@ -119,6 +121,7 @@ private:
     bool m_hasPersistentAccess { false };
     WebCore::MediaDeviceHashSalts m_deviceIdentifierHashSalts;
     CompletionHandler<void(bool)> m_decisionCompletionHandler;
+    Function<void()> m_beforeStartingCaptureCallback;
 };
 
 String convertEnumerationToString(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2099,7 +2099,7 @@ public:
 
 #if ENABLE(MEDIA_STREAM)
     void setMockCaptureDevicesEnabledOverride(std::optional<bool>);
-    void willStartCapture(const UserMediaPermissionRequestProxy&, CompletionHandler<void()>&&);
+    void willStartCapture(UserMediaPermissionRequestProxy&, CompletionHandler<void()>&&);
 #endif
 
     void maybeInitializeSandboxExtensionHandle(WebProcessProxy&, const URL&, const URL& resourceDirectoryURL, bool checkAssumedReadAccessToResourceURL, CompletionHandler<void(std::optional<SandboxExtensionHandle>)>&&);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1097,6 +1097,7 @@
 		A17C483B2C98E5C20023F3C7 /* webp-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F45C63FE28178A530090DFAB /* webp-image.html */; };
 		A17C483C2C98E5C20023F3C7 /* WebProcessKillIDBCleanup-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51714EB21CF8C761004723C4 /* WebProcessKillIDBCleanup-1.html */; };
 		A17C483D2C98E5C20023F3C7 /* WebProcessKillIDBCleanup-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51714EB31CF8C761004723C4 /* WebProcessKillIDBCleanup-2.html */; };
+		A17C483E2C98E5C20023F3AA /* media-session-capture.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597AA /* media-session-capture.html */; };
 		A17C483E2C98E5C20023F3C7 /* webrtc-remote-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */; };
 		A17C483F2C98E5C20023F3C7 /* webrtc-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EC /* webrtc-remote.html */; };
 		A17C48402C98E5C20023F3C7 /* WebsiteDataStoreCustomPaths.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5120C83B1E674E350025B250 /* WebsiteDataStoreCustomPaths.html */; };
@@ -1840,6 +1841,7 @@
 				A17C46D12C98E54B0023F3C7 /* many-same-origin-iframes.html in Copy Resources */,
 				A17C46D22C98E54B0023F3C7 /* media-loading.html in Copy Resources */,
 				A17C47D22C98E5C20023F3C7 /* media-remote.html in Copy Resources */,
+				A17C483E2C98E5C20023F3AA /* media-session-capture.html in Copy Resources */,
 				A17C46802C98E4D20023F3C7 /* MediaPlaybackSleepAssertion.html in Copy Resources */,
 				A17C46D32C98E54B0023F3C7 /* mediastreamtrack-detached.html in Copy Resources */,
 				A17C46812C98E4D20023F3C7 /* MemoryCacheDisableWithinResourceLoadDelegate.html in Copy Resources */,
@@ -2078,6 +2080,7 @@
 		0766DD1F1A5AD5200023E3BB /* PendingAPIRequestURL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PendingAPIRequestURL.cpp; sourceTree = "<group>"; };
 		076E507E1F45031E006E9F5A /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
 		0794740C25CA0BDE00C597EB /* MediaSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSession.mm; sourceTree = "<group>"; };
+		0794742C25CB33B000C597AA /* media-session-capture.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-session-capture.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EB /* media-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-remote.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EC /* webrtc-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote-iframe.html"; sourceTree = "<group>"; };
@@ -5073,6 +5076,7 @@
 				7A6A2C711DCCFB0200C0D085 /* LocalStorageQuirkEnabled.html */,
 				7A33FF2F27C82F0B00D7E03E /* LockdownModePDF.html */,
 				0794742C25CB33B000C597EB /* media-remote.html */,
+				0794742C25CB33B000C597AA /* media-session-capture.html */,
 				9B59F12920340854009E63D5 /* mso-list-compat-mode.html */,
 				9BCD4119206D5ED7001D71BE /* mso-list-on-h4.html */,
 				9BF356CC202D44F200F71160 /* mso-list.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/media-session-capture.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/media-session-capture.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body onload="notifyLoaded()">
+    <video id=video controls autoplay playsinline></video>
+    <script>
+function notifyLoaded()
+{
+    if (window.webkit)
+        window.webkit.messageHandlers.gum.postMessage("PASS");
+}
+
+function startCapture()
+{
+    navigator.mediaDevices.getUserMedia({ audio:true, video:true }).then(stream => {
+        window.actionState = "";
+        video.srcObject = stream;
+
+        registerActionHandlers();
+        registerMuteHandlers();
+
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("PASS");
+    }, (e) => {
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("FAIL: "  + e);
+    });
+}
+
+function registerActionHandlers()
+{
+    navigator.mediaSession.setActionHandler("togglecamera", action => {
+        addToActionState(action.isActivating ? "activating camera" : "deactivating camera");
+    });
+    navigator.mediaSession.setActionHandler("togglemicrophone", action => {
+        addToActionState(action.isActivating ? "activating microphone" : "deactivating microphone");
+    });
+}
+
+function registerMuteHandlers()
+{
+    video.srcObject.getAudioTracks()[0].onmute = () => addToActionState("muting microphone");
+    video.srcObject.getAudioTracks()[0].onunmute = () => addToActionState("unmuting microphone");
+
+    video.srcObject.getVideoTracks()[0].onmute = () => addToActionState("muting camera");
+    video.srcObject.getVideoTracks()[0].onunmute = () => addToActionState("unmuting camera");
+}
+
+function setCameraActive(shouldActivate)
+{
+    if (!window.internals) {
+        window.webkit.messageHandlers.gum.postMessage("test requires internals");
+        return;
+    }
+
+    window.internals.withUserGesture(() => {
+        navigator.mediaSession.setCameraActive(shouldActivate).then(() => {
+            addToActionState("setCameraActive successful");
+            if (window.webkit)
+                window.webkit.messageHandlers.gum.postMessage("PASS");
+        }, (e) => {
+            addToActionState("setCameraActive not successful");
+            if (window.webkit)
+                window.webkit.messageHandlers.gum.postMessage("FAIL setCameraActive " + e);
+        });
+    });
+}
+
+function setMicrophoneActive(shouldActivate)
+{
+    if (!window.internals) {
+        window.webkit.messageHandlers.gum.postMessage("test requires internals");
+        return;
+    }
+
+    window.internals.withUserGesture(() => {
+        navigator.mediaSession.setMicrophoneActive(shouldActivate).then(() => {
+            addToActionState("setMicrophoneActive successful");
+            if (window.webkit)
+                window.webkit.messageHandlers.gum.postMessage("PASS");
+        }, (e) => {
+            addToActionState("setMicrophoneActive not successful");
+            if (window.webkit)
+                window.webkit.messageHandlers.gum.postMessage("FAIL setMicrophoneActive " + e);
+        });
+    });
+}
+
+function addToActionState(state)
+{
+    window.actionState += state + ", ";
+}
+
+function validateActionState(state)
+{
+    window.actionState += "end";
+    if (window.webkit)
+        window.webkit.messageHandlers.gum.postMessage(state === actionState ? "PASS" : "FAIL, got " + window.actionState);
+    window.actionState = "";
+}
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 41195127df9638b14331dc90d5baed7a2d4ea636
<pre>
mediaSession.setCameraActive/setMicrophoneActive callback is executed after WebPage is notified of muted state
<a href="https://bugs.webkit.org/show_bug.cgi?id=279887">https://bugs.webkit.org/show_bug.cgi?id=279887</a>
<a href="https://rdar.apple.com/problem/136219468">rdar://problem/136219468</a>

Reviewed by Eric Carlson.

Let&apos;s start with the following scenario:
1. User starts capturing camera and microphone
2. User mutes capture using Safari UI
3. User tries to unmute capture using MediaSession setCameraActive/setMicrophoneActive

At step 2, WebPage is notified of being muted and triggers MediaSession actions as well as mute/unmute MediaStreamTrack events.
This is all good.

At step 3, WebPageProxy will make a request to grant capture restart.
When this request is granted, WebPageProxy will first mute other pages and unmute itself.
This will trigger new MediaSession actions as well as mute/unmute MediaStreamTrack events.

It will then notify WebPage that the unmute capture request is validated.
This will trigger resolution of the MediaSession setCameraActive/setMicrophoneActive promise.

The consequence is that the order of events/actions and promise resolution is wrong.
In addition, a number of action handlers are executed even though they were not needed since unmuting was requested via setCameraActive/setMicrophoneActive.

To fix this, we add a new callback to UserMediaPermissionRequestProxy which will be called if the request is allowed but before WebPageProxy unmutes itself.
This will give a correct ordering and will remove the additional action handler calls.

Covered by added API test.

* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
(WebKit::UserMediaPermissionRequestProxy::setBeforeStartingCaptureCallback):
(WebKit::UserMediaPermissionRequestProxy::Function&lt;void):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::validateCaptureStateUpdate):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::(WebKit2, ToggleCaptureWhenRestarting)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/media-session-capture.html: Added.

Canonical link: <a href="https://commits.webkit.org/283925@main">https://commits.webkit.org/283925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fefacb5adef0a2de4806955a13828d54603a3981

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18773 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12676 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39948 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61912 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73579 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15685 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58726 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9610 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43015 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->