### PR TITLE
Adopt more smart pointers in LibWebRTCCodecsProxy, RemoteDisplayListRecorder, and RemoteDisplayListRecorderProxy

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBrush.h
+++ b/Source/WebCore/platform/graphics/SourceBrush.h
@@ -46,6 +46,7 @@ public:
 
     WEBCORE_EXPORT Gradient* gradient() const;
     WEBCORE_EXPORT Pattern* pattern() const;
+    RefPtr<Pattern> protectedPattern() const { return pattern(); }
     WEBCORE_EXPORT const AffineTransform& gradientSpaceTransform() const;
     WEBCORE_EXPORT std::optional<RenderingResourceIdentifier> gradientIdentifier() const;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -172,10 +172,10 @@ void RemoteDisplayListRecorder::setState(DisplayList::SetState&& item)
         return true;
     };
 
-    if (!fixPatternTileImage(item.state().fillBrush().pattern()) || !fixBrushGradient(item.state().fillBrush()))
+    if (!fixPatternTileImage(item.state().fillBrush().protectedPattern().get()) || !fixBrushGradient(item.state().fillBrush()))
         return;
 
-    if (!fixPatternTileImage(item.state().strokeBrush().pattern()) || !fixBrushGradient(item.state().strokeBrush()))
+    if (!fixPatternTileImage(item.state().strokeBrush().protectedPattern().get()) || !fixBrushGradient(item.state().strokeBrush()))
         return;
 
     handleItem(WTFMove(item));
@@ -265,15 +265,15 @@ void RemoteDisplayListRecorder::drawFilteredImageBufferInternal(std::optional<Re
     }
 
     for (auto& effect : filter.effectsOfType(FilterEffect::Type::FEImage)) {
-        auto& feImage = downcast<FEImage>(effect.get());
+        Ref feImage = downcast<FEImage>(effect.get());
 
-        auto effectImage = sourceImage(feImage.sourceImage().imageIdentifier());
+        auto effectImage = sourceImage(feImage->sourceImage().imageIdentifier());
         if (!effectImage) {
             ASSERT_NOT_REACHED();
             return;
         }
 
-        feImage.setImageSource(WTFMove(*effectImage));
+        feImage->setImageSource(WTFMove(*effectImage));
     }
 
     handleItem(DisplayList::DrawFilteredImageBuffer(sourceImageIdentifier, sourceImageRect, filter), sourceImageBuffer.get(), results);
@@ -337,7 +337,7 @@ void RemoteDisplayListRecorder::drawDecomposedGlyphs(RenderingResourceIdentifier
 
 void RemoteDisplayListRecorder::drawDisplayListItems(Vector<WebCore::DisplayList::Item>&& items, const FloatPoint& destination)
 {
-    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap(), controlFactory());
+    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap(), protectedControlFactory());
 }
 
 void RemoteDisplayListRecorder::drawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -610,7 +610,7 @@ void RemoteDisplayListRecorder::clearRect(const FloatRect& rect)
 
 void RemoteDisplayListRecorder::drawControlPart(Ref<ControlPart> part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style), controlFactory());
+    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style), protectedControlFactory());
 }
 
 #if USE(CG)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -150,7 +150,8 @@ private:
 
     RemoteResourceCache& resourceCache() const;
     WebCore::ControlFactory& controlFactory();
-    WebCore::GraphicsContext& drawingContext() { return m_imageBuffer->context(); }
+    Ref<WebCore::ControlFactory> protectedControlFactory() { return controlFactory(); }
+    WebCore::GraphicsContext& drawingContext() { return Ref { m_imageBuffer }->context(); }
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier) const;
     std::optional<WebCore::SourceImage> sourceImage(WebCore::RenderingResourceIdentifier) const;
 

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -79,6 +79,7 @@ private:
     auto createDecoderCallback(VideoDecoderIdentifier, bool useRemoteFrames, bool enableAdditionalLogging);
     std::unique_ptr<WebCore::WebRTCVideoDecoder> createLocalDecoder(VideoDecoderIdentifier, WebCore::VideoCodecType, bool useRemoteFrames, bool enableAdditionalLogging);
     WorkQueue& workQueue() const { return m_queue; }
+    Ref<WorkQueue> protectedWorkQueue() const { return m_queue; }
 
     // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -240,7 +240,7 @@ void LibWebRTCCodecsProxy::flushDecoder(VideoDecoderIdentifier identifier, Compl
     doDecoderTask(identifier, [&](auto& decoder) {
         decoder.webrtcDecoder->flush();
         // FIXME: It would be nice to ASSERT that when executing callback, the decoding task deque is empty.
-        workQueue().dispatch(WTFMove(completionHandler));
+        protectedWorkQueue()->dispatch(WTFMove(completionHandler));
     });
 }
 
@@ -499,7 +499,7 @@ void LibWebRTCCodecsProxy::flushEncoder(VideoEncoderIdentifier identifier, Compl
     if (auto* encoder = findEncoder(identifier))
         webrtc::flushLocalEncoder(encoder->webrtcEncoder);
     // FIXME: It would be nice to ASSERT that when executing callback, the encoding task deque is empty.
-    workQueue().dispatch(WTFMove(callback));
+    protectedWorkQueue()->dispatch(WTFMove(callback));
 }
 
 void LibWebRTCCodecsProxy::setEncodeRates(VideoEncoderIdentifier identifier, uint32_t bitRate, uint32_t frameRate, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -539,10 +539,10 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
 
 bool RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
 {
-    if (auto imageBuffer = image.imageBufferIfExists())
+    if (RefPtr imageBuffer = image.imageBufferIfExists())
         return recordResourceUse(*imageBuffer);
 
-    if (auto nativeImage = image.nativeImageIfExists())
+    if (RefPtr nativeImage = image.nativeImageIfExists())
         return recordResourceUse(*nativeImage);
 
     return true;


### PR DESCRIPTION
#### 90680d756766091c46b6a4d80f7d20388bcca87a
<pre>
Adopt more smart pointers in LibWebRTCCodecsProxy, RemoteDisplayListRecorder, and RemoteDisplayListRecorderProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=279926">https://bugs.webkit.org/show_bug.cgi?id=279926</a>
<a href="https://rdar.apple.com/136253336">rdar://136253336</a>

Reviewed by Chris Dumez and Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::SourceBrush::protectedPattern const):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setState):
(WebKit::RemoteDisplayListRecorder::drawFilteredImageBufferInternal):
(WebKit::RemoteDisplayListRecorder::drawDisplayListItems):
(WebKit::RemoteDisplayListRecorder::drawControlPart):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
(WebKit::RemoteDisplayListRecorder::protectedControlFactory):
(WebKit::RemoteDisplayListRecorder::drawingContext):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::flushDecoder):
(WebKit::LibWebRTCCodecsProxy::flushEncoder):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):

Canonical link: <a href="https://commits.webkit.org/283897@main">https://commits.webkit.org/283897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f0d8fa06698eb392f5c2d0ee45d49b34f24317a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71763 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54183 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58547 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15952 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61629 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58615 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3136 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10296 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42898 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->