### PR TITLE
Deploy even more smart pointers in Source/WebKit/NetworkProcess and Source/WebKit/UIProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -210,7 +210,7 @@ void WebSWServerToContextConnection::fireBackgroundFetchEvent(ServiceWorkerIdent
 void WebSWServerToContextConnection::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier serviceWorkerIdentifier, const BackgroundFetchInformation& info, CompletionHandler<void(bool)>&& callback)
 {
     if (!m_processingFunctionalEventCount++)
-        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        protectedConnection()->protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     sendWithAsyncReply(Messages::WebSWContextManagerConnection::FireBackgroundFetchClickEvent { serviceWorkerIdentifier, info }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](bool wasProcessed) mutable {
         CheckedPtr checkedThis = weakThis.get();
@@ -218,7 +218,7 @@ void WebSWServerToContextConnection::fireBackgroundFetchClickEvent(ServiceWorker
             return callback(wasProcessed);
 
         if (!--checkedThis->m_processingFunctionalEventCount)
-            checkedThis->m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { checkedThis->webProcessIdentifier() }, 0);
+            checkedThis->protectedConnection()->protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { checkedThis->webProcessIdentifier() }, 0);
 
         callback(wasProcessed);
     });

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -224,7 +224,7 @@ private:
     void sendMessageToFrontend(const String& message) override;
     ConnectionType connectionType() const override { return ConnectionType::Local; }
 
-    WebPageProxy* platformCreateFrontendPage();
+    RefPtr<WebPageProxy> platformCreateFrontendPage();
     void platformCreateFrontendWindow();
     void platformCloseFrontendPageAndWindow();
 

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -176,7 +176,7 @@ static Ref<WebsiteDataStore> inspectorWebsiteDataStore()
     return WebsiteDataStore::create(WTFMove(configuration), PAL::SessionID::generatePersistentSessionID());
 }
 
-WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
+RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
 {
     ASSERT(m_inspectedPage);
     ASSERT(!m_inspectorView);
@@ -293,12 +293,12 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
         nullptr, // hideContextMenu
     };
 
-    WebPageProxy* inspectorPage = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_inspectorView.get()));
+    RefPtr inspectorPage = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_inspectorView.get()));
     ASSERT(inspectorPage);
 
-    WKPageSetPageUIClient(toAPI(inspectorPage), &uiClient.base);
-    WKPageSetPageNavigationClient(toAPI(inspectorPage), &navigationClient.base);
-    WKPageSetPageContextMenuClient(toAPI(inspectorPage), &contextMenuClient.base);
+    WKPageSetPageUIClient(toAPI(inspectorPage.get()), &uiClient.base);
+    WKPageSetPageNavigationClient(toAPI(inspectorPage.get()), &navigationClient.base);
+    WKPageSetPageContextMenuClient(toAPI(inspectorPage.get()), &contextMenuClient.base);
 
     return inspectorPage;
 }

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -313,7 +313,7 @@ using namespace WebCore;
 
 void WebInspectorUIProxy::didBecomeActive()
 {
-    m_inspectorPage->legacyMainFrameProcess().send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
+    protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::attachmentViewDidChange(NSView *oldView, NSView *newView)
@@ -441,7 +441,7 @@ void WebInspectorUIProxy::showSavePanel(NSWindow *frontendWindow, NSURL *platfor
         didShowModal([savePanel runModal]);
 }
 
-WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
+RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
 {
     RefPtr inspectedPage = m_inspectedPage.get();
     ASSERT(m_inspectedPage);
@@ -462,9 +462,8 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration: WebKit::wrapper(configuration.get()) inspectedPage:inspectedPage.get()]);
     [m_inspectorViewController.get() setDelegate:m_objCAdapter.get()];
 
-    WebPageProxy *inspectorPage = [m_inspectorViewController webView]->_page.get();
+    RefPtr inspectorPage = [m_inspectorViewController webView]->_page.get();
     ASSERT(inspectorPage);
-
     return inspectorPage;
 }
 
@@ -474,7 +473,7 @@ void WebInspectorUIProxy::platformCreateFrontendWindow()
 
     NSRect savedWindowFrame = NSZeroRect;
     if (RefPtr inspectedPage = protectedInspectedPage()) {
-        NSString *savedWindowFrameString = inspectedPage->pageGroup().preferences().inspectorWindowFrame();
+        NSString *savedWindowFrameString = inspectedPage->protectedPageGroup()->protectedPreferences()->inspectorWindowFrame();
         savedWindowFrame = NSRectFromString(savedWindowFrameString);
     }
 
@@ -554,7 +553,7 @@ void WebInspectorUIProxy::platformHide()
 void WebInspectorUIProxy::platformResetState()
 {
     if (RefPtr inspectedPage = m_inspectedPage.get())
-        inspectedPage->pageGroup().preferences().deleteInspectorWindowFrame();
+        inspectedPage->protectedPageGroup()->protectedPreferences()->deleteInspectorWindowFrame();
 }
 
 void WebInspectorUIProxy::platformBringToFront()
