### PR TITLE
Adopt more smart pointers in PlaybackSessionManagerProxy and VideoPresentationManagerProxy

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -76,8 +76,8 @@ void PlaybackSessionModelContext::removeClient(PlaybackSessionModelClient& clien
 
 void PlaybackSessionModelContext::sendRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
 {
-    if (m_manager)
-        m_manager->sendRemoteCommand(m_contextId, command, argument);
+    if (RefPtr manager = m_manager.get())
+        manager->sendRemoteCommand(m_contextId, command, argument);
 }
 
 void PlaybackSessionModelContext::setVideoReceiverEndpoint(const WebCore::VideoReceiverEndpoint& endpoint)
@@ -103,21 +103,21 @@ void PlaybackSessionModelContext::setVideoReceiverEndpoint(const WebCore::VideoR
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void PlaybackSessionModelContext::setSpatialTrackingLabel(const String& label)
 {
-    if (m_manager)
-        m_manager->setSpatialTrackingLabel(m_contextId, label);
+    if (RefPtr manager = m_manager.get())
+        manager->setSpatialTrackingLabel(m_contextId, label);
 }
 #endif
 
 void PlaybackSessionModelContext::addNowPlayingMetadataObserver(const WebCore::NowPlayingMetadataObserver& nowPlayingInfo)
 {
-    if (m_manager)
-        m_manager->addNowPlayingMetadataObserver(m_contextId, nowPlayingInfo);
+    if (RefPtr manager = m_manager.get())
+        manager->addNowPlayingMetadataObserver(m_contextId, nowPlayingInfo);
 }
 
 void PlaybackSessionModelContext::removeNowPlayingMetadataObserver(const WebCore::NowPlayingMetadataObserver& nowPlayingInfo)
 {
-    if (m_manager)
-        m_manager->removeNowPlayingMetadataObserver(m_contextId, nowPlayingInfo);
+    if (RefPtr manager = m_manager.get())
+        manager->removeNowPlayingMetadataObserver(m_contextId, nowPlayingInfo);
 }
 
 void PlaybackSessionModelContext::setSoundStageSize(WebCore::AudioSessionSoundStageSize size)
@@ -126,36 +126,36 @@ void PlaybackSessionModelContext::setSoundStageSize(WebCore::AudioSessionSoundSt
         return;
 
     m_soundStageSize = size;
-    if (m_manager)
-        m_manager->setSoundStageSize(m_contextId, size);
+    if (RefPtr manager = m_manager.get())
+        manager->setSoundStageSize(m_contextId, size);
 }
 
 void PlaybackSessionModelContext::play()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->play(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->play(m_contextId);
 }
 
 void PlaybackSessionModelContext::pause()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->pause(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->pause(m_contextId);
 }
 
 void PlaybackSessionModelContext::togglePlayState()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->togglePlayState(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->togglePlayState(m_contextId);
 }
 
 void PlaybackSessionModelContext::beginScrubbing()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->beginScrubbing(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->beginScrubbing(m_contextId);
 
     m_isScrubbing = true;
 }
@@ -163,8 +163,8 @@ void PlaybackSessionModelContext::beginScrubbing()
 void PlaybackSessionModelContext::endScrubbing()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->endScrubbing(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->endScrubbing(m_contextId);
 
     m_isScrubbing = false;
     m_playbackStartedTimeNeedsUpdate = isPlaying();
@@ -173,50 +173,50 @@ void PlaybackSessionModelContext::endScrubbing()
 void PlaybackSessionModelContext::seekToTime(double time, double toleranceBefore, double toleranceAfter)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, time, ", toleranceBefore: ", toleranceBefore, ", toleranceAfter: ", toleranceAfter);
-    if (m_manager)
-        m_manager->seekToTime(m_contextId, time, toleranceBefore, toleranceAfter);
+    if (RefPtr manager = m_manager.get())
+        manager->seekToTime(m_contextId, time, toleranceBefore, toleranceAfter);
 }
 
 void PlaybackSessionModelContext::fastSeek(double time)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, time);
-    if (m_manager)
-        m_manager->fastSeek(m_contextId, time);
+    if (RefPtr manager = m_manager.get())
+        manager->fastSeek(m_contextId, time);
 }
 
 void PlaybackSessionModelContext::beginScanningForward()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->beginScanningForward(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->beginScanningForward(m_contextId);
 }
 
 void PlaybackSessionModelContext::beginScanningBackward()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->beginScanningBackward(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->beginScanningBackward(m_contextId);
 }
 
 void PlaybackSessionModelContext::endScanning()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->endScanning(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->endScanning(m_contextId);
 }
 
 void PlaybackSessionModelContext::setDefaultPlaybackRate(double defaultPlaybackRate)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, defaultPlaybackRate);
-    if (m_manager)
-        m_manager->setDefaultPlaybackRate(m_contextId, defaultPlaybackRate);
+    if (RefPtr manager = m_manager.get())
+        manager->setDefaultPlaybackRate(m_contextId, defaultPlaybackRate);
 }
 
 void PlaybackSessionModelContext::setPlaybackRate(double playbackRate)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, playbackRate);
