### PR TITLE
Reduce IPInt register usage and support JITless calls

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-implicit-return.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-implicit-return.js
@@ -4,9 +4,7 @@ import * as assert from "../assert.js"
 let wat = `
 (module
     (func (export "test") (result i32)
-        (v128.const i32x4 2 3 4 5)
-        (i32x4.extract_lane 0)
-        (return)
+        (i32.const 5)
     )
 )
 `
@@ -14,7 +12,7 @@ let wat = `
 async function test() {
     const instance = await instantiate(wat, {});
     const { test } = instance.exports
-    assert.eq(test(), 2)
+    assert.eq(test(), 5)
 }
 
 await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-simd-i32-params.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-simd-i32-params.js
@@ -3,9 +3,13 @@ import * as assert from "../assert.js"
 
 let wat = `
 (module
-    (func (export "test") (result i32)
+    (func (export "test") (param i32) (param i32) (result i32)
         (v128.const i32x4 2 3 4 5)
-        (i32x4.extract_lane 0)
+        (i32x4.extract_lane 2)
+        (local.get 0)
+        (local.get 1)
+        (i32.div_s)
+        (i32.add)
         (return)
     )
 )
@@ -14,7 +18,7 @@ let wat = `
 async function test() {
     const instance = await instantiate(wat, {});
     const { test } = instance.exports
-    assert.eq(test(), 2)
+    assert.eq(test(0, 2), 4)
 }
 
 await assert.asyncTest(test())

--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -123,6 +123,7 @@ LLINT_DECLARE_ROUTINE_VALIDATE(fuzzer_return_early_from_loop_hint);
 LLINT_DECLARE_ROUTINE_VALIDATE(js_to_wasm_wrapper_entry);
 LLINT_DECLARE_ROUTINE_VALIDATE(wasm_to_wasm_wrapper_entry);
 LLINT_DECLARE_ROUTINE_VALIDATE(wasm_to_js_wrapper_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_trampoline);
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 #define LLINT_OP_EXTRAS(validateLabel) bitwise_cast<void*>(validateLabel)
@@ -181,6 +182,7 @@ static LLIntOperations llintOperations()
             LLINT_ROUTINE(js_to_wasm_wrapper_entry)
             LLINT_ROUTINE(wasm_to_wasm_wrapper_entry)
             LLINT_ROUTINE(wasm_to_js_wrapper_entry)
+            LLINT_ROUTINE(ipint_trampoline)
 
             LLINT_OP(op_catch)
             LLINT_OP(wasm_catch)

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1490,6 +1490,7 @@ op :wasm_function_prologue_simd
 op :js_to_wasm_wrapper_entry
 op :wasm_to_wasm_wrapper_entry
 op :wasm_to_js_wrapper_entry
+op :ipint_trampoline
 
 op :js_trampoline_op_call
 op :js_trampoline_op_call_ignore_result

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -22,98 +22,135 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# IPInt: the WASM in-place interpreter
-# DISCLAIMER: not tested on x86 yet (as of 05 Jul 2023); IPInt may break *very* badly.
+# IPInt: the Wasm in-place interpreter
 #
-# docs by Daniel Liu <daniel_liu4@apple.com / danlliu@umich.edu>; 2023 intern project
+# docs by Daniel Liu <daniel_liu4@apple.com>; started as a 2023 intern project
 #
-# 0. OfflineASM:
-# --------------
-#
-# For a crash course on OfflineASM, check out LowLevelInterpreter.asm.
-#
-# 1. Code Structure
-# -----------------
-#
-# IPInt is designed to start up quickly and interpret WASM code efficiently. To optimize for speed, we utilize a jump
-# table, using the opcode's first byte as an offset. This jump table is set up in _ipint_setup. 
-# For more complex opcodes (ex. SIMD), we define additional jump tables that utilize further bytes as indices.
-#
-# 2. Setting Up
-# -------------
-#
-# Before we can execute WebAssembly, we have to handle the call frame that is given to us. This is handled in _ipint_entry.
-# We start by saving registers to the stack as per the system calling convention. Then, we have IPInt specific logic:
-#
-# 2.1. Locals
-# -----------
-#
-# To ensure that we are able to access local variables quickly, we allocate a section of the stack to store local variables.
-# We allocate 8 bytes for each local variable on the stack.
-#
-# Additionally, we need to load the parameters to the function into local variables. As per the calling convention, arguments
-# are passed via registers, and then on the stack if all argument registers have been exhausted. Thus, we need to handle those
-# cases. We keep track of the number of arguments in IPIntCallee, allowing us to know exactly where to load arguments from.
-#
-# Finally, we set the value of the `PL` (pointer to locals) register to the position of the first local. This allows us to quickly
-# index into locals.
-#
-# 2.2. Bytecode and Metadata
-# --------------------------
-#
-# The final step before executing is to load the bytecode to execute, as well as the metadata. For an explanation of why we use
-# metadata in IPInt, check out WasmIPIntGenerator.cpp. We load these into registers `PB` (pointer to bytecode) and `PM` (pointer
-# to metadata). Additionally, registers `PC` (program counter) and `MC` (metadata counter) are set to 0.
-#
-# 3. Executing WebAssembly
-# ------------------------
-#
-# WebAssembly execution revolves around a stack machine, which we run on the program stack. We work with the constraint
-# that the stack must be 16B aligned by ensuring that pushes and pops are always 16B. This makes certain opcodes (ex. drop)
-# much easier as well.
-#
-# For each instruction, we align its assembly to a 256B boundary. Thus, we can take (address of instruction 0) + opcode * 256
-# to find the exact point where we need to jump for each opcode without any dependent loads.
-#
-# 4. Returning
-# ------------
-#
-# To return values to the caller, IPInt uses the standard WebAssembly calling convention. Return values are passed in the
-# system return registers, and on the stack if not possible. After this, we perform cleanup logic to reset the stack to its
-# original state, and return to the caller.
+# Contents:
+# 0. Documentation comments
+# 1. Interpreter definitions
+#   1.1: Register definitions
+#   1.2: Constant definitions
+# 2. Core interpreter macros
+# 3. Helper interpreter macros
+# 4. Interpreter entrypoints
+# 5. Instruction implementation
 #
 
-#################################
-# Register and Size Definitions #
-#################################
+##############################
+# 1. Interpreter definitions #
+##############################
 
-# PC = t4
-if X86_64 or ARM64 or ARM64E or RISCV64
-    const MC = t5  # Metadata counter (index into metadata)
-    const PL = t6  # Pointer to locals (index into locals)
-elsif ARMv7
-    const MC = t6
-    const PL = t7
-else
-    const MC = invalidGPR
-    const PL = invalidGPR
-end
-const PM = metadataTable
+# -------------------------
+# 1.1: Register definitions
+# -------------------------
+
+# IPInt uses a number of core registers which store the interpreter's state:
+# - PC: (Program Counter) IPInt's program counter. This records the interpreter's position in Wasm bytecode.
+# - MC: (Metadata Counter) IPInt's metadata pointer. This records the corresponding position in generated metadata.
+# - WI: (Wasm Instance) pointer to the current JSWebAssemblyInstance object. This is used for accessing
+#       function-specific data.
+# - PL: (Pointer to Locals) pointer to the address of local 0 in the current function. This is used for accessing
+#       locals quickly.
+# - MB: (Memory Base) pointer to the current Wasm memory base address.
+# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking.
+#
+# Additionally, there are a few registers that are optionally supported for optimization:
+# - IB: (Instruction Base) pointer to the address of the `unreachable` (0x00) label, removing the need to reload
+#       this address at every dispatch.
+# - HR: (Hoist Register) used for hoisting the load of the next opcode in Wasm instructions with low register
+#       pressure, helping reduce the impact of load misses.
+#
+# Finally, we provide four "sc" (safe for call) registers which are guaranteed to not overlap with argument
+# registers (sc0, sc1, sc2, sc3)
 
 if ARM64 or ARM64E
-    const IB = t7  # instruction base
+    const PC = csr7
+    const MC = csr6
+    const WI = csr0
+    const PL = t6
+    const MB = csr3
+    const BC = csr4
+
+    const IB = t7
+    const HR = t3
+
+    const sc0 = ws0
+    const sc1 = ws1
+    const sc2 = ws2
+    const sc3 = ws3
+elsif X86_64
+    const PC = csr2
+    const MC = csr1
+    const WI = csr0
+    const PL = t6
+    const MB = csr3
+    const BC = csr4
+
+    const IB = invalidGPR
+    const HR = invalidGPR
+
+    const sc0 = t0
+    const sc1 = t4
+    const sc2 = t7
+    const sc3 = t5
+elsif RISCV64
+    const PC = csr7
+    const MC = csr6
+    const WI = csr0
+    const PL = csr10
+    const MB = csr3
+    const BC = csr4
+
+    const IB = invalidGPR
+    const HR = invalidGPR
+
+    const sc0 = ws0
+    const sc1 = ws1
+    const sc2 = csr9
+    const sc3 = csr10
+elsif ARMv7
+    const PC = csr1
+    const MC = t6
+    const WI = csr0
+    const PL = t7
+    const MB = invalidGPR
+    const BC = invalidGPR
+
+    const IB = invalidGPR
+    const HR = invalidGPR
+
+    const sc0 = t4
+    const sc1 = t5
+    const sc2 = t6
+    const sc3 = t7
+else
+    const PC = invalidGPR
+    const MC = invalidGPR
+    const WI = invalidGPR
+    const PL = invalidGPR
+    const MB = invalidGPR
+    const BC = invalidGPR
+
+    const IB = invalidGPR
+    const HR = invalidGPR
+
+    const sc0 = invalidGPR
+    const sc1 = invalidGPR
+    const sc2 = invalidGPR
+    const sc3 = invalidGPR
 end
 
-# TODO: SIMD support, since locals will need double the space. Can we do it only sometimes?
-# May just need to write metadata that rewrites offsets. May be worth the space savings.
-# Actually, what if we just use the same thing but have a SIMD section separately allocated that
-# is "pointed" to by the 8B entries on the stack? Easier and we only need to allocate SIMD when we need
-# instead of blowing up the stack. Argument copying a little trickier though.
+# -------------------------
+# 1.2: Constant definitions
+# -------------------------
 
 const PtrSize = constexpr (sizeof(void*))
 const MachineRegisterSize = constexpr (sizeof(CPURegister))
 const SlotSize = constexpr (sizeof(Register))
-const LocalSize = SlotSize
+
+# amount of memory a local takes up on the stack (16 bytes for a v128)
+const LocalSize = 16
 const StackValueSize = 16
 
 const wasmInstance = csr0
@@ -127,17 +164,44 @@ end
 
 const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfIPIntCalleeSaveRegisters * SlotSize - MachineRegisterSize
 
-##########
-# Macros #
-##########
-
-# Callee Save
-
 # FIXME: This happens to work because UnboxedWasmCalleeStackSlot sits in the extra space we should be more precise in case we want to use an even number of callee saves in the future.
-const IPIntCalleeSaveSpaceStackAligned = 2*CalleeSaveSpaceStackAligned
+const IPIntCalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfIPIntCalleeSaveRegisters + constexpr Wasm::numberOfIPIntInternalRegisters
+const IPIntCalleeSaveSpaceStackAligned = (IPIntCalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
+const IPIntCalleeSaveSpaceStackAligned = 2*IPIntCalleeSaveSpaceStackAligned
+
+# ---------------------------
+# 1.2: Optional optimizations
+# ---------------------------
+
+macro IfIPIntUsesIB(m)
+    if ARM64 or ARM64E
+        m()
+    end
+end
+
+macro IfIPIntUsesHR(m, m2)
+    if ARM64 or ARM64E
+        m()
+    else
+        m2()
+    end
+end
+
+macro HoistNextOpcode(offset)
+    IfIPIntUsesHR(macro()
+        loadb offset[PC], HR
+    end, macro() end)
+end
+
+##############################
+# 2. Core interpreter macros #
+##############################
+
+# -----------------------------------
+# 2.1: Core interpreter functionality
+# -----------------------------------
 
 # Get IPIntCallee object at startup
-
 macro getIPIntCallee()
     loadp Callee[cfr], ws0
 if JSVALUE64
@@ -150,7 +214,6 @@ end
 end
 
 # Tail-call dispatch
-
 macro advancePC(amount)
     addp amount, PC
 end
@@ -168,7 +231,6 @@ macro advanceMCByReg(amount)
 end
 
 # Typed push/pop to make code pretty
-
 macro pushFloat32FT0()
     pushFPR()
 end
@@ -201,6 +263,51 @@ macro popFloat64FT1()
     popFPR1()
 end
 
+macro decodeLEBVarUInt32(offset, dst, scratch1, scratch2, scratch3, scratch4)
+    # if it's a single byte, fastpath it
+    const tempPC = scratch4
+    leap offset[PC], tempPC
+    loadb [tempPC], dst
+
+    bbb dst, 0x80, .fastpath
+    # otherwise, set up for second iteration
+    # next shift is 7
+    move 7, scratch1
+    # take off high bit
+    subi 0x80, dst
+.loop:
+    addp 1, tempPC
+    loadb [tempPC], scratch2
+    # scratch3 = high bit 7
+    # leave scratch2 with low bits 6-0
+    move 0x80, scratch3
+    andi scratch2, scratch3
+    xori scratch3, scratch2
+    lshifti scratch1, scratch2
+    addi 7, scratch1
+    ori scratch2, dst
+    bbneq scratch3, 0, .loop
+.fastpath:
+end
+
+macro checkStackOverflow(callee, scratch)
+    loadi Wasm::IPIntCallee::m_maxFrameSizeInV128[callee], scratch
+    lshiftp 4, scratch
+    subp cfr, scratch, scratch
+
+    bpa scratch, cfr, .stackOverflow
+    bpbeq JSWebAssemblyInstance::m_softStackLimit[wasmInstance], scratch, .stackHeightOK
+
+.stackOverflow:
+    ipintException(StackOverflow)
+
+.stackHeightOK:
+end
+
+# ----------------------
+# 2.2: Code organization
+# ----------------------
+
 # Instruction labels
 # Important Note: If you don't use the unaligned global label from C++ (in our case we use the
 # labels in InPlaceInterpreter.cpp) then some linkers will still remove the definition which
@@ -227,8 +334,11 @@ macro reservedOpcode(opcode)
     unimplementedInstruction(_reserved_%opcode%)
 end
 
-# Memory
+# ---------------------------------------
+# 2.3: Interacting with the outside world
+# ---------------------------------------
 
+# Memory
 macro ipintReloadMemory()
     if ARM64 or ARM64E
         loadpairq JSWebAssemblyInstance::m_cachedMemory[wasmInstance], memoryBase, boundsCheckingSize
@@ -274,14 +384,12 @@ macro operationCallMayThrow(fn)
 end
 
 # Exception handling
-
 macro ipintException(exception)
     storei constexpr Wasm::ExceptionType::%exception%, ArgumentCountIncludingThis + PayloadOffset[cfr]
     jmp _wasm_throw_from_slow_path_trampoline
 end
 
 # OSR
-
 macro ipintPrologueOSR(increment)
 if JIT and not ARMv7
     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
@@ -404,38 +512,9 @@ if JIT and not ARMv7
 end
 end
 
-
-
-macro decodeLEBVarUInt32(offset, dst, scratch1, scratch2, scratch3, scratch4)
-    # if it's a single byte, fastpath it
-    const tempPC = scratch4
-    leap offset[PC], tempPC
-    loadb [PB, tempPC], dst
-
-    bbb dst, 0x80, .fastpath
-    # otherwise, set up for second iteration
-    # next shift is 7
-    move 7, scratch1
-    # take off high bit
-    subi 0x80, dst
-.loop:
-    addp 1, tempPC
-    loadb [PB, tempPC], scratch2
-    # scratch3 = high bit 7
-    # leave scratch2 with low bits 6-0
-    move 0x80, scratch3
-    andi scratch2, scratch3
-    xori scratch3, scratch2
-    lshifti scratch1, scratch2
-    addi 7, scratch1
-    ori scratch2, dst
-    bbneq scratch3, 0, .loop
-.fastpath:
-end
-
-########################
-# In-Place Interpreter #
-########################
+################################
+# 3. Helper interpreter macros #
+################################
 
 macro argumINTAlign(instrname)
     aligned _ipint_argumINT%instrname%_validate 64
@@ -455,22 +534,13 @@ macro uintAlign(instrname)
     _uint%instrname%:
 end
 
-macro checkStackOverflow(callee, scratch)
-    loadi Wasm::IPIntCallee::m_maxFrameSizeInV128[callee], scratch
-    lshiftp 4, scratch
-    subp cfr, scratch, scratch
-
-    bpa scratch, cfr, .stackOverflow
-    bpbeq JSWebAssemblyInstance::m_softStackLimit[wasmInstance], scratch, .stackHeightOK
-
-.stackOverflow:
-    ipintException(StackOverflow)
-
-.stackHeightOK:
-end
+##############################
+# 4. Interpreter entrypoints #
+##############################
 
 global _ipint_entry
 _ipint_entry:
+.ipint_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     preserveCallerPCAndCFR()
     saveIPIntRegisters()
@@ -492,13 +562,11 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 
     move sp, PL
 
-    if ARM64 or ARM64E
+    IfIPIntUsesIB(macro ()
         pcrtoaddr _ipint_unreachable, IB
-    end
-    loadp Wasm::IPIntCallee::m_bytecode[ws0], PB
-    move 0, PC
-    loadp Wasm::IPIntCallee::m_metadata[ws0], PM
-    move 0, MC
+    end)
+    loadp Wasm::IPIntCallee::m_bytecode[ws0], PC
+    loadp Wasm::IPIntCallee::m_metadata[ws0], MC
     # Load memory
     ipintReloadMemory()
 
@@ -521,77 +589,6 @@ else
     ret
 end
 
-global _ipint_entry_simd
-_ipint_entry_simd:
-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
-    preserveCallerPCAndCFR()
-    saveIPIntRegisters()
-    storep wasmInstance, CodeBlock[cfr]
-    getIPIntCallee()
-
-    checkStackOverflow(ws0, csr3)
-
-    # Allocate space for locals and rethrow values
-    if ARM64 or ARM64E
-        loadpairi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], csr0, csr3
-    else
-        loadi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], csr0
-        loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], csr3
-    end
-    addq csr3, csr0
-    mulq LocalSize, csr0
-    move sp, csr3
-    subq csr0, sp
-    move sp, csr4
-    loadp Wasm::IPIntCallee::m_argumINTBytecodePointer[ws0], PM
-
-    push csr0, csr1, csr2, csr3
-
-    # PM = location in argumINT bytecode
-    # csr0 = tmp
-    # csr1 = dst
-    # csr2 = src
-    # csr3 = end
-    # csr4 = for dispatch
-
-const argumINTDest = csr1
-const argumINTSrc = csr2
-    move csr4, argumINTDest
-    leap FirstArgumentOffset[cfr], argumINTSrc
-
-    argumINTDispatch()
-
-.ipint_entry_end_local_simd:
-    # zero out remaining locals
-    bqeq argumINTDest, csr3, .ipint_entry_finish_zero_simd
-    storeq 0, [argumINTDest]
-    addq 8, argumINTDest
-
-    jmp .ipint_entry_end_local_simd
-.ipint_entry_finish_zero_simd:
-    pop csr3, csr2, csr1, csr0
-
-    loadp CodeBlock[cfr], wasmInstance
-    # OSR Check
-    ipintPrologueOSR(5)
-
-    move sp, PL
-
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
-    loadp Wasm::IPIntCallee::m_bytecode[ws0], PB
-    move 0, PC
-    loadp Wasm::IPIntCallee::m_metadata[ws0], PM
-    move 0, MC
-    # Load memory
-    ipintReloadMemory()
-
-    nextIPIntInstruction()
-else
-    break
-end
-
 macro ipintCatchCommon()
     getVMFromCallFrame(t3, t0)
     restoreCalleeSavesFromVMEntryFrameCalleeSavesBuffer(t3, t0)
@@ -608,8 +605,10 @@ macro ipintCatchCommon()
     if ARM64 or ARM64E
         pcrtoaddr _ipint_unreachable, IB
     end
-    loadp Wasm::IPIntCallee::m_bytecode[ws0], PB
-    loadp Wasm::IPIntCallee::m_metadata[ws0], PM
+    loadp Wasm::IPIntCallee::m_bytecode[ws0], t0
+    loadp Wasm::IPIntCallee::m_metadata[ws0], t1
+    addp t0, PC
+    addp t1, MC
 
     # Recompute PL
     if ARM64 or ARM64E
@@ -619,12 +618,11 @@ macro ipintCatchCommon()
         loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], t1
     end
     addq t1, t0
-    # FIXME: Can this be an leaq?
     mulq LocalSize, t0
     addq IPIntCalleeSaveSpaceStackAligned, t0
     subq cfr, t0, PL
 
-    loadi [PM, MC], t0
+    loadi [MC], t0
     # 1 << 4 == StackValueSize
     lshiftq 4, t0
     addq IPIntCalleeSaveSpaceStackAligned, t0
@@ -665,17 +663,23 @@ else
     break
 end
 
-# Value-representation-specific code.
+# Trampoline entrypoints
+
+op(ipint_trampoline, macro ()
+    tagReturnAddress sp
+    jmp .ipint_entry
+end)
+
+#################################
+# 5. Instruction implementation #
+#################################
+
 if JSVALUE64 and (ARM64 or ARM64E or X86_64)
     include InPlaceInterpreter64
 elsif ARMv7
     include InPlaceInterpreter32_64
 else
 # For unimplemented architectures: make sure that the assertions can still find the labels
-
-    #############################
-    # 0x00 - 0x11: control flow #
-    #############################
 
 unimplementedInstruction(_unreachable)
 unimplementedInstruction(_nop)
@@ -709,11 +713,6 @@ unimplementedInstruction(_select_t)
 reservedOpcode(0x1d)
 reservedOpcode(0x1e)
 reservedOpcode(0x1f)
-
-    ###################################
-    # 0x20 - 0x26: get and set values #
-    ###################################
-
 unimplementedInstruction(_local_get)
 unimplementedInstruction(_local_set)
 unimplementedInstruction(_local_tee)
@@ -747,20 +746,10 @@ unimplementedInstruction(_i64_store16_mem)
 unimplementedInstruction(_i64_store32_mem)
 unimplementedInstruction(_memory_size)
 unimplementedInstruction(_memory_grow)
-
-    ################################
-    # 0x41 - 0x44: constant values #
-    ################################
-
 unimplementedInstruction(_i32_const)
 unimplementedInstruction(_i64_const)
 unimplementedInstruction(_f32_const)
 unimplementedInstruction(_f64_const)
-
-    ###############################
-    # 0x45 - 0x4f: i32 comparison #
-    ###############################
-
 unimplementedInstruction(_i32_eqz)
 unimplementedInstruction(_i32_eq)
 unimplementedInstruction(_i32_ne)
@@ -772,11 +761,6 @@ unimplementedInstruction(_i32_le_s)
 unimplementedInstruction(_i32_le_u)
 unimplementedInstruction(_i32_ge_s)
 unimplementedInstruction(_i32_ge_u)
-
-    ###############################
-    # 0x50 - 0x5a: i64 comparison #
-    ###############################
-
 unimplementedInstruction(_i64_eqz)
 unimplementedInstruction(_i64_eq)
 unimplementedInstruction(_i64_ne)
@@ -788,33 +772,18 @@ unimplementedInstruction(_i64_le_s)
 unimplementedInstruction(_i64_le_u)
 unimplementedInstruction(_i64_ge_s)
 unimplementedInstruction(_i64_ge_u)
-
-    ###############################
-    # 0x5b - 0x60: f32 comparison #
-    ###############################
-
 unimplementedInstruction(_f32_eq)
 unimplementedInstruction(_f32_ne)
 unimplementedInstruction(_f32_lt)
 unimplementedInstruction(_f32_gt)
 unimplementedInstruction(_f32_le)
 unimplementedInstruction(_f32_ge)
-
-    ###############################
-    # 0x61 - 0x66: f64 comparison #
-    ###############################
-
 unimplementedInstruction(_f64_eq)
 unimplementedInstruction(_f64_ne)
 unimplementedInstruction(_f64_lt)
 unimplementedInstruction(_f64_gt)
 unimplementedInstruction(_f64_le)
 unimplementedInstruction(_f64_ge)
-
-    ###############################
-    # 0x67 - 0x78: i32 operations #
-    ###############################
-
 unimplementedInstruction(_i32_clz)
 unimplementedInstruction(_i32_ctz)
 unimplementedInstruction(_i32_popcnt)
@@ -833,11 +802,6 @@ unimplementedInstruction(_i32_shr_s)
 unimplementedInstruction(_i32_shr_u)
 unimplementedInstruction(_i32_rotl)
 unimplementedInstruction(_i32_rotr)
-
-    ###############################
-    # 0x79 - 0x8a: i64 operations #
-    ###############################
-
 unimplementedInstruction(_i64_clz)
 unimplementedInstruction(_i64_ctz)
 unimplementedInstruction(_i64_popcnt)
@@ -856,11 +820,6 @@ unimplementedInstruction(_i64_shr_s)
 unimplementedInstruction(_i64_shr_u)
 unimplementedInstruction(_i64_rotl)
 unimplementedInstruction(_i64_rotr)
-
-    ###############################
-    # 0x8b - 0x98: f32 operations #
-    ###############################
-
 unimplementedInstruction(_f32_abs)
 unimplementedInstruction(_f32_neg)
 unimplementedInstruction(_f32_ceil)
@@ -875,11 +834,6 @@ unimplementedInstruction(_f32_div)
 unimplementedInstruction(_f32_min)
 unimplementedInstruction(_f32_max)
 unimplementedInstruction(_f32_copysign)
-
-    ###############################
-    # 0x99 - 0xa6: f64 operations #
-    ###############################
-
 unimplementedInstruction(_f64_abs)
 unimplementedInstruction(_f64_neg)
 unimplementedInstruction(_f64_ceil)
@@ -894,11 +848,6 @@ unimplementedInstruction(_f64_div)
 unimplementedInstruction(_f64_min)
 unimplementedInstruction(_f64_max)
 unimplementedInstruction(_f64_copysign)
-
-    ############################
-    # 0xa7 - 0xc4: conversions #
-    ############################
-
 unimplementedInstruction(_i32_wrap_i64)
 unimplementedInstruction(_i32_trunc_f32_s)
 unimplementedInstruction(_i32_trunc_f32_u)
@@ -940,11 +889,6 @@ reservedOpcode(0xcc)
 reservedOpcode(0xcd)
 reservedOpcode(0xce)
 reservedOpcode(0xcf)
-
-    #####################
-    # 0xd0 - 0xd2: refs #
-    #####################
-
 unimplementedInstruction(_ref_null_t)
 unimplementedInstruction(_ref_is_null)
 unimplementedInstruction(_ref_func)
@@ -995,7 +939,7 @@ unimplementedInstruction(_atomic)
 reservedOpcode(0xff)
 
     #######################
-    ## 0xFC instructions ##
+    ## 0xfc instructions ##
     #######################
 
 unimplementedInstruction(_i32_trunc_sat_f32_s)
@@ -1021,7 +965,6 @@ unimplementedInstruction(_table_fill)
     ## SIMD Instructions ##
     #######################
 
-# 0xFD 0x00 - 0xFD 0x0B: memory
 unimplementedInstruction(_simd_v128_load_mem)
 unimplementedInstruction(_simd_v128_load_8x8s_mem)
 unimplementedInstruction(_simd_v128_load_8x8u_mem)
@@ -1034,11 +977,7 @@ unimplementedInstruction(_simd_v128_load16_splat_mem)
 unimplementedInstruction(_simd_v128_load32_splat_mem)
 unimplementedInstruction(_simd_v128_load64_splat_mem)
 unimplementedInstruction(_simd_v128_store_mem)
-
-# 0xFD 0x0C: v128.const
 unimplementedInstruction(_simd_v128_const)
-
-# 0xFD 0x0D - 0xFD 0x14: splat (+ shuffle/swizzle)
 unimplementedInstruction(_simd_i8x16_shuffle)
 unimplementedInstruction(_simd_i8x16_swizzle)
 unimplementedInstruction(_simd_i8x16_splat)
@@ -1047,15 +986,12 @@ unimplementedInstruction(_simd_i32x4_splat)
 unimplementedInstruction(_simd_i64x2_splat)
 unimplementedInstruction(_simd_f32x4_splat)
 unimplementedInstruction(_simd_f64x2_splat)
-
-# 0xFD 0x15 - 0xFD 0x22: extract and replace lanes
 unimplementedInstruction(_simd_i8x16_extract_lane_s)
 unimplementedInstruction(_simd_i8x16_extract_lane_u)
 unimplementedInstruction(_simd_i8x16_replace_lane)
 unimplementedInstruction(_simd_i16x8_extract_lane_s)
 unimplementedInstruction(_simd_i16x8_extract_lane_u)
 unimplementedInstruction(_simd_i16x8_replace_lane)
-
 unimplementedInstruction(_simd_i32x4_extract_lane)
 unimplementedInstruction(_simd_i32x4_replace_lane)
 unimplementedInstruction(_simd_i64x2_extract_lane)
@@ -1064,8 +1000,6 @@ unimplementedInstruction(_simd_f32x4_extract_lane)
 unimplementedInstruction(_simd_f32x4_replace_lane)
 unimplementedInstruction(_simd_f64x2_extract_lane)
 unimplementedInstruction(_simd_f64x2_replace_lane)
-
-# 0xFD 0x23 - 0xFD 0x2C: i8x16 operations
 unimplementedInstruction(_simd_i8x16_eq)
 unimplementedInstruction(_simd_i8x16_ne)
 unimplementedInstruction(_simd_i8x16_lt_s)
@@ -1076,8 +1010,6 @@ unimplementedInstruction(_simd_i8x16_le_s)
 unimplementedInstruction(_simd_i8x16_le_u)
 unimplementedInstruction(_simd_i8x16_ge_s)
 unimplementedInstruction(_simd_i8x16_ge_u)
-
-# 0xFD 0x2D - 0xFD 0x36: i8x16 operations
 unimplementedInstruction(_simd_i16x8_eq)
 unimplementedInstruction(_simd_i16x8_ne)
 unimplementedInstruction(_simd_i16x8_lt_s)
@@ -1088,8 +1020,6 @@ unimplementedInstruction(_simd_i16x8_le_s)
 unimplementedInstruction(_simd_i16x8_le_u)
 unimplementedInstruction(_simd_i16x8_ge_s)
 unimplementedInstruction(_simd_i16x8_ge_u)
-
-# 0xFD 0x37 - 0xFD 0x40: i32x4 operations
 unimplementedInstruction(_simd_i32x4_eq)
 unimplementedInstruction(_simd_i32x4_ne)
 unimplementedInstruction(_simd_i32x4_lt_s)
@@ -1100,24 +1030,18 @@ unimplementedInstruction(_simd_i32x4_le_s)
 unimplementedInstruction(_simd_i32x4_le_u)
 unimplementedInstruction(_simd_i32x4_ge_s)
 unimplementedInstruction(_simd_i32x4_ge_u)
-
-# 0xFD 0x41 - 0xFD 0x46: f32x4 operations
 unimplementedInstruction(_simd_f32x4_eq)
 unimplementedInstruction(_simd_f32x4_ne)
 unimplementedInstruction(_simd_f32x4_lt)
 unimplementedInstruction(_simd_f32x4_gt)
 unimplementedInstruction(_simd_f32x4_le)
 unimplementedInstruction(_simd_f32x4_ge)
-
-# 0xFD 0x47 - 0xFD 0x4c: f64x2 operations
 unimplementedInstruction(_simd_f64x2_eq)
 unimplementedInstruction(_simd_f64x2_ne)
 unimplementedInstruction(_simd_f64x2_lt)
 unimplementedInstruction(_simd_f64x2_gt)
 unimplementedInstruction(_simd_f64x2_le)
 unimplementedInstruction(_simd_f64x2_ge)
-
-# 0xFD 0x4D - 0xFD 0x53: v128 operations
 unimplementedInstruction(_simd_v128_not)
 unimplementedInstruction(_simd_v128_and)
 unimplementedInstruction(_simd_v128_andnot)
@@ -1125,8 +1049,6 @@ unimplementedInstruction(_simd_v128_or)
 unimplementedInstruction(_simd_v128_xor)
 unimplementedInstruction(_simd_v128_bitselect)
 unimplementedInstruction(_simd_v128_any_true)
-
-# 0xFD 0x54 - 0xFD 0x5D: v128 load/store lane
 unimplementedInstruction(_simd_v128_load8_lane_mem)
 unimplementedInstruction(_simd_v128_load16_lane_mem)
 unimplementedInstruction(_simd_v128_load32_lane_mem)
@@ -1137,12 +1059,8 @@ unimplementedInstruction(_simd_v128_store32_lane_mem)
 unimplementedInstruction(_simd_v128_store64_lane_mem)
 unimplementedInstruction(_simd_v128_load32_zero_mem)
 unimplementedInstruction(_simd_v128_load64_zero_mem)
-
-# 0xFD 0x5E - 0xFD 0x5F: f32x4/f64x2 conversion
 unimplementedInstruction(_simd_f32x4_demote_f64x2_zero)
 unimplementedInstruction(_simd_f64x2_promote_low_f32x4)
-
-# 0xFD 0x60 - 0x66: i8x16 operations
 unimplementedInstruction(_simd_i8x16_abs)
 unimplementedInstruction(_simd_i8x16_neg)
 unimplementedInstruction(_simd_i8x16_popcnt)
@@ -1150,14 +1068,10 @@ unimplementedInstruction(_simd_i8x16_all_true)
 unimplementedInstruction(_simd_i8x16_bitmask)
 unimplementedInstruction(_simd_i8x16_narrow_i16x8_s)
 unimplementedInstruction(_simd_i8x16_narrow_i16x8_u)
-
-# 0xFD 0x67 - 0xFD 0x6A: f32x4 operations
 unimplementedInstruction(_simd_f32x4_ceil)
 unimplementedInstruction(_simd_f32x4_floor)
 unimplementedInstruction(_simd_f32x4_trunc)
 unimplementedInstruction(_simd_f32x4_nearest)
-
-# 0xFD 0x6B - 0xFD 0x73: i8x16 binary operations
 unimplementedInstruction(_simd_i8x16_shl)
 unimplementedInstruction(_simd_i8x16_shr_s)
 unimplementedInstruction(_simd_i8x16_shr_u)
@@ -1167,31 +1081,18 @@ unimplementedInstruction(_simd_i8x16_add_sat_u)
 unimplementedInstruction(_simd_i8x16_sub)
 unimplementedInstruction(_simd_i8x16_sub_sat_s)
 unimplementedInstruction(_simd_i8x16_sub_sat_u)
-
-# 0xFD 0x74 - 0xFD 0x75: f64x2 operations
 unimplementedInstruction(_simd_f64x2_ceil)
 unimplementedInstruction(_simd_f64x2_floor)
-
-# 0xFD 0x76 - 0xFD 0x79: i8x16 binary operations
 unimplementedInstruction(_simd_i8x16_min_s)
 unimplementedInstruction(_simd_i8x16_min_u)
 unimplementedInstruction(_simd_i8x16_max_s)
 unimplementedInstruction(_simd_i8x16_max_u)
-
-# 0xFD 0x7A: f64x2 trunc
 unimplementedInstruction(_simd_f64x2_trunc)
-
-# 0xFD 0x7B: i8x16 avgr_u
 unimplementedInstruction(_simd_i8x16_avgr_u)
-
-# 0xFD 0x7C - 0xFD 0x7F: extadd_pairwise
 unimplementedInstruction(_simd_i16x8_extadd_pairwise_i8x16_s)
 unimplementedInstruction(_simd_i16x8_extadd_pairwise_i8x16_u)
 unimplementedInstruction(_simd_i32x4_extadd_pairwise_i16x8_s)
 unimplementedInstruction(_simd_i32x4_extadd_pairwise_i16x8_u)
-
-# 0xFD 0x80 0x01 - 0xFD 0x93 0x01: i16x8 operations
-
 unimplementedInstruction(_simd_i16x8_abs)
 unimplementedInstruction(_simd_i16x8_neg)
 unimplementedInstruction(_simd_i16x8_q15mulr_sat_s)
@@ -1212,13 +1113,7 @@ unimplementedInstruction(_simd_i16x8_add_sat_u)
 unimplementedInstruction(_simd_i16x8_sub)
 unimplementedInstruction(_simd_i16x8_sub_sat_s)
 unimplementedInstruction(_simd_i16x8_sub_sat_u)
-
-# 0xFD 0x94 0x01: f64x2.nearest
-
 unimplementedInstruction(_simd_f64x2_nearest)
-
-# 0xFD 0x95 0x01 - 0xFD 0x9F 0x01: i16x8 operations
-
 unimplementedInstruction(_simd_i16x8_mul)
 unimplementedInstruction(_simd_i16x8_min_s)
 unimplementedInstruction(_simd_i16x8_min_u)
@@ -1230,9 +1125,6 @@ unimplementedInstruction(_simd_i16x8_extmul_low_i8x16_s)
 unimplementedInstruction(_simd_i16x8_extmul_high_i8x16_s)
 unimplementedInstruction(_simd_i16x8_extmul_low_i8x16_u)
 unimplementedInstruction(_simd_i16x8_extmul_high_i8x16_u)
-
-# 0xFD 0xA0 0x01 - 0xFD 0xBF 0x01: i32x4 operations
-
 unimplementedInstruction(_simd_i32x4_abs)
 unimplementedInstruction(_simd_i32x4_neg)
 reservedOpcode(0xfda201)
@@ -1265,9 +1157,6 @@ unimplementedInstruction(_simd_i32x4_extmul_low_i16x8_s)
 unimplementedInstruction(_simd_i32x4_extmul_high_i16x8_s)
 unimplementedInstruction(_simd_i32x4_extmul_low_i16x8_u)
 unimplementedInstruction(_simd_i32x4_extmul_high_i16x8_u)
-
-# 0xFD 0xC0 0x01 - 0xFD 0xDF 0x01: i64x2 operations
-
 unimplementedInstruction(_simd_i64x2_abs)
 unimplementedInstruction(_simd_i64x2_neg)
 reservedOpcode(0xfdc201)
@@ -1300,9 +1189,6 @@ unimplementedInstruction(_simd_i64x2_extmul_low_i32x4_s)
 unimplementedInstruction(_simd_i64x2_extmul_high_i32x4_s)
 unimplementedInstruction(_simd_i64x2_extmul_low_i32x4_u)
 unimplementedInstruction(_simd_i64x2_extmul_high_i32x4_u)
-
-# 0xFD 0xE0 0x01 - 0xFD 0xEB 0x01: f32x4 operations
-
 unimplementedInstruction(_simd_f32x4_abs)
 unimplementedInstruction(_simd_f32x4_neg)
 reservedOpcode(0xfde201)
@@ -1315,9 +1201,6 @@ unimplementedInstruction(_simd_f32x4_min)
 unimplementedInstruction(_simd_f32x4_max)
 unimplementedInstruction(_simd_f32x4_pmin)
 unimplementedInstruction(_simd_f32x4_pmax)
-
-# 0xFD 0xEC 0x01 - 0xFD 0xF7 0x01: f64x2 operations
-
 unimplementedInstruction(_simd_f64x2_abs)
 unimplementedInstruction(_simd_f64x2_neg)
 reservedOpcode(0xfdee01)
@@ -1330,9 +1213,6 @@ unimplementedInstruction(_simd_f64x2_min)
 unimplementedInstruction(_simd_f64x2_max)
 unimplementedInstruction(_simd_f64x2_pmin)
 unimplementedInstruction(_simd_f64x2_pmax)
-
-# 0xFD 0xF8 0x01 - 0xFD 0xFF 0x01: trunc/convert
-
 unimplementedInstruction(_simd_i32x4_trunc_sat_f32x4_s)
 unimplementedInstruction(_simd_i32x4_trunc_sat_f32x4_u)
 unimplementedInstruction(_simd_f32x4_convert_i32x4_s)
@@ -1428,3 +1308,4 @@ unimplementedInstruction(_i64_atomic_rmw8_cmpxchg_u)
 unimplementedInstruction(_i64_atomic_rmw16_cmpxchg_u)
 unimplementedInstruction(_i64_atomic_rmw32_cmpxchg_u)
 end
+

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -712,7 +712,7 @@ extern "C" void ipint_catch_all_entry();
 #define FOR_EACH_IPINT_UINT_OPCODE(m) \
     m(0x00, uint_r0) \
     m(0x01, uint_r1) \
-    m(0x02, uint_fr1) \
+    m(0x02, uint_fr0) \
     m(0x03, uint_stack) \
     m(0x04, uint_ret) \
 

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -265,41 +265,6 @@ MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunk()
     });
     return codeRef;
 }
-
-MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunkSIMD()
-{
-    static LazyNeverDestroyed<MacroAssemblerCodeRef<JITThunkPtrTag>> codeRef;
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [&] {
-        JSInterfaceJIT jit;
-        void* ptr = reinterpret_cast<void*>(ipint_entry_simd);
-        void* untagged = untaggedPtr(ptr);
-        void* retagged = nullptr;
-#if ENABLE(JIT_CAGE)
-        if (Options::useJITCage())
-#else
-        if (false)
-#endif
-            retagged = tagCodePtr<OperationPtrTag>(untagged);
-        else
-            retagged = WTF::tagNativeCodePtrImpl<OperationPtrTag>(untagged);
-
-        assertIsTaggedWith<OperationPtrTag>(retagged);
-
-#if ENABLE(WEBASSEMBLY)
-        CCallHelpers::RegisterID scratch = Wasm::wasmCallingConvention().prologueScratchGPRs[0];
-#else
-        CCallHelpers::RegisterID scratch = JSInterfaceJIT::regT0;
-#endif
-        jit.tagReturnAddress();
-        jit.move(JSInterfaceJIT::TrustedImmPtr(retagged), scratch);
-        jit.farJump(scratch, OperationPtrTag);
-
-        LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::LLIntThunk);
-        codeRef.construct(FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "inPlaceInterpreterEntryThunkSIMD"_s, "LLInt %s jump to prologue thunk", "function for wasm in place interpreter"));
-    });
-    return codeRef;
-}
 #endif // ENABLE(WEBASSEMBLY)
 
 MacroAssemblerCodeRef<JSEntryPtrTag> defaultCallThunk()

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -131,7 +131,6 @@ MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID, OpcodeSize);
 MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunk();
 MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunkSIMD();
 MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunk();
-MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunkSIMD();
 #endif // ENABLE(WEBASSEMBLY)
 
 } } // namespace JSC::LLInt

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2801,6 +2801,10 @@ op(wasm_function_prologue_simd, macro ()
     crash()
 end)
 
+op(ipint_trampoline, macro ()
+    crash()
+end)
+
 _wasm_trampoline_wasm_call:
 _wasm_trampoline_wasm_call_indirect:
 _wasm_trampoline_wasm_call_ref:

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -486,12 +486,13 @@ public:
     // I couldn't figure out how to stop LLIntOffsetsExtractor.cpp from yelling at me.
     // So just making these public.
     const uint8_t* m_bytecode;
-    const uint32_t m_bytecodeLength;
+    const uint8_t* m_bytecodeEnd;
     Vector<uint8_t> m_metadataVector;
     const uint8_t* m_metadata;
     Vector<uint8_t> m_argumINTBytecode;
     const uint8_t* m_argumINTBytecodePointer;
-    const uint32_t m_returnMetadata;
+    Vector<uint8_t> m_uINTBytecode;
+    const uint8_t* m_uINTBytecodePointer;
 
     unsigned m_localSizeToAlloc;
     unsigned m_numRethrowSlotsToAlloc;

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -43,6 +43,7 @@ namespace JSC { namespace Wasm {
 constexpr unsigned numberOfLLIntCalleeSaveRegisters = 2;
 constexpr unsigned numberOfIPIntCalleeSaveRegisters = 3;
 constexpr unsigned numberOfLLIntInternalRegisters = 2;
+constexpr unsigned numberOfIPIntInternalRegisters = 2;
 
 struct ArgumentLocation {
 #if USE(JSVALUE32_64)

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -88,7 +88,16 @@ public:
 
 private:
 
-    void addBlankSpace(size_t);
+    inline void addBlankSpace(size_t);
+    template <typename T> inline void addBlankSpace() { addBlankSpace(sizeof(T)); };
+
+    template <typename T> inline void appendMetadata(T t)
+    {
+        auto size = m_metadata.size();
+        addBlankSpace<T>();
+        WRITE_TO_METADATA(m_metadata.data() + size, t, T);
+    };
+
     void addLength(size_t length);
     void addLEB128ConstantInt32AndLength(uint32_t value, size_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, size_t length);
@@ -101,7 +110,7 @@ private:
 
     std::span<const uint8_t> m_bytecode;
     Vector<uint8_t> m_metadata { };
-    uint32_t m_returnMetadata { 0 };
+    Vector<uint8_t, 8> m_uINTBytecode { };
 
     uint32_t m_bytecodeOffset { 0 };
     unsigned m_maxFrameSizeInV128 { 0 };
@@ -115,10 +124,6 @@ private:
     Vector<const TypeDefinition*> m_signatures;
     HashMap<IPIntPC, IPIntTierUpCounter::OSREntryData> m_tierUpCounter;
     Vector<UnlinkedHandlerInfo> m_exceptionHandlers;
-
-    // Optimization to skip large numbers of blocks
-
-    Vector<uint32_t> m_repeatedControlFlowInstructionMetadataOffsets;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -43,9 +43,34 @@ Expected<std::unique_ptr<FunctionIPIntMetadataGenerator>, String> parseAndCompil
 
 namespace IPInt {
 
-#pragma pack(1)
+constexpr static unsigned STACK_ENTRY_SIZE = 16; // bytes
+struct IPIntStackEntry {
+    union {
+        int32_t i32;
+        float f32;
+        int64_t i64;
+        double f64;
+        v128_t v128;
+        EncodedJSValue ref;
+    };
+};
 
-// mINT: mini-interpreter / minimalist interpreter (whichever floats your boat)
+constexpr static unsigned LOCAL_SIZE = 16; // bytes
+struct IPIntLocal {
+    union {
+        int32_t i32;
+        float f32;
+        int64_t i64;
+        double f64;
+        v128_t v128;
+        EncodedJSValue ref;
+    };
+};
+
+static_assert(sizeof(IPIntStackEntry) == STACK_ENTRY_SIZE);
+static_assert(sizeof(IPIntLocal) == LOCAL_SIZE);
+
+#pragma pack(1)
 
 // Metadata structure for control flow instructions
 
@@ -54,110 +79,93 @@ struct InstructionLengthMetadata {
 };
 
 struct BlockMetadata {
-    uint32_t newPC; // 2B for new PC
-    uint32_t newMC; // 2B for new MC
+    uint32_t deltaPC; // 4B for new PC
+    uint32_t deltaMC; // 4B for new MC
 };
 
 struct IfMetadata {
-    uint32_t elsePC; // 4B PC for new else PC
-    uint32_t elseMC; // 4B MC of new else MC
+    uint32_t elseDeltaPC; // 4B PC for new else PC
+    uint32_t elseDeltaMC; // 4B MC of new else MC
     InstructionLengthMetadata instructionLength;
 };
 
-struct throwMetadata {
+struct ThrowMetadata {
     uint32_t exceptionIndex; // 4B for exception index
 };
 
-struct rethrowMetadata {
+struct RethrowMetadata {
     uint32_t tryDepth; // 4B for try depth
 };
 
-struct catchMetadata {
+struct CatchMetadata {
     uint32_t stackSizeInV128; // 4B for stack size
 };
 
-struct branchTargetMetadata {
-    BlockMetadata block; // 2B for stack values to pop
-    uint16_t toPop; // 2B for stack values to keep
-    uint16_t toKeep;
+struct BranchTargetMetadata {
+    BlockMetadata block; // 8B for target
+    uint16_t toPop; // 2B for stack values to pop
+    uint16_t toKeep; // 2B for stack values to keep
 };
 
-struct branchMetadata {
-    branchTargetMetadata target;
+struct BranchMetadata {
+    BranchTargetMetadata target;
     InstructionLengthMetadata instructionLength;
 };
 
-struct switchMetadata {
+struct SwitchMetadata {
     uint32_t size; // 4B for number of jump targets
-    branchTargetMetadata target[0];
+    BranchTargetMetadata target[0];
 };
 
 // Global get/set metadata structure
 
-struct globalMetadata {
+struct GlobalMetadata {
     uint32_t index; // 4B for index of global
     InstructionLengthMetadata instructionLength;
     uint8_t bindingMode; // 1B for bindingMode
     uint8_t isRef; // 1B for ref flag
 };
 
-// Constant metadat structures
+// Constant metadata structures
 
-struct const32Metadata {
+struct Const32Metadata {
     InstructionLengthMetadata instructionLength;
     uint32_t value;
 };
 
-struct const64Metadata {
+struct Const64Metadata {
     InstructionLengthMetadata instructionLength;
     uint64_t value;
 };
 
-struct const128Metadata {
+struct Const128Metadata {
     InstructionLengthMetadata instructionLength;
     v128_t value;
 };
 
-struct tableInitMetadata {
+struct TableInitMetadata {
     uint32_t elementIndex; // 4B for index of element
     uint32_t tableIndex; // 4B for index of table
-    uint32_t dst; // 4B for destination (set by interpreter)
-    uint32_t src; // 4B for source (set by interpreter)
-    uint32_t length; // 4B for length (set by interpreter)
     InstructionLengthMetadata instructionLength;
 };
 
-struct tableFillMetadata {
+struct TableFillMetadata {
     uint32_t tableIndex; // 4B for index of table
-    EncodedJSValue fill; // 8B for fill value
-    uint32_t offset; // 4B for offset (set by interpreter)
-    uint32_t length; // 4B for length (set by interpreter)
     InstructionLengthMetadata instructionLength;
 };
 
-struct tableGrowMetadata {
+struct TableGrowMetadata {
     uint32_t tableIndex; // 4B for index of table
-    EncodedJSValue fill; // 8B for fill value
-    uint32_t length; // 4B for length (set by interpreter)
     InstructionLengthMetadata instructionLength;
 };
 
-struct tableCopyMetadata {
+struct TableCopyMetadata {
     uint32_t dstTableIndex; // 4B for index of destination table
     uint32_t srcTableIndex; // 4B for index of source table
-    uint32_t dstOffset; // 4B for destination offset (set by interpreter)
-    uint32_t srcOffset; // 4B for source offset (set by interpreter)
-    uint32_t length; // 4B for length (set by interpreter)
     InstructionLengthMetadata instructionLength;
 };
 
 // Metadata structure for calls:
-
-struct calleeMetadata {
-    JSWebAssemblyInstance* instance; // Ptr for callee instance (set by operation)
-    void* entrypoint; // Ptr for callee entrypoint (set by operation)
-    EncodedJSValue boxedCallee; // 8B for callee (set by operation)
-};
 
 enum class CallArgumentBytecode : uint8_t { // (mINT)
     ArgumentGPR = 0x0, // 0x00 - 0x07: push into a0, a1, ...
@@ -168,20 +176,16 @@ enum class CallArgumentBytecode : uint8_t { // (mINT)
     End = 0xf // 0x0f: stop
 };
 
-struct callMetadata {
+struct CallMetadata {
     uint8_t length; // 1B for instruction length
     uint32_t functionIndex; // 4B for decoded index
-    calleeMetadata callee;
     CallArgumentBytecode argumentBytecode[0];
 };
 
-struct callIndirectMetadata {
+struct CallIndirectMetadata {
     uint8_t length; // 1B for length
     uint32_t tableIndex; // 4B for table index
     uint32_t typeIndex; // 4B for type index
-    uint32_t functionRef; // 4B for function ref (set by interpreter)
-    CallFrame* callFrame; // Ptr for call frame (set by interpreter)
-    calleeMetadata callee;
     CallArgumentBytecode argumentBytecode[0];
 };
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -126,15 +126,14 @@ void IPIntPlan::compileFunction(uint32_t functionIndex)
         auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
         ASSERT(!callee->entrypoint());
 
-        if (Options::useJIT()) {
 #if ENABLE(JIT)
-            if (m_moduleInformation->usesSIMD(functionIndex))
-                callee->setEntrypoint(LLInt::inPlaceInterpreterEntryThunkSIMD().retaggedCode<WasmEntryPtrTag>());
-            else
-                callee->setEntrypoint(LLInt::inPlaceInterpreterEntryThunk().retaggedCode<WasmEntryPtrTag>());
+        if (Options::useJIT())
+            callee->setEntrypoint(LLInt::inPlaceInterpreterEntryThunk().retaggedCode<WasmEntryPtrTag>());
+#else
+        if (false);
 #endif
-        } else
-            callee->setEntrypoint(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(wasm_function_prologue_trampoline));
+        else
+            callee->setEntrypoint(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(ipint_trampoline));
         ipintCallee = callee.ptr();
         m_calleesVector[functionIndex] = WTFMove(callee);
     } else
@@ -153,32 +152,25 @@ void IPIntPlan::compileFunction(uint32_t functionIndex)
 
 }
 
-// FIXME: Get IPInt working again now that we don't always JIT wrappers.
-bool IPIntPlan::ensureEntrypoint(IPIntCallee& ipintCallee, unsigned functionIndex)
+bool IPIntPlan::ensureEntrypoint(IPIntCallee&, unsigned functionIndex)
 {
     if (m_entrypoints[functionIndex])
         return true;
 
-    if (!LIKELY(Options::useJIT()))
-        return false;
-
-    UNUSED_PARAM(ipintCallee);
-    UNUSED_PARAM(functionIndex);
-    return false;
+    m_entrypoints[functionIndex] = JSEntrypointCallee::create(m_moduleInformation->internalFunctionTypeIndices[functionIndex], m_moduleInformation->usesSIMD(functionIndex));
+    return true;
 }
 
 void IPIntPlan::didCompleteCompilation()
 {
     generateStubsIfNecessary();
 
-#if ENABLE(JIT)
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
         m_callees = m_calleesVector.data();
         if (!m_moduleInformation->clobberingTailCalls().isEmpty())
             computeTransitiveTailCalls();
     }
-#endif
 
     if (m_compilerMode == CompilerMode::Validation)
         return;
@@ -193,8 +185,11 @@ void IPIntPlan::didCompleteCompilation()
                 }
             }
         }
-        if (auto& callee = m_entrypoints[functionIndex])
+        if (auto& callee = m_entrypoints[functionIndex]) {
+            if (callee->compilationMode() == CompilationMode::JSToWasmEntrypointMode)
+                static_cast<JSEntrypointCallee*>(callee.get())->setWasmCallee(CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get()));
             m_jsEntrypointCallees.add(functionIndex, callee);
+        }
     }
 
     for (auto& unlinked : m_unlinkedWasmToWasmCalls) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -53,32 +53,32 @@ namespace IPInt {
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prologue_osr, CallFrame* callFrame);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntLocal* pl);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
 #endif
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, v128_t* stack, uint64_t* pl);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, uint64_t* arguments, unsigned exceptionIndex);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, IPIntStackEntry* arguments, unsigned exceptionIndex);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, uint64_t* pl, unsigned tryDepth);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, tableInitMetadata* metadata);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, tableFillMetadata* metadata);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, tableGrowMetadata* metadata);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, IPIntStackEntry* sp, TableInitMetadata* metadata);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, IPIntStackEntry* sp, TableFillMetadata* metadata);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(current_memory);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_grow, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_init, int32_t, int32_t, int64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_init, int32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(data_drop, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_copy, int32_t, int32_t, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_fill, int32_t, int32_t, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(elem_drop, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, tableCopyMetadata* metadata);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, IPIntStackEntry* sp, TableCopyMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, callIndirectMetadata* call);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, callMetadata* call);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, unsigned* functionIndex, CallIndirectMetadata* call);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned functionIndex, EncodedJSValue* callee);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue value);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -1,0 +1,263 @@
+
+# IPInt debugger scripts for looking at the state of the program
+# Run with:
+# lldb -s debug_ipint.lldb -- jsc (args)
+
+import lldb
+
+import bisect
+import struct
+from pathlib import Path
+
+ARCH = 'arm64'
+
+if ARCH == 'arm64':
+    PC_REG = 'x26'
+    MC_REG = 'x25'
+    PL_REG = 'x6'
+
+# Read all instruction opcodes from InPlaceInterpreter64.asm
+
+IPINT_INSTRUCTIONS = [
+    'unreachable', 'nop', 'block', 'loop', 'if', 'else', 'try', 'catch', 'throw', 'rethrow', 'end', 'br', 'br_if',
+    'br_table', 'return', 'call', 'call_indirect', 'delegate', 'catch_all', 'drop', 'select', 'select_t', 'local_get',
+    'local_set', 'local_tee', 'global_get', 'global_set', 'table_get', 'table_set', 'i32_load_mem', 'i64_load_mem',
+    'f32_load_mem', 'f64_load_mem', 'i32_load8s_mem', 'i32_load8u_mem', 'i32_load16s_mem', 'i32_load16u_mem',
+    'i64_load8s_mem', 'i64_load8u_mem', 'i64_load16s_mem', 'i64_load16u_mem', 'i64_load32s_mem', 'i64_load32u_mem',
+    'i32_store_mem', 'i64_store_mem', 'f32_store_mem', 'f64_store_mem', 'i32_store8_mem', 'i32_store16_mem',
+    'i64_store8_mem', 'i64_store16_mem', 'i64_store32_mem', 'memory_size', 'memory_grow', 'i32_const', 'i64_const',
+    'f32_const', 'f64_const', 'i32_eqz', 'i32_eq', 'i32_ne', 'i32_lt_s', 'i32_lt_u', 'i32_gt_s', 'i32_gt_u', 'i32_le_s',
+    'i32_le_u', 'i32_ge_s', 'i32_ge_u', 'i64_eqz', 'i64_eq', 'i64_ne', 'i64_lt_s', 'i64_lt_u', 'i64_gt_s', 'i64_gt_u',
+    'i64_le_s', 'i64_le_u', 'i64_ge_s', 'i64_ge_u', 'f32_eq', 'f32_ne', 'f32_lt', 'f32_gt', 'f32_le', 'f32_ge', 'f64_eq',
+    'f64_ne', 'f64_lt', 'f64_gt', 'f64_le', 'f64_ge', 'i32_clz', 'i32_ctz', 'i32_popcnt', 'i32_add', 'i32_sub',
+    'i32_mul', 'i32_div_s', 'i32_div_u', 'i32_rem_s', 'i32_rem_u', 'i32_and', 'i32_or', 'i32_xor', 'i32_shl',
+    'i32_shr_s', 'i32_shr_u', 'i32_rotl', 'i32_rotr', 'i64_clz', 'i64_ctz', 'i64_popcnt', 'i64_add', 'i64_sub',
+    'i64_mul', 'i64_div_s', 'i64_div_u', 'i64_rem_s', 'i64_rem_u', 'i64_and', 'i64_or', 'i64_xor', 'i64_shl',
+    'i64_shr_s', 'i64_shr_u', 'i64_rotl', 'i64_rotr', 'f32_abs', 'f32_neg', 'f32_ceil', 'f32_floor', 'f32_trunc',
+    'f32_nearest', 'f32_sqrt', 'f32_add', 'f32_sub', 'f32_mul', 'f32_div', 'f32_min', 'f32_max', 'f32_copysign',
+    'f64_abs', 'f64_neg', 'f64_ceil', 'f64_floor', 'f64_trunc', 'f64_nearest', 'f64_sqrt', 'f64_add', 'f64_sub',
+    'f64_mul', 'f64_div', 'f64_min', 'f64_max', 'f64_copysign', 'i32_wrap_i64', 'i32_trunc_f32_s', 'i32_trunc_f32_u',
+    'i32_trunc_f64_s', 'i32_trunc_f64_u', 'i64_extend_i32_s', 'i64_extend_i32_u', 'i64_trunc_f32_s', 'i64_trunc_f32_u',
+    'i64_trunc_f64_s', 'i64_trunc_f64_u', 'f32_convert_i32_s', 'f32_convert_i32_u', 'f32_convert_i64_s',
+    'f32_convert_i64_u', 'f32_demote_f64', 'f64_convert_i32_s', 'f64_convert_i32_u', 'f64_convert_i64_s',
+    'f64_convert_i64_u', 'f64_promote_f32', 'i32_reinterpret_f32', 'i64_reinterpret_f64', 'f32_reinterpret_i32',
+    'f64_reinterpret_i64', 'i32_extend8_s', 'i32_extend16_s', 'i64_extend8_s', 'i64_extend16_s', 'i64_extend32_s',
+    'ref_null_t', 'ref_is_null', 'ref_func', 'fc_block', 'simd', 'atomic', 'i32_trunc_sat_f32_s', 'i32_trunc_sat_f32_u',
+    'i32_trunc_sat_f64_s', 'i32_trunc_sat_f64_u', 'i64_trunc_sat_f32_s', 'i64_trunc_sat_f32_u', 'i64_trunc_sat_f64_s',
+    'i64_trunc_sat_f64_u', 'memory_init', 'data_drop', 'memory_copy', 'memory_fill', 'table_init', 'elem_drop',
+    'table_copy', 'table_grow', 'table_size', 'table_fill', 'simd_v128_const', 'simd_i32x4_extract_lane',
+    'memory_atomic_notify', 'memory_atomic_wait32', 'memory_atomic_wait64', 'atomic_fence', 'i32_atomic_load',
+    'i64_atomic_load', 'i32_atomic_load8_u', 'i32_atomic_load16_u', 'i64_atomic_load8_u', 'i64_atomic_load16_u',
+    'i64_atomic_load32_u', 'i32_atomic_store', 'i64_atomic_store', 'i32_atomic_store8_u', 'i32_atomic_store16_u',
+    'i64_atomic_store8_u', 'i64_atomic_store16_u', 'i64_atomic_store32_u', 'i32_atomic_rmw_add', 'i64_atomic_rmw_add',
+    'i32_atomic_rmw8_add_u', 'i32_atomic_rmw16_add_u', 'i64_atomic_rmw8_add_u', 'i64_atomic_rmw16_add_u',
+    'i64_atomic_rmw32_add_u', 'i32_atomic_rmw_sub', 'i64_atomic_rmw_sub', 'i32_atomic_rmw8_sub_u',
+    'i32_atomic_rmw16_sub_u', 'i64_atomic_rmw8_sub_u', 'i64_atomic_rmw16_sub_u', 'i64_atomic_rmw32_sub_u',
+    'i32_atomic_rmw_and', 'i64_atomic_rmw_and', 'i32_atomic_rmw8_and_u', 'i32_atomic_rmw16_and_u',
+    'i64_atomic_rmw8_and_u', 'i64_atomic_rmw16_and_u', 'i64_atomic_rmw32_and_u', 'i32_atomic_rmw_or',
+    'i64_atomic_rmw_or', 'i32_atomic_rmw8_or_u', 'i32_atomic_rmw16_or_u', 'i64_atomic_rmw8_or_u', 'i64_atomic_rmw16_or_u',
+    'i64_atomic_rmw32_or_u', 'i32_atomic_rmw_xor', 'i64_atomic_rmw_xor', 'i32_atomic_rmw8_xor_u',
+    'i32_atomic_rmw16_xor_u', 'i64_atomic_rmw8_xor_u', 'i64_atomic_rmw16_xor_u', 'i64_atomic_rmw32_xor_u',
+    'i32_atomic_rmw_xchg', 'i64_atomic_rmw_xchg', 'i32_atomic_rmw8_xchg_u', 'i32_atomic_rmw16_xchg_u',
+    'i64_atomic_rmw8_xchg_u', 'i64_atomic_rmw16_xchg_u', 'i64_atomic_rmw32_xchg_u', 'i32_atomic_rmw_cmpxchg',
+    'i64_atomic_rmw_cmpxchg', 'i32_atomic_rmw8_cmpxchg_u', 'i32_atomic_rmw16_cmpxchg_u', 'i64_atomic_rmw8_cmpxchg_u',
+    'i64_atomic_rmw16_cmpxchg_u', 'i64_atomic_rmw32_cmpxchg_u']
+
+stop_commands = lldb.SBStringList()
+stop_commands.AppendString("ipint_state")
+
+go_commands = lldb.SBStringList()
+go_commands.AppendString("ipint_state")
+go_commands.AppendString("c")
+
+breakpoints = []
+breakpoints_enabled = []
+breakpoint_locs = []
+
+
+def print_value(mem, result):
+    print(' '.join(f'{x:02x}' for x in mem), file=result)
+    # interpret as a bunch of stuff
+    SP = ' ' * 10
+    print(f'{SP}\033[92mi32\033[0m{SP}{SP}\033[93mf32\033[0m{SP}{SP}\033[94mi64\033[0m{SP}{SP}\033[95mf64\033[0m', file=result)
+    i32 = struct.unpack('ixxxxxxxxxxxx', mem)[0]
+    f32 = struct.unpack('fxxxxxxxxxxxx', mem)[0]
+    i64 = struct.unpack('qxxxxxxxx', mem)[0]
+    f64 = struct.unpack('dxxxxxxxx', mem)[0]
+    print(f'{i32:^23}{f32:^23.5f}{i64:^23}{f64:^23.5f}', file=result)
+
+
+def print_stack(proc, frame, result, num_entries=None):
+    gprs = {}
+    for reg in frame.regs[0]:
+        gprs[reg.name] = int(reg.value[2:], 16)
+    pl = gprs[PL_REG]
+
+    ptr = frame.sp
+    i = 0
+
+    if ptr == pl:
+        print('no stack entries', file=result)
+    else:
+        print('(top of stack)', file=result)
+
+    while ptr != pl and (num_entries is None or i < num_entries):
+        print(f'\n---- stack[{i:2}] ----', file=result)
+        error = lldb.SBError()
+        mem = proc.ReadMemory(ptr, 16, error)
+        if error.Success():
+            mem = bytearray(mem)
+            print_value(mem, result)
+        else:
+            print(f'can\'t read stack memory at address 0x{ptr:016x} :(', file=result)
+            break
+        ptr += 16
+        i += 1
+
+
+def ipint_state(debugger, command, exe_ctx, result, internal_dict):
+    print("Current interpreter state:", file=result)
+    print("--------------------------", file=result)
+
+    proc = debugger.GetTargetAtIndex(0).process
+    frame = proc.selected_thread.frame[0]
+    regs = frame.regs
+
+    # Figure out where we are if breakpoints is populated
+    if len(breakpoints) != 0:
+        # current PC
+        pc = frame.pc
+        i = bisect.bisect(breakpoint_locs, pc) - 1
+        if i < 0:
+            print(f'\033[1m\033[91mnot in IPInt bounds!!!\033[0m')
+        else:
+            print(f'\033[1mCurrently executing: \033[93m{IPINT_INSTRUCTIONS[i]}\033[0m', file=result)
+
+    gprs = {}
+    for reg in regs[0]:
+        gprs[reg.name] = int(reg.value[2:], 16)
+
+    # PC = x26
+    pc = gprs[PC_REG]
+    mc = gprs[MC_REG]
+
+    print(f'PC = 0x{pc:x}', file=result)
+
+    # preview 8 bytes of PC
+    if True:
+        error = lldb.SBError()
+        mem = proc.ReadMemory(pc, 8, error)
+        if error.Success():
+            print(' '.join(f'{x:02x}' for x in mem), file=result)
+        else:
+            print('???', file=result)
+    print('', file=result)
+
+    if mc != 0:
+        print(f'MC = 0x{mc:x}', file=result)
+
+        # preview 8 bytes of MC
+        if True:
+            error = lldb.SBError()
+            mem = proc.ReadMemory(mc, 8, error)
+            if error.Success():
+                print(' '.join(f'{x:02x}' for x in mem), file=result)
+            else:
+                print('???', file=result)
+        print('', file=result)
+    else:
+        print('\033[1m\033[94mno metadata generated\033[0m\n', file=result)
+
+    print_stack(proc, frame, result, 2)
+
+
+def ipint_stack(debugger, command, exec_ctx, result, internal_dict):
+    proc = debugger.GetTargetAtIndex(0).process
+    frame = proc.selected_thread.frame[0]
+    try:
+        print_stack(proc, frame, result, int(command))
+    except ValueError:
+        print('usage: ipint_stack <num_stack_entries>', file=result)
+
+
+def ipint_local(debugger, command, exec_ctx, result, internal_dict):
+    try:
+        local_index = int(command)
+    except ValueError:
+        print('usage: ipint_local <local_idx>', file=result)
+        return
+
+    proc = debugger.GetTargetAtIndex(0).process
+    frame = proc.selected_thread.frame[0]
+
+    gprs = {}
+    for reg in frame.regs[0]:
+        gprs[reg.name] = int(reg.value[2:], 16)
+
+    pl = gprs[PL_REG]
+    LOCAL_SIZE = 16
+    error = lldb.SBError()
+    ptr = pl + LOCAL_SIZE * local_index
+    mem = proc.ReadMemory(ptr, 16, error)
+    if error.Success():
+        mem = bytearray(mem)
+        print_value(mem, result)
+    else:
+        print(f'can\'t read stack memory at address 0x{ptr:016x} (bad local index?)', file=result)
+
+
+def ipint_continue_until(debugger, command, exec_ctx, result, internal_dict):
+    try:
+        op_index = IPINT_INSTRUCTIONS.index(command)
+        for i in range(len(IPINT_INSTRUCTIONS)):
+            breakpoints[i].enabled = (i == op_index)
+
+        proc = debugger.GetTargetAtIndex(0).process
+        proc.Continue()
+
+        for i in range(len(IPINT_INSTRUCTIONS)):
+            breakpoints[i].enabled = True
+    except ValueError:
+        print(f'can\'t find operation {command}', file=result)
+
+
+def ipint_break_at(debugger, command, exec_ctx, result, internal_dict):
+    try:
+        op_index = IPINT_INSTRUCTIONS.index(command)
+        breakpoints[op_index].enabled = True
+    except ValueError:
+        print(f'can\'t find operation {command}', file=result)
+
+
+def ipint_disable_all_breakpoints(debugger, command, exec_ctx, result, internal_dict):
+    for brk in breakpoints:
+        brk.enabled = False
+
+
+def ipint_reenable_all_breakpoints(debugger, command, exec_ctx, result, internal_dict):
+    for brk in breakpoints:
+        brk.enabled = True
+
+
+def set_breakpoints(debugger, command, exe_ctx, result, internal_dict):
+    print("Initializing internal breakpoints...", file=result)
+    target = debugger.GetTargetAtIndex(0)
+
+    for instr in IPINT_INSTRUCTIONS:
+        brk = target.BreakpointCreateByName(f'ipint_{instr}')
+        brk.SetCommandLineCommands(stop_commands)
+        breakpoints.append(brk)
+        breakpoint_locs.append(brk.locations[0].GetLoadAddress())
+    print("done!", file=result)
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_state ipint_state')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_stack ipint_stack')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_local ipint_local')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_continue_until ipint_continue_until')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_break_at ipint_break_at')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_disable_all_breakpoints ipint_disable_all_breakpoints')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_reenable_all_breakpoints ipint_reenable_all_breakpoints')
+    debugger.HandleCommand('command script add -f debug_ipint.set_breakpoints set_breakpoints')
+    print("IPInt debugger ready")


### PR DESCRIPTION
#### 82e443e19211b53ce41ef890967bf6a9291806dd
<pre>
Reduce IPInt register usage and support JITless calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=279934">https://bugs.webkit.org/show_bug.cgi?id=279934</a>
<a href="https://rdar.apple.com/136256088">rdar://136256088</a>

Reviewed by Yusuke Suzuki.

This patch performs a signficant cleanup of IPInt code. The key changes:
- Introduced a new register assignment for IPInt&apos;s internal registers. PC/PB and MC/MB have been
  condensed to PC and MC, and metadata now stores relative offsets in the bytecode/metadata
  instead of absolute positions.
  - Reducing the number of registers used also allows us to significantly clean up calling.
- Added support for JITless calls into IPInt.
- Removed instances of IPInt writing to metadata in the interpreter, ensuring that metadata is
  static.
- Added LLDB scripting to support debugging IPInt.

* JSTests/wasm/ipint-tests/ipint-test-implicit-return.js: Copied from JSTests/wasm/ipint-tests/ipint-test-simd.js.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.i32.i32.const.5.async test):
* JSTests/wasm/ipint-tests/ipint-test-simd-i32-params.js: Copied from JSTests/wasm/ipint-tests/ipint-test-simd.js.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.i32.param.i32.result.i32.v128.const.i32x4.2.3.4.5.i32x4.extract_lane.2.local.0.local.1.i32.div_s.i32.add.return.async test):
* JSTests/wasm/ipint-tests/ipint-test-simd.js:
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.i32.v128.const.i32x4.2.3.4.5.i32x4.extract_lane.0.return.async test):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.i32.v128.const.i32x4.0.1.2.3.i32x4.extract_lane.0.return.async test): Deleted.
* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::inPlaceInterpreterEntryThunk):
(JSC::LLInt::inPlaceInterpreterEntryThunkSIMD): Deleted.
* Source/JavaScriptCore/llint/LLIntThunks.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
(JSC::Wasm::JITLessJSEntrypointCallee::JITLessJSEntrypointCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128V128Constant):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace):
(JSC::Wasm::FunctionIPIntMetadataGenerator::appendMetadata):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::tryToResolveEntryTarget):
(JSC::Wasm::IPIntGenerator::tryToResolveExitTarget):
(JSC::Wasm::IPIntGenerator::tryToResolveBranchTarget):
(JSC::Wasm::IPIntGenerator::curPC):
(JSC::Wasm::IPIntGenerator::nextPC):
(JSC::Wasm::IPIntGenerator::curMC):
(JSC::Wasm::IPIntGenerator::addConstant):
(JSC::Wasm::IPIntGenerator::addTableInit):
(JSC::Wasm::IPIntGenerator::addTableGrow):
(JSC::Wasm::IPIntGenerator::addTableFill):
(JSC::Wasm::IPIntGenerator::addTableCopy):
(JSC::Wasm::IPIntGenerator::getGlobal):
(JSC::Wasm::IPIntGenerator::setGlobal):
(JSC::Wasm::IPIntGenerator::coalesceControlFlow):
(JSC::Wasm::IPIntGenerator::resolveEntryTarget):
(JSC::Wasm::IPIntGenerator::resolveExitTarget):
(JSC::Wasm::IPIntGenerator::addBlock):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addTry):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addThrow):
(JSC::Wasm::IPIntGenerator::addRethrow):
(JSC::Wasm::IPIntGenerator::addBranch):
(JSC::Wasm::IPIntGenerator::addSwitch):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::fprToIndex):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::condenseControlFlowInstructions): Deleted.
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
(JSC::Wasm::IPIntPlan::ensureEntrypoint):
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::doWasmCall):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Tools/lldb/debug_ipint.py: Added.
(print_value):
(print_stack):
(ipint_state):
(ipint_stack):
(ipint_local):
(ipint_continue_until):
(ipint_break_at):
(ipint_disable_all_breakpoints):
(ipint_reenable_all_breakpoints):
(set_breakpoints):
(__lldb_init_module):

Canonical link: <a href="https://commits.webkit.org/284022@main">https://commits.webkit.org/284022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be983c0f7984de400016ab575485a7602d7ea44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19067 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43488 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16267 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17608 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61224 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73865 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67354 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15880 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61888 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3415 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89133 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10375 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43299 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15730 "Found 7 new JSC stress test failures: wasm.yaml/wasm/gc/bug250613.js.wasm-bbq, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->