### PR TITLE
[TZone] Update to export annotation for exported WebCore classes

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePayLogoSystemImage.h
+++ b/Source/WebCore/Modules/applepay/ApplePayLogoSystemImage.h
@@ -41,7 +41,7 @@ enum class ApplePayLogoStyle : bool {
 };
 
 class WEBCORE_EXPORT ApplePayLogoSystemImage final : public SystemImage {
-    WTF_MAKE_TZONE_ALLOCATED(ApplePayLogoSystemImage);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ApplePayLogoSystemImage, WEBCORE_EXPORT);
 public:
     static Ref<ApplePayLogoSystemImage> create(ApplePayLogoStyle applePayLogoStyle)
     {

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
@@ -51,7 +51,7 @@ public:
 };
 
 class WEBCORE_EXPORT LegacyCDM final {
-    WTF_MAKE_TZONE_ALLOCATED(LegacyCDM);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(LegacyCDM, WEBCORE_EXPORT);
 public:
     explicit LegacyCDM(const String& keySystem);
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
@@ -43,7 +43,7 @@ class IDBConnectionProxy;
 }
 
 class WEBCORE_EXPORT IDBDatabaseNameAndVersionRequest final : public ThreadSafeRefCounted<IDBDatabaseNameAndVersionRequest>, public IDBActiveDOMObject {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IDBDatabaseNameAndVersionRequest);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBDatabaseNameAndVersionRequest, WEBCORE_EXPORT);
 public:
     using InfoCallback = Function<void(std::optional<Vector<IDBDatabaseNameAndVersion>>&&)>;
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -61,7 +61,7 @@ namespace IDBClient {
 class IDBConnectionToServer;
 
 class WEBCORE_EXPORT IDBConnectionProxy final {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IDBConnectionProxy);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBConnectionProxy, WEBCORE_EXPORT);
 public:
     IDBConnectionProxy(IDBConnectionToServer&);
 

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.h
@@ -36,7 +36,7 @@ class MediaStreamPrivate;
 struct MediaRecorderPrivateOptions;
 
 class WEBCORE_EXPORT MediaRecorderProvider {
-    WTF_MAKE_TZONE_ALLOCATED(MediaRecorderProvider);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(MediaRecorderProvider, WEBCORE_EXPORT);
 public:
     MediaRecorderProvider() = default;
     virtual ~MediaRecorderProvider() = default;

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -43,7 +43,7 @@ class Model;
 class TransformationMatrix;
 
 class WEBCORE_EXPORT ModelPlayer : public RefCounted<ModelPlayer> {
-    WTF_MAKE_TZONE_ALLOCATED(ModelPlayer);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ModelPlayer, WEBCORE_EXPORT);
 public:
     virtual ~ModelPlayer();
 

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
@@ -34,7 +34,7 @@ class ModelPlayer;
 class ModelPlayerClient;
 
 class WEBCORE_EXPORT ModelPlayerProvider {
-    WTF_MAKE_TZONE_ALLOCATED(ModelPlayerProvider);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ModelPlayerProvider, WEBCORE_EXPORT);
 public:
     virtual ~ModelPlayerProvider();
 

--- a/Source/WebCore/Modules/reporting/Report.h
+++ b/Source/WebCore/Modules/reporting/Report.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class FormData;
 
 class WEBCORE_EXPORT Report : public RefCounted<Report> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Report);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(Report, WEBCORE_EXPORT);
 public:
     static Ref<Report> create(const String& type, const String& url, RefPtr<ReportBody>&&);
 

