### PR TITLE
Handle non-provisional load failure with site isolation in PLT

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -57,7 +57,7 @@ private:
     void beforeStart() final;
 
     // FrameLoadStateObserver
-    void didFinishLoad(const URL&) final;
+    void didFinishLoad(IsMainFrame, const URL&) final;
 
     void appendRequestToLoad(URL&&, Supplement&&);
     void loadRequestToFrame();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -105,7 +105,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(span8(soAuthorizationPostDidStartMessageToParent)));
 }
 
-void SubFrameSOAuthorizationSession::didFinishLoad(const URL&)
+void SubFrameSOAuthorizationSession::didFinishLoad(IsMainFrame, const URL&)
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("didFinishLoad");
     RefPtr frame = WebFrameProxy::webFrame(m_frameID);

--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -93,9 +93,9 @@ void FrameLoadState::didFailProvisionalLoad()
     m_provisionalURL = { };
     m_unreachableURL = m_lastUnreachableURL;
 
-    m_observers.forEach([](FrameLoadStateObserver& observer) {
+    m_observers.forEach([&](FrameLoadStateObserver& observer) {
         observer.didCancelProvisionalLoad();
-        observer.didFailProvisionalLoad();
+        observer.didFailProvisionalLoad(m_unreachableURL);
     });
 }
 
@@ -122,7 +122,7 @@ void FrameLoadState::didFinishLoad()
     m_state = State::Finished;
 
     m_observers.forEach([&](FrameLoadStateObserver& observer) {
-        observer.didFinishLoad(m_url);
+        observer.didFinishLoad(m_isMainFrame, m_url);
     });
 }
 
@@ -132,6 +132,9 @@ void FrameLoadState::didFailLoad()
     ASSERT(m_provisionalURL.isEmpty());
 
     m_state = State::Finished;
+    m_observers.forEach([&](FrameLoadStateObserver& observer) {
+        observer.didFailLoad(m_url);
+    });
 }
 
 void FrameLoadState::didSameDocumentNotification(const URL& url)

--- a/Source/WebKit/UIProcess/FrameLoadState.h
+++ b/Source/WebKit/UIProcess/FrameLoadState.h
@@ -46,11 +46,12 @@ public:
     virtual ~FrameLoadStateObserver() = default;
     virtual void didReceiveProvisionalURL(const URL&) { }
     virtual void didStartProvisionalLoad(const URL&) { }
-    virtual void didFailProvisionalLoad() { }
+    virtual void didFailProvisionalLoad(const URL&) { }
+    virtual void didFailLoad(const URL&) { }
     virtual void didCancelProvisionalLoad() { }
     virtual void didCommitProvisionalLoad() { }
     virtual void didCommitProvisionalLoad(IsMainFrame) { }
-    virtual void didFinishLoad(const URL&) { }
+    virtual void didFinishLoad(IsMainFrame, const URL&) { }
 };
 
 class FrameLoadState {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6939,6 +6939,11 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
 
         callLoadCompletionHandlersIfNecessary(false);
     }
+
+    RefPtr process = dynamicDowncast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
+    RefPtr parentFrame = frame->parentFrame();
+    if (m_preferences->siteIsolationEnabled() && parentFrame && parentFrame->process().coreProcessIdentifier() != process->coreProcessIdentifier())
+        frame->notifyParentOfLoadCompletion(*process);
 }
 
 void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, SameDocumentNavigationType navigationType, URL&& url, const UserData& userData)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -163,16 +163,23 @@ private:
         m_loadingFrameCount++;
     }
 
-    void didFailProvisionalLoad() final
+    void didFailProvisionalLoad(const URL&) final
     {
         ASSERT(m_loadingFrameCount);
         m_loadingFrameCount--;
     }
 
-    void didFinishLoad(const URL&) final
+    void didFailLoad(const URL&) final
     {
         ASSERT(m_loadingFrameCount);
         m_loadingFrameCount--;
+    }
+
+    void didFinishLoad(IsMainFrame, const URL& url) final
+    {
+        ASSERT(m_loadingFrameCount);
+        m_loadingFrameCount--;
+        // FIXME: Assert that m_loadingFrameCount is zero if this is a main frame.
     }
 
     size_t m_loadingFrameCount { 0 };


### PR DESCRIPTION
#### 4b59b2e31035562e0a562820edec38c66c0448c2
<pre>
Handle non-provisional load failure with site isolation in PLT
<a href="https://bugs.webkit.org/show_bug.cgi?id=279921">https://bugs.webkit.org/show_bug.cgi?id=279921</a>
<a href="https://rdar.apple.com/136251106">rdar://136251106</a>

Reviewed by Ryosuke Niwa.

Most frame load failures are provisional load failures, but occasionally we get a non-provisional
load failure.  For various historical reasons, one of the ways this can be hit is if there&apos;s a
cross-site iframe loaded and the response of the main resource has this HTTP header:

Content-Security-Policy: frame-ancestors &apos;none&apos;

When that happens, it exposed two issues.  First, we were not notifying the parent frame of the
load completion, so the main frame&apos;s load event never happened.  Second, the new accounting of
the number of loading frames in PageLoadTimingFrameLoadStateObserver was not listening for
didFailLoad calls.  This PR fixes both, and I verified this fixes the subtest of PLT with site
isolation enabled.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::didFinishLoad):
* Source/WebKit/UIProcess/FrameLoadState.cpp:
(WebKit::FrameLoadState::didFailProvisionalLoad):
(WebKit::FrameLoadState::didFinishLoad):
(WebKit::FrameLoadState::didFailLoad):
* Source/WebKit/UIProcess/FrameLoadState.h:
(WebKit::FrameLoadStateObserver::didFailProvisionalLoad):
(WebKit::FrameLoadStateObserver::didFailLoad):
(WebKit::FrameLoadStateObserver::didFinishLoad):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailLoadForFrame):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, RedirectToCSP)):

Canonical link: <a href="https://commits.webkit.org/283886@main">https://commits.webkit.org/283886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c28188ab2c9dcee96a4b7e9f110132ad018332c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71734 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54167 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58529 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15934 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58597 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9500 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3118 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10287 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42866 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->