### PR TITLE
Remove --platform=wincairo alias from all tools

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -234,7 +234,7 @@ ALWAYS_EXCLUDED_PATTERNS = ('*.a',)
 MINIFIED_EXCLUDED_PATTERNS = (*ALWAYS_EXCLUDED_PATTERNS, '*.dSYM', 'DerivedSources')
 
 def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
-    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'visionos', 'watchos', 'win', 'wincairo', 'wpe')
+    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'visionos', 'watchos', 'win', 'wpe')
     global _configurationBuildDirectory
 
     print("Archiving built product from directory: %s" % _configurationBuildDirectory)
@@ -256,7 +256,7 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
             return createZip(_configurationBuildDirectory, 'minified-' + configuration, excludePatterns=MINIFIED_EXCLUDED_PATTERNS, embedParentDirectoryNameOnDarwin=True)
         else:
             return createZip(_configurationBuildDirectory, configuration, excludePatterns=ALWAYS_EXCLUDED_PATTERNS, embedParentDirectoryNameOnDarwin=True)
-    elif platform in ('win', 'wincairo'):
+    elif platform == 'win':
         binDirectory = os.path.join(_configurationBuildDirectory, 'bin')
         thinDirectory = os.path.join(_configurationBuildDirectory, 'thin')
         thinBinDirectory = os.path.join(thinDirectory, 'bin')
@@ -345,7 +345,7 @@ def unzipArchive(directoryToExtractTo, configuration):
 
 
 def extractBuiltProduct(configuration, platform):
-    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'visionos', 'watchos', 'win', 'wincairo', 'wpe')
+    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'visionos', 'watchos', 'win', 'wpe')
 
     archiveFile = os.path.join(_topLevelBuildDirectory, configuration + '.zip')
 
@@ -354,13 +354,13 @@ def extractBuiltProduct(configuration, platform):
 
     if platform in ('mac', 'ios', 'visionos', 'tvos', 'watchos'):
         return unzipArchive(_topLevelBuildDirectory, configuration)
-    elif platform in ('gtk', 'jsc-only', 'win', 'wincairo', 'wpe'):
+    elif platform in ('gtk', 'jsc-only', 'win', 'wpe'):
         print('Extracting: {}'.format(_configurationBuildDirectory))
         if unzipArchive(_configurationBuildDirectory, configuration):
             return 1
 
         # Restore WebKitRequirements version for test bot use
-        if platform in ('win', 'wincairo'):
+        if platform == 'win':
             libDirectory = os.getenv('WEBKIT_LIBRARIES') or os.path.join(webkitTopAbsPath, 'WebKitLibraries', 'win')
             os.makedirs(libDirectory, exist_ok=True)
             shutil.copy(os.path.join(_configurationBuildDirectory, 'WebKitRequirementsWin64.zip.config'), libDirectory)

--- a/Tools/CISupport/test-result-archive
+++ b/Tools/CISupport/test-result-archive
@@ -59,7 +59,7 @@ def compress_spindumps(layoutTestResultsDir):
                     gzip_file(root, name)
 
 def archive_test_results(configuration, platform, layoutTestResultsDir):
-    assert platform in ('mac', 'win', 'gtk', 'wincairo', 'ios', 'watchos', 'wpe', 'visionos')
+    assert platform in ('mac', 'win', 'gtk', 'ios', 'watchos', 'wpe', 'visionos')
 
     try:
         os.unlink(archiveFile)
@@ -83,7 +83,7 @@ def archive_test_results(configuration, platform, layoutTestResultsDir):
     elif platform in ('gtk', 'wpe'):
         if subprocess.call(["zip", "-r", "-2", archiveFile, "."], cwd=layoutTestResultsDir):
             return 1
-    elif platform in ('win', 'wincairo'):
+    elif platform == 'win':
         with zipfile.ZipFile(archiveFile, 'w', zipfile.ZIP_DEFLATED) as archiveZip:
             for path, dirNames, fileNames in os.walk(layoutTestResultsDir):
                 relativePath = os.path.relpath(path, layoutTestResultsDir)

