### PR TITLE
[Writing Tools] Lists are sometimes erroneously preserved after performing a Rewrite

### DIFF
--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -597,7 +597,7 @@ void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRang
             weakThis->compositionSessionDidReceiveTextWithReplacementRangeAsync(sourceAnimationUUID, destinationAnimationUUID, attributedText, range, context, finished, runMode);
     };
 
-    // We only get a single replace call for smart replies with finished = true. We use this flag to not run the final replace for a compsition
+    // We only get a single replace call for smart replies with finished = true. We use this flag to not run the final replace for a composition
     // session, so for smart replies, we need to make sure to not send with this flag, so that we can be sure to do the animation for smart replies.
     if (session.compositionType == WritingTools::SessionCompositionType::SmartReply)
         finished = false;


### PR DESCRIPTION
#### 958f4375433b5c5cfad045340432774ca115e9a0
<pre>
[Writing Tools] Lists are sometimes erroneously preserved after performing a Rewrite
<a href="https://bugs.webkit.org/show_bug.cgi?id=279907">https://bugs.webkit.org/show_bug.cgi?id=279907</a>
<a href="https://rdar.apple.com/136234063">rdar://136234063</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

When rewriting some content that has lists within it, the tab characters preceding and succeeding the tab bullet
points mistakenly get the `WTWritingToolsPreserved` attribute applied to them. This is because currently, all elements
with `whitespace:pre` have the attribute added. However, tabs are unique because when inserting a tab character, WebKit
automatically generates a span and applies the `whitespace:pre` property to it.

Fix by checking for this special case and avoiding the attribute.

This fix also has the benefit of slightly improving the rewrite animations, since there are less partial replacements
involved now.

Also add a test.

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(elementQualifiesForWritingToolsPreservation):
(hasAncestorQualifyingForWritingToolsPreservation):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, CompositionWithTabCharacters)):

Canonical link: <a href="https://commits.webkit.org/283883@main">https://commits.webkit.org/283883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b075305bf220ba77ad699fb70a188304ecfab900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71674 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18758 "Build is in progress. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54152 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/18758 "Build is in progress. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15884 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73373 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11584 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15542 "Found 1 new test failure: fast/loader/stop-provisional-loads.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61596 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58547 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9456 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3071 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10285 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42806 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->