-    if (m_manager)
-        m_manager->setPlaybackRate(m_contextId, playbackRate);
+    if (RefPtr manager = m_manager.get())
+        manager->setPlaybackRate(m_contextId, playbackRate);
 }
 
 void PlaybackSessionModelContext::selectAudioMediaOption(uint64_t index)
@@ -225,8 +225,8 @@ void PlaybackSessionModelContext::selectAudioMediaOption(uint64_t index)
         return;
 
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, index);
-    if (m_manager)
-        m_manager->selectAudioMediaOption(m_contextId, index);
+    if (RefPtr manager = m_manager.get())
+        manager->selectAudioMediaOption(m_contextId, index);
 }
 
 void PlaybackSessionModelContext::selectLegibleMediaOption(uint64_t index)
@@ -235,15 +235,15 @@ void PlaybackSessionModelContext::selectLegibleMediaOption(uint64_t index)
         return;
 
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, index);
-    if (m_manager)
-        m_manager->selectLegibleMediaOption(m_contextId, index);
+    if (RefPtr manager = m_manager.get())
+        manager->selectLegibleMediaOption(m_contextId, index);
 }
 
 void PlaybackSessionModelContext::togglePictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->togglePictureInPicture(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->togglePictureInPicture(m_contextId);
 }
 
 void PlaybackSessionModelContext::enterFullscreen()
@@ -263,22 +263,22 @@ void PlaybackSessionModelContext::exitFullscreen()
 void PlaybackSessionModelContext::enterInWindowFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->enterInWindow(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->enterInWindow(m_contextId);
 }
 
 void PlaybackSessionModelContext::exitInWindowFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->exitInWindow(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->exitInWindow(m_contextId);
 }
 
 void PlaybackSessionModelContext::toggleMuted()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->toggleMuted(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->toggleMuted(m_contextId);
 }
 
 void PlaybackSessionModelContext::setMuted(bool muted)
@@ -287,8 +287,8 @@ void PlaybackSessionModelContext::setMuted(bool muted)
         return;
 
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, muted);
-    if (m_manager)
-        m_manager->setMuted(m_contextId, muted);
+    if (RefPtr manager = m_manager.get())
+        manager->setMuted(m_contextId, muted);
 }
 
 void PlaybackSessionModelContext::setVolume(double volume)
@@ -297,15 +297,15 @@ void PlaybackSessionModelContext::setVolume(double volume)
         return;
 
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, volume);
-    if (m_manager)
-        m_manager->setVolume(m_contextId, volume);
+    if (RefPtr manager = m_manager.get())
+        manager->setVolume(m_contextId, volume);
 }
 
 void PlaybackSessionModelContext::setPlayingOnSecondScreen(bool value)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, value);
-    if (m_manager)
-        m_manager->setPlayingOnSecondScreen(m_contextId, value);
+    if (RefPtr manager = m_manager.get())
+        manager->setPlayingOnSecondScreen(m_contextId, value);
 }
 
 void PlaybackSessionModelContext::playbackStartedTimeChanged(double playbackStartedTime)
@@ -516,7 +516,8 @@ PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->legacyMainFrameProcess().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess(), *this);
+    RefPtr protectedPage = m_page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), protectedPage->webPageIDInMainFrameProcess(), *this);
 }
 
 PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
@@ -531,7 +532,7 @@ void PlaybackSessionManagerProxy::invalidate()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     if (RefPtr page = m_page.get()) {
-        page->legacyMainFrameProcess().removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
         m_page = nullptr;
     }
 
