### PR TITLE
Have WebPageProxy::pageClient() return a pointer instead of a reference

### DIFF
--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.cpp
@@ -56,7 +56,10 @@ WebCore::FloatRect TargetedElementInfo::boundsInWebView() const
     RefPtr page = m_page.get();
     if (!page)
         return { };
-    return page->pageClient().rootViewToWebView(boundsInRootView());
+    RefPtr pageClient = page->pageClient();
+    if (!pageClient)
+        return { };
+    return pageClient->rootViewToWebView(boundsInRootView());
 }
 
 void TargetedElementInfo::childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&& completion) const

--- a/Source/WebKit/UIProcess/API/APITargetedElementRequest.cpp
+++ b/Source/WebKit/UIProcess/API/APITargetedElementRequest.cpp
@@ -57,8 +57,10 @@ void TargetedElementRequest::setSearchText(WTF::String&& searchText)
 WebCore::TargetedElementRequest TargetedElementRequest::makeRequest(const WebKit::WebPageProxy& page) const
 {
     auto request = m_request;
-    if (std::holds_alternative<WebCore::FloatPoint>(m_request.data))
-        request.data = page.protectedPageClient()->webViewToRootView(point());
+    if (std::holds_alternative<WebCore::FloatPoint>(m_request.data)) {
+        if (RefPtr pageClient = page.pageClient())
+            request.data = pageClient->webViewToRootView(point());
+    }
     return request;
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -407,7 +407,7 @@ void WKPageGoBack(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
     auto& page = *toImpl(pageRef);
-    if (page.pageClient().hasBrowsingWarning()) {
+    if (RefPtr pageClient = page.pageClient(); pageClient->hasBrowsingWarning()) {
         WKPageReload(pageRef);
         return;
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -198,16 +198,20 @@ void Attachment::updateFromSerializedRepresentation(Ref<WebCore::SharedBuffer>&&
     if (!m_webPage)
         return;
 
+    RefPtr pageClient = m_webPage->pageClient();
+    if (!pageClient)
+        return;
+
     auto serializedData = serializedRepresentation->createNSData();
     if (!serializedData)
         return;
 
-    NSFileWrapper *fileWrapper = [NSKeyedUnarchiver unarchivedObjectOfClasses:m_webPage->pageClient().serializableFileWrapperClasses() fromData:serializedData.get() error:nullptr];
+    RetainPtr fileWrapper = [NSKeyedUnarchiver unarchivedObjectOfClasses:pageClient->serializableFileWrapperClasses() fromData:serializedData.get() error:nullptr];
     if (![fileWrapper isKindOfClass:NSFileWrapper.class])
         return;
 
     m_isCreatedFromSerializedRepresentation = true;
-    setFileWrapperAndUpdateContentType(fileWrapper, contentType);
+    setFileWrapperAndUpdateContentType(fileWrapper.get(), contentType);
     m_webPage->updateAttachmentAttributes(*this, [] { });
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -233,7 +233,7 @@ void webkit_web_view_set_background_color(WebKitWebView* webView, WebKitColor* b
     auto color = webkitColorToWebCoreColor(backgroundColor);
     page.setBackgroundColor(color);
 #if ENABLE(WPE_PLATFORM)
-    if (auto* view = static_cast<WebKit::PageClientImpl&>(page.pageClient()).wpeView()) {
+    if (auto* view = static_cast<WebKit::PageClientImpl&>(*page.pageClient()).wpeView()) {
         if (color.isOpaque()) {
             WPERectangle rect { 0, 0, wpe_view_get_width(view), wpe_view_get_height(view) };
             wpe_view_set_opaque_rectangles(view, &rect, 1);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -329,11 +329,11 @@ void VideoPresentationModelContext::fullscreenModeChanged(WebCore::HTMLMediaElem
 #if PLATFORM(IOS_FAMILY)
 UIViewController *VideoPresentationModelContext::presentingViewController()
 {
-    if (!m_manager)
+    if (!m_manager || !m_manager->m_page)
         return nullptr;
 
-    if (auto* page = m_manager->m_page.get())
-        return page->protectedPageClient()->presentingViewController();
+    if (RefPtr pageClient = m_manager->m_page->pageClient())
+        return pageClient->presentingViewController();
     return nullptr;
 }
 
@@ -926,7 +926,8 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 
     RetainPtr view = model->layerHostView() ? static_cast<WKLayerHostView*>(model->layerHostView()) : createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 #if USE(EXTENSIONKIT)
-    if (UIView *visibilityPropagationView = m_page->pageClient().createVisibilityPropagationView())
+    RefPtr pageClient = m_page->pageClient();
+    if (UIView *visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nullptr)
         [view setVisibilityPropagationView:visibilityPropagationView];
 #else
     UNUSED_VARIABLE(view);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -135,12 +135,12 @@ void NetworkProcessProxy::getWindowSceneAndBundleIdentifierForPaymentPresentatio
     auto sceneIdentifier = nullString();
     auto bundleIdentifier = WebCore::applicationBundleIdentifier();
     auto page = WebProcessProxy::webPage(webPageProxyIdentifier);
-    if (!page) {
+    if (!page || !page->pageClient()) {
         completionHandler(sceneIdentifier, bundleIdentifier);
         return;
     }
 
-    sceneIdentifier = page->pageClient().sceneID();
+    sceneIdentifier = page->pageClient()->sceneID();
     RetainPtr<WKWebView> webView = page->cocoaView();
     id webViewUIDelegate = [webView UIDelegate];
     if ([webViewUIDelegate respondsToSelector:@selector(_hostSceneIdentifierForWebView:)])

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -234,7 +234,7 @@ void ProvisionalPageProxy::cancel()
 
 void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& websitePolicies)
 {
-    m_drawingArea = m_page->pageClient().createDrawingAreaProxy(protectedProcess());
+    m_drawingArea = m_page->protectedPageClient()->createDrawingAreaProxy(protectedProcess());
 
     bool registerWithInspectorController { true };
     if (websitePolicies)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -407,8 +407,10 @@ void ScrollingTreeScrollingNodeDelegateIOS::stopAnimatedScroll()
 void ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *scrollView, WKBEScrollViewScrollUpdate *update, void (^completion)(BOOL handled))
 {
     auto* scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
-    if (scrollingCoordinatorProxy)
-        scrollingCoordinatorProxy->webPageProxy().pageClient().handleAsynchronousCancelableScrollEvent(scrollView, update, completion);
+    if (scrollingCoordinatorProxy) {
+        if (RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient())
+            pageClient->handleAsynchronousCancelableScrollEvent(scrollView, update, completion);
+    }
 }
 #endif
 
@@ -484,7 +486,11 @@ void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureR
     if (!scrollingCoordinatorProxy)
         return;
 
-    if (auto touchIdentifier = scrollingCoordinatorProxy->webPageProxy().pageClient().activeTouchIdentifierForGestureRecognizer(gestureRecognizer))
+    RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient();
+    if (!pageClient)
+        return;
+
+    if (auto touchIdentifier = pageClient->activeTouchIdentifierForGestureRecognizer(gestureRecognizer))
         m_activeTouchActions = scrollingCoordinatorProxy->activeTouchActionsForTouchIdentifier(*touchIdentifier);
 }
 
@@ -494,7 +500,8 @@ void ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer(U
     if (!scrollingCoordinatorProxy)
         return;
 
-    scrollingCoordinatorProxy->webPageProxy().pageClient().cancelPointersForGestureRecognizer(gestureRecognizer);
+    if (RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient())
+        pageClient->cancelPointersForGestureRecognizer(gestureRecognizer);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -1117,7 +1117,8 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
     }
 #endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    requestContext.get().windowSceneIdentifier = m_webPageProxy->pageClient().sceneID();
+    if (auto* pageClient = m_webPageProxy->pageClient())
+        requestContext.get().windowSceneIdentifier = pageClient->sceneID();
 
     [m_proxy performAuthorizationRequestsForContext:requestContext.get() withCompletionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, handler = WTFMove(handler)](id<ASCCredentialProtocol> credential, NSError *error) mutable {
         callOnMainRunLoop([weakThis, handler = WTFMove(handler), credential = retainPtr(credential), error = retainPtr(error)] () mutable {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -899,9 +899,8 @@ public:
     void clearSelection(std::optional<WebCore::FrameIdentifier> = std::nullopt);
     void restoreSelectionInFocusedEditableElement();
 
-    PageClient& pageClient() const;
-    Ref<PageClient> protectedPageClient() const;
-    RefPtr<PageClient> optionalProtectedPageClient() const;
+    PageClient* pageClient() const;
+    RefPtr<PageClient> protectedPageClient() const;
 
     void setViewNeedsDisplay(const WebCore::Region&);
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated);

--- a/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
@@ -64,25 +64,25 @@ void WebPageProxy::loadRecentSearches(IPC::Connection&, const String&, Completio
 
 void WebPageProxy::didInitiateLoadForResource(WebCore::ResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ResourceRequest&& request)
 {
-    if (auto* manager = pageClient().webResourceLoadManager())
+    if (auto* manager = pageClient() ? pageClient()->webResourceLoadManager() : nullptr)
         manager->didInitiateLoad(resourceID, frameID, WTFMove(request));
 }
 
 void WebPageProxy::didSendRequestForResource(WebCore::ResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ResourceRequest&& request, WebCore::ResourceResponse&& redirectResponse)
 {
-    if (auto* manager = pageClient().webResourceLoadManager())
+    if (auto* manager = pageClient() ? pageClient()->webResourceLoadManager() : nullptr)
         manager->didSendRequest(resourceID, frameID, WTFMove(request), WTFMove(redirectResponse));
 }
 
 void WebPageProxy::didReceiveResponseForResource(WebCore::ResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ResourceResponse&& response)
 {
-    if (auto* manager = pageClient().webResourceLoadManager())
+    if (auto* manager = pageClient() ? pageClient()->webResourceLoadManager() : nullptr)
         manager->didReceiveResponse(resourceID, frameID, WTFMove(response));
 }
 
 void WebPageProxy::didFinishLoadForResource(WebCore::ResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ResourceError&& error)
 {
-    if (auto* manager = pageClient().webResourceLoadManager())
+    if (auto* manager = pageClient() ? pageClient()->webResourceLoadManager() : nullptr)
         manager->didFinishLoad(resourceID, frameID, WTFMove(error));
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6684,7 +6684,8 @@ static WebKit::WritingDirection coreWritingDirection(NSWritingDirection directio
 #else
             platformReplacement = nsReplacement;
 #endif
-            page->pageClient().replaceDictationAlternatives(platformReplacement.get(), context);
+            if (RefPtr pageClient = page->pageClient())
+                pageClient->replaceDictationAlternatives(platformReplacement.get(), context);
         }
         page->clearDictationAlternatives(WTFMove(contextsToRemove));
     });

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -178,6 +178,10 @@ void WebPageProxy::windowAndViewFramesChanged(const FloatRect& viewFrameInWindow
 {
     // In case the UI client overrides getWindowFrame(), we call it here to make sure we send the appropriate window frame.
     m_uiClient->windowFrame(*this, [this, protectedThis = Ref { *this }, viewFrameInWindowCoordinates, accessibilityViewCoordinates] (FloatRect windowFrameInScreenCoordinates) {
+        RefPtr pageClient = this->pageClient();
+        if (!pageClient)
+            return;
+
         FloatRect windowFrameInUnflippedScreenCoordinates = protectedPageClient()->convertToUserSpace(windowFrameInScreenCoordinates);
 
         m_viewWindowCoordinates = makeUnique<ViewWindowCoordinates>();
@@ -267,7 +271,8 @@ void WebPageProxy::setPromisedDataForImage(IPC::Connection& connection, const St
     if (!sharedMemoryArchive)
         return;
     archiveBuffer = sharedMemoryArchive->createSharedBuffer(sharedMemoryArchive->size());
-    protectedPageClient()->setPromisedDataForImage(pasteboardName, WTFMove(imageBuffer), ResourceResponseBase::sanitizeSuggestedFilename(filename), extension, title, url, visibleURL, WTFMove(archiveBuffer), originIdentifier);
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->setPromisedDataForImage(pasteboardName, WTFMove(imageBuffer), ResourceResponseBase::sanitizeSuggestedFilename(filename), extension, title, url, visibleURL, WTFMove(archiveBuffer), originIdentifier);
 }
 
 #endif
@@ -284,7 +289,8 @@ void WebPageProxy::setSmartInsertDeleteEnabled(bool isSmartInsertDeleteEnabled)
 
 void WebPageProxy::didPerformDictionaryLookup(const DictionaryPopupInfo& dictionaryPopupInfo)
 {
-    protectedPageClient()->didPerformDictionaryLookup(dictionaryPopupInfo);
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->didPerformDictionaryLookup(dictionaryPopupInfo);
 }
 
 void WebPageProxy::registerWebProcessAccessibilityToken(std::span<const uint8_t> data)
@@ -293,22 +299,26 @@ void WebPageProxy::registerWebProcessAccessibilityToken(std::span<const uint8_t>
         return;
 
     // Note: The WebFrameProxy with this FrameIdentifier might not exist in the UI process. See rdar://130998804.
-    protectedPageClient()->accessibilityWebProcessTokenReceived(data, legacyMainFrameProcess().connection().remoteProcessID());
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->accessibilityWebProcessTokenReceived(data, legacyMainFrameProcess().connection().remoteProcessID());
 }
 
 void WebPageProxy::makeFirstResponder()
 {
-    protectedPageClient()->makeFirstResponder();
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->makeFirstResponder();
 }
 
 void WebPageProxy::assistiveTechnologyMakeFirstResponder()
 {
-    protectedPageClient()->assistiveTechnologyMakeFirstResponder();
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->assistiveTechnologyMakeFirstResponder();
 }
 
 bool WebPageProxy::useFormSemanticContext() const
 {
-    return protectedPageClient()->useFormSemanticContext();
+    RefPtr pageClient = this->pageClient();
+    return pageClient && pageClient->useFormSemanticContext();
 }
 
 void WebPageProxy::semanticContextDidChange()
@@ -336,7 +346,10 @@ void WebPageProxy::executeSavedCommandBySelector(IPC::Connection& connection, co
 {
     MESSAGE_CHECK_COMPLETION(isValidKeypressCommandName(selector), connection, completionHandler(false));
 
-    completionHandler(protectedPageClient()->executeSavedCommandBySelector(selector));
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return completionHandler(false);
+    completionHandler(pageClient->executeSavedCommandBySelector(selector));
 }
 
 bool WebPageProxy::shouldDelayWindowOrderingForEvent(const WebKit::WebMouseEvent& event)
@@ -377,23 +390,27 @@ void WebPageProxy::handleAcceptsFirstMouse(bool acceptsFirstMouse)
 
 void WebPageProxy::setRemoteLayerTreeRootNode(RemoteLayerTreeNode* rootNode)
 {
-    protectedPageClient()->setRemoteLayerTreeRootNode(rootNode);
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->setRemoteLayerTreeRootNode(rootNode);
     m_frozenRemoteLayerTreeHost = nullptr;
 }
 
 CALayer *WebPageProxy::acceleratedCompositingRootLayer() const
 {
-    return protectedPageClient()->acceleratedCompositingRootLayer();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? pageClient->acceleratedCompositingRootLayer() : nullptr;
 }
 
 CALayer *WebPageProxy::headerBannerLayer() const
 {
-    return protectedPageClient()->headerBannerLayer();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? pageClient->headerBannerLayer() : nullptr;
 }
 
 CALayer *WebPageProxy::footerBannerLayer() const
 {
-    return protectedPageClient()->footerBannerLayer();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? pageClient->footerBannerLayer() : nullptr;
 }
 
 int WebPageProxy::headerBannerHeight() const
@@ -497,9 +514,13 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
 {
     if (!contextMenu.items.size())
         return completionHandler(std::nullopt);
+
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return completionHandler(std::nullopt);
     
-    RetainPtr<WKPDFMenuTarget> menuTarget = adoptNS([[WKPDFMenuTarget alloc] init]);
-    RetainPtr<NSMenu> nsMenu = adoptNS([[NSMenu alloc] init]);
+    RetainPtr menuTarget = adoptNS([[WKPDFMenuTarget alloc] init]);
+    RetainPtr nsMenu = adoptNS([[NSMenu alloc] init]);
     [nsMenu setAllowsContextMenuPlugIns:false];
     for (unsigned i = 0; i < contextMenu.items.size(); i++) {
         auto& item = contextMenu.items[i];
@@ -509,7 +530,7 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
             continue;
         }
         
-        RetainPtr<NSMenuItem> nsItem = adoptNS([[NSMenuItem alloc] init]);
+        RetainPtr nsItem = adoptNS([[NSMenuItem alloc] init]);
         [nsItem setTitle:item.title];
         [nsItem setEnabled:item.enabled == ContextMenuItemEnablement::Enabled];
         [nsItem setState:item.state];
@@ -520,7 +541,7 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
         [nsItem setTag:item.tag];
         [nsMenu insertItem:nsItem.get() atIndex:i];
     }
-    NSWindow *window = protectedPageClient()->platformWindow();
+    NSWindow *window = pageClient->platformWindow();
     auto location = [window convertRectFromScreen: { contextMenu.point, NSZeroSize }].origin;
     auto event = createSyntheticEventForContextMenu(location);
 
@@ -540,33 +561,42 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 void WebPageProxy::showTelephoneNumberMenu(const String& telephoneNumber, const WebCore::IntPoint& point, const WebCore::IntRect& rect)
 {
-    RetainPtr<NSMenu> menu = menuForTelephoneNumber(telephoneNumber, protectedPageClient()->viewForPresentingRevealPopover(), rect);
-    protectedPageClient()->showPlatformContextMenu(menu.get(), point);
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+
+    RetainPtr menu = menuForTelephoneNumber(telephoneNumber, pageClient->viewForPresentingRevealPopover(), rect);
+    pageClient->showPlatformContextMenu(menu.get(), point);
 }
 #endif
 
 CGRect WebPageProxy::boundsOfLayerInLayerBackedWindowCoordinates(CALayer *layer) const
 {
-    return protectedPageClient()->boundsOfLayerInLayerBackedWindowCoordinates(layer);
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? pageClient->boundsOfLayerInLayerBackedWindowCoordinates(layer) : CGRect { };
 }
 
 void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const EditorState& newEditorState)
 {
     bool couldChangeSecureInputState = newEditorState.isInPasswordField != oldEditorState.isInPasswordField || oldEditorState.selectionIsNone;
     // Selection being none is a temporary state when editing. Flipping secure input state too quickly was causing trouble (not fully understood).
-    if (couldChangeSecureInputState && !newEditorState.selectionIsNone)
-        protectedPageClient()->updateSecureInputState();
+    if (couldChangeSecureInputState && !newEditorState.selectionIsNone) {
+        if (RefPtr pageClient = this->pageClient())
+            pageClient->updateSecureInputState();
+    }
     
     if (newEditorState.shouldIgnoreSelectionChanges)
         return;
 
     updateFontAttributesAfterEditorStateChange();
-    protectedPageClient()->selectionDidChange();
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->selectionDidChange();
 }
 
 void WebPageProxy::startWindowDrag()
 {
-    protectedPageClient()->startWindowDrag();
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->startWindowDrag();
 }
 
 NSWindow *WebPageProxy::platformWindow()
@@ -576,23 +606,30 @@ NSWindow *WebPageProxy::platformWindow()
 
 void WebPageProxy::rootViewToWindow(const WebCore::IntRect& viewRect, WebCore::IntRect& windowRect)
 {
-    windowRect = protectedPageClient()->rootViewToWindow(viewRect);
+    RefPtr pageClient = this->pageClient();
+    windowRect = pageClient ? pageClient->rootViewToWindow(viewRect) : WebCore::IntRect { };
 }
 
 void WebPageProxy::showValidationMessage(const IntRect& anchorClientRect, const String& message)
 {
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+
     m_validationBubble = protectedPageClient()->createValidationBubble(message, { m_preferences->minimumFontSize() });
     m_validationBubble->showRelativeTo(anchorClientRect);
 }
 
 NSView *WebPageProxy::inspectorAttachmentView()
 {
-    return protectedPageClient()->inspectorAttachmentView();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? pageClient->inspectorAttachmentView() : nullptr;
 }
 
 _WKRemoteObjectRegistry *WebPageProxy::remoteObjectRegistry()
 {
-    return protectedPageClient()->remoteObjectRegistry();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? pageClient->remoteObjectRegistry() : nullptr;
 }
 
 #if ENABLE(CONTEXT_MENUS)
@@ -631,24 +668,28 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteA
 
 RetainPtr<NSView> WebPageProxy::Internals::platformView() const
 {
-    return [page->protectedPageClient()->platformWindow() contentView];
+    RefPtr pageClient = page->pageClient();
+    return pageClient ? [pageClient->platformWindow() contentView] : nullptr;
 }
 
 #if ENABLE(PDF_PLUGIN)
 
 void WebPageProxy::createPDFHUD(PDFPluginIdentifier identifier, const WebCore::IntRect& rect)
 {
-    protectedPageClient()->createPDFHUD(identifier, rect);
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->createPDFHUD(identifier, rect);
 }
 
 void WebPageProxy::removePDFHUD(PDFPluginIdentifier identifier)
 {
-    protectedPageClient()->removePDFHUD(identifier);
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->removePDFHUD(identifier);
 }
 
 void WebPageProxy::updatePDFHUDLocation(PDFPluginIdentifier identifier, const WebCore::IntRect& rect)
 {
-    protectedPageClient()->updatePDFHUDLocation(identifier, rect);
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->updatePDFHUDLocation(identifier, rect);
 }
 
 void WebPageProxy::pdfZoomIn(PDFPluginIdentifier identifier)
@@ -766,7 +807,8 @@ void WebPageProxy::showImageInQuickLookPreviewPanel(ShareableBitmap& imageBitmap
     // When presenting the shared QLPreviewPanel, QuickLook will search the responder chain for a suitable panel controller.
     // Make sure that we (by default) start the search at the web view, which knows how to vend the Visual Search preview
     // controller as a delegate and data source for the preview panel.
-    protectedPageClient()->makeFirstResponder();
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->makeFirstResponder();
 
     auto previewPanel = [PAL::getQLPreviewPanelClass() sharedPreviewPanel];
     [previewPanel makeKeyAndOrderFront:nil];
@@ -813,9 +855,12 @@ void WebPageProxy::handleContextMenuWritingTools(WebCore::WritingTools::Requeste
         ASSERT_NOT_REACHED();
         return;
     }
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
 
     auto selectionRect = editorState.postLayoutData->selectionBoundingRect;
-    protectedPageClient()->handleContextMenuWritingTools(tool, selectionRect);
+    pageClient->handleContextMenuWritingTools(tool, selectionRect);
 }
 
 #endif

--- a/Source/WebKit/UIProcess/win/WebPageProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPageProxyWin.cpp
@@ -74,7 +74,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState&, const EditorState&)
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
 uint64_t WebPageProxy::viewWidget()
 {
-    return reinterpret_cast<uint64_t>(static_cast<PageClientImpl&>(pageClient()).viewWidget());
+    return reinterpret_cast<uint64_t>(static_cast<PageClientImpl&>(*pageClient()).viewWidget());
 }
 #endif
 

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -29,6 +29,7 @@
 #include "EditorState.h"
 #include "InputMethodState.h"
 #include "PageClientImpl.h"
+#include "UserMessage.h"
 #include "WebProcessProxy.h"
 #include <WebCore/PlatformEvent.h>
 
@@ -57,20 +58,25 @@ void WebPageProxy::platformInitialize()
 
 struct wpe_view_backend* WebPageProxy::viewBackend()
 {
-    return static_cast<PageClientImpl&>(pageClient()).viewBackend();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? static_cast<PageClientImpl&>(*pageClient).viewBackend() : nullptr;
 }
 
 #if ENABLE(WPE_PLATFORM)
 WPEView* WebPageProxy::wpeView() const
 {
-    return static_cast<PageClientImpl&>(pageClient()).wpeView();
+    RefPtr pageClient = this->pageClient();
+    return pageClient ? static_cast<PageClientImpl&>(*pageClient).wpeView() : nullptr;
 }
 #endif
 
 void WebPageProxy::bindAccessibilityTree(const String& plugID)
 {
 #if USE(ATK)
-    auto* accessible = static_cast<PageClientImpl&>(pageClient()).accessible();
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+    auto* accessible = static_cast<PageClientImpl&>(*pageClient).accessible();
     atk_socket_embed(ATK_SOCKET(accessible), const_cast<char*>(plugID.utf8().data()));
     atk_object_notify_state_change(accessible, ATK_STATE_TRANSIENT, FALSE);
 #else
@@ -80,13 +86,18 @@ void WebPageProxy::bindAccessibilityTree(const String& plugID)
 
 void WebPageProxy::didUpdateEditorState(const EditorState&, const EditorState& newEditorState)
 {
-    if (!newEditorState.shouldIgnoreSelectionChanges)
-        pageClient().selectionDidChange();
+    if (!newEditorState.shouldIgnoreSelectionChanges) {
+        if (RefPtr pageClient = this->pageClient())
+            pageClient->selectionDidChange();
+    }
 }
 
 void WebPageProxy::sendMessageToWebViewWithReply(UserMessage&& message, CompletionHandler<void(UserMessage&&)>&& completionHandler)
 {
-    static_cast<PageClientImpl&>(pageClient()).sendMessageToWebView(WTFMove(message), WTFMove(completionHandler));
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return completionHandler({ });
+    static_cast<PageClientImpl&>(*pageClient).sendMessageToWebView(WTFMove(message), WTFMove(completionHandler));
 }
 
 void WebPageProxy::sendMessageToWebView(UserMessage&& message)
@@ -96,7 +107,8 @@ void WebPageProxy::sendMessageToWebView(UserMessage&& message)
 
 void WebPageProxy::setInputMethodState(std::optional<InputMethodState>&& state)
 {
-    static_cast<PageClientImpl&>(pageClient()).setInputMethodState(WTFMove(state));
+    if (RefPtr pageClient = this->pageClient())
+        static_cast<PageClientImpl&>(*pageClient).setInputMethodState(WTFMove(state));
 }
 
 #if USE(GBM)
@@ -200,10 +212,13 @@ void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
     }
 
 #if USE(COORDINATED_GRAPHICS)
-    static_cast<PageClientImpl&>(pageClient()).callAfterNextPresentationUpdate(WTFMove(callback));
-#else
-    callback();
+    if (RefPtr pageClient = this->pageClient()) {
+        static_cast<PageClientImpl&>(*pageClient).callAfterNextPresentationUpdate(WTFMove(callback));
+        return;
+    }
 #endif
+
+    callback();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### a3151425d94b96689127e959c43ee446eef3b51b
<pre>
Have WebPageProxy::pageClient() return a pointer instead of a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=279950">https://bugs.webkit.org/show_bug.cgi?id=279950</a>

Reviewed by Ryosuke Niwa.

Have WebPageProxy::pageClient() return a pointer instead of a reference.
WebPageProxy::m_pageClient is a WeakPtr and the pointer can get nulled out
if the WKWebView gets deallocated. However, `pageClient()` was asserting
that m_pageClient is non-null and would return a C++ reference. This keeps
leading to crashes such as the one fixed in 283815@main since it is easy
for the WebPageProxy to outlive the WKWebView.

To make this less error prone, I&apos;m updating pageClient() to return a
pointer instead of a reference and updating call sites to null check it.

* Source/WebKit/UIProcess/API/APITargetedElementInfo.cpp:
(API::TargetedElementInfo::boundsInWebView const):
* Source/WebKit/UIProcess/API/APITargetedElementRequest.cpp:
(API::TargetedElementRequest::makeRequest const):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGoBack):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::updateFromSerializedRepresentation):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::presentingViewController):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
(WebKit::WebPageProxy::layerTreeCommitComplete):
(WebKit::WebPageProxy::handleClickForDataDetectionResult):
(WebKit::WebPageProxy::scrollingNodeScrollViewDidScroll):
(WebKit::WebPageProxy::scrollingUpdatesDisabledForTesting):
(WebKit::WebPageProxy::startDrag):
(WebKit::WebPageProxy::platformRegisterAttachment):
(WebKit::WebPageProxy::insertDictatedTextAsync):
(WebKit::WebPageProxy::addDictationAlternative):
(WebKit::WebPageProxy::Internals::paymentCoordinatorPresentingWindow const):
(WebKit::WebPageProxy::didCreateContextInWebProcessForVisibilityPropagation):
(WebKit::WebPageProxy::didCreateContextInGPUProcessForVisibilityPropagation):
(WebKit::WebPageProxy::didCreateContextInModelProcessForVisibilityPropagation):
(WebKit::WebPageProxy::updateFullscreenVideoTextRecognition):
(WebKit::WebPageProxy::fullscreenVideoTextRecognitionTimerFired):
(WebKit::WebPageProxy::createAppHighlightInSelectedRange):
(WebKit::WebPageProxy::canHandleContextMenuTranslation const):
(WebKit::WebPageProxy::handleContextMenuTranslation):
(WebKit::WebPageProxy::canHandleContextMenuWritingTools const):
(WebKit::WebPageProxy::shouldForceForegroundPriorityForClientNavigation const):
(WebKit::WebPageProxy::setWritingToolsActive):
(WebKit::WebPageProxy::addTextAnimationForAnimationIDWithCompletionHandler):
(WebKit::WebPageProxy::didEndPartialIntelligenceTextAnimationImpl):
(WebKit::WebPageProxy::writingToolsTextReplacementsFinished):
(WebKit::WebPageProxy::removeTextAnimationForAnimationID):
(WebKit::WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID):
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::getWindowSceneAndBundleIdentifierForPaymentPresentation):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::pageClient const):
(WebKit::WebPageProxy::protectedPageClient const):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::didChangeBackForwardList):
(WebKit::WebPageProxy::willGoToBackForwardListItem):
(WebKit::WebPageProxy::shouldKeepCurrentBackForwardListItemInList):
(WebKit::WebPageProxy::setTopContentInset):
(WebKit::WebPageProxy::setUnderPageBackgroundColorOverride):
(WebKit::WebPageProxy::setViewNeedsDisplay):
(WebKit::WebPageProxy::requestScroll):
(WebKit::WebPageProxy::viewScrollPosition const):
(WebKit::WebPageProxy::updateActivityState):
(WebKit::WebPageProxy::activityStateDidChange):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::layerHostingModeDidChange):
(WebKit::WebPageProxy::viewSize const):
(WebKit::WebPageProxy::stopMakingViewBlankDueToLackOfRenderingUpdateIfNecessary):
(WebKit::WebPageProxy::makeViewBlankIfUnpaintedSinceLastLoadCommit):
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::didPerformDragControllerAction):
(WebKit::WebPageProxy::startDrag):
(WebKit::WebPageProxy::setDragCaretRect):
(WebKit::WebPageProxy::processNextQueuedMouseEvent):
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::handlePreventableTouchEvent):
(WebKit::WebPageProxy::touchEventHandlingCompleted):
(WebKit::WebPageProxy::handleTouchEvent):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPageProxy::preferencesDidChange):
(WebKit::WebPageProxy::didStartProgress):
(WebKit::WebPageProxy::didChangeProgress):
(WebKit::WebPageProxy::didFinishProgress):
(WebKit::WebPageProxy::didDestroyNavigationShared):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::willPerformClientRedirectForFrame):
(WebKit::WebPageProxy::didCancelClientRedirectForFrame):
(WebKit::WebPageProxy::didChangeProvisionalURLForFrameShared):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebPageProxy::didChangeMainDocument):
(WebKit::WebPageProxy::viewIsBecomingVisible):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
(WebKit::WebPageProxy::didReachLayoutMilestone):
(WebKit::WebPageProxy::didDisplayInsecureContentForFrame):
(WebKit::WebPageProxy::didRunInsecureContentForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::didNavigateWithNavigationDataShared):
(WebKit::WebPageProxy::didPerformClientRedirectShared):
(WebKit::WebPageProxy::didPerformServerRedirectShared):
(WebKit::WebPageProxy::didUpdateHistoryTitle):
(WebKit::WebPageProxy::didEnterFullscreen):
(WebKit::WebPageProxy::didExitFullscreen):
(WebKit::WebPageProxy::didCleanupFullscreen):
(WebKit::WebPageProxy::closePage):
(WebKit::WebPageProxy::setWindowFrame):
(WebKit::WebPageProxy::getWindowFrame):
(WebKit::WebPageProxy::getWindowFrameWithCallback):
(WebKit::WebPageProxy::screenToRootView):
(WebKit::WebPageProxy::rootViewToScreen):
(WebKit::WebPageProxy::syncRootViewToScreen):
(WebKit::WebPageProxy::accessibilityScreenToRootView):
(WebKit::WebPageProxy::rootViewToAccessibilityScreen):
(WebKit::WebPageProxy::didChangeViewportProperties):
(WebKit::WebPageProxy::pageDidScroll):
(WebKit::WebPageProxy::runOpenPanel):
(WebKit::WebPageProxy::showShareSheet):
(WebKit::WebPageProxy::showContactPicker):
(WebKit::WebPageProxy::didChangeContentSize):
(WebKit::WebPageProxy::didChangeIntrinsicContentSize):
(WebKit::WebPageProxy::showColorPicker):
(WebKit::WebPageProxy::showDataListSuggestions):
(WebKit::WebPageProxy::showDateTimePicker):
(WebKit::WebPageProxy::compositionWasCanceled):
(WebKit::WebPageProxy::registerInsertionUndoGrouping):
(WebKit::WebPageProxy::canUndoRedo):
(WebKit::WebPageProxy::executeUndoRedo):
(WebKit::WebPageProxy::clearAllEditCommands):
(WebKit::WebPageProxy::setTextIndicator):
(WebKit::WebPageProxy::clearTextIndicator):
(WebKit::WebPageProxy::setTextIndicatorAnimationProgress):
(WebKit::WebPageProxy::showPopupMenu):
(WebKit::WebPageProxy::showContextMenu):
(WebKit::WebPageProxy::didShowContextMenu):
(WebKit::WebPageProxy::didDismissContextMenu):
(WebKit::WebPageProxy::registerEditCommand):
(WebKit::WebPageProxy::canUndo):
(WebKit::WebPageProxy::canRedo):
(WebKit::WebPageProxy::takeFocus):
(WebKit::WebPageProxy::setToolTip):
(WebKit::WebPageProxy::setCursor):
(WebKit::WebPageProxy::setCursorHiddenUntilMouseMoves):
(WebKit::WebPageProxy::keyEventHandlingCompleted):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::enterAcceleratedCompositingMode):
(WebKit::WebPageProxy::didFirstLayerFlush):
(WebKit::WebPageProxy::exitAcceleratedCompositingMode):
(WebKit::WebPageProxy::updateAcceleratedCompositingMode):
(WebKit::WebPageProxy::recentGamepadAccessStateChanged):
(WebKit::WebPageProxy::setGamepadsConnected):
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
(WebKit::WebPageProxy::computeHasVisualSearchResults):
(WebKit::WebPageProxy::showMediaControlsContextMenu):
(WebKit::WebPageProxy::drawPageBorderForPrinting):
(WebKit::WebPageProxy::recommendedScrollbarStyleDidChange):
(WebKit::WebPageProxy::didChangeScrollOffsetPinningForMainFrame):
(WebKit::WebPageProxy::themeColorChanged):
(WebKit::WebPageProxy::pageExtendedBackgroundColorDidChange):
(WebKit::WebPageProxy::sampledPageTopColorChanged):
(WebKit::WebPageProxy::didFinishLoadingDataForCustomContentProvider):
(WebKit::WebPageProxy::showDictationAlternativeUI):
(WebKit::WebPageProxy::removeDictationAlternatives):
(WebKit::WebPageProxy::dictationAlternatives):
(WebKit::WebPageProxy::showCorrectionPanel):
(WebKit::WebPageProxy::dismissCorrectionPanel):
(WebKit::WebPageProxy::dismissCorrectionPanelSoon):
(WebKit::WebPageProxy::recordAutocorrectionResponse):
(WebKit::WebPageProxy::setEditableElementIsFocused):
(WebKit::WebPageProxy::takeViewSnapshot):
(WebKit::WebPageProxy::navigationGestureDidBegin):
(WebKit::WebPageProxy::navigationGestureWillEnd):
(WebKit::WebPageProxy::navigationGestureDidEnd):
(WebKit::WebPageProxy::willRecordNavigationSnapshot):
(WebKit::WebPageProxy::navigationGestureSnapshotWasRemoved):
(WebKit::WebPageProxy::willBeginViewGesture):
(WebKit::WebPageProxy::didEndViewGesture):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::updateReportedMediaCaptureState):
(WebKit::WebPageProxy::videoControlsManagerDidChange):
(WebKit::WebPageProxy::handleControlledElementIDResponse const):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::immediateActionAnimationControllerForHitTestResult):
(WebKit::WebPageProxy::didHandleAcceptedCandidate):
(WebKit::WebPageProxy::performSwitchHapticFeedback):
(WebKit::WebPageProxy::addPlaybackTargetPickerClient):
(WebKit::WebPageProxy::removePlaybackTargetPickerClient):
(WebKit::WebPageProxy::showPlaybackTargetPicker):
(WebKit::WebPageProxy::playbackTargetPickerClientStateDidChange):
(WebKit::WebPageProxy::setMockMediaPlaybackTargetPickerEnabled):
(WebKit::WebPageProxy::setMockMediaPlaybackTargetPickerState):
(WebKit::WebPageProxy::mockMediaPlaybackTargetPickerDismissPopup):
(WebKit::WebPageProxy::didChangeBackgroundColor):
(WebKit::WebPageProxy::didRestoreScrollPosition):
(WebKit::WebPageProxy::useDarkAppearance const):
(WebKit::WebPageProxy::useElevatedUserInterfaceLevel const):
(WebKit::WebPageProxy::writePromisedAttachmentToPasteboard):
(WebKit::WebPageProxy::didInvalidateDataForAttachment):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachment):
(WebKit::WebPageProxy::webViewDidMoveToWindow):
(WebKit::WebPageProxy::gpuProcessDidFinishLaunching):
(WebKit::WebPageProxy::gpuProcessExited):
(WebKit::WebPageProxy::modelProcessDidFinishLaunching):
(WebKit::WebPageProxy::modelProcessExited):
(WebKit::WebPageProxy::requestScrollToRect):
(WebKit::WebPageProxy::beginTextRecognitionForVideoInElementFullScreen):
(WebKit::WebPageProxy::cancelTextRecognitionForVideoInElementFullScreen):
(WebKit::WebPageProxy::updateDefaultSpatialTrackingLabel):
(WebKit::WebPageProxy::hasActiveNowPlayingSessionChanged):
(WebKit::WebPageProxy::setAllowsLayoutViewportHeightExpansion):
(WebKit::WebPageProxy::optionalProtectedPageClient const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp:
(WebKit::WebPageProxy::didInitiateLoadForResource):
(WebKit::WebPageProxy::didSendRequestForResource):
(WebKit::WebPageProxy::didReceiveResponseForResource):
(WebKit::WebPageProxy::didFinishLoadForResource):
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::accentColorDidChange):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView removeEmojiAlternatives]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computeLayoutViewportRect const):
(WebKit::WebPageProxy::scrollingNodeScrollViewWillStartPanGesture):
(WebKit::WebPageProxy::scrollingNodeScrollWillStartScroll):
(WebKit::WebPageProxy::scrollingNodeScrollDidEndScroll):
(WebKit::WebPageProxy::handleAutocorrectionContext):
(WebKit::WebPageProxy::didReceivePositionInformation):
(WebKit::WebPageProxy::saveImageToLibrary):
(WebKit::WebPageProxy::interpretKeyEvent):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::relayAccessibilityNotification):
(WebKit::WebPageProxy::assistiveTechnologyMakeFirstResponder):
(WebKit::WebPageProxy::couldNotRestorePageState):
(WebKit::WebPageProxy::restorePageState):
(WebKit::WebPageProxy::restorePageCenterAndScale):
(WebKit::WebPageProxy::didGetTapHighlightGeometries):
(WebKit::WebPageProxy::updateInputContextAfterBlurringAndRefocusingElement):
(WebKit::WebPageProxy::elementDidFocus):
(WebKit::WebPageProxy::elementDidBlur):
(WebKit::WebPageProxy::updateFocusedElementInformation):
(WebKit::WebPageProxy::focusedElementDidChangeInputMode):
(WebKit::WebPageProxy::didReleaseAllTouchPoints):
(WebKit::WebPageProxy::showInspectorHighlight):
(WebKit::WebPageProxy::hideInspectorHighlight):
(WebKit::WebPageProxy::showInspectorIndication):
(WebKit::WebPageProxy::hideInspectorIndication):
(WebKit::WebPageProxy::enableInspectorNodeSearch):
(WebKit::WebPageProxy::disableInspectorNodeSearch):
(WebKit::WebPageProxy::didPerformDictionaryLookup):
(WebKit::WebPageProxy::setRemoteLayerTreeRootNode):
(WebKit::WebPageProxy::showPlaybackTargetPicker):
(WebKit::WebPageProxy::commitPotentialTapFailed):
(WebKit::WebPageProxy::didNotHandleTapAsClick):
(WebKit::WebPageProxy::didHandleTapAsHover):
(WebKit::WebPageProxy::didCompleteSyntheticClick):
(WebKit::WebPageProxy::disableDoubleTapGesturesDuringTapIfNecessary):
(WebKit::WebPageProxy::handleSmartMagnificationInformationForPotentialTap):
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::dispatchDidUpdateEditorState):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::hardwareKeyboardAvailabilityChanged):
(WebKit::WebPageProxy::didHandleDragStartRequest):
(WebKit::WebPageProxy::didHandleAdditionalDragItemsRequest):
(WebKit::WebPageProxy::willReceiveEditDragSnapshot):
(WebKit::WebPageProxy::didReceiveEditDragSnapshot):
(WebKit::WebPageProxy::requestPasswordForQuickLookDocumentInMainFrameShared):
(WebKit::WebPageProxy::isDesktopClassBrowsingRecommended const):
(WebKit::WebPageProxy::showDataDetectorsUIForPositionInformation):
(WebKit::WebPageProxy::insertionPointColorDidChange):
(WebKit::WebPageProxy::platformUnderPageBackgroundColor const):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::windowAndViewFramesChanged):
(WebKit::WebPageProxy::setPromisedDataForImage):
(WebKit::WebPageProxy::didPerformDictionaryLookup):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::makeFirstResponder):
(WebKit::WebPageProxy::assistiveTechnologyMakeFirstResponder):
(WebKit::WebPageProxy::useFormSemanticContext const):
(WebKit::WebPageProxy::executeSavedCommandBySelector):
(WebKit::WebPageProxy::setRemoteLayerTreeRootNode):
(WebKit::WebPageProxy::acceleratedCompositingRootLayer const):
(WebKit::WebPageProxy::headerBannerLayer const):
(WebKit::WebPageProxy::footerBannerLayer const):
(WebKit::WebPageProxy::showPDFContextMenu):
(WebKit::WebPageProxy::showTelephoneNumberMenu):
(WebKit::WebPageProxy::boundsOfLayerInLayerBackedWindowCoordinates const):
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::startWindowDrag):
(WebKit::WebPageProxy::rootViewToWindow):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::inspectorAttachmentView):
(WebKit::WebPageProxy::remoteObjectRegistry):
(WebKit::WebPageProxy::Internals::platformView const):
(WebKit::WebPageProxy::createPDFHUD):
(WebKit::WebPageProxy::removePDFHUD):
(WebKit::WebPageProxy::updatePDFHUDLocation):
(WebKit::WebPageProxy::showImageInQuickLookPreviewPanel):
(WebKit::WebPageProxy::handleContextMenuWritingTools):
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::didUpdateEditorState):

Canonical link: <a href="https://commits.webkit.org/283935@main">https://commits.webkit.org/283935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe224e0005ccd6f896032e711e4a1830190e0c83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18970 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54262 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39952 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17328 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61917 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16402 "Found 1 new test failure: imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73582 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58723 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3229 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43018 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->