### PR TITLE
Add supported `text-wrap*` properties auto-completion support in Web Inspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -395,6 +395,9 @@ WI.CSSKeywordCompletions.InheritedProperties = new Set([
     "text-rendering",
     "text-shadow",
     "text-transform",
+    "text-wrap",
+    "text-wrap-mode",
+    "text-wrap-style",
     "visibility",
     "white-space",
     "widows",
@@ -1382,6 +1385,15 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
     ],
     "text-underline-width": [
         "normal", "medium", "auto", "thick", "thin", "calc()",
+    ],
+    "text-wrap": [
+        "wrap", "nowrap", "balance", "stable", 
+    ],
+    "text-wrap-mode": [
+        "wrap", "nowrap",
+    ],
+    "text-wrap-style": [
+        "auto", "balance", "stable",
     ],
     "transform-style": [
         "flat", "preserve-3d",


### PR DESCRIPTION
#### cb9a4af6b097967df7771ccf90ab916f4d1067df
<pre>
Add supported `text-wrap*` properties auto-completion support in Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=266391">https://bugs.webkit.org/show_bug.cgi?id=266391</a>
<a href="https://rdar.apple.com/136234779">rdar://136234779</a>

Reviewed by NOBODY (OOPS!).

This patch adds `text-wrap`, `text-wrap-mode` and `text-wrap-style` support for
auto-completion in Web Inspector for all supported except `pretty` since majority
of them are enabled since Safari 17.4

For case of `text-wrap: pretty`, the enablement is pending on webkit.org/b/279923.

* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb9a4af6b097967df7771ccf90ab916f4d1067df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71789 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54197 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15981 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73487 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61648 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61693 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9533 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3159 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42923 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->