### PR TITLE
[GStreamer] Build broken with GStreamer < 1.24

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -79,6 +79,43 @@ static void initializeDMABufAvailability()
     });
 }
 
+#if !GST_CHECK_VERSION(1, 24, 0)
+static GstVideoFormat drmFourccToGstVideoFormat(uint32_t fourcc)
+{
+    switch (fourcc) {
+    case DRM_FORMAT_XRGB8888:
+        return GST_VIDEO_FORMAT_BGRx;
+    case DRM_FORMAT_XBGR8888:
+        return GST_VIDEO_FORMAT_RGBx;
+    case DRM_FORMAT_ARGB8888:
+        return GST_VIDEO_FORMAT_BGRA;
+    case DRM_FORMAT_ABGR8888:
+        return GST_VIDEO_FORMAT_RGBA;
+    case DRM_FORMAT_YUV420:
+        return GST_VIDEO_FORMAT_I420;
+    case DRM_FORMAT_YVU420:
+        return GST_VIDEO_FORMAT_YV12;
+    case DRM_FORMAT_NV12:
+        return GST_VIDEO_FORMAT_NV12;
+    case DRM_FORMAT_NV21:
+        return GST_VIDEO_FORMAT_NV21;
+    case DRM_FORMAT_YUV444:
+        return GST_VIDEO_FORMAT_Y444;
+    case DRM_FORMAT_YUV411:
+        return GST_VIDEO_FORMAT_Y41B;
+    case DRM_FORMAT_YUV422:
+        return GST_VIDEO_FORMAT_Y42B;
+    case DRM_FORMAT_P010:
+        return GST_VIDEO_FORMAT_P010_10LE;
+    default:
+        break;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return GST_VIDEO_FORMAT_UNKNOWN;
+}
+#endif
+
 static GRefPtr<GstCaps> buildDMABufCaps()
 {
     GRefPtr<GstCaps> caps = adoptGRef(gst_caps_from_string("video/x-raw(memory:DMABuf), width = " GST_VIDEO_SIZE_RANGE ", height = " GST_VIDEO_SIZE_RANGE ", framerate = " GST_VIDEO_FPS_RANGE));
@@ -126,7 +163,7 @@ static GRefPtr<GstCaps> buildDMABufCaps()
 #else
         GValue value = G_VALUE_INIT;
         g_value_init(&value, G_TYPE_STRING);
-        g_value_set_string(&value, gst_video_format_to_string(gst_video_dma_drm_fourcc_to_format(format.fourcc)));
+        g_value_set_string(&value, gst_video_format_to_string(drmFourccToGstVideoFormat(format.fourcc)));
         gst_value_list_append_value(&supportedFormats, &value);
         g_value_unset(&value);
 #endif


### PR DESCRIPTION
#### e8e6a2556246ffca82e1630b81eb874f30cb218e
<pre>
[GStreamer] Build broken with GStreamer &lt; 1.24
<a href="https://bugs.webkit.org/show_bug.cgi?id=279910">https://bugs.webkit.org/show_bug.cgi?id=279910</a>

Reviewed by Philippe Normand.

Add our own helper drmFourccToGstVideoFormat() and use it instead of
gst_video_dma_drm_fourcc_to_format() when GStreamer &lt; 1.24.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(drmFourccToGstVideoFormat):
(buildDMABufCaps):

Canonical link: <a href="https://commits.webkit.org/283909@main">https://commits.webkit.org/283909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65addc852386fa2aa4a906d347cead083a395ff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71841 "Built successfully") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70853 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58610 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/39915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17285 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11749 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58684 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9574 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3190 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10302 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42975 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->