### PR TITLE
AX: Support multiple replacement strings in AXTextOperation

### DIFF
--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-expected.txt
@@ -14,6 +14,16 @@ PASS: operationResult[0] === '[replaced string]'
 PASS: operationResult[1] === '[replaced string]'
 PASS: operationResult[2] === '[Replaced String]'
 PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT4: [Replaced String] quick brown [replaced string] jumps over the [replaced string] dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'three'
+PASS: operationResult[1] === 'two'
+PASS: operationResult[2] === 'One'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT5: One quick brown two jumps over the three dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'three'
+PASS: operationResult[1] === 'two'
+PASS: operationResult[2] === ''
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT6:  quick brown two jumps over the three dog.'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case-expected.txt
@@ -11,6 +11,16 @@ PASS: operationResult[0] === '[Replaced string]'
 PASS: operationResult[1] === '[Replaced string]'
 PASS: operationResult[2] === '[Replaced string]'
 PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: [Replaced string] quick brown [Replaced string] jumps over the [Replaced string] dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'Three'
+PASS: operationResult[1] === 'Two'
+PASS: operationResult[2] === 'One'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT4: One quick brown Two jumps over the Three dog.'
+PASS: operationResult.length === 3
+PASS: operationResult[0] === 'Three'
+PASS: operationResult[1] === 'Two'
+PASS: operationResult[2] === ''
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT5:  quick brown Two jumps over the Three dog.'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case.html
@@ -10,6 +10,8 @@
     <p contenteditable="true" id="text">The quick brown <span id="target1">fox</span> jumps over the lazy dog.</p>
     <p contenteditable="true" id="text2">TEXT2: <span id="target2">The</span> quick brown fox jumps over the lazy dog.</p>
     <p contenteditable="true" id="text3">TEXT3: <span id="target3">The</span> quick brown <span id="target4">fox</span> jumps over the <span id="target5">lazy</span> dog.</p>
+    <p contenteditable="true" id="text4">TEXT4: <span id="target6">The</span> quick brown <span id="target7">fox</span> jumps over the <span id="target8">lazy</span> dog.</p>
+    <p contenteditable="true" id="text5">TEXT5: <span id="target9">The</span> quick brown <span id="target10">fox</span> jumps over the <span id="target11">lazy</span> dog.</p>
 </div>
 
 <script>