@@ -723,7 +722,7 @@ void WebInspectorUIProxy::windowFrameDidChange()
         return;
 
     NSString *frameString = NSStringFromRect([m_inspectorWindow frame]);
-    inspectedPage->pageGroup().preferences().setInspectorWindowFrame(frameString);
+    inspectedPage->protectedPageGroup()->protectedPreferences()->setInspectorWindowFrame(frameString);
 }
 
 void WebInspectorUIProxy::windowFullScreenDidChange()
@@ -846,15 +845,15 @@ void WebInspectorUIProxy::platformAttach()
     switch (m_attachmentSide) {
     case AttachmentSide::Bottom:
         [inspectorView setAutoresizingMask:NSViewWidthSizable | NSViewMaxYMargin];
-        currentDimension = inspectorPagePreferences().inspectorAttachedHeight();
+        currentDimension = protectedInspectorPagePreferences()->inspectorAttachedHeight();
         break;
     case AttachmentSide::Right:
         [inspectorView setAutoresizingMask:NSViewHeightSizable | NSViewMinXMargin];
-        currentDimension = inspectorPagePreferences().inspectorAttachedWidth();
+        currentDimension = protectedInspectorPagePreferences()->inspectorAttachedWidth();
         break;
     case AttachmentSide::Left:
         [inspectorView setAutoresizingMask:NSViewHeightSizable | NSViewMaxXMargin];
-        currentDimension = inspectorPagePreferences().inspectorAttachedWidth();
+        currentDimension = protectedInspectorPagePreferences()->inspectorAttachedWidth();
         break;
     }
 

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -254,7 +254,7 @@ static void webProcessDidCrash(WKPageRef, const void* clientInfo)
     inspector->closeForCrash();
 }
 
-WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
+RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
 {
     ASSERT(m_inspectedPage);
 
@@ -303,9 +303,9 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     m_inspectedViewParentWindow = ::GetParent(m_inspectedViewWindow);
     auto view = WebView::create(r, pageConfiguration, m_inspectedViewParentWindow);
     m_inspectorView = &view.leakRef();
-    auto inspectorPage = m_inspectorView->page();
+    RefPtr inspectorPage = m_inspectorView->page();
     m_inspectorViewWindow = reinterpret_cast<HWND>(inspectorPage->viewWidget());
-    WKPageSetPageNavigationClient(toAPI(inspectorPage), &navigationClient.base);
+    WKPageSetPageNavigationClient(toAPI(inspectorPage.get()), &navigationClient.base);
 
     inspectorPage->setURLSchemeHandlerForScheme(InspectorResourceURLSchemeHandler::create(), "inspector-resource"_s);
 

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -102,7 +102,7 @@ static Ref<WebsiteDataStore> inspectorWebsiteDataStore()
     return WebsiteDataStore::create(WTFMove(configuration), PAL::SessionID::generatePersistentSessionID());
 }
 
-WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
+RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
 {
     auto* inspectedWPEView = m_inspectedPage->wpeView();
     if (!inspectedWPEView)
@@ -147,7 +147,7 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     wpe_view_set_toplevel(wpeView, nullptr);
     wpe_toplevel_resize(m_inspectorWindow.get(), initialWindowWidth, initialWindowHeight);
 
-    return page.ptr();
+    return page;
 }
 
 void WebInspectorUIProxy::platformCreateFrontendWindow()

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -210,24 +210,24 @@ void WebUserContentControllerProxy::addUserScript(API::UserScript& userScript, I
 
     m_userScripts->elements().append(&userScript);
 
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->identifier(), userScript.userScript() } }, immediately), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->identifier(), userScript.userScript() } }, immediately), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript)
 {
     Ref<API::ContentWorld> world = userScript.contentWorld();
 
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveUserScript(world->identifier(), userScript.identifier()), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::RemoveUserScript(world->identifier(), userScript.identifier()), identifier());
 
     m_userScripts->elements().removeAll(&userScript);
 }
 
 void WebUserContentControllerProxy::removeAllUserScripts(API::ContentWorld& world)
 {
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScripts({ world.identifier() }), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::RemoveAllUserScripts({ world.identifier() }), identifier());
 
     m_userScripts->removeAllOfTypeMatching<API::UserScript>([&](const auto& userScript) {
         return &userScript->contentWorld() == &world;
@@ -283,24 +283,24 @@ void WebUserContentControllerProxy::addUserStyleSheet(API::UserStyleSheet& userS
 
     m_userStyleSheets->elements().append(&userStyleSheet);
 
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->identifier(), userStyleSheet.userStyleSheet() } }), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->identifier(), userStyleSheet.userStyleSheet() } }), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& userStyleSheet)
 {
     Ref<API::ContentWorld> world = userStyleSheet.contentWorld();
 
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveUserStyleSheet(world->identifier(), userStyleSheet.identifier()), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::RemoveUserStyleSheet(world->identifier(), userStyleSheet.identifier()), identifier());
 
     m_userStyleSheets->elements().removeAll(&userStyleSheet);
 }
 
 void WebUserContentControllerProxy::removeAllUserStyleSheets(API::ContentWorld& world)
 {
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserStyleSheets({ world.identifier() }), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::RemoveAllUserStyleSheets({ world.identifier() }), identifier());
 
     m_userStyleSheets->removeAllOfTypeMatching<API::UserStyleSheet>([&](const auto& userStyleSheet) {
         return &userStyleSheet->contentWorld() == &world;
@@ -325,8 +325,8 @@ void WebUserContentControllerProxy::removeAllUserStyleSheets()
             return entry.key->identifier();
         });
 
