### PR TITLE
[EWS] pre-existing failures in macOS - ASSERTION FAILED: didRemove in Source/WebKit/UIProcess/WebPageProxy

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8084,14 +8084,3 @@ imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/global-mutable-prototy
 # Below tests give `Error fetching /interfaces/webidl.idl` in test output
 imported/w3c/web-platform-tests/WebIDL/idlharness.any.html [ Skip ]
 imported/w3c/web-platform-tests/WebIDL/idlharness.any.worker.html [ Skip ]
-
-# https://bugs.webkit.org/show_bug.cgi?id=279917 ([EWS] pre-existing failures in macOS - ASSERTION FAILED: didRemove in Source/WebKit/UIProcess/WebPageProxy (279917))
-fast/loader/stop-provisional-loads.html [ Skip ]
-http/tests/contentextensions/block-cookies-in-image-load-in-onunload.html [ Skip ]
-http/tests/navigation/image-load-in-pagehide-handler.html [ Skip ]
-http/tests/navigation/image-load-in-unload-handler.html [ Skip ]
-http/wpt/beacon/sendBeacon-in-pagehide.html [ Skip ]
-http/wpt/fetch/fetch-in-pagehide.html [ Skip ]
-imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/report-only-from-unsafe-none.https.html [ Skip ]
-imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/report-only-same-origin-report-to.https.html [ Skip ]
-imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/report-only-same-origin.https.html [ Skip ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6652,7 +6652,8 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame()) {
         internals().pageLoadState.didCommitLoad(transaction, certificateInfo, markPageInsecure, usedLegacyTLS, wasPrivateRelayed, frameInfo.securityOrigin);
         m_shouldSuppressNextAutomaticNavigationSnapshot = false;
-        m_framesWithSubresourceLoadingForPageLoadTiming.clear();
+        if (m_preferences->siteIsolationEnabled())
+            m_framesWithSubresourceLoadingForPageLoadTiming.clear();
     } else if (markPageInsecure)
         internals().pageLoadState.didDisplayOrRunInsecureContent(transaction);
 


### PR DESCRIPTION
#### e22cd14e006661575f4314395eb67ef2e5a6276d
<pre>
[EWS] pre-existing failures in macOS - ASSERTION FAILED: didRemove in Source/WebKit/UIProcess/WebPageProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=279917">https://bugs.webkit.org/show_bug.cgi?id=279917</a>
<a href="https://rdar.apple.com/136245139">rdar://136245139</a>

Reviewed by Ryosuke Niwa.

One of the things I said in 283819@main applies only with site isolation on.
With site isolation off we do get the WebPageProxy::didDestroyFrame message for
each destroyed frame and we should not clear the m_framesWithSubresourceLoadingForPageLoadTiming
because we will receive a message saying to remove each frame, and we want to continue
to assert that those removals each correspond with an addition.

* LayoutTests/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):

Canonical link: <a href="https://commits.webkit.org/283887@main">https://commits.webkit.org/283887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7d9a54868689dd50426e62ee8b58b754fb96634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71754 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18647 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58546 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15951 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17199 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58614 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/9520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10288 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/42889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/43965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/45152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/43704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->