### PR TITLE
[TZone] Annotate the subclass tree of SVGAttributeAnimator

### DIFF
--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SVGAttributeAnimator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -33,6 +34,7 @@ class SVGElement;
 
 template<typename AnimatedProperty, typename AnimationFunction>
 class SVGAnimatedPropertyAnimator : public SVGAttributeAnimator {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedPropertyAnimator);
 public:
     using AnimatorAnimatedProperty = AnimatedProperty;
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
@@ -31,6 +31,7 @@
 #include "SVGAnimationAdditiveListFunctionImpl.h"
 #include "SVGAnimationAdditiveValueFunctionImpl.h"
 #include "SVGAnimationDiscreteFunctionImpl.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -42,6 +43,7 @@ template<typename AnimatedPropertyAnimator1, typename AnimatedPropertyAnimator2>
 class SVGAnimatedPropertyPairAnimator;
 
 class SVGAnimatedAngleAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedAngle, SVGAnimationAngleFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedAngleAnimator);
     friend class SVGAnimatedPropertyPairAnimator<SVGAnimatedAngleAnimator, SVGAnimatedOrientTypeAnimator>;
     friend class SVGAnimatedAngleOrientAnimator;
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedAngle, SVGAnimationAngleFunction>;
@@ -61,6 +63,7 @@ private:
 };
 
 class SVGAnimatedBooleanAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedBoolean, SVGAnimationBooleanFunction>  {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedBooleanAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedBoolean, SVGAnimationBooleanFunction>;
 
 public:
@@ -81,6 +84,7 @@ private:
 
 template<typename EnumType>
 class SVGAnimatedEnumerationAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedEnumeration, SVGAnimationEnumerationFunction<EnumType>> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedEnumerationAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedEnumeration, SVGAnimationEnumerationFunction<EnumType>>;
     using Base::Base;
     using Base::m_animated;
@@ -102,6 +106,7 @@ private:
 };
 
 class SVGAnimatedIntegerAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedInteger, SVGAnimationIntegerFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedIntegerAnimator);
     friend class SVGAnimatedPropertyPairAnimator<SVGAnimatedIntegerAnimator, SVGAnimatedIntegerAnimator>;
     friend class SVGAnimatedIntegerPairAnimator;
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedInteger, SVGAnimationIntegerFunction>;
@@ -122,6 +127,7 @@ private:
 };
 
 class SVGAnimatedLengthAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedLength, SVGAnimationLengthFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedLengthAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedLength, SVGAnimationLengthFunction>;
 
 public:
@@ -143,6 +149,7 @@ private:
 };
 
 class SVGAnimatedLengthListAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedLengthList, SVGAnimationLengthListFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedLengthListAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedLengthList, SVGAnimationLengthListFunction>;
 
 public:
@@ -164,6 +171,7 @@ private:
 };
 
 class SVGAnimatedNumberAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedNumber, SVGAnimationNumberFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedNumberAnimator);
     friend class SVGAnimatedPropertyPairAnimator<SVGAnimatedNumberAnimator, SVGAnimatedNumberAnimator>;
     friend class SVGAnimatedNumberPairAnimator;
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedNumber, SVGAnimationNumberFunction>;
@@ -183,6 +191,7 @@ private:
 };
 
 class SVGAnimatedNumberListAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedNumberList, SVGAnimationNumberListFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedNumberListAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedNumberList, SVGAnimationNumberListFunction>;
     using Base::Base;
     
@@ -200,6 +209,7 @@ private:
 };
 
 class SVGAnimatedPathSegListAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedPathSegList, SVGAnimationPathSegListFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedPathSegListAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedPathSegList, SVGAnimationPathSegListFunction>;
     using Base::Base;
 
@@ -218,6 +228,7 @@ private:
 };
 
 class SVGAnimatedPointListAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedPointList, SVGAnimationPointListFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedPointListAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedPointList, SVGAnimationPointListFunction>;
     using Base::Base;
     
@@ -235,6 +246,7 @@ private:
 };
 
 class SVGAnimatedOrientTypeAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedOrientType, SVGAnimationOrientTypeFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedOrientTypeAnimator);
     friend class SVGAnimatedPropertyPairAnimator<SVGAnimatedAngleAnimator, SVGAnimatedOrientTypeAnimator>;
     friend class SVGAnimatedAngleOrientAnimator;
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedOrientType, SVGAnimationOrientTypeFunction>;
@@ -256,6 +268,7 @@ private:
 };
 
 class SVGAnimatedPreserveAspectRatioAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedPreserveAspectRatio, SVGAnimationPreserveAspectRatioFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedPreserveAspectRatioAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedPreserveAspectRatio, SVGAnimationPreserveAspectRatioFunction>;
     using Base::Base;
 