-        for (auto& process : m_processes)
-            process.send(Messages::WebUserContentController::RemoveAllUserStyleSheets(worldIdentifiers), identifier());
+        for (Ref process : m_processes)
+            process->send(Messages::WebUserContentController::RemoveAllUserStyleSheets(worldIdentifiers), identifier());
 
         m_userStyleSheets->elements().clear();
 
@@ -383,8 +383,8 @@ void WebUserContentControllerProxy::removeUserMessageHandlerForName(const String
 
 void WebUserContentControllerProxy::removeAllUserMessageHandlers(API::ContentWorld& world)
 {
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScriptMessageHandlersForWorlds({ world.identifier() }), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::RemoveAllUserScriptMessageHandlersForWorlds({ world.identifier() }), identifier());
 
     m_scriptMessageHandlers.removeIf([&](auto& entry) {
         return entry.value->world().identifier() == world.identifier();
@@ -393,8 +393,8 @@ void WebUserContentControllerProxy::removeAllUserMessageHandlers(API::ContentWor
 
 void WebUserContentControllerProxy::removeAllUserMessageHandlers()
 {
-    for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScriptMessageHandlers(), identifier());
+    for (Ref process : m_processes)
+        process->send(Messages::WebUserContentController::RemoveAllUserScriptMessageHandlers(), identifier());
 
     m_scriptMessageHandlers.clear();
 }

--- a/Source/WebKit/UIProcess/WebPageGroup.cpp
+++ b/Source/WebKit/UIProcess/WebPageGroup.cpp
@@ -93,7 +93,12 @@ WebPageGroup::~WebPageGroup()
 
 WebPreferences& WebPageGroup::preferences() const
 {
-    return *m_preferences;
+    return m_preferences;
+}
+
+Ref<WebPreferences> WebPageGroup::protectedPreferences() const
+{
+    return m_preferences;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageGroup.h
+++ b/Source/WebKit/UIProcess/WebPageGroup.h
@@ -51,10 +51,11 @@ public:
     const WebPageGroupData& data() const { return m_data; }
 
     WebPreferences& preferences() const;
+    Ref<WebPreferences> protectedPreferences() const;
 
 private:
     WebPageGroupData m_data;
-    RefPtr<WebPreferences> m_preferences;
+    Ref<WebPreferences> m_preferences;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 65a85c2a99264546b4aefe314154877cb1da36f0
<pre>
Deploy even more smart pointers in Source/WebKit/NetworkProcess and Source/WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279956">https://bugs.webkit.org/show_bug.cgi?id=279956</a>

Reviewed by Youenn Fablet.

Deployed more smart pointers as warned by clang static analyzers.

* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchClickEvent):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::sendMessage):
(WebKit::DrawingAreaProxy::sendMessageWithAsyncReply):
(WebKit::DrawingAreaProxy::didChangeViewExposedRect):
(WebKit::DrawingAreaProxy::viewExposedRectChangedTimerFired):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::connect):
(WebKit::WebInspectorUIProxy::reset):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::createFrontendPage):
(WebKit::WebInspectorUIProxy::attachAvailabilityChanged):
(WebKit::WebInspectorUIProxy::save):
(WebKit::WebInspectorUIProxy::shouldOpenAttached):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::didBecomeActive):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
(WebKit::WebInspectorUIProxy::platformResetState):
(WebKit::WebInspectorUIProxy::windowFrameDidChange):
(WebKit::WebInspectorUIProxy::platformAttach):
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::minimumSizeForAutoLayoutDidChange):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::addUserScript):
(WebKit::WebUserContentControllerProxy::removeUserScript):
(WebKit::WebUserContentControllerProxy::removeAllUserScripts):
(WebKit::WebUserContentControllerProxy::addUserStyleSheet):
(WebKit::WebUserContentControllerProxy::removeUserStyleSheet):
(WebKit::WebUserContentControllerProxy::removeAllUserStyleSheets):
(WebKit::WebUserContentControllerProxy::removeAllUserMessageHandlers):
* Source/WebKit/UIProcess/WebPageGroup.cpp:
(WebKit::WebPageGroup::protectedPreferences const):
* Source/WebKit/UIProcess/WebPageGroup.h:

Canonical link: <a href="https://commits.webkit.org/284011@main">https://commits.webkit.org/284011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aaab24120e5e0c78217826dabe3e1e623e9e365

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72145 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19227 "Failed to checkout and rebase branch from PR 33885") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/19227 "Failed to checkout and rebase branch from PR 33885") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58831 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40137 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/17584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73841 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15866 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58905 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3400 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10365 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43275 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->