### PR TITLE
[CoordinatedGraphics] Simplify TextureMapperPlatformLayerProxy lock handling

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.cpp
@@ -47,7 +47,6 @@ GraphicsLayerContentsDisplayDelegateGBM::GraphicsLayerContentsDisplayDelegateGBM
         if (!m_isOpaque)
             flags.add(TextureMapperFlags::ShouldBlend);
 
-        Locker locker { proxy.lock() };
         proxy.pushNextBuffer(CoordinatedPlatformLayerBufferDMABuf::create(Ref { *m_buffer }, flags, WTFMove(m_fence)));
     });
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3313,7 +3313,6 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor()
 
     ++m_sampleCount;
 
-    Locker locker { m_platformLayer->lock() };
     if (!m_platformLayer->isActive()) {
         GST_ERROR_OBJECT(pipeline(), "TextureMapperPlatformLayerProxy is inactive");
         textureMapperPlatformLayerProxyWasInvalidated();
@@ -3808,7 +3807,6 @@ GstElement* MediaPlayerPrivateGStreamer::createHolePunchVideoSink()
 void MediaPlayerPrivateGStreamer::pushNextHolePunchBuffer()
 {
     ASSERT(isHolePunchRenderingEnabled());
-    Locker locker { m_platformLayer->lock() };
     m_platformLayer->pushNextBuffer(CoordinatedPlatformLayerBufferHolePunch::create(m_size, m_videoSink.get(), m_quirksManagerForTesting ? m_quirksManagerForTesting.copyRef() : RefPtr { &GStreamerQuirksManager::singleton() }));
 }
 

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -66,7 +66,6 @@ FloatSize MediaPlayerPrivateHolePunch::naturalSize() const
 
 void MediaPlayerPrivateHolePunch::pushNextHolePunchBuffer()
 {
-    Locker locker { m_platformLayer->lock() };
     proxy.pushNextBuffer(CoordinatedPlatformLayerBufferHolePunch::create(m_size));
 }
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -94,7 +94,6 @@ ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend(const Param
             if (!image)
                 return;
 
-            Locker locker { proxy.lock() };
             OptionSet<TextureMapperFlags> flags;
             if (image->hasAlpha())
                 flags.add(TextureMapperFlags::ShouldBlend);

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -309,7 +309,6 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
             flags.add(TextureMapperFlags::ShouldBlend);
 
         auto fboSize = getInternalFramebufferSize();
-        Locker locker { proxy.lock() };
         proxy.pushNextBuffer(CoordinatedPlatformLayerBufferRGB::create(m_compositorTextureID, fboSize, flags, WTFMove(m_frameFence)));
     });
     m_layerContentsDisplayDelegate = GraphicsLayerContentsDisplayDelegateTextureMapper::create(WTFMove(proxy));

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerAsyncContentsDisplayDelegateTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerAsyncContentsDisplayDelegateTextureMapper.cpp
@@ -50,7 +50,6 @@ bool GraphicsLayerAsyncContentsDisplayDelegateTextureMapper::tryCopyToLayer(Imag
     if (!image)
         return false;
 
-    Locker locker { m_proxy->lock() };
     OptionSet<TextureMapperFlags> flags;
     if (image->hasAlpha())
         flags.add(TextureMapperFlags::ShouldBlend);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
@@ -60,11 +60,9 @@ public:
 
     virtual ~TextureMapperPlatformLayerProxy();
 
-    Lock& lock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
-    bool isActive() const;
-
     ContentType contentType() const { return m_contentType; }
 
+    bool isActive();
     void activateOnCompositingThread(Compositor*, TextureMapperLayer*);
     void invalidate();
     void swapBuffer();
@@ -76,6 +74,8 @@ public:
 
 private:
     explicit TextureMapperPlatformLayerProxy(ContentType);
+
+    bool isActiveLocked() const;
 
     bool scheduleUpdateOnCompositorThread(Function<void()>&&);
     void compositorThreadUpdateTimerFired();

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -74,8 +74,6 @@ private:
             OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
             if (!m_isOpaque)
                 flags.add(TextureMapperFlags::ShouldBlend);
-
-            Locker locker { proxy.lock() };
             proxy.pushNextBuffer(CoordinatedPlatformLayerBufferDMABuf::create(Ref { *m_displayBuffer }, flags, WTFMove(m_fenceFD)));
         });
     }


### PR DESCRIPTION
#### e8cea6c44da232ef7cab9cd9e015d351ad788b2b
<pre>
[CoordinatedGraphics] Simplify TextureMapperPlatformLayerProxy lock handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=279964">https://bugs.webkit.org/show_bug.cgi?id=279964</a>

Reviewed by Nikolas Zimmermann.

Make the lock private and just take the lock on pushNextBuffer instead
of locking explicitly from the callers.

* Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.cpp:
(WebCore::GraphicsLayerContentsDisplayDelegateGBM::GraphicsLayerContentsDisplayDelegateGBM):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushTextureToCompositor):
(WebCore::MediaPlayerPrivateGStreamer::pushNextHolePunchBuffer):
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp:
(WebCore::MediaPlayerPrivateHolePunch::pushNextHolePunchBuffer):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitialize):
* Source/WebCore/platform/graphics/texmap/GraphicsLayerAsyncContentsDisplayDelegateTextureMapper.cpp:
(WebCore::GraphicsLayerAsyncContentsDisplayDelegateTextureMapper::tryCopyToLayer):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp:
(WebCore::TextureMapperPlatformLayerProxy::isActiveLocked const):
(WebCore::TextureMapperPlatformLayerProxy::isActive):
(WebCore::TextureMapperPlatformLayerProxy::pushNextBuffer):
(WebCore::TextureMapperPlatformLayerProxy::dropCurrentBufferWhilePreservingTexture):
(WebCore::TextureMapperPlatformLayerProxy::scheduleUpdateOnCompositorThread):
(WebCore::TextureMapperPlatformLayerProxy::isActive const): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:

Canonical link: <a href="https://commits.webkit.org/283914@main">https://commits.webkit.org/283914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11604a48497a329460ebde11bf51195b3f79f8e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71837 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54225 "Passed tests") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73535 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61676 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58680 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3186 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10303 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42971 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->