--- a/Source/WebCore/Modules/reporting/ReportBody.h
+++ b/Source/WebCore/Modules/reporting/ReportBody.h
@@ -33,7 +33,7 @@ namespace WebCore {
 enum class ViolationReportType : uint8_t;
 
 class WEBCORE_EXPORT ReportBody : public RefCounted<ReportBody> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ReportBody);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ReportBody, WEBCORE_EXPORT);
 public:
     virtual ~ReportBody();
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -45,7 +45,7 @@ class ReportingObserver;
 class ScriptExecutionContext;
 
 class WEBCORE_EXPORT ReportingScope final : public RefCounted<ReportingScope>, public ContextDestructionObserver, public CanMakeWeakPtr<ReportingScope> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ReportingScope);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ReportingScope, WEBCORE_EXPORT);
 public:
     static Ref<ReportingScope> create(ScriptExecutionContext&);
     virtual ~ReportingScope();

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -38,7 +38,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT SpeechSynthesisUtterance final : public PlatformSpeechSynthesisUtteranceClient, public RefCounted<SpeechSynthesisUtterance>, public ActiveDOMObject, public EventTarget {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SpeechSynthesisUtterance);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(SpeechSynthesisUtterance, WEBCORE_EXPORT);
 public:
     using UtteranceCompletionHandler = Function<void(const SpeechSynthesisUtterance&)>;
     static Ref<SpeechSynthesisUtterance> create(ScriptExecutionContext&, const String&, UtteranceCompletionHandler&&);

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -42,7 +42,7 @@ OBJC_CLASS CIContext;
 namespace WebCore {
 
 class WEBCORE_EXPORT ARKitBadgeSystemImage final : public SystemImage {
-    WTF_MAKE_TZONE_ALLOCATED(ARKitBadgeSystemImage);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ARKitBadgeSystemImage, WEBCORE_EXPORT);
 public:
     static Ref<ARKitBadgeSystemImage> create(Image& image)
     {

--- a/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
@@ -38,6 +38,8 @@
 namespace fido {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FidoHidPacket);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FidoHidInitPacket);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FidoHidContinuationPacket);
 
 FidoHidPacket::FidoHidPacket(Vector<uint8_t>&& data, uint32_t channelId)
     : m_data(WTFMove(data))

