### PR TITLE
Fix unexpected smart pointer static analyzer warnings in WebCore and WebKit

### DIFF
--- a/Source/WebCore/css/CSSFontFeatureValue.h
+++ b/Source/WebCore/css/CSSFontFeatureValue.h
@@ -42,6 +42,7 @@ public:
 
     const FontTag& tag() const { return m_tag; }
     const CSSPrimitiveValue& value() const { return m_value; }
+    Ref<CSSPrimitiveValue> protectedValue() const { return m_value; }
     String customCSSText() const;
 
     bool equals(const CSSFontFeatureValue&) const;

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.h
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.h
@@ -35,6 +35,7 @@ public:
     static Ref<CSSFontStyleWithAngleValue> create(Ref<CSSPrimitiveValue>&& obliqueAngle);
 
     const CSSPrimitiveValue& obliqueAngle() const { return m_obliqueAngle; }
+    Ref<CSSPrimitiveValue> protectedObliqueAngle() const { return m_obliqueAngle; }
 
     String customCSSText() const;
     bool equals(const CSSFontStyleWithAngleValue&) const;

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -40,6 +40,7 @@ public:
 
     const FontTag& tag() const { return m_tag; }
     const CSSPrimitiveValue& value() const { return m_value; }
+    Ref<CSSPrimitiveValue> protectedValue() const;
     String customCSSText() const;
 
     bool equals(const CSSFontVariationValue&) const;
@@ -53,8 +54,6 @@ public:
 
 private:
     CSSFontVariationValue(FontTag, Ref<CSSPrimitiveValue>&&);