@@ -51,6 +53,31 @@ if (window.accessibilityController) {
         output += expect("operationResult[1]", "'[Replaced string]'");
         output += expect("operationResult[2]", "'[Replaced string]'");
         output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: [Replaced string] quick brown [Replaced string] jumps over the [Replaced string] dog.'");
+
+        // Validate that the case of the replacement string is preserved across multiple replacements with individual replacement strings.
+        text = accessibilityController.accessibleElementById("text4");
+        markers = [await selectElementTextById("target8"), await selectElementTextById("target7"), await selectElementTextById("target6")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplacePreserveCase", markers, ["Three", "Two", "One"], /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'Three'");
+        output += expect("operationResult[1]", "'Two'");
+        output += expect("operationResult[2]", "'One'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT4: One quick brown Two jumps over the Three dog.'");
+
+        // Assert the behavior when fewer individual replacement strings than the number of ranges are provided.
+        // THIS IS NOT A VALID USE OF THE API. This test case asserts the existing behavior to catch accidental changes.
+        text = accessibilityController.accessibleElementById("text5");
+        markers = [await selectElementTextById("target11"), await selectElementTextById("target10"), await selectElementTextById("target9")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplacePreserveCase", markers, ["Three", "Two"], /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'Three'");
+        output += expect("operationResult[1]", "'Two'");
+        output += expect("operationResult[2]", "''");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT5:  quick brown Two jumps over the Three dog.'");
 
         document.getElementById("test-content").remove();
         debug(output);

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace.html
@@ -11,6 +11,8 @@
     <p contenteditable="true" id="text2">TEXT2: <span id="target2">The</span> quick brown fox jumps over the lazy dog.</p>
     <p contenteditable="true" id="text3">TEXT3: The quick brown fox jumps over the <span id="target3">lazy</span> dog.</p>
     <p contenteditable="true" id="text4">TEXT4: <span id="target4">The</span> quick brown  <span id="target5">fox</span> jumps over the <span id="target6">lazy</span> dog.</p>
+    <p contenteditable="true" id="text5">TEXT5: <span id="target7">The</span> quick brown  <span id="target8">fox</span> jumps over the <span id="target9">lazy</span> dog.</p>
+    <p contenteditable="true" id="text6">TEXT6: <span id="target10">The</span> quick brown  <span id="target11">fox</span> jumps over the <span id="target12">lazy</span> dog.</p>
 </div>
 
 <script>
@@ -51,7 +53,7 @@ if (window.accessibilityController) {
         output += expect("operationResult[0]", "'LAZY'");
         output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: The quick brown fox jumps over the LAZY dog.'");
 
-        // Validate that the case of the replacement string is preserved across multiple replacements.
+        // Validate that the case of the replacement string is modified appropriately across multiple replacements.
         text = accessibilityController.accessibleElementById("text4");
         markers = [await selectElementTextById("target6"), await selectElementTextById("target5"), await selectElementTextById("target4")];
         await waitForNotification(text, "AXValueChanged", () => {
@@ -62,6 +64,31 @@ if (window.accessibilityController) {
         output += expect("operationResult[1]", "'[replaced string]'");
         output += expect("operationResult[2]", "'[Replaced String]'");
         output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT4: [Replaced String] quick brown [replaced string] jumps over the [replaced string] dog.'");
+
+        // Validate that the case of the replacement string is modified appropriately across multiple replacements with individual replacement strings.
+        text = accessibilityController.accessibleElementById("text5");
+        markers = [await selectElementTextById("target9"), await selectElementTextById("target8"), await selectElementTextById("target7")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, ["Three", "Two", "One"], /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'three'");
+        output += expect("operationResult[1]", "'two'");
+        output += expect("operationResult[2]", "'One'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT5: One quick brown two jumps over the three dog.'");
+
+        // Assert the behavior when fewer individual replacement strings than the number of ranges are provided.
+        // THIS IS NOT A VALID USE OF THE API. This test case asserts the existing behavior to catch accidental changes.
+        text = accessibilityController.accessibleElementById("text6");
+        markers = [await selectElementTextById("target12"), await selectElementTextById("target11"), await selectElementTextById("target10")];
+        await waitForNotification(text, "AXValueChanged", () => {
+            operationResult = text.performTextOperation("TextOperationReplace", markers, ["Three", "Two"], /* smart replace */ false);
+        });
+        output += expect("operationResult.length", "3");
+        output += expect("operationResult[0]", "'three'");
+        output += expect("operationResult[1]", "'two'");
+        output += expect("operationResult[2]", "''");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT6:  quick brown two jumps over the three dog.'");
 
         document.getElementById("test-content").remove();
         debug(output);

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -649,7 +649,7 @@ enum class AccessibilityTextOperationSmartReplace : bool { No, Yes };
 struct AccessibilityTextOperation {
     Vector<SimpleRange> textRanges; // text on which perform the operation.
     AccessibilityTextOperationType type { AccessibilityTextOperationType::Select };
-    String replacementText; // For type = Replace, ReplacePreserveCase.
+    Vector<String> replacementStrings; // For type = Replace, ReplacePreserveCase.
     AccessibilityTextOperationSmartReplace smartReplace { AccessibilityTextOperationSmartReplace::Yes };
 };
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1029,12 +1029,22 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
     if (!frame)
         return result;
 
-    for (const auto& textRange : operation.textRanges) {
+    size_t replacementStringsCount = operation.replacementStrings.size();
+    bool useFirstReplacementStringForAllReplacements = (replacementStringsCount == 1);
+
+    for (size_t i = 0; i < operation.textRanges.size(); ++i) {
+        auto textRange = operation.textRanges[i];
+
+        String replacementString;
+        if (useFirstReplacementStringForAllReplacements)
+            replacementString = operation.replacementStrings[0];
+        else if (i < replacementStringsCount)
+            replacementString = operation.replacementStrings[i];
+
         if (!frame->selection().setSelectedRange(textRange, Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes))
             continue;
 
         String text = plainText(textRange);
-        String replacementString = operation.replacementText;
         bool replaceSelection = false;
         switch (operation.type) {
         case AccessibilityTextOperationType::Capitalize:

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -417,6 +417,12 @@ static id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>&, NSS
 #define NSAccessibilityTextOperationReplacementString @"AXTextOperationReplacementString"
 #endif
 
+#ifndef NSAccessibilityTextOperationIndividualReplacementStrings
+// Array of replacement text for operation replace. The array should contain
+// the same number of items as the number of text operation ranges.
+#define NSAccessibilityTextOperationIndividualReplacementStrings @"AXTextOperationIndividualReplacementStrings"
+#endif
+
 #ifndef NSAccessibilityTextOperationSmartReplace
 // Boolean specifying whether a smart replacement should be performed.
 #define NSAccessibilityTextOperationSmartReplace @"AXTextOperationSmartReplace"
@@ -673,7 +679,7 @@ static std::pair<AccessibilitySearchTextCriteria, AccessibilityTextOperation> ac
     }
 
     if ([replacementStringParameter isKindOfClass:[NSString class]])
-        operation.replacementText = replacementStringParameter;
+        operation.replacementStrings = { String(replacementStringParameter) };
 
     if ([searchStringsParameter isKindOfClass:[NSArray class]])
         criteria.searchStrings = makeVector<String>(searchStringsParameter);
@@ -717,6 +723,7 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
 
     NSArray *markerRanges = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationMarkerRanges];
     NSString *operationType = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationType];
+    NSArray *individualReplacementStrings = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationIndividualReplacementStrings];
     NSString *replacementString = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationReplacementString];
     NSNumber *smartReplace = [parameterizedAttribute objectForKey:NSAccessibilityTextOperationSmartReplace];
 
@@ -740,8 +747,10 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
             operation.type = AccessibilityTextOperationType::Uppercase;
     }
 
-    if ([replacementString isKindOfClass:[NSString class]])
-        operation.replacementText = replacementString;
+    if ([individualReplacementStrings isKindOfClass:[NSArray class]]) {
+        operation.replacementStrings = makeVector<String>(individualReplacementStrings);
+    } else if ([replacementString isKindOfClass:[NSString class]])
+        operation.replacementStrings = { String(replacementString) };
 
     if ([smartReplace isKindOfClass:[NSNumber class]])
         operation.smartReplace = [smartReplace boolValue] ? AccessibilityTextOperationSmartReplace::Yes : AccessibilityTextOperationSmartReplace::No;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -128,7 +128,7 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textInputMarkedText
 void AccessibilityUIElement::setBoolAttributeValue(JSStringRef, bool) { }
 void AccessibilityUIElement::setValue(JSStringRef) { }
 JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef, JSValueRef, JSStringRef, JSStringRef) { return nullptr; }
-JSValueRef AccessibilityUIElement::performTextOperation(JSContextRef, JSStringRef, JSValueRef, JSStringRef, bool) { return nullptr; }
+JSValueRef AccessibilityUIElement::performTextOperation(JSContextRef, JSStringRef, JSValueRef, JSValueRef, bool) { return nullptr; }
 bool AccessibilityUIElement::isOnScreen() const { return true; }
 JSValueRef AccessibilityUIElement::mathRootRadicand(JSContextRef) { return { }; }
 unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -298,7 +298,7 @@ public:
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity);
     JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction);
