### PR TITLE
CoreAudioSharedUnit::voiceActivityDetected() should be called on main thread

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -43,7 +43,6 @@ namespace WebCore {
 #if PLATFORM(MAC) && HAVE(VOICEACTIVITYDETECTION)
 static int speechActivityListenerCallback(AudioObjectID deviceID, UInt32, const AudioObjectPropertyAddress*, void*)
 {
-    ASSERT(isMainRunLoop());
     CoreAudioSharedUnit::processVoiceActivityEvent(deviceID);
     return 0;
 }
@@ -92,7 +91,9 @@ void CoreAudioSharedUnit::processVoiceActivityEvent(AudioObjectID deviceID)
     if (voiceDetected != 1)
         return;
 
-    CoreAudioSharedUnit::unit().voiceActivityDetected();
+    callOnMainRunLoop([] {
+        CoreAudioSharedUnit::unit().voiceActivityDetected();
+    });
 }
 #endif // PLATFORM(MAC) && HAVE(VOICEACTIVITYDETECTION)
 


### PR DESCRIPTION
#### cb23e73e0dfda6778d4830a42e73c188713f48a9
<pre>
CoreAudioSharedUnit::voiceActivityDetected() should be called on main thread
<a href="https://rdar.apple.com/136280173">rdar://136280173</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279961">https://bugs.webkit.org/show_bug.cgi?id=279961</a>

Reviewed by Jean-Yves Avenard.

kVoiceActivityDetectionState callback can be called on any thread.
Now that we use a timer, we need CoreAudioSharedUnit::voiceActivityDetected to be run on main thread.
We thus add a missing callOnMainRunLoop in CoreAudioSharedUnit::processVoiceActivityEvent.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(WebCore::speechActivityListenerCallback):
(WebCore::CoreAudioSharedUnit::processVoiceActivityEvent):

Canonical link: <a href="https://commits.webkit.org/283915@main">https://commits.webkit.org/283915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e895ff7e2d13bcc22da603a3383154512e6e4ecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71834 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54223 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16015 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73532 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15645 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58679 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3185 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42968 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->