### PR TITLE
Remove OffscreenCanvasRenderingContext2D's commit() method

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-border.html
+++ b/LayoutTests/fast/canvas/offscreen-border.html
@@ -20,7 +20,6 @@ requestAnimationFrame(function() {
     square.rect(50, 50, 100, 100);
     offscreenContext.fillStyle = 'green';
     offscreenContext.fill(square);
-    offscreenContext.commit();
 
     requestAnimationFrame(function() {
         if (window.testRunner)

--- a/LayoutTests/fast/canvas/offscreen-clipped.html
+++ b/LayoutTests/fast/canvas/offscreen-clipped.html
@@ -20,7 +20,6 @@ requestAnimationFrame(function() {
     square.rect(50, 50, 100, 100);
     offscreenContext.fillStyle = 'red';
     offscreenContext.fill(square);
-    offscreenContext.commit();
 
     requestAnimationFrame(function() {
         if (window.testRunner)

--- a/LayoutTests/fast/canvas/offscreen-giant.html
+++ b/LayoutTests/fast/canvas/offscreen-giant.html
@@ -22,7 +22,6 @@ requestAnimationFrame(function() {
     square.rect(0, 0, 100, 10);
     offscreenContext.fillStyle = 'green';
     offscreenContext.fill(square);
-    offscreenContext.commit();
 
     requestAnimationFrame(function() {
         if (window.testRunner)

--- a/LayoutTests/fast/canvas/offscreen-scaling.html
+++ b/LayoutTests/fast/canvas/offscreen-scaling.html
@@ -18,7 +18,6 @@ requestAnimationFrame(function() {
     square.rect(50, 50, 100, 100);
     offscreenContext.fillStyle = 'red';
     offscreenContext.fill(square);
-    offscreenContext.commit();
 
     requestAnimationFrame(function() {
       if (window.testRunner)

--- a/LayoutTests/fast/canvas/offscreen-toggle-display.html
+++ b/LayoutTests/fast/canvas/offscreen-toggle-display.html
@@ -20,7 +20,6 @@ requestAnimationFrame(function() {
     square.rect(50, 50, 100, 100);
     offscreenContext.fillStyle = 'green';
     offscreenContext.fill(square);
-    offscreenContext.commit();
 
     requestAnimationFrame(function() {
         canvas.style.display = "none";

--- a/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas-expected.txt
+++ b/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas-expected.txt
@@ -1,4 +1,4 @@
 
 PASS capture of an OffscreenCanvas with 2D context
-FAIL capture of an OffscreenCanvas with WebGL context ctx.commit is not a function. (In 'ctx.commit()', 'ctx.commit' is undefined)
+PASS capture of an OffscreenCanvas with WebGL context
 

--- a/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html
+++ b/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html
@@ -30,7 +30,6 @@ var testOffScreenCanvasCommits = function(drawFunction, message) {
     recorder.start(1000);
 
     var ctx = drawFunction(offscreen);
-    ctx.commit();
   }, message);
 };
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -748,7 +748,6 @@ PASS OffscreenCanvasRenderingContext2D interface object name
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's "constructor" property
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's @@unscopables property
-PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -346,7 +346,6 @@ PASS OffscreenCanvasRenderingContext2D interface object name
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's "constructor" property
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's @@unscopables property
-PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl
@@ -1573,7 +1573,6 @@ interface OffscreenCanvas : EventTarget {
 
 [Exposed=(Window,Worker)]
 interface OffscreenCanvasRenderingContext2D {
-  undefined commit();
   readonly attribute OffscreenCanvas canvas;
 };
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/idlharness.any-expected.txt
@@ -1,18 +1,18 @@
 
 PASS idl_test setup
-FAIL idl_test validation Validation error at line 2210 in html, inside `enum BinaryType`:
+FAIL idl_test validation Validation error at line 2209 in html, inside `enum BinaryType`:
 enum BinaryType { "blob", "arraybuffer"
      ^ The name "BinaryType" of type "enum" was already seen
 
-Validation error at line 2212 in html, inside `interface WebSocket`:
+Validation error at line 2211 in html, inside `interface WebSocket`:
 interface WebSocket : EventTarget {
           ^ The name "WebSocket" of type "interface" was already seen
 
-Validation error at line 2243 in html, inside `interface CloseEvent`:
+Validation error at line 2242 in html, inside `interface CloseEvent`:
 interface CloseEvent : Event {
           ^ The name "CloseEvent" of type "interface" was already seen
 
-Validation error at line 2251 in html, inside `dictionary CloseEventInit`:
+Validation error at line 2250 in html, inside `dictionary CloseEventInit`:
 dictionary CloseEventInit : EventInit {
            ^ The name "CloseEventInit" of type "dictionary" was already seen
 PASS WebSocket interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/idlharness.any.worker-expected.txt
@@ -1,18 +1,18 @@
 
 PASS idl_test setup
-FAIL idl_test validation Validation error at line 2210 in html, inside `enum BinaryType`:
+FAIL idl_test validation Validation error at line 2209 in html, inside `enum BinaryType`:
 enum BinaryType { "blob", "arraybuffer"
      ^ The name "BinaryType" of type "enum" was already seen
 
-Validation error at line 2212 in html, inside `interface WebSocket`:
+Validation error at line 2211 in html, inside `interface WebSocket`:
 interface WebSocket : EventTarget {
           ^ The name "WebSocket" of type "interface" was already seen
 
-Validation error at line 2243 in html, inside `interface CloseEvent`:
+Validation error at line 2242 in html, inside `interface CloseEvent`:
 interface CloseEvent : Event {
           ^ The name "CloseEvent" of type "interface" was already seen
 
-Validation error at line 2251 in html, inside `dictionary CloseEventInit`:
+Validation error at line 2250 in html, inside `dictionary CloseEventInit`:
 dictionary CloseEventInit : EventInit {
            ^ The name "CloseEventInit" of type "dictionary" was already seen
 PASS WebSocket interface: existence and properties of interface object

--- a/LayoutTests/inspector/canvas/resources/recording-2d.js
+++ b/LayoutTests/inspector/canvas/resources/recording-2d.js
@@ -400,11 +400,6 @@ function performActions() {
             ctx.roundRect(0, 0, 50, 50, [23]);
             ctx.roundRect(0, 0, 150, 150, [{x: 24, y: 42}]);
         },
-        /* FIXME: Disabled as per webkit.org/b/272591. Should be fully removed if we manage to remove this method.
-        () => {
-            ctx.commit?.();
-        },
-        */
         () => {
             TestPage.dispatchEventToFrontend("LastFrame");
         },

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -748,7 +748,6 @@ PASS OffscreenCanvasRenderingContext2D interface object name
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's "constructor" property
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's @@unscopables property
-PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -345,7 +345,6 @@ PASS OffscreenCanvasRenderingContext2D interface object name
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's "constructor" property
 PASS OffscreenCanvasRenderingContext2D interface: existence and properties of interface prototype object's @@unscopables property
-PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5353,21 +5353,6 @@ ObservableEnabled:
     WebCore:
       default: false
 
-OffscreenCanvasDeprecatedCommitEnabled:
-  type: bool
-  status: testable
-  category: dom
-  humanReadableName: "OffscreenCanvasRenderingContext2D's deprecated commit() method"
-  humanReadableDescription: "Support for OffscreenCanvasRenderingContext2D's deprecated commit() method"
-  condition: ENABLE(OFFSCREEN_CANVAS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 OffscreenCanvasEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -77,11 +77,6 @@ OffscreenCanvasRenderingContext2D::OffscreenCanvasRenderingContext2D(CanvasBase&
 
 OffscreenCanvasRenderingContext2D::~OffscreenCanvasRenderingContext2D() = default;
 
-void OffscreenCanvasRenderingContext2D::commit()
-{
-    downcast<OffscreenCanvas>(canvasBase()).commitToPlaceholderCanvas();
-}
-
 void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
 {
     auto& context = *canvasBase().scriptExecutionContext();

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -43,8 +43,6 @@ public:
 
     OffscreenCanvas& canvas() const { return downcast<OffscreenCanvas>(canvasBase()); }
 
-    void commit();
-
     void setFont(const String&);
     CanvasDirection direction() const;
     void fillText(const String& text, double x, double y, std::optional<double> maxWidth = std::nullopt);

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -36,7 +36,6 @@
     CallTracer=InspectorCanvasCallTracer,
 ] interface OffscreenCanvasRenderingContext2D {
     readonly attribute OffscreenCanvas canvas;
-    [EnabledBySetting=OffscreenCanvasDeprecatedCommitEnabled] undefined commit();
 };
 
 OffscreenCanvasRenderingContext2D includes CanvasState;


### PR DESCRIPTION
#### 9dd1cb41ff2ab707b996986397382f2f9a9a6840
<pre>
Remove OffscreenCanvasRenderingContext2D&apos;s commit() method
<a href="https://bugs.webkit.org/show_bug.cgi?id=279966">https://bugs.webkit.org/show_bug.cgi?id=279966</a>
<a href="https://rdar.apple.com/136744205">rdar://136744205</a>

Reviewed by Matt Woodrow.

This was disabled in 278047@main without fallout. It seems reasonable
to now remove the corresponding code.

* LayoutTests/fast/canvas/offscreen-border.html:
* LayoutTests/fast/canvas/offscreen-clipped.html:
* LayoutTests/fast/canvas/offscreen-giant.html:
* LayoutTests/fast/canvas/offscreen-scaling.html:
* LayoutTests/fast/canvas/offscreen-toggle-display.html:
* LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas-expected.txt:
* LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-offscreencanvas.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl:
* LayoutTests/imported/w3c/web-platform-tests/websockets/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/idlharness.any.worker-expected.txt:
* LayoutTests/inspector/canvas/resources/recording-2d.js:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::commit): Deleted.
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:

Canonical link: <a href="https://commits.webkit.org/287142@main">https://commits.webkit.org/287142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6560f9789411f4090c33c9e10568c702be22e75e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61440 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19361 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41753 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28055 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71599 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84480 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77690 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69666 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5979 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68921 "Found 2 new API test failures: /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17186 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11318 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99999 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5765 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/9021 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21838 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->