@@ -757,145 +758,145 @@ void PlaybackSessionManagerProxy::handleControlledElementIDResponse(PlaybackSess
 void PlaybackSessionManagerProxy::play(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::Play(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::Play(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::pause(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::Pause(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::Pause(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::togglePlayState(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::TogglePlayState(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::TogglePlayState(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::beginScrubbing(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::BeginScrubbing(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::BeginScrubbing(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::endScrubbing(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EndScrubbing(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::EndScrubbing(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::seekToTime(PlaybackSessionContextIdentifier contextId, double time, double toleranceBefore, double toleranceAfter)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SeekToTime(contextId, time, toleranceBefore, toleranceAfter), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SeekToTime(contextId, time, toleranceBefore, toleranceAfter), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::fastSeek(PlaybackSessionContextIdentifier contextId, double time)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::FastSeek(contextId, time), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::FastSeek(contextId, time), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::beginScanningForward(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::BeginScanningForward(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::BeginScanningForward(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::beginScanningBackward(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::BeginScanningBackward(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::BeginScanningBackward(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::endScanning(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EndScanning(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::EndScanning(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setDefaultPlaybackRate(PlaybackSessionContextIdentifier contextId, double defaultPlaybackRate)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetDefaultPlaybackRate(contextId, defaultPlaybackRate), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetDefaultPlaybackRate(contextId, defaultPlaybackRate), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setPlaybackRate(PlaybackSessionContextIdentifier contextId, double playbackRate)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetPlaybackRate(contextId, playbackRate), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetPlaybackRate(contextId, playbackRate), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::selectAudioMediaOption(PlaybackSessionContextIdentifier contextId, uint64_t index)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SelectAudioMediaOption(contextId, index), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SelectAudioMediaOption(contextId, index), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::selectLegibleMediaOption(PlaybackSessionContextIdentifier contextId, uint64_t index)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SelectLegibleMediaOption(contextId, index), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SelectLegibleMediaOption(contextId, index), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::togglePictureInPicture(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::TogglePictureInPicture(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::TogglePictureInPicture(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::enterFullscreen(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EnterFullscreen(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::EnterFullscreen(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::exitFullscreen(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::ExitFullscreen(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::ExitFullscreen(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::enterInWindow(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EnterInWindow(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::EnterInWindow(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::exitInWindow(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::ExitInWindow(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::ExitInWindow(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::toggleMuted(PlaybackSessionContextIdentifier contextId)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::ToggleMuted(contextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::ToggleMuted(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setMuted(PlaybackSessionContextIdentifier contextId, bool muted)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetMuted(contextId, muted), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetMuted(contextId, muted), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setVolume(PlaybackSessionContextIdentifier contextId, double volume)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetVolume(contextId, volume), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetVolume(contextId, volume), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setPlayingOnSecondScreen(PlaybackSessionContextIdentifier contextId, bool value)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetPlayingOnSecondScreen(contextId, value), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetPlayingOnSecondScreen(contextId, value), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::sendRemoteCommand(PlaybackSessionContextIdentifier contextId, WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SendRemoteCommand(contextId, command, argument), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SendRemoteCommand(contextId, command, argument), page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContextIdentifier contextId, const WebCore::VideoReceiverEndpoint& endpoint)
@@ -972,7 +973,7 @@ void PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint(PlaybackSessionCo
 void PlaybackSessionManagerProxy::setSpatialTrackingLabel(PlaybackSessionContextIdentifier contextId, const String& label)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetSpatialTrackingLabel(contextId, label), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetSpatialTrackingLabel(contextId, label), page->webPageIDInMainFrameProcess());
 }
 #endif
 
@@ -991,7 +992,7 @@ void PlaybackSessionManagerProxy::removeNowPlayingMetadataObserver(PlaybackSessi
 void PlaybackSessionManagerProxy::setSoundStageSize(PlaybackSessionContextIdentifier contextId, WebCore::AudioSessionSoundStageSize size)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetSoundStageSize(contextId, size), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetSoundStageSize(contextId, size), page->webPageIDInMainFrameProcess());
 }
 
 bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()
@@ -1006,7 +1007,7 @@ bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()
 void PlaybackSessionManagerProxy::requestControlledElementID()
 {
     if (RefPtr page = m_page.get(); m_controlsManagerContextId)
-        page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::HandleControlledElementIDRequest(m_controlsManagerContextId), page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::HandleControlledElementIDRequest(m_controlsManagerContextId), page->webPageIDInMainFrameProcess());
 }
 
 RefPtr<PlatformPlaybackSessionInterface> PlaybackSessionManagerProxy::controlsManagerInterface()

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -282,48 +282,49 @@ void VideoPresentationModelContext::setVideoDimensions(const WebCore::FloatSize&
 
 void VideoPresentationModelContext::requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_manager) {
+    RefPtr manager = m_manager.get();
+    if (!manager) {
         completionHandler();
         return;
     }
 
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    m_manager->requestCloseAllMediaPresentations(m_contextId, finishedWithMedia, WTFMove(completionHandler));
+    manager->requestCloseAllMediaPresentations(m_contextId, finishedWithMedia, WTFMove(completionHandler));
 }
 
 void VideoPresentationModelContext::requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool finishedWithMedia)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, mode, ", finishedWithMedia: ", finishedWithMedia);
-    if (m_manager)
-        m_manager->requestFullscreenMode(m_contextId, mode, finishedWithMedia);
+    if (RefPtr manager = m_manager.get())
+        manager->requestFullscreenMode(m_contextId, mode, finishedWithMedia);
 }
 
 void VideoPresentationModelContext::setVideoLayerFrame(WebCore::FloatRect frame)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, frame);
-    if (m_manager)
-        m_manager->setVideoLayerFrame(m_contextId, frame);
+    if (RefPtr manager = m_manager.get())
+        manager->setVideoLayerFrame(m_contextId, frame);
 }
 
 void VideoPresentationModelContext::setVideoLayerGravity(WebCore::MediaPlayerEnums::VideoGravity gravity)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, gravity);
-    if (m_manager)
-        m_manager->setVideoLayerGravity(m_contextId, gravity);
+    if (RefPtr manager = m_manager.get())
+        manager->setVideoLayerGravity(m_contextId, gravity);
 }
 
 void VideoPresentationModelContext::setVideoFullscreenFrame(WebCore::FloatRect frame)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, frame);
-    if (m_manager)
-        m_manager->setVideoFullscreenFrame(m_contextId, frame);
+    if (RefPtr manager = m_manager.get())
+        manager->setVideoFullscreenFrame(m_contextId, frame);
 }
 
 void VideoPresentationModelContext::fullscreenModeChanged(WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, mode);
-    if (m_manager)
-        m_manager->fullscreenModeChanged(m_contextId, mode);
+    if (RefPtr manager = m_manager.get())
+        manager->fullscreenModeChanged(m_contextId, mode);
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -346,85 +347,85 @@ RetainPtr<UIViewController> VideoPresentationModelContext::createVideoFullscreen
 void VideoPresentationModelContext::requestUpdateInlineRect()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->requestUpdateInlineRect(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->requestUpdateInlineRect(m_contextId);
 }
 
 void VideoPresentationModelContext::requestVideoContentLayer()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->requestVideoContentLayer(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->requestVideoContentLayer(m_contextId);
 }
 
 void VideoPresentationModelContext::returnVideoContentLayer()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->returnVideoContentLayer(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->returnVideoContentLayer(m_contextId);
 }
 
 void VideoPresentationModelContext::returnVideoView()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->returnVideoView(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->returnVideoView(m_contextId);
 }
 
 void VideoPresentationModelContext::didSetupFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->didSetupFullscreen(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->didSetupFullscreen(m_contextId);
 }
 
 void VideoPresentationModelContext::failedToEnterFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->failedToEnterFullscreen(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->failedToEnterFullscreen(m_contextId);
 }
 
 void VideoPresentationModelContext::didEnterFullscreen(const WebCore::FloatSize& size)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, size);
-    if (m_manager)
-        m_manager->didEnterFullscreen(m_contextId, size);
+    if (RefPtr manager = m_manager.get())
+        manager->didEnterFullscreen(m_contextId, size);
 }
 
 void VideoPresentationModelContext::willExitFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->willExitFullscreen(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->willExitFullscreen(m_contextId);
 }
 
 void VideoPresentationModelContext::didExitFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->didExitFullscreen(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->didExitFullscreen(m_contextId);
 }
 
 void VideoPresentationModelContext::didCleanupFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->didCleanupFullscreen(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->didCleanupFullscreen(m_contextId);
 }
 
 void VideoPresentationModelContext::fullscreenMayReturnToInline()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->fullscreenMayReturnToInline(m_contextId);
+    if (RefPtr manager = m_manager.get())
+        manager->fullscreenMayReturnToInline(m_contextId);
 }
 
 void VideoPresentationModelContext::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&& completionHandler)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->requestRouteSharingPolicyAndContextUID(m_contextId, WTFMove(completionHandler));
+    if (RefPtr manager = m_manager.get())
+        manager->requestRouteSharingPolicyAndContextUID(m_contextId, WTFMove(completionHandler));
     else
         completionHandler(WebCore::RouteSharingPolicy::Default, emptyString());
 }
@@ -432,15 +433,15 @@ void VideoPresentationModelContext::requestRouteSharingPolicyAndContextUID(Compl
 void VideoPresentationModelContext::didEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->hasVideoInPictureInPictureDidChange(true);
+    if (RefPtr manager = m_manager.get())
+        manager->hasVideoInPictureInPictureDidChange(true);
 }
 
 void VideoPresentationModelContext::didExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (m_manager)
-        m_manager->hasVideoInPictureInPictureDidChange(false);
+    if (RefPtr manager = m_manager.get())
+        manager->hasVideoInPictureInPictureDidChange(false);
 }
 
 void VideoPresentationModelContext::willEnterPictureInPicture()
@@ -513,7 +514,8 @@ VideoPresentationManagerProxy::VideoPresentationManagerProxy(WebPageProxy& page,
     , m_playbackSessionManagerProxy(playbackSessionManagerProxy)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->legacyMainFrameProcess().addMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess(), *this);
+    RefPtr protectedPage = m_page.get();
+    protectedPage->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), protectedPage->webPageIDInMainFrameProcess(), *this);
 }
 
 VideoPresentationManagerProxy::~VideoPresentationManagerProxy()
@@ -527,8 +529,8 @@ VideoPresentationManagerProxy::~VideoPresentationManagerProxy()
 void VideoPresentationManagerProxy::invalidate()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (m_page) {
-        m_page->legacyMainFrameProcess().removeMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get()) {
+        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
         m_page = nullptr;
     }
 
@@ -596,8 +598,8 @@ void VideoPresentationManagerProxy::applicationDidBecomeActive()
 
 void VideoPresentationManagerProxy::requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier contextId, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&& callback)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().sendWithAsyncReply(Messages::VideoPresentationManager::RequestRouteSharingPolicyAndContextUID(contextId), WTFMove(callback), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::VideoPresentationManager::RequestRouteSharingPolicyAndContextUID(contextId), WTFMove(callback), page->webPageIDInMainFrameProcess());
     else
         callback({ }, { });
 }
@@ -704,7 +706,8 @@ void VideoPresentationManagerProxy::forEachSession(Function<void(VideoPresentati
 
 void VideoPresentationManagerProxy::requestBitmapImageForCurrentTime(PlaybackSessionContextIdentifier identifier, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
 {
-    if (!m_page) {
+    RefPtr page = m_page.get();
+    if (!page) {
         completionHandler(std::nullopt);
         return;
     }
@@ -727,7 +730,7 @@ void VideoPresentationManagerProxy::requestBitmapImageForCurrentTime(PlaybackSes
         return;
     }
 
-    gpuProcess->requestBitmapImageForCurrentTime(m_page->legacyMainFrameProcess().coreProcessIdentifier(), playerIdentifier, WTFMove(completionHandler));
+    gpuProcess->requestBitmapImageForCurrentTime(page->protectedLegacyMainFrameProcess()->coreProcessIdentifier(), playerIdentifier, WTFMove(completionHandler));
 }
 
 void VideoPresentationManagerProxy::addVideoInPictureInPictureDidChangeObserver(const VideoInPictureInPictureDidChangeObserver& observer)
@@ -775,8 +778,8 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
         [playerLayer layoutIfNeeded];
     }
 
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), page->webPageIDInMainFrameProcess());
 
     return model->playerLayer();
 }
@@ -873,8 +876,8 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
         model->setVideoView(videoView.get());
     }
 
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), page->webPageIDInMainFrameProcess());
 
     return model->videoView();
 }
@@ -889,7 +892,8 @@ void VideoPresentationManagerProxy::willRemoveLayerForID(PlaybackSessionContextI
 
 void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingDeviceScaleFactor, HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
     auto [model, interface] = ensureModelAndInterface(contextId);
@@ -926,7 +930,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 
     RetainPtr view = model->layerHostView() ? static_cast<WKLayerHostView*>(model->layerHostView()) : createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 #if USE(EXTENSIONKIT)
-    RefPtr pageClient = m_page->pageClient();
+    RefPtr pageClient = page->pageClient();
     if (UIView *visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nullptr)
         [view setVisibilityPropagationView:visibilityPropagationView];
 #else
@@ -934,15 +938,15 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*m_page->drawingArea()).remoteLayerTreeHost().rootNode();
+    auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*page->drawingArea()).remoteLayerTreeHost().rootNode();
     UIView *parentView = rootNode ? rootNode->uiView() : nil;
     interface->setupFullscreen(*model->layerHostView(), screenRect, videoDimensions, parentView, videoFullscreenMode, allowsPictureInPicture, standby, blocksReturnToFullscreenFromPictureInPicture);
 #else
     UNUSED_PARAM(videoDimensions);
     UNUSED_PARAM(blocksReturnToFullscreenFromPictureInPicture);
     IntRect initialWindowRect;
-    m_page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
-    interface->setupFullscreen(*model->layerHostView(), initialWindowRect, m_page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);
+    page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
+    interface->setupFullscreen(*model->layerHostView(), initialWindowRect, page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);
 #endif
 }
 
@@ -1002,7 +1006,8 @@ void VideoPresentationManagerProxy::enterFullscreen(PlaybackSessionContextIdenti
 
 void VideoPresentationManagerProxy::exitFullscreen(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect finalRect, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (!m_page) {
+    RefPtr page = m_page.get();
+    if (!page) {
         completionHandler(false);
         return;
     }
@@ -1015,10 +1020,10 @@ void VideoPresentationManagerProxy::exitFullscreen(PlaybackSessionContextIdentif
 
 #if !PLATFORM(IOS_FAMILY)
     IntRect finalWindowRect;
-    m_page->rootViewToWindow(enclosingIntRect(finalRect), finalWindowRect);
+    page->rootViewToWindow(enclosingIntRect(finalRect), finalWindowRect);
 #else
     if (hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard))
-        m_page->fullscreenMayReturnToInline();
+        page->fullscreenMayReturnToInline();
 #endif
 
     if (m_mockVideoPresentationModeEnabled) {
@@ -1034,7 +1039,7 @@ void VideoPresentationManagerProxy::exitFullscreen(PlaybackSessionContextIdentif
 #if PLATFORM(IOS_FAMILY)
     completionHandler(ensureInterface(contextId)->exitFullscreen(finalRect));
 #else
-    completionHandler(ensureInterface(contextId)->exitFullscreen(finalWindowRect, m_page->platformWindow()));
+    completionHandler(ensureInterface(contextId)->exitFullscreen(finalWindowRect, page->platformWindow()));
 #endif
 }
 
@@ -1118,14 +1123,15 @@ void VideoPresentationManagerProxy::cleanupFullscreen(PlaybackSessionContextIden
 
 void VideoPresentationManagerProxy::preparedToReturnToInline(PlaybackSessionContextIdentifier contextId, bool visible, WebCore::FloatRect inlineRect)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
-    m_page->fullscreenMayReturnToInline();
+    page->fullscreenMayReturnToInline();
 
 #if !PLATFORM(IOS_FAMILY)
     IntRect inlineWindowRect;
-    m_page->rootViewToWindow(enclosingIntRect(inlineRect), inlineWindowRect);
+    page->rootViewToWindow(enclosingIntRect(inlineRect), inlineWindowRect);
 #endif
 
     if (m_mockVideoPresentationModeEnabled)
@@ -1134,7 +1140,7 @@ void VideoPresentationManagerProxy::preparedToReturnToInline(PlaybackSessionCont
 #if PLATFORM(IOS_FAMILY)
     ensureInterface(contextId)->preparedToReturnToInline(visible, inlineRect);
 #else
-    ensureInterface(contextId)->preparedToReturnToInline(visible, inlineWindowRect, m_page->platformWindow());
+    ensureInterface(contextId)->preparedToReturnToInline(visible, inlineWindowRect, page->platformWindow());
 #endif
 }
 
@@ -1149,13 +1155,13 @@ void VideoPresentationManagerProxy::preparedToExitFullscreen(PlaybackSessionCont
 void VideoPresentationManagerProxy::setRequiresTextTrackRepresentation(PlaybackSessionContextIdentifier contextId , bool requiresTextTrackRepresentation)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::SetRequiresTextTrackRepresentation(contextId, requiresTextTrackRepresentation), m_page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetRequiresTextTrackRepresentation(contextId, requiresTextTrackRepresentation), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier contextId , const IntRect& bounds)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::SetTextTrackRepresentationBounds(contextId, bounds), m_page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetTextTrackRepresentationBounds(contextId, bounds), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::textTrackRepresentationUpdate(PlaybackSessionContextIdentifier contextId, ShareableBitmap::Handle&& textTrack)
@@ -1201,26 +1207,26 @@ void VideoPresentationManagerProxy::requestCloseAllMediaPresentations(PlaybackSe
 
 void VideoPresentationManagerProxy::requestFullscreenMode(PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool finishedWithMedia)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::RequestFullscreenMode(contextId, mode, finishedWithMedia), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::RequestFullscreenMode(contextId, mode, finishedWithMedia), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::requestUpdateInlineRect(PlaybackSessionContextIdentifier contextId)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::RequestUpdateInlineRect(contextId), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::RequestUpdateInlineRect(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::requestVideoContentLayer(PlaybackSessionContextIdentifier contextId)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::RequestVideoContentLayer(contextId), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::RequestVideoContentLayer(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::returnVideoContentLayer(PlaybackSessionContextIdentifier contextId)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::ReturnVideoContentLayer(contextId), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::ReturnVideoContentLayer(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::returnVideoView(PlaybackSessionContextIdentifier contextId)
@@ -1244,23 +1250,24 @@ void VideoPresentationManagerProxy::didSetupFullscreen(PlaybackSessionContextIde
 #if PLATFORM(IOS_FAMILY)
     enterFullscreen(contextId);
 #else
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::DidSetupFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidSetupFullscreen(contextId), page->webPageIDInMainFrameProcess());
 #endif
 }
 
 void VideoPresentationManagerProxy::willExitFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::WillExitFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::WillExitFullscreen(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::didExitFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
-    m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::DidExitFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
+    page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidExitFullscreen(contextId), page->webPageIDInMainFrameProcess());
 
 #if PLATFORM(IOS_FAMILY)
     if (ensureInterface(contextId)->changingStandbyOnly()) {
@@ -1268,32 +1275,33 @@ void VideoPresentationManagerProxy::didExitFullscreen(PlaybackSessionContextIden
         return;
     }
 #endif
-    m_page->didExitFullscreen(contextId);
+    page->didExitFullscreen(contextId);
     callCloseCompletionHandlers();
 }
 
 void VideoPresentationManagerProxy::didEnterFullscreen(PlaybackSessionContextIdentifier contextId, const WebCore::FloatSize& size)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
     std::optional<FloatSize> optionalSize;
     if (!size.isEmpty())
         optionalSize = size;
 
-    m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::DidEnterFullscreen(contextId, optionalSize), m_page->webPageIDInMainFrameProcess());
+    page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidEnterFullscreen(contextId, optionalSize), page->webPageIDInMainFrameProcess());
 
 #if PLATFORM(IOS_FAMILY)
     if (ensureInterface(contextId)->changingStandbyOnly())
         return;
 #endif
-    m_page->didEnterFullscreen(contextId);
+    page->didEnterFullscreen(contextId);
 }
 
 void VideoPresentationManagerProxy::failedToEnterFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::FailedToEnterFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::FailedToEnterFullscreen(contextId), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextIdentifier contextId)
@@ -1322,7 +1330,7 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
         model->setLayerHostView(nullptr);
     }
 
-    page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::DidCleanupFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
+    page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidCleanupFullscreen(contextId), page->webPageIDInMainFrameProcess());
 
     if (!hasMode(HTMLMediaElementEnums::VideoFullscreenModeInWindow)) {
         interface->setMode(HTMLMediaElementEnums::VideoFullscreenModeNone, false);
@@ -1334,7 +1342,8 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
 
 void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
     auto [model, interface] = ensureModelAndInterface(contextId);
@@ -1348,7 +1357,7 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
         [hostingUpdateCoordinator addLayerHierarchyHostingView:view->_hostingView.get()];
         OSObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
         fenceSendRight = MachSendRight::adopt(xpc_dictionary_copy_mach_send(xpcRepresentationHostingCoordinator.get(), machPortKey));
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::SetVideoLayerFrameFenced(contextId, frame, WTFMove(fenceSendRight)), m_page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetVideoLayerFrameFenced(contextId, frame, WTFMove(fenceSendRight)), page->webPageIDInMainFrameProcess());
         [hostingUpdateCoordinator commit];
         return;
     }
@@ -1356,36 +1365,36 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
     fenceSendRight = MachSendRight::adopt([UIWindow _synchronizeDrawingAcrossProcesses]);
 #endif // USE(EXTENSIONKIT)
 #else
-    if (DrawingAreaProxy* drawingArea = m_page->drawingArea())
+    if (DrawingAreaProxy* drawingArea = page->drawingArea())
         fenceSendRight = drawingArea->createFence();
 #endif
 
-    m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::SetVideoLayerFrameFenced(contextId, frame, WTFMove(fenceSendRight)), m_page->webPageIDInMainFrameProcess());
+    page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetVideoLayerFrameFenced(contextId, frame, WTFMove(fenceSendRight)), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::setVideoLayerGravity(PlaybackSessionContextIdentifier contextId, WebCore::MediaPlayerEnums::VideoGravity gravity)
 {
     // FIXME: gravity should be sent as an enum instead of an unsigned.
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::SetVideoLayerGravityEnum(contextId, (unsigned)gravity), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetVideoLayerGravityEnum(contextId, (unsigned)gravity), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::setVideoFullscreenFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)
 {
     if (RefPtr page = m_page.get())
-        page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::SetVideoFullscreenFrame(contextId, frame), m_page->webPageIDInMainFrameProcess());
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetVideoFullscreenFrame(contextId, frame), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::fullscreenModeChanged(PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::FullscreenModeChanged(contextId, mode), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::FullscreenModeChanged(contextId, mode), page->webPageIDInMainFrameProcess());
 }
 
 void VideoPresentationManagerProxy::fullscreenMayReturnToInline(PlaybackSessionContextIdentifier contextId)
 {
-    if (m_page)
-        m_page->legacyMainFrameProcess().send(Messages::VideoPresentationManager::FullscreenMayReturnToInline(contextId, m_page->isViewVisible()), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::FullscreenMayReturnToInline(contextId, page->isViewVisible()), page->webPageIDInMainFrameProcess());
 }
 
 #endif


### PR DESCRIPTION
#### d43ec2c6ee3129a34902915efc7177a6811a10f5
<pre>
Adopt more smart pointers in PlaybackSessionManagerProxy and VideoPresentationManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=279955">https://bugs.webkit.org/show_bug.cgi?id=279955</a>
<a href="https://rdar.apple.com/136272392">rdar://136272392</a>

Reviewed by Jean-Yves Avenard.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::sendRemoteCommand):
(WebKit::PlaybackSessionModelContext::setSpatialTrackingLabel):
(WebKit::PlaybackSessionModelContext::addNowPlayingMetadataObserver):
(WebKit::PlaybackSessionModelContext::removeNowPlayingMetadataObserver):
(WebKit::PlaybackSessionModelContext::setSoundStageSize):
(WebKit::PlaybackSessionModelContext::play):
(WebKit::PlaybackSessionModelContext::pause):
(WebKit::PlaybackSessionModelContext::togglePlayState):
(WebKit::PlaybackSessionModelContext::beginScrubbing):
(WebKit::PlaybackSessionModelContext::endScrubbing):
(WebKit::PlaybackSessionModelContext::seekToTime):
(WebKit::PlaybackSessionModelContext::fastSeek):
(WebKit::PlaybackSessionModelContext::beginScanningForward):
(WebKit::PlaybackSessionModelContext::beginScanningBackward):
(WebKit::PlaybackSessionModelContext::endScanning):
(WebKit::PlaybackSessionModelContext::setDefaultPlaybackRate):
(WebKit::PlaybackSessionModelContext::setPlaybackRate):
(WebKit::PlaybackSessionModelContext::selectAudioMediaOption):
(WebKit::PlaybackSessionModelContext::selectLegibleMediaOption):
(WebKit::PlaybackSessionModelContext::togglePictureInPicture):
(WebKit::PlaybackSessionModelContext::enterInWindowFullscreen):
(WebKit::PlaybackSessionModelContext::exitInWindowFullscreen):
(WebKit::PlaybackSessionModelContext::toggleMuted):
(WebKit::PlaybackSessionModelContext::setMuted):
(WebKit::PlaybackSessionModelContext::setVolume):
(WebKit::PlaybackSessionModelContext::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::invalidate):
(WebKit::PlaybackSessionManagerProxy::play):
(WebKit::PlaybackSessionManagerProxy::pause):
(WebKit::PlaybackSessionManagerProxy::togglePlayState):
(WebKit::PlaybackSessionManagerProxy::beginScrubbing):
(WebKit::PlaybackSessionManagerProxy::endScrubbing):
(WebKit::PlaybackSessionManagerProxy::seekToTime):
(WebKit::PlaybackSessionManagerProxy::fastSeek):
(WebKit::PlaybackSessionManagerProxy::beginScanningForward):
(WebKit::PlaybackSessionManagerProxy::beginScanningBackward):
(WebKit::PlaybackSessionManagerProxy::endScanning):
(WebKit::PlaybackSessionManagerProxy::setDefaultPlaybackRate):
(WebKit::PlaybackSessionManagerProxy::setPlaybackRate):
(WebKit::PlaybackSessionManagerProxy::selectAudioMediaOption):
(WebKit::PlaybackSessionManagerProxy::selectLegibleMediaOption):
(WebKit::PlaybackSessionManagerProxy::togglePictureInPicture):
(WebKit::PlaybackSessionManagerProxy::enterFullscreen):
(WebKit::PlaybackSessionManagerProxy::exitFullscreen):
(WebKit::PlaybackSessionManagerProxy::enterInWindow):
(WebKit::PlaybackSessionManagerProxy::exitInWindow):
(WebKit::PlaybackSessionManagerProxy::toggleMuted):
(WebKit::PlaybackSessionManagerProxy::setMuted):
(WebKit::PlaybackSessionManagerProxy::setVolume):
(WebKit::PlaybackSessionManagerProxy::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionManagerProxy::sendRemoteCommand):
(WebKit::PlaybackSessionManagerProxy::setSpatialTrackingLabel):
(WebKit::PlaybackSessionManagerProxy::setSoundStageSize):
(WebKit::PlaybackSessionManagerProxy::requestControlledElementID):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::requestCloseAllMediaPresentations):
(WebKit::VideoPresentationModelContext::requestFullscreenMode):
(WebKit::VideoPresentationModelContext::setVideoLayerFrame):
(WebKit::VideoPresentationModelContext::setVideoLayerGravity):
(WebKit::VideoPresentationModelContext::setVideoFullscreenFrame):
(WebKit::VideoPresentationModelContext::fullscreenModeChanged):
(WebKit::VideoPresentationModelContext::requestUpdateInlineRect):
(WebKit::VideoPresentationModelContext::requestVideoContentLayer):
(WebKit::VideoPresentationModelContext::returnVideoContentLayer):
(WebKit::VideoPresentationModelContext::returnVideoView):
(WebKit::VideoPresentationModelContext::didSetupFullscreen):
(WebKit::VideoPresentationModelContext::failedToEnterFullscreen):
(WebKit::VideoPresentationModelContext::didEnterFullscreen):
(WebKit::VideoPresentationModelContext::willExitFullscreen):
(WebKit::VideoPresentationModelContext::didExitFullscreen):
(WebKit::VideoPresentationModelContext::didCleanupFullscreen):
(WebKit::VideoPresentationModelContext::fullscreenMayReturnToInline):
(WebKit::VideoPresentationModelContext::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationModelContext::didEnterPictureInPicture):
(WebKit::VideoPresentationModelContext::didExitPictureInPicture):
(WebKit::VideoPresentationManagerProxy::VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::invalidate):
(WebKit::VideoPresentationManagerProxy::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
(WebKit::VideoPresentationManagerProxy::requestBitmapImageForCurrentTime):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::exitFullscreen):
(WebKit::VideoPresentationManagerProxy::preparedToReturnToInline):
(WebKit::VideoPresentationManagerProxy::setRequiresTextTrackRepresentation):
(WebKit::VideoPresentationManagerProxy::setTextTrackRepresentationBounds):
(WebKit::VideoPresentationManagerProxy::requestFullscreenMode):
(WebKit::VideoPresentationManagerProxy::requestUpdateInlineRect):
(WebKit::VideoPresentationManagerProxy::requestVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::returnVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::didSetupFullscreen):
(WebKit::VideoPresentationManagerProxy::willExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::failedToEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
(WebKit::VideoPresentationManagerProxy::setVideoLayerGravity):
(WebKit::VideoPresentationManagerProxy::setVideoFullscreenFrame):
(WebKit::VideoPresentationManagerProxy::fullscreenModeChanged):
(WebKit::VideoPresentationManagerProxy::fullscreenMayReturnToInline):

Canonical link: <a href="https://commits.webkit.org/283975@main">https://commits.webkit.org/283975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaf6f25537b6e76f7fe308f78955b515960bc737

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54318 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40012 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73683 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61781 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9667 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3288 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10343 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43121 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->