-
-    Ref<CSSPrimitiveValue> protectedValue() const;
 
     FontTag m_tag;
     Ref<CSSPrimitiveValue> m_value;

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -188,7 +188,7 @@ FontSelectionValue fontStyleAngleFromCSSValue(const CSSValue& value, const CSSTo
 std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue& value)
 {
     if (auto* fontStyleValue = dynamicDowncast<CSSFontStyleWithAngleValue>(value))
-        return fontStyleAngleFromCSSValueDeprecated(fontStyleValue->obliqueAngle());
+        return fontStyleAngleFromCSSValueDeprecated(fontStyleValue->protectedObliqueAngle());
 
     auto valueID = value.valueID();
     if (valueID == CSSValueNormal)
@@ -201,7 +201,7 @@ std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue
 std::optional<FontSelectionValue> fontStyleFromCSSValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)
 {
     if (auto* fontStyleValue = dynamicDowncast<CSSFontStyleWithAngleValue>(value))
-        return fontStyleAngleFromCSSValue(fontStyleValue->obliqueAngle(), conversionData);
+        return fontStyleAngleFromCSSValue(fontStyleValue->protectedObliqueAngle(), conversionData);
 
     auto valueID = value.valueID();
     if (valueID == CSSValueNormal)
@@ -416,9 +416,9 @@ FontFeatureSettings fontFeatureSettingsFromCSSValue(const CSSValue& value, const
     }
 
     FontFeatureSettings settings;
-    for (auto& item : downcast<CSSValueList>(value)) {
-        auto& feature = downcast<CSSFontFeatureValue>(item);
-        settings.insert(FontFeature(feature.tag(), feature.value().resolveAsNumber<int>(conversionData)));
+    for (Ref item : downcast<CSSValueList>(value)) {
+        auto& feature = downcast<CSSFontFeatureValue>(item.get());
+        settings.insert(FontFeature(feature.tag(), feature.protectedValue()->resolveAsNumber<int>(conversionData)));
     }
     return settings;
 }
@@ -433,9 +433,9 @@ FontVariationSettings fontVariationSettingsFromCSSValue(const CSSValue& value, c
     }
 
     FontVariationSettings settings;
-    for (auto& item : downcast<CSSValueList>(value)) {
-        auto& feature = downcast<CSSFontVariationValue>(item);
-        settings.insert({ feature.tag(), feature.value().resolveAsNumber<float>(conversionData) });
+    for (Ref item : downcast<CSSValueList>(value)) {
+        auto& feature = downcast<CSSFontVariationValue>(item.get());
+        settings.insert({ feature.tag(), feature.protectedValue()->resolveAsNumber<float>(conversionData) });
     }
     return settings;
 }
@@ -465,11 +465,11 @@ FontSizeAdjust fontSizeAdjustFromCSSValue(const CSSValue& value, const CSSToLeng
         return FontCascadeDescription::initialFontSizeAdjust();
 
     auto metric = fromCSSValueID<FontSizeAdjust::Metric>(downcast<CSSPrimitiveValue>(pair->first()).valueID());
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(pair->second());
-    if (primitiveValue.isNumber())
-        return { metric, FontSizeAdjust::ValueType::Number, primitiveValue.resolveAsNumber(conversionData) };
+    Ref primitiveValue = downcast<CSSPrimitiveValue>(pair->second());
+    if (primitiveValue->isNumber())
+        return { metric, FontSizeAdjust::ValueType::Number, primitiveValue->resolveAsNumber(conversionData) };
 
-    ASSERT(primitiveValue.valueID() == CSSValueFromFont);
+    ASSERT(primitiveValue->valueID() == CSSValueFromFont);
     return { metric, FontSizeAdjust::ValueType::FromFont, std::nullopt };
 }
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
@@ -53,15 +53,15 @@ RemoteTextDetector::~RemoteTextDetector() = default;
 
 const SharedPreferencesForWebProcess& RemoteTextDetector::sharedPreferencesForWebProcess() const
 {
-    return m_backend->sharedPreferencesForWebProcess();
+    return protectedBackend()->sharedPreferencesForWebProcess();
 }
 
-Ref<WebCore::ShapeDetection::TextDetector> RemoteTextDetector::protectedBacking()
+Ref<WebCore::ShapeDetection::TextDetector> RemoteTextDetector::protectedBacking() const
 {
     return backing();
 }
 
-Ref<RemoteRenderingBackend> RemoteTextDetector::protectedBackend()
+Ref<RemoteRenderingBackend> RemoteTextDetector::protectedBackend() const
 {
     return m_backend.get();
 }

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -72,9 +72,9 @@ private:
     RemoteTextDetector& operator=(const RemoteTextDetector&) = delete;
     RemoteTextDetector& operator=(RemoteTextDetector&&) = delete;
 
-    WebCore::ShapeDetection::TextDetector& backing() { return m_backing; }
-    Ref<WebCore::ShapeDetection::TextDetector> protectedBacking();
-    Ref<RemoteRenderingBackend> protectedBackend();
+    WebCore::ShapeDetection::TextDetector& backing() const { return m_backing; }
+    Ref<WebCore::ShapeDetection::TextDetector> protectedBacking() const;
+    Ref<RemoteRenderingBackend> protectedBackend() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/Shared/Cocoa/WKNSArray.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSArray.mm
@@ -51,8 +51,13 @@
 
 - (id)objectAtIndex:(NSUInteger)i
 {
-    RefPtr object = _array->at(i);
+    RefPtr object = self._protectedArray->at(i);
     return object ? (id)object->wrapper() : [NSNull null];
+}
+
+- (RefPtr<API::Array>)_protectedArray
+{
+    return _array.get();
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
@@ -37,6 +37,11 @@ ResponsivenessTimer::ResponsivenessTimer(ResponsivenessTimer::Client& client, Se
 
 ResponsivenessTimer::~ResponsivenessTimer() = default;
 
+Ref<ResponsivenessTimer::Client> ResponsivenessTimer::protectedClient() const
+{
+    return m_client.get();
+}
+
 void ResponsivenessTimer::invalidate()
 {
     m_timer.stop();
@@ -119,7 +124,7 @@ bool ResponsivenessTimer::mayBecomeUnresponsive() const
     if (isLibgmallocEnabled)
         return false;
 
-    return m_client->mayBecomeUnresponsive();
+    return protectedClient()->mayBecomeUnresponsive();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -77,6 +77,8 @@ public:
     void processTerminated();
 
 private:
+    Ref<Client> protectedClient() const;
+
     void timerFired();
 
     bool mayBecomeUnresponsive() const;


### PR DESCRIPTION
#### d8110645bb86fc8679dcf52e4d41c7548bc102a1
<pre>
Fix unexpected smart pointer static analyzer warnings in WebCore and WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=279920">https://bugs.webkit.org/show_bug.cgi?id=279920</a>

Reviewed by Geoffrey Garen.

Fix unexpected smart pointer clang static analyzer warnings in WebCore and WebKit.

* Source/WebCore/css/CSSFontFeatureValue.h:
* Source/WebCore/css/CSSFontStyleWithAngleValue.h:
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontStyleFromCSSValueDeprecated):
(WebCore::Style::fontStyleFromCSSValue):
(WebCore::Style::fontFeatureSettingsFromCSSValue):
(WebCore::Style::fontVariationSettingsFromCSSValue):
(WebCore::Style::fontSizeAdjustFromCSSValue):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp:
(WebKit::RemoteTextDetector::sharedPreferencesForWebProcess const):
(WebKit::RemoteTextDetector::protectedBacking const):
(WebKit::RemoteTextDetector::protectedBackend const):
(WebKit::RemoteTextDetector::protectedBacking): Deleted.
(WebKit::RemoteTextDetector::protectedBackend): Deleted.
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h:
(WebKit::RemoteTextDetector::backing const):
(WebKit::RemoteTextDetector::backing): Deleted.
* Source/WebKit/Shared/Cocoa/WKNSArray.mm:
(-[WKNSArray objectAtIndex:]):
(-[WKNSArray _protectedArray]):
* Source/WebKit/UIProcess/ResponsivenessTimer.cpp:
(WebKit::ResponsivenessTimer::protectedClient const):
(WebKit::ResponsivenessTimer::mayBecomeUnresponsive const):
* Source/WebKit/UIProcess/ResponsivenessTimer.h:

Canonical link: <a href="https://commits.webkit.org/283889@main">https://commits.webkit.org/283889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60516a61292fffe1e996972d9926c1ef15ea22e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71727 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54166 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58524 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15929 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15575 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58592 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3113 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10289 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42858 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->