### PR TITLE
Make MediaSource::m_sourceBuffers/activeSourceBuffers a Ref

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -108,7 +108,7 @@ void ManagedMediaSource::monitorSourceBuffers()
 {
     MediaSource::monitorSourceBuffers();
 
-    if (!activeSourceBuffers() || !activeSourceBuffers()->length()) {
+    if (!activeSourceBuffers()->length()) {
         setStreaming(true);
         return;
     }

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -124,8 +124,8 @@ public:
     ReadyState readyState() const;
     ExceptionOr<void> endOfStream(std::optional<EndOfStreamError>);
 
-    SourceBufferList* sourceBuffers() { return m_sourceBuffers.get(); }
-    SourceBufferList* activeSourceBuffers() { return m_activeSourceBuffers.get(); }
+    Ref<SourceBufferList> sourceBuffers() const;
+    Ref<SourceBufferList> activeSourceBuffers() const;
     ExceptionOr<Ref<SourceBuffer>> addSourceBuffer(const String& type);
     ExceptionOr<void> removeSourceBuffer(SourceBuffer&);
     static bool isTypeSupported(ScriptExecutionContext&, const String& type);
@@ -226,8 +226,8 @@ private:
 
     static URLRegistry* s_registry;
 
-    RefPtr<SourceBufferList> m_sourceBuffers;
-    RefPtr<SourceBufferList> m_activeSourceBuffers;
+    const Ref<SourceBufferList> m_sourceBuffers;
+    const Ref<SourceBufferList> m_activeSourceBuffers;
     std::optional<SeekTarget> m_pendingSeekTarget;
     std::optional<MediaTimePromise::AutoRejectProducer> m_seekTargetPromise;
     bool m_openDeferred { false };

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -75,7 +75,7 @@ bool MediaSourceInterfaceMainThread::isStreamingContent() const
     if (RefPtr managedMediasource = dynamicDowncast<ManagedMediaSource>(m_mediaSource))
         return managedMediasource && managedMediasource->streamingAllowed() && managedMediasource->streaming();
     // We can assume that if we have active source buffers, later networking activity (such as stream or XHR requests) will be media related.
-    return m_mediaSource->activeSourceBuffers() && m_mediaSource->activeSourceBuffers()->length();
+    return m_mediaSource->activeSourceBuffers()->length();
 }
 
 bool MediaSourceInterfaceMainThread::attachToElement(WeakPtr<HTMLMediaElement>&& element)


### PR DESCRIPTION
#### ee5a960d47ef6581afa351d0b708698d732eac7b
<pre>
Make MediaSource::m_sourceBuffers/activeSourceBuffers a Ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=279958">https://bugs.webkit.org/show_bug.cgi?id=279958</a>
<a href="https://rdar.apple.com/136276512">rdar://136276512</a>

Reviewed by Youenn Fablet.

Those two members can&apos;t ever be null.

No change in observable behavior.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::completeSeek):
(WebCore::MediaSource::seekToTime):
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::setDuration):
(WebCore::MediaSource::setDurationInternal):
(WebCore::MediaSource::streamEndedWithError):
(WebCore::MediaSource::openIfInEndedState):
(WebCore::MediaSource::onReadyStateChange):
(WebCore::MediaSource::activeRanges const):
(WebCore::MediaSource::regenerateActiveSourceBuffers):
(WebCore::MediaSource::updateBufferedIfNeeded):
(WebCore::MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged):
(WebCore::MediaSource::memoryPressure):
(WebCore::MediaSource::sourceBuffers const):
(WebCore::MediaSource::activeSourceBuffers const):
* Source/WebCore/Modules/mediasource/MediaSource.h:
(WebCore::MediaSource::sourceBuffers): Deleted.
(WebCore::MediaSource::activeSourceBuffers): Deleted.
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp:
(WebCore::MediaSourceInterfaceMainThread::isStreamingContent const):

Canonical link: <a href="https://commits.webkit.org/283911@main">https://commits.webkit.org/283911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee18ea483a6f910009b8a71788a3af8fbbf83e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71842 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18734 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70854 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17286 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11750 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/67467 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58685 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15048 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3191 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42976 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->