--- a/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.h
@@ -45,7 +45,7 @@ namespace fido {
 // FidoHidInitPacket cannot store the entire payload, further payload
 // information is stored in HidContinuationPackets.
 class WEBCORE_EXPORT FidoHidPacket {
-    WTF_MAKE_TZONE_ALLOCATED(FidoHidPacket);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(FidoHidPacket, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(FidoHidPacket);
 public:
     FidoHidPacket(Vector<uint8_t>&& data, uint32_t channelId);
@@ -69,6 +69,7 @@ protected:
 // is the length of the entire message payload, and the data is only the portion
 // of the payload that will fit into the HidInitPacket.
 class WEBCORE_EXPORT FidoHidInitPacket : public FidoHidPacket {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(FidoHidInitPacket, WEBCORE_EXPORT);
 public:
     // Creates a packet from the serialized data of an initialization packet. As
     // this is the first packet, the payload length of the entire message will be
@@ -93,6 +94,7 @@ private:
 // packet sequence will be the sequence number of this particular packet, from
 // 0x00 to 0x7f.
 class WEBCORE_EXPORT FidoHidContinuationPacket : public FidoHidPacket {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(FidoHidContinuationPacket, WEBCORE_EXPORT);
 public:
     // Creates a packet from the serialized data of a continuation packet. As an
     // HidInitPacket would have arrived earlier with the total payload size,

--- a/Source/WebCore/dom/StaticNodeList.h
+++ b/Source/WebCore/dom/StaticNodeList.h
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT StaticNodeList final : public NodeList {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(StaticNodeList);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(StaticNodeList, WEBCORE_EXPORT);
 public:
     static Ref<StaticNodeList> create(Vector<Ref<Node>>&& nodes = { })
     {

--- a/Source/WebCore/dom/TrustedHTML.h
+++ b/Source/WebCore/dom/TrustedHTML.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT TrustedHTML : public ScriptWrappable, public RefCounted<TrustedHTML> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TrustedHTML);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedHTML, WEBCORE_EXPORT);
 public:
     static Ref<TrustedHTML> create(const String& data);
     ~TrustedHTML() = default;

--- a/Source/WebCore/dom/TrustedScript.h
+++ b/Source/WebCore/dom/TrustedScript.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT TrustedScript final : public ScriptWrappable, public RefCounted<TrustedScript> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TrustedScript);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedScript, WEBCORE_EXPORT);
 public:
     static Ref<TrustedScript> create(const String& data);
     ~TrustedScript() = default;

--- a/Source/WebCore/dom/TrustedScriptURL.h
+++ b/Source/WebCore/dom/TrustedScriptURL.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT TrustedScriptURL : public ScriptWrappable, public RefCounted<TrustedScriptURL> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TrustedScriptURL);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedScriptURL, WEBCORE_EXPORT);
 public:
     static Ref<TrustedScriptURL> create(const String& data);
     ~TrustedScriptURL() = default;

--- a/Source/WebCore/fileapi/AsyncFileStream.h
+++ b/Source/WebCore/fileapi/AsyncFileStream.h
@@ -42,7 +42,7 @@ class FileStreamClient;
 class FileStream;
 
 class WEBCORE_EXPORT AsyncFileStream {
-    WTF_MAKE_TZONE_ALLOCATED(AsyncFileStream);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(AsyncFileStream, WEBCORE_EXPORT);
 public:
     explicit AsyncFileStream(FileStreamClient&);
     ~AsyncFileStream();

--- a/Source/WebCore/html/canvas/Path2D.h
+++ b/Source/WebCore/html/canvas/Path2D.h
@@ -37,7 +37,7 @@ namespace WebCore {
 struct DOMMatrix2DInit;
 
 class WEBCORE_EXPORT Path2D final : public RefCounted<Path2D>, public CanvasPath {
-    WTF_MAKE_TZONE_ALLOCATED(Path2D);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(Path2D, WEBCORE_EXPORT);
 public:
     virtual ~Path2D();
 

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -99,7 +99,7 @@ private:
 };
 
 class WEBCORE_EXPORT WebVTTParser final {
-    WTF_MAKE_TZONE_ALLOCATED(WebVTTParser);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(WebVTTParser, WEBCORE_EXPORT);
 public:
     enum ParseState {
         Initial,

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -54,7 +54,7 @@ class InspectorFrontendClientLocal : public InspectorFrontendClient {
     WTF_MAKE_NONCOPYABLE(InspectorFrontendClientLocal);
 public:
     class WEBCORE_EXPORT Settings {
-        WTF_MAKE_TZONE_ALLOCATED(Settings);
+        WTF_MAKE_TZONE_ALLOCATED_EXPORT(Settings, WEBCORE_EXPORT);
     public:
         Settings() = default;
         virtual ~Settings() = default;

--- a/Source/WebCore/platform/NowPlayingManager.h
+++ b/Source/WebCore/platform/NowPlayingManager.h
@@ -52,7 +52,7 @@ public:
 };
 
 class WEBCORE_EXPORT NowPlayingManager : public RemoteCommandListenerClient {
-    WTF_MAKE_TZONE_ALLOCATED(NowPlayingManager);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(NowPlayingManager, WEBCORE_EXPORT);
 public:
     NowPlayingManager();
     ~NowPlayingManager();

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -64,7 +64,7 @@ protected:
 };
 
 class WEBCORE_EXPORT PlatformSpeechSynthesizer : public RefCounted<PlatformSpeechSynthesizer> {
-    WTF_MAKE_TZONE_ALLOCATED(PlatformSpeechSynthesizer);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlatformSpeechSynthesizer, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<PlatformSpeechSynthesizer> create(PlatformSpeechSynthesizerClient&);
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -35,7 +35,7 @@ namespace WebCore {
 using AcceleratedEffects = Vector<Ref<AcceleratedEffect>>;
 
 class WEBCORE_EXPORT AcceleratedEffectStack : public RefCounted<AcceleratedEffectStack> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AcceleratedEffectStack);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(AcceleratedEffectStack, WEBCORE_EXPORT);
 public:
     static Ref<AcceleratedEffectStack> create();
 

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -101,7 +101,7 @@ public:
 };
 
 class WEBCORE_EXPORT AudioSession {
-    WTF_MAKE_TZONE_ALLOCATED(AudioSession);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(AudioSession, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(AudioSession);
     friend class UniqueRef<AudioSession>;
     friend UniqueRef<AudioSession> WTF::makeUniqueRefWithoutFastMallocCheck<AudioSession>();

--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -34,7 +34,7 @@ namespace WebCore {
 WEBCORE_EXPORT bool operator==(const AudioStreamBasicDescription&, const AudioStreamBasicDescription&);
 
 class WEBCORE_EXPORT CAAudioStreamDescription final : public AudioStreamDescription {
-    WTF_MAKE_TZONE_ALLOCATED(CAAudioStreamDescription);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(CAAudioStreamDescription, WEBCORE_EXPORT);
 public:
     CAAudioStreamDescription(const AudioStreamBasicDescription&);
     CAAudioStreamDescription(double, uint32_t, PCMFormat, bool);

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
@@ -47,7 +47,7 @@ class Logger;
 namespace WebCore {
 
 class WEBCORE_EXPORT SharedRoutingArbitratorToken : public CanMakeWeakPtr<SharedRoutingArbitratorToken> {
-    WTF_MAKE_TZONE_ALLOCATED(SharedRoutingArbitratorToken);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SharedRoutingArbitratorToken, WEBCORE_EXPORT);
 public:
     static UniqueRef<SharedRoutingArbitratorToken> create();
     const void* logIdentifier() const;

--- a/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.h
+++ b/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.h
@@ -39,7 +39,7 @@ class GeolocationPositionData;
 class RegistrableDomain;
 
 class WEBCORE_EXPORT CoreLocationGeolocationProvider {
-    WTF_MAKE_TZONE_ALLOCATED(CoreLocationGeolocationProvider);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(CoreLocationGeolocationProvider, WEBCORE_EXPORT);
 public:
     class Client {
     public:

--- a/Source/WebCore/platform/graphics/MIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class ContentType;
 
 class WEBCORE_EXPORT MIMETypeCache {
-    WTF_MAKE_TZONE_ALLOCATED(MIMETypeCache);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(MIMETypeCache, WEBCORE_EXPORT);
 public:
     MIMETypeCache() = default;
     virtual ~MIMETypeCache() = default;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -336,7 +336,7 @@ public:
 };
 
 class WEBCORE_EXPORT MediaPlayer : public MediaPlayerEnums, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayer, WTF::DestructionThread::Main> {
-    WTF_MAKE_TZONE_ALLOCATED(MediaPlayer);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(MediaPlayer, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(MediaPlayer);
 public:
     static Ref<MediaPlayer> create(MediaPlayerClient&);

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -43,7 +43,7 @@ enum class AddTimeRangeOption : uint8_t {
 };
 
 class WEBCORE_EXPORT PlatformTimeRanges final {
-    WTF_MAKE_TZONE_ALLOCATED(PlatformTimeRanges);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlatformTimeRanges, WEBCORE_EXPORT);
 public:
     PlatformTimeRanges();
     PlatformTimeRanges(const MediaTime& start, const MediaTime& end);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -47,7 +47,7 @@ namespace WebCore {
 enum class VideoFrameRotation : uint16_t;
 
 class WEBCORE_EXPORT LocalSampleBufferDisplayLayer final : public SampleBufferDisplayLayer {
-    WTF_MAKE_TZONE_ALLOCATED(LocalSampleBufferDisplayLayer);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(LocalSampleBufferDisplayLayer, WEBCORE_EXPORT);
 public:
     static RefPtr<LocalSampleBufferDisplayLayer> create(SampleBufferDisplayLayerClient&);
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT ImageBufferIOSurfaceBackend : public ImageBufferCGBackend {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ImageBufferIOSurfaceBackend);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ImageBufferIOSurfaceBackend, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(ImageBufferIOSurfaceBackend);
 public:
     static IntSize calculateSafeBackendSize(const Parameters&);

--- a/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h
+++ b/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h
@@ -44,7 +44,7 @@ enum class AppKitControlSystemImageType : uint8_t {
 };
 
 class WEBCORE_EXPORT AppKitControlSystemImage : public SystemImage {
-    WTF_MAKE_TZONE_ALLOCATED(AppKitControlSystemImage);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(AppKitControlSystemImage, WEBCORE_EXPORT);
 public:
     virtual ~AppKitControlSystemImage() = default;
 

--- a/Source/WebCore/platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.h
+++ b/Source/WebCore/platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT ScrollbarTrackCornerSystemImageMac final : public AppKitControlSystemImage {
-    WTF_MAKE_TZONE_ALLOCATED(ScrollbarTrackCornerSystemImageMac);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollbarTrackCornerSystemImageMac, WEBCORE_EXPORT);
 public:
     static Ref<ScrollbarTrackCornerSystemImageMac> create();
     static Ref<ScrollbarTrackCornerSystemImageMac> create(WebCore::Color&& tintColor, bool useDarkAppearance);

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit final : public PlaybackSessionInterfaceIOS {
-    WTF_MAKE_TZONE_ALLOCATED(PlaybackSessionInterfaceAVKit);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlaybackSessionInterfaceAVKit, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceAVKit);
 public:
     static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel&);

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -55,7 +55,7 @@ class WEBCORE_EXPORT PlaybackSessionInterfaceIOS
     : public PlaybackSessionModelClient
     , public RefCounted<PlaybackSessionInterfaceIOS>
     , public CanMakeCheckedPtr<PlaybackSessionInterfaceIOS> {
-    WTF_MAKE_TZONE_ALLOCATED(PlaybackSessionInterfaceIOS);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlaybackSessionInterfaceIOS, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceIOS);
 public:
     void initialize();

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -46,7 +46,7 @@ class WEBCORE_EXPORT PlaybackSessionInterfaceMac final
     : public PlaybackSessionModelClient
     , public RefCounted<PlaybackSessionInterfaceMac>
     , public CanMakeCheckedPtr<PlaybackSessionInterfaceMac> {
-    WTF_MAKE_TZONE_ALLOCATED(PlaybackSessionInterfaceMac);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlaybackSessionInterfaceMac, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceMac);
 public:
     static Ref<PlaybackSessionInterfaceMac> create(PlaybackSessionModel&);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
@@ -39,7 +39,7 @@ class MediaStreamTrackPrivate;
 
 class WEBCORE_EXPORT MediaRecorderPrivateMock final
     : public MediaRecorderPrivate {
-    WTF_MAKE_TZONE_ALLOCATED(MediaRecorderPrivateMock);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(MediaRecorderPrivateMock, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivateMock);
 public:
     explicit MediaRecorderPrivateMock(MediaStreamPrivate&);

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
@@ -42,7 +42,7 @@ class LibWebRTCAudioModule;
 class PlatformAudioData;
 
 class WEBCORE_EXPORT AudioMediaStreamTrackRenderer : public LoggerHelper {
-    WTF_MAKE_TZONE_ALLOCATED(AudioMediaStreamTrackRenderer);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(AudioMediaStreamTrackRenderer, WEBCORE_EXPORT);
 public:
     struct Init {
         Function<void()>&& crashCallback;

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.h
@@ -46,7 +46,7 @@ struct MediaDecodingConfiguration;
 struct MediaEncodingConfiguration;
 
 class WEBCORE_EXPORT WebRTCProvider {
-    WTF_MAKE_TZONE_ALLOCATED(WebRTCProvider);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(WebRTCProvider, WEBCORE_EXPORT);
 public:
     static UniqueRef<WebRTCProvider> create();
     WebRTCProvider() = default;

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -67,7 +67,7 @@ class RegistrableDomain;
 struct PeerConnectionFactoryAndThreads;
 
 class WEBCORE_EXPORT LibWebRTCProvider : public WebRTCProvider {
-    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCProvider);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(LibWebRTCProvider, WEBCORE_EXPORT);
 public:
     static UniqueRef<LibWebRTCProvider> create();
 

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -51,7 +51,7 @@ struct PolicyContainer;
 
 // BlobRegistryImpl is not thread-safe. It should only be called from main thread.
 class WEBCORE_EXPORT BlobRegistryImpl {
-    WTF_MAKE_TZONE_ALLOCATED(BlobRegistryImpl);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(BlobRegistryImpl, WEBCORE_EXPORT);
 public:
     virtual ~BlobRegistryImpl();
 

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -47,7 +47,7 @@ namespace WebCore {
 
 // Use eager initialization for the WeakPtrFactory since we construct WeakPtrs on a non-main thread.
 class WEBCORE_EXPORT CookieStorageObserver : public CanMakeWeakPtr<CookieStorageObserver, WeakPtrFactoryInitialization::Eager> {
-    WTF_MAKE_TZONE_ALLOCATED(CookieStorageObserver);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(CookieStorageObserver, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(CookieStorageObserver);
 public:
     explicit CookieStorageObserver(NSHTTPCookieStorage *);

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "MediaRecorderProvider.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_RECORDER) && PLATFORM(COCOA)
 
@@ -33,11 +34,14 @@
 #include <WebCore/MediaRecorderPrivate.h>
 #include <WebCore/Page.h>
 #include <WebCore/Settings.h>
-#include <wtf/TZoneMallocInlines.h>
+
+#endif // ENABLE(MEDIA_RECORDER) && PLATFORM(COCOA)
 
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaRecorderProvider);
+
+#if ENABLE(MEDIA_RECORDER) && PLATFORM(COCOA)
 
 using namespace WebCore;
 
@@ -51,6 +55,6 @@ std::unique_ptr<WebCore::MediaRecorderPrivate> MediaRecorderProvider::createMedi
     return WebCore::MediaRecorderProvider::createMediaRecorderPrivate(stream, options);
 }
 
-}
-
 #endif // ENABLE(MEDIA_RECORDER) && PLATFORM(COCOA)
+
+}


### PR DESCRIPTION
#### 98298c2126a1e78cc6e8f768a1f2076974864214
<pre>
[TZone] Update to export annotation for exported WebCore classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=279924">https://bugs.webkit.org/show_bug.cgi?id=279924</a>
<a href="https://rdar.apple.com/136253091">rdar://136253091</a>

Reviewed by David Degazio.

Changed the TZone annotations for WEBCORE_EXPORT&apos;ed classes from WTF_MAKE_TZONE_ALLOCATED annotations to
WTF_MAKE_TZONE_ALLOCATED_EXPORT annotations and similar changes for the other flavors of *_TZONE_ALLOCATED
annotations.

Also fixed the #ifdef&apos;ing of WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp to match the #ifdef&apos;ing
of Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp, its super class.

* Source/WebCore/Modules/applepay/ApplePayLogoSystemImage.h:
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h:
* Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.h:
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerProvider.h:
* Source/WebCore/Modules/reporting/Report.h:
* Source/WebCore/Modules/reporting/ReportBody.h:
* Source/WebCore/Modules/reporting/ReportingScope.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h:
* Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp:
* Source/WebCore/Modules/webauthn/fido/FidoHidPacket.h:
* Source/WebCore/dom/StaticNodeList.h:
* Source/WebCore/dom/TrustedHTML.h:
* Source/WebCore/dom/TrustedScript.h:
* Source/WebCore/dom/TrustedScriptURL.h:
* Source/WebCore/fileapi/AsyncFileStream.h:
* Source/WebCore/html/canvas/Path2D.h:
* Source/WebCore/html/track/WebVTTParser.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/platform/NowPlayingManager.h:
* Source/WebCore/platform/PlatformSpeechSynthesizer.h:
* Source/WebCore/platform/animation/AcceleratedEffectStack.h:
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h:
* Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.h:
* Source/WebCore/platform/graphics/MIMETypeCache.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h:
* Source/WebCore/platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h:
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h:
* Source/WebCore/platform/mediastream/WebRTCProvider.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
* Source/WebCore/platform/network/BlobRegistryImpl.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp:

Canonical link: <a href="https://commits.webkit.org/283967@main">https://commits.webkit.org/283967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6d58e04d7d35359c17a96e9588368351820d927

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54178 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11660 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15594 "Found 2 new test failures: fast/loader/subframe-navigate-during-main-frame-load.html http/tests/resourceLoadStatistics/no-third-party-cookie-blocking-when-itp-is-off.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61630 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html imported/w3c/web-platform-tests/pointerevents/coalesced_events_attributes_under_load.https.optional.html?mouse (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61677 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3132 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->