@@ -274,6 +287,7 @@ private:
 };
 
 class SVGAnimatedRectAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedRect, SVGAnimationRectFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedRectAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedRect, SVGAnimationRectFunction>;
 
 public:
@@ -292,6 +306,7 @@ private:
 };
 
 class SVGAnimatedStringAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedString, SVGAnimationStringFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedStringAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedString, SVGAnimationStringFunction>;
     using Base::Base;
 
@@ -332,6 +347,7 @@ private:
 };
 
 class SVGAnimatedTransformListAnimator final : public SVGAnimatedPropertyAnimator<SVGAnimatedTransformList, SVGAnimationTransformListFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedTransformListAnimator);
     using Base = SVGAnimatedPropertyAnimator<SVGAnimatedTransformList, SVGAnimationTransformListFunction>;
     using Base::Base;
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SVGAttributeAnimator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -33,6 +34,7 @@ class SVGElement;
 
 template<typename AnimatedPropertyAnimator1, typename AnimatedPropertyAnimator2>
 class SVGAnimatedPropertyPairAnimator : public SVGAttributeAnimator {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGAnimatedPropertyPairAnimator);
 public:
     using AnimatedProperty1 = typename AnimatedPropertyAnimator1::AnimatorAnimatedProperty;
     using AnimatedProperty2 = typename AnimatedPropertyAnimator2::AnimatorAnimatedProperty;

--- a/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
@@ -28,11 +28,13 @@
 #include "SVGPropertyAnimator.h"
 #include "SVGPropertyTraits.h"
 #include "SVGValueProperty.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 template<typename PropertyType, typename AnimationFunction>
 class SVGPrimitivePropertyAnimator : public SVGPropertyAnimator<AnimationFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPrimitivePropertyAnimator);
     using Base = SVGPropertyAnimator<AnimationFunction>;
     using ValuePropertyType = SVGValueProperty<PropertyType>;
     using Base::Base;

--- a/Source/WebCore/svg/properties/SVGPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimator.h
@@ -29,11 +29,13 @@
 #include "ComputedStyleExtractor.h"
 #include "SVGAttributeAnimator.h"
 #include "SVGElement.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
     
 template<typename AnimationFunction>
 class SVGPropertyAnimator : public SVGAttributeAnimator {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGPropertyAnimator);
 public:
     bool isDiscrete() const override { return m_function.isDiscrete(); }
 

--- a/Source/WebCore/svg/properties/SVGValuePropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyAnimator.h
@@ -26,11 +26,13 @@
 #pragma once
 
 #include "SVGPropertyAnimator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 template<typename PropertyType, typename AnimationFunction>
 class SVGValuePropertyAnimator : public SVGPropertyAnimator<AnimationFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGValuePropertyAnimator);
     using Base = SVGPropertyAnimator<AnimationFunction>;
     using Base::Base;
     using Base::applyAnimatedStylePropertyChange;

--- a/Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h
@@ -26,11 +26,13 @@
 #pragma once
 
 #include "SVGPropertyAnimator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 template<typename ListType, typename AnimationFunction>
 class SVGValuePropertyListAnimator : public SVGPropertyAnimator<AnimationFunction> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SVGValuePropertyListAnimator);
     using Base = SVGPropertyAnimator<AnimationFunction>;
     using Base::Base;
     using Base::applyAnimatedStylePropertyChange;


### PR DESCRIPTION
#### 55979f46d9a6ddbd5608517a3bc9e3f2feaf6c32
<pre>
[TZone] Annotate the subclass tree of SVGAttributeAnimator
<a href="https://bugs.webkit.org/show_bug.cgi?id=279928">https://bugs.webkit.org/show_bug.cgi?id=279928</a>
<a href="https://rdar.apple.com/136254664">rdar://136254664</a>

Reviewed by David Degazio.

TZone annotated the derived class tree of SVGAttributeAnimator.  Given that these subclasses are
fully implemented in .h files, used the WTF_MAKE_TZONE_ALLOCATED_INLINE annotation.

* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimator.h:
* Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h:
* Source/WebCore/svg/properties/SVGPropertyAnimator.h:
* Source/WebCore/svg/properties/SVGValuePropertyAnimator.h:
* Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h:

Canonical link: <a href="https://commits.webkit.org/283968@main">https://commits.webkit.org/283968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2ef2f33298791b33ac3fd1018779401cc2e8a5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54194 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12604 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3149 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42916 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->