### PR TITLE
Fix debug assertion after 283819@main

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -165,7 +165,7 @@ private:
 
     void didFailProvisionalLoad() final
     {
-        ASSERT(!m_loadingFrameCount);
+        ASSERT(m_loadingFrameCount);
         m_loadingFrameCount--;
     }
 


### PR DESCRIPTION
#### 225a5d2170fb06ed9657307f36d813ace089f876
<pre>
Fix debug assertion after 283819@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=279900">https://bugs.webkit.org/show_bug.cgi?id=279900</a>
<a href="https://rdar.apple.com/136225651">rdar://136225651</a>

Unreviewed.

In 283819@main I introduced an assertion that always fails when a provisional load fails.
I just misplaced a &apos;!&apos;.  I need to assert that m_loadingFrameCount is nonzero before decrementing it.
This is covered by at least these tests in debug builds:

TestWebKitAPI.SiteIsolation.CancelProvisionalLoad
TestWebKitAPI.SiteIsolation.NavigateIframeToProvisionalNavigationFailure
TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure
TestWebKitAPI.SiteIsolation.OpenProvisionalFailure
TestWebKitAPI.SiteIsolation.ProvisionalLoadFailure
TestWebKitAPI.SiteIsolation.ProvisionalLoadFailureOnCrossSiteRedirect

* Source/WebKit/UIProcess/WebPageProxyInternals.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/225a5d2170fb06ed9657307f36d813ace089f876

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67602 "Failed to checkout and rebase branch from PR 33831") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/46981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20234 "Failed to checkout and rebase branch from PR 33831") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/18739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/54779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/18543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/71651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/18739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70669 "Failed to checkout and rebase branch from PR 33831") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/54779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/20234 "Failed to checkout and rebase branch from PR 33831") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/71651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/54779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/20234 "Failed to checkout and rebase branch from PR 33831") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/17097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/54779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/20234 "Failed to checkout and rebase branch from PR 33831") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66847 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/11561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/18543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/73351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/11596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/20234 "Failed to checkout and rebase branch from PR 33831") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/73351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/20234 "Failed to checkout and rebase branch from PR 33831") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/45049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/43604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->