--- a/Tools/Scripts/download-github-release.py
+++ b/Tools/Scripts/download-github-release.py
@@ -39,7 +39,7 @@ PUBLIC_GITHUB_API_ENDPOINT = 'https://api.github.com/'
 DESCRIPTION = '''Downloads a release binary from a GitHub repository.
 (Requests the latest release unless a specific tag is provided.)
 
-Intended for download of vswhere.exe and WinCairoRequirements.zip,
+Intended for download of vswhere.exe and WebKitRequirementsWin64.zip,
 but may be used for arbitrary binaries / repositories.
 
 Checks whether the desired version already exists in the output directory

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1746,7 +1746,6 @@ sub determinePortName()
         'jsc-only' => JSCOnly,
         playstation => PlayStation,
         win => Win,
-        wincairo => Win,
         wpe => WPE
     );
 

--- a/Tools/Scripts/webkitpy/common/config/ports.py
+++ b/Tools/Scripts/webkitpy/common/config/ports.py
@@ -68,11 +68,11 @@ class DeprecatedPort(object):
             "jsc-only": JscOnlyPort,
             "mac": MacPort,
             "mac-wk2": MacWK2Port,
-            "wincairo": WinCairoPort,
+            "win": WinPort,
             "wpe": WpePort,
         }
         default_port = {
-            "Windows": WinCairoPort,
+            "Windows": WinPort,
             "Darwin": MacPort,
         }
         # Do we really need MacPort as the ultimate default?
@@ -167,19 +167,8 @@ class MacWK2Port(DeprecatedPort):
     port_flag_name = "mac-wk2"
 
 
-class WinCairoPort(DeprecatedPort):
-    port_flag_name = "wincairo"
-
-    def build_webkit_command(self, build_style=None):
-        command = super(WinCairoPort, self).build_webkit_command(build_style=build_style)
-        command.append('--wincairo')
-        return command
-
-    def run_webkit_tests_command(self, build_style=None):
-        command = super(WinCairoPort, self).run_webkit_tests_command(build_style)
-        command.append("--wincairo")
-        return command
-
+class WinPort(DeprecatedPort):
+    port_flag_name = "win"
 
 class GtkWK2Port(DeprecatedPort):
     port_flag_name = "gtk-wk2"

--- a/Tools/Scripts/webkitpy/common/config/ports_unittest.py
+++ b/Tools/Scripts/webkitpy/common/config/ports_unittest.py
@@ -56,11 +56,11 @@ class DeprecatedPortTest(unittest.TestCase):
         self.assertEqual(WpePort().build_webkit_command(), DeprecatedPort().script_shell_command("build-webkit") + ["--wpe", "--update-wpe", DeprecatedPort().makeArgs()])
         self.assertEqual(WpePort().build_webkit_command(build_style="debug"), DeprecatedPort().script_shell_command("build-webkit") + ["--debug", "--wpe", "--update-wpe", DeprecatedPort().makeArgs()])
 
-    def test_wincairo_port(self):
-        self.assertEqual(WinCairoPort().flag(), "--port=wincairo")
-        self.assertEqual(WinCairoPort().run_webkit_tests_command(), DeprecatedPort().script_shell_command("run-webkit-tests") + ["--wincairo"])
-        self.assertEqual(WinCairoPort().build_webkit_command(), DeprecatedPort().script_shell_command("build-webkit") + ["--wincairo"])
-        self.assertEqual(WinCairoPort().build_webkit_command(build_style="debug"), DeprecatedPort().script_shell_command("build-webkit") + ["--debug", "--wincairo"])
+    def test_win_port(self):
+        self.assertEqual(WinPort().flag(), "--port=win")
+        self.assertEqual(WinPort().run_webkit_tests_command(), DeprecatedPort().script_shell_command("run-webkit-tests"))
+        self.assertEqual(WinPort().build_webkit_command(), DeprecatedPort().script_shell_command("build-webkit"))
+        self.assertEqual(WinPort().build_webkit_command(build_style="debug"), DeprecatedPort().script_shell_command("build-webkit") + ["--debug"])
 
     def test_jsconly_port(self):
         self.assertEqual(JscOnlyPort().flag(), "--port=jsc-only")

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -86,10 +86,6 @@ class VersionNameMap(object):
             'linux': {},
         }
 
-        # wincairo uses the same versions as Windows
-        self.mapping[PUBLIC_TABLE]['wincairo'] = self.mapping[PUBLIC_TABLE]['win']
-
-
     @classmethod
     def _automap_to_major_version(cls, prefix, minimum=Version(1), maximum=Version(1)):
         result = {}

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -67,9 +67,6 @@ def platform_options(use_globs=False):
         optparse.make_option('--win', action='store_const', dest='platform',
             const=('win'),
             help=('Alias for --platform=win')),
-        optparse.make_option('--wincairo', action='store_const', dest='platform',
-            const=('win'),
-            help=('Alias for --platform=win')),
         optparse.make_option('--maccatalyst', action='store_const', dest='platform',
             const=('maccatalyst'),
             help=('Alias for --platform=maccatalyst')),
@@ -136,9 +133,6 @@ class PortFactory(object):
         port_name is None, this routine attempts to guess at the most
         appropriate port on this platform."""
         port_name = port_name or self._default_port()
-        if port_name == 'wincairo':
-            port_name = 'win'
-
         classes = []
         for port_class in self.PORT_CLASSES:
             module_name, class_name = port_class.rsplit('.', 1)

--- a/Tools/Scripts/webkitpy/port/factory_unittest.py
+++ b/Tools/Scripts/webkitpy/port/factory_unittest.py
@@ -66,11 +66,6 @@ class FactoryTest(unittest.TestCase):
         self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), cls=win.WinPort)
         self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), options=self.webkit_options, cls=win.WinPort)
 
-    def test_wincairo(self):
-        self.assert_port(port_name='wincairo', os_name='win', os_version=Version.from_name('Win10'), cls=win.WinPort)
-        self.assert_port(port_name='wincairo-win10', cls=win.WinPort)
-        self.assert_port(port_name='wincairo-win10-wk2', cls=win.WinPort)
-
     def test_gtk(self):
         self.assert_port(port_name='gtk', cls=gtk.GtkPort)
 


### PR DESCRIPTION
#### 2ec95e33df6fd824b3f7ee31d356514c3a4e3c5f
<pre>
Remove --platform=wincairo alias from all tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=279948">https://bugs.webkit.org/show_bug.cgi?id=279948</a>

Reviewed by Ross Kirsling.

EWS and post-commit buildbots have finished the migration to
`--platform=win`. Now we can remove `--platform=wincairo` alias from
all tools.

* Tools/CISupport/built-product-archive:
(archiveBuiltProduct):
(extractBuiltProduct):
* Tools/CISupport/test-result-archive:
(archive_test_results):
* Tools/Scripts/download-github-release.py:
* Tools/Scripts/webkitdirs.pm:
(determinePortName):
* Tools/Scripts/webkitpy/common/config/ports.py:
(DeprecatedPort.port):
(WinPort):
(WinCairoPort): Deleted.
(WinCairoPort.build_webkit_command): Deleted.
(WinCairoPort.run_webkit_tests_command): Deleted.
* Tools/Scripts/webkitpy/common/config/ports_unittest.py:
(DeprecatedPortTest.test_win_port):
(DeprecatedPortTest.test_wincairo_port): Deleted.
* Tools/Scripts/webkitpy/common/version_name_map.py:
(VersionNameMap.__init__):
* Tools/Scripts/webkitpy/port/factory.py:
(platform_options):
(PortFactory.get):
* Tools/Scripts/webkitpy/port/factory_unittest.py:
(FactoryTest.test_win):
(FactoryTest.test_wincairo): Deleted.

Canonical link: <a href="https://commits.webkit.org/283939@main">https://commits.webkit.org/283939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aedd9e5f9c5ec07d7c6ac833e9ce36aaae1ae186

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71786 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54195 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34663 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/67243 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17230 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/60848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73483 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/66978 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11694 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15618 "Found 1 new test failure: fast/loader/subframe-navigate-during-main-frame-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61691 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3154 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88746 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10321 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42920 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15652 "Found 4 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/tail-call.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->