### PR TITLE
CSSCalc::simplify: bail if Type::multiply returns nullopt

### DIFF
--- a/LayoutTests/css3/calc/product-more-than-127-factors-expected.txt
+++ b/LayoutTests/css3/calc/product-more-than-127-factors-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/css3/calc/product-more-than-127-factors.html
+++ b/LayoutTests/css3/calc/product-more-than-127-factors.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style>
+  p {
+    /* equivalent to calc((1px ** 16) ** 8 / 1px), where ** is the exponent operator */
+    width: calc(
+      (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+        (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+          (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+            (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+              (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+                (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+                  (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px *
+                    (1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px * 1px /
+                      (1px))))))))));
+  }
+  </style>
+</head>
+
+<body>
+  <p>This test passes if it does not crash</p>
+  <script>
+    if (window.testRunner)
+      window.testRunner.dumpAsText();
+  </script>
+</body>
+
+</html>

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -792,7 +792,8 @@ std::optional<Child> simplify(Product& root, const SimplificationOptions& option
             },
             [&](const Percentage& percentage) -> bool {
                 auto multipliedType = Type::multiply(productResult.type, getType(percentage));
-                ASSERT(multipliedType);
+                if (!multipliedType)
+                    return false;
 
                 productResult.type = *multipliedType;
                 productResult.value *= percentage.value;
@@ -800,7 +801,8 @@ std::optional<Child> simplify(Product& root, const SimplificationOptions& option
             },
             [&](const CanonicalDimension& canonicalDimension) -> bool {
                 auto multipliedType = Type::multiply(productResult.type, getType(canonicalDimension.dimension));
-                ASSERT(multipliedType);
+                if (!multipliedType)
+                    return false;
 
                 productResult.type = *multipliedType;
                 productResult.value *= canonicalDimension.value;
@@ -816,7 +818,8 @@ std::optional<Child> simplify(Product& root, const SimplificationOptions& option
                     [&](const Percentage& percentage) -> bool {
                         auto invertedPercentageChildType = Type::invert(getType(percentage));
                         auto multipliedType = Type::multiply(productResult.type, invertedPercentageChildType);
-                        ASSERT(multipliedType);
+                        if (!multipliedType)
+                            return false;
 
                         productResult.type = *multipliedType;
                         productResult.value /= percentage.value;
@@ -825,7 +828,8 @@ std::optional<Child> simplify(Product& root, const SimplificationOptions& option
                     [&](const CanonicalDimension& canonicalDimension) -> bool {
                         auto invertedCanonicalDimensionType = Type::invert(getType(canonicalDimension));
                         auto multipliedType = Type::multiply(productResult.type, invertedCanonicalDimensionType);
-                        ASSERT(multipliedType);
+                        if (!multipliedType)
+                            return false;
 
                         productResult.type = *multipliedType;
                         productResult.value /= canonicalDimension.value;


### PR DESCRIPTION
#### 028a859fd9383974ba8f4930e5a4901b25166d77
<pre>
CSSCalc::simplify: bail if Type::multiply returns nullopt
<a href="https://bugs.webkit.org/show_bug.cgi?id=279880">https://bugs.webkit.org/show_bug.cgi?id=279880</a>
<a href="https://rdar.apple.com/136012557">rdar://136012557</a>

Reviewed by Antti Koivisto.

When simplifying a product expression, CSSCalc::simplify calls
Type::multiply to figure out the type from multiplying two types.
It&apos;s possible to craft an expression such that Type::multiply returns
std::nullopt, which CSSCalc::simplify doesn&apos;t expect and hence crashes.
One example is:

  ((1px ** 16) ** 8) / 1px

where ** is the power function, which should be unrolled to a product
expression. Fix this by returning early with failure if Type::multiply
returns std::nullopt.

* LayoutTests/css3/calc/product-more-than-127-factors-expected.txt: Added.
* LayoutTests/css3/calc/product-more-than-127-factors.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):

Canonical link: <a href="https://commits.webkit.org/283931@main">https://commits.webkit.org/283931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cf58cf7c92bfda23e22bed55211c468ba776891

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71813 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54209 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17257 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73511 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3167 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42947 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->