### PR TITLE
Add `ruby-*` properties auto-completion support in Web Inspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -375,6 +375,9 @@ WI.CSSKeywordCompletions.InheritedProperties = new Set([
     "print-color-adjust",
     "quotes",
     "resize",
+    "ruby-align",
+    "ruby-overhang",
+    "ruby-position",
     "shape-rendering",
     "speak-as",
     "stroke",
@@ -1316,6 +1319,15 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
     ],
     "resize": [
         "none", "auto", "both", "horizontal", "vertical",
+    ],
+    "ruby-align": [
+        "start", "center", "space-between", "space-around",
+    ],
+    "ruby-overhang": [
+        "auto", "none",
+    ],
+    "ruby-position": [
+        "over", "under", "inter-character",
     ],
     "shape-rendering": [
         "auto", "optimizeSpeed", "geometricPrecision", "crispedges",


### PR DESCRIPTION
#### f84f31e4fb0eb58aa89fac5bc38dc68a2453d808
<pre>
Add `ruby-*` properties auto-completion support in Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=279915">https://bugs.webkit.org/show_bug.cgi?id=279915</a>
<a href="https://rdar.apple.com/136240293">rdar://136240293</a>

Reviewed by NOBODY (OOPS!).

This patch adds `ruby-position` (unprefixed), `ruby-align` and `ruby-overhang`
properties auto-completion support based on our current implementation in
Web Inspector.

We don&apos;t support `ruby-position: alternate` (based on CSSProperties.json),
so this just adds remaining implemented properties support.

* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f84f31e4fb0eb58aa89fac5bc38dc68a2453d808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71792 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54199 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15975 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17236 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11700 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15620 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-activesourcebuffers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61649 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61694 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3156 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->