### PR TITLE
[site-isolation] Cross origin <iframe>s should not (usually) draw a background color.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/basic-transparent-iframe-expected.html
+++ b/LayoutTests/http/tests/site-isolation/basic-transparent-iframe-expected.html
@@ -1,0 +1,2 @@
+<body bgcolor=blue>
+</body>

--- a/LayoutTests/http/tests/site-isolation/basic-transparent-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/basic-transparent-iframe.html
@@ -1,0 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/no-background.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <head>
-<meta name="fuzzy" content="maxDifference=2; totalPixels=177504" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-177504" />
 <script>
 if (window.testRunner)
     testRunner.waitUntilDone();

--- a/LayoutTests/http/tests/site-isolation/page-zoom.html
+++ b/LayoutTests/http/tests/site-isolation/page-zoom.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <head>
-<meta name="fuzzy" content="maxDifference=104; totalPixels=0-372" />
+<meta name="fuzzy" content="maxDifference=104; totalPixels=0-373" />
 <script>
 if (window.testRunner)
     testRunner.waitUntilDone();

--- a/LayoutTests/http/tests/site-isolation/resources/no-background.html
+++ b/LayoutTests/http/tests/site-isolation/resources/no-background.html
@@ -1,0 +1,5 @@
+<body>
+</body>
+<script>
+onload = () => { window.parent.postMessage("onload", "*"); }
+</script>