-    JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSStringRef replacement, bool shouldSmartReplace);
+    JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace);
 
     // Text-specific
     JSRetainPtr<JSStringRef> characterAtOffset(int offset);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -216,7 +216,7 @@ interface AccessibilityUIElement {
     AccessibilityUIElement uiElementForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
     DOMString selectTextWithCriteria(DOMString ambiguityResolution, object searchStrings, DOMString replacementString, DOMString activity);
     object searchTextWithCriteria(object searchStrings, DOMString startFrom, DOMString direction);
-    object performTextOperation(DOMString operationType, object markerRanges, DOMString replacement, boolean shouldSmartReplace);
+    object performTextOperation(DOMString operationType, object markerRanges, object replacementStrings, boolean shouldSmartReplace);
     boolean setSelectedTextRange(unsigned long location, unsigned long length);
 
     // Scroll area attributes.


### PR DESCRIPTION
#### f20ec536521f2da91bd2993b1a9034e456d1f907
<pre>
AX: Support multiple replacement strings in AXTextOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=279888">https://bugs.webkit.org/show_bug.cgi?id=279888</a>
<a href="https://rdar.apple.com/problem/136220931">rdar://problem/136220931</a>

Reviewed by Tyler Wilcock.

WebKit’s `AXTextOperation` parameterized accessibility attribute, among its other capabilities,
lets you replace text across multiple text marker ranges in an editable text field. It takes a
dictionary as its parameter, with an array of text marker ranges to be replaced, and one
replacement string. The existing API mirrors the contract for a simple find-and-replace
operation. Utilizing `AXSearchTextWithCriteria`, you can locate text marker ranges for a search
string and, substitute them with a replacement string using `AXTextOperation`. However,
AXTextOperation’s usability is severely limited beyond this specific use case.

This change adds the ability to replace _individual_ ranges with different replacement strings,
allowing AXTextOperations to be used outside the narrow scope of a simple find-and-replace
operation, enabling richer replacements from an accessibility client, like Grammarly (which
intends to use this attribute).

A new `AXTextOperationIndividualReplacementStrings` key has been added to the `AXTextOperation`
parameter dictionary, which expects an array of strings as its value. This array is expected to
have the same length as the `AXTextOperationMarkerRanges` array, where each replacement string
corresponds to one replacement range.

Client pseudo-code:

```
// Editable text: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
// To replace &quot;dolor&quot; -&gt; &quot;foo&quot; and &quot;elit&quot; -&gt; &quot;bar&quot;:
CFTypeRef result;
AXUIElementCopyParameterizedAttributeValue(element, &quot;AXTextOperation&quot;, @[
  NSAccessibilityTextOperationType: NSAccessibilityTextOperationReplace,
  NSAccessibilityTextOperationIndividualReplacementStrings: @[ @&quot;bar&quot;, @&quot;foo&quot; ],
  NSAccessibilityTextOperationMarkerRanges: @[ rangeOfElit, rangeOfDolor ]
], &amp;result)
```

This is an additive change to the AXTextOperation API. The existing
`AXTextOperationReplacementString` key for providing a single replacement string will continue
to work as expected.

* LayoutTests/accessibility/mac/text-operation/text-operation-replace-expected.txt:
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case-expected.txt:
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-preserve-case.html:
* LayoutTests/accessibility/mac/text-operation/text-operation-replace.html:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::performTextOperation):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(accessibilityTextCriteriaForParameterizedAttribute):
(accessibilityTextOperationForParameterizedAttribute):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::performTextOperation):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::textOperationParameterizedAttribute):
(WTR::AccessibilityUIElement::performTextOperation):

Canonical link: <a href="https://commits.webkit.org/284044@main">https://commits.webkit.org/284044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a24ba4b68fda677583b9cabdfd8bee8fa4ede9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12783 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16203 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61844 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15148 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3357 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43217 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->