### PR TITLE
[TZone] Fixup annotations for RemoteXRView

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
@@ -34,7 +34,7 @@
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
 #include <WebCore/WebGPUXRView.h>
-#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
@@ -34,6 +34,7 @@
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
@@ -64,7 +65,7 @@ class ObjectHeap;
 }
 
 class RemoteXRView final : public IPC::StreamMessageReceiver {
-    WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteXRView);
+    WTF_MAKE_TZONE_ALLOCATED(RemoteXRView);
 public:
     static Ref<RemoteXRView> create(WebCore::WebGPU::XRView& xrView, WebGPU::ObjectHeap& objectHeap, RemoteGPU& gpu, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
     {


### PR DESCRIPTION
#### 184126c66aa21f19335fc2d14018a34995138074
<pre>
[TZone] Fixup annotations for RemoteXRView
<a href="https://bugs.webkit.org/show_bug.cgi?id=279935">https://bugs.webkit.org/show_bug.cgi?id=279935</a>
<a href="https://rdar.apple.com/136256202">rdar://136256202</a>

Reviewed by David Degazio and Mike Wyrzykowski.

The class declaration in RemoteXRView.h needs to include wtf/TZoneMalloc.h and the class needs to be annotated with
WTF_MAKE_TZONE_ALLOCATED.  The definition in RemoteXRView.cpp needs to include wtf/TZoneMallocInlines.h for the
TZone directive, WTF_MAKE_TZONE_ALLOCATED_IMPL, that is already properly in the file.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h:

Canonical link: <a href="https://commits.webkit.org/283966@main">https://commits.webkit.org/283966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64df2e1bb52c07582ea865d2ebbc169c262874ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18853 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54182 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39855 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11675 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15600 "Found 1 new test failure: fast/loader/subframe-navigate-during-main-frame-load.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61634 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-fit-fill.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-has-scrollbars.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61681 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3148 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42901 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->