--- a/LayoutTests/http/tests/site-isolation/selection-focus.html
+++ b/LayoutTests/http/tests/site-isolation/selection-focus.html
@@ -1,4 +1,5 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-91" />
 <script>
     function setFocus() {
         frame.focus();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1069,8 +1069,8 @@ bool RenderLayerCompositor::updateCompositingLayers(CompositingUpdateType update
         m_secondaryBackingStoreBytes = 0;
 
         auto& frame = m_renderView.frameView().frame();
-        bool isMainFrame = isRootFrameCompositor();
-        LOG_WITH_STREAM(Compositing, stream << "\nUpdate " << m_rootLayerUpdateCount << " of " << (isMainFrame ? "main frame"_s : makeString("frame "_s, frame.frameID().object().toUInt64())) << " - compositing policy is " << m_compositingPolicy);
+        bool isRootFrame = isRootFrameCompositor();
+        LOG_WITH_STREAM(Compositing, stream << "\nUpdate " << m_rootLayerUpdateCount << " of " << (isRootFrame ? "root frame"_s : makeString("frame "_s, frame.frameID().object().toUInt64())) << " - compositing policy is " << m_compositingPolicy);
     }
 #endif
 
@@ -4002,7 +4002,7 @@ bool RenderLayerCompositor::isAsyncScrollableStickyLayer(const RenderLayer& laye
 
 #if PLATFORM(IOS_FAMILY)
     // iOS WK1 has fixed/sticky support in the main frame via WebFixedPositionContent.
-    return isRootFrameCompositor();
+    return isMainFrameCompositor();
 #else
     return false;
 #endif
@@ -4226,7 +4226,7 @@ bool RenderLayerCompositor::requiresScrollLayer(RootLayerAttachment attachment) 
     auto& frameView = m_renderView.frameView();
 
     // This applies when the application UI handles scrolling, in which case RenderLayerCompositor doesn't need to manage it.
-    if (frameView.delegatedScrollingMode() == DelegatedScrollingMode::DelegatedToNativeScrollView && isRootFrameCompositor())
+    if (frameView.delegatedScrollingMode() == DelegatedScrollingMode::DelegatedToNativeScrollView && isMainFrameCompositor())
         return false;
 
     // We need to handle our own scrolling if we're:
@@ -4365,6 +4365,11 @@ bool RenderLayerCompositor::isRootFrameCompositor() const
     return m_renderView.frameView().frame().isRootFrame();
 }
 
+bool RenderLayerCompositor::isMainFrameCompositor() const
+{
+    return m_renderView.frameView().frame().isMainFrame();
+}
+
 bool RenderLayerCompositor::shouldCompositeOverflowControls() const
 {
     auto& frameView = m_renderView.frameView();
@@ -4375,7 +4380,7 @@ bool RenderLayerCompositor::shouldCompositeOverflowControls() const
     if (documentUsesTiledBacking())
         return true;
 
-    if (m_overflowControlsHostLayer && isRootFrameCompositor())
+    if (m_overflowControlsHostLayer && isMainFrameCompositor())
         return true;
 
 #if !USE(COORDINATED_GRAPHICS)
@@ -4404,7 +4409,7 @@ bool RenderLayerCompositor::requiresScrollCornerLayer() const
 #if HAVE(RUBBER_BANDING)
 bool RenderLayerCompositor::requiresOverhangAreasLayer() const
 {
-    if (!isRootFrameCompositor())
+    if (!isMainFrameCompositor())
         return false;
 
     // We do want a layer if we're using tiled drawing and can scroll.
@@ -4416,7 +4421,7 @@ bool RenderLayerCompositor::requiresOverhangAreasLayer() const
 
 bool RenderLayerCompositor::requiresContentShadowLayer() const
 {
-    if (!isRootFrameCompositor())
+    if (!isMainFrameCompositor())
         return false;
 
 #if PLATFORM(COCOA)
@@ -4437,7 +4442,7 @@ bool RenderLayerCompositor::requiresContentShadowLayer() const
 
 GraphicsLayer* RenderLayerCompositor::updateLayerForTopOverhangArea(bool wantsLayer)
 {
-    if (!isRootFrameCompositor())
+    if (!isMainFrameCompositor())
         return nullptr;
 
     if (!wantsLayer) {
@@ -4456,7 +4461,7 @@ GraphicsLayer* RenderLayerCompositor::updateLayerForTopOverhangArea(bool wantsLa
 
 GraphicsLayer* RenderLayerCompositor::updateLayerForBottomOverhangArea(bool wantsLayer)
 {
-    if (!isRootFrameCompositor())
+    if (!isMainFrameCompositor())
         return nullptr;
 
     if (!wantsLayer) {
@@ -4477,7 +4482,7 @@ GraphicsLayer* RenderLayerCompositor::updateLayerForBottomOverhangArea(bool want
 
 GraphicsLayer* RenderLayerCompositor::updateLayerForHeader(bool wantsLayer)
 {
-    if (!isRootFrameCompositor())
+    if (!isMainFrameCompositor())
         return nullptr;
 
     if (!wantsLayer) {
@@ -4513,7 +4518,7 @@ GraphicsLayer* RenderLayerCompositor::updateLayerForHeader(bool wantsLayer)
 
 GraphicsLayer* RenderLayerCompositor::updateLayerForFooter(bool wantsLayer)
 {
-    if (!isRootFrameCompositor())
+    if (!isMainFrameCompositor())
         return nullptr;
 
     if (!wantsLayer) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -592,6 +592,7 @@ private:
 
     bool documentUsesTiledBacking() const;
     bool isRootFrameCompositor() const;
+    bool isMainFrameCompositor() const;
 
     void updateCompositingForLayerTreeAsTextDump();
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -642,10 +642,10 @@ bool RenderView::shouldPaintBaseBackground() const
     auto* ownerElement = document.ownerElement();
 
     // Fill with a base color if we're the root document.
-    if (!ownerElement)
+    if (frameView.frame().isMainFrame())
         return !frameView.isTransparent();
 
-    if (ownerElement->hasTagName(HTMLNames::frameTag))
+    if (ownerElement && ownerElement->hasTagName(HTMLNames::frameTag))
         return true;
 
     // Locate the <body> element using the DOM. This is easier than trying
@@ -662,7 +662,7 @@ bool RenderView::shouldPaintBaseBackground() const
     if (is<HTMLFrameSetElement>(*body))
         return true;
 
-    auto* frameRenderer = ownerElement->renderer();
+    auto* frameRenderer = ownerElement ? ownerElement->renderer() : nullptr;
     if (!frameRenderer)
         return false;
 


### PR DESCRIPTION
#### 6b79ff056204ba9eb5d90e85fdeb7117015f39a6
<pre>
[site-isolation] Cross origin &lt;iframe&gt;s should not (usually) draw a background color.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279954">https://bugs.webkit.org/show_bug.cgi?id=279954</a>
&lt;<a href="https://rdar.apple.com/136270045">rdar://136270045</a>&gt;

Reviewed by Simon Fraser.

Adds &apos;isMainFrameCompositor&apos; to RenderLayerCompositor to distinguish between
actual main-frame compositors, vs process root ones.

Use this to avoid setting a lot of extra layers that should only been needed on
the actual main frame (like the overhang areas layer for overscroll).

Also fixes RenderView::shouldPaintBaseBackground() to detect being a main-frame
using the Frame hierarchy instead of checking for an owner element. This is
still somewhat wrong, since it wants the owner element to check for a &apos;frame&apos;
tag, which can&apos;t be done cross-process.

* LayoutTests/http/tests/site-isolation/basic-transparent-iframe-expected.html: Added.
* LayoutTests/http/tests/site-isolation/basic-transparent-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/no-background.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::isAsyncScrollableStickyLayer const):
(WebCore::RenderLayerCompositor::requiresScrollLayer const):
(WebCore::RenderLayerCompositor::isMainFrameCompositor const):
(WebCore::RenderLayerCompositor::shouldCompositeOverflowControls const):
(WebCore::RenderLayerCompositor::requiresOverhangAreasLayer const):
(WebCore::RenderLayerCompositor::requiresContentShadowLayer const):
(WebCore::RenderLayerCompositor::updateLayerForTopOverhangArea):
(WebCore::RenderLayerCompositor::updateLayerForBottomOverhangArea):
(WebCore::RenderLayerCompositor::updateLayerForHeader):
(WebCore::RenderLayerCompositor::updateLayerForFooter):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::shouldPaintBaseBackground const):

Canonical link: <a href="https://commits.webkit.org/284131@main">https://commits.webkit.org/284131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59cb7e7dd99d58bf13c1f32a7878c20746d2657e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54317 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16114 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73697 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61774 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58777 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61784 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3280 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->