### PR TITLE
Adopt smart pointers in ActiveDOMObjectEventDispatchTask

### DIFF
--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -155,25 +155,25 @@ public:
         , m_object(object)
         , m_dispatchEvent(WTFMove(dispatchEvent))
     {
-        ++m_object.m_pendingActivityInstanceCount;
+        ++m_object->m_pendingActivityInstanceCount;
     }
 
     ~ActiveDOMObjectEventDispatchTask()
     {
-        ASSERT(m_object.m_pendingActivityInstanceCount);
-        --m_object.m_pendingActivityInstanceCount;
+        ASSERT(m_object->m_pendingActivityInstanceCount);
+        --m_object->m_pendingActivityInstanceCount;
     }
 
     void execute() final
     {
         // If this task executes after the script execution context has been stopped, don't
         // actually dispatch the event.
-        if (m_object.isAllowedToRunScript())
+        if (m_object->isAllowedToRunScript())
             m_dispatchEvent();
     }
 
 private:
-    ActiveDOMObject& m_object;
+    Ref<ActiveDOMObject> m_object;
     Function<void()> m_dispatchEvent;
 };
 


### PR DESCRIPTION
#### b9686691bf1f1715a2505a3a70e041c9ce0c450a
<pre>
Adopt smart pointers in ActiveDOMObjectEventDispatchTask
<a href="https://bugs.webkit.org/show_bug.cgi?id=279973">https://bugs.webkit.org/show_bug.cgi?id=279973</a>

Reviewed by Chris Dumez.

Use a Ref instead of a raw reference to store the ActiveDOMObject.

* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObjectEventDispatchTask::ActiveDOMObjectEventDispatchTask):
(WebCore::ActiveDOMObjectEventDispatchTask::~ActiveDOMObjectEventDispatchTask):

Canonical link: <a href="https://commits.webkit.org/283961@main">https://commits.webkit.org/283961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f062840f00d88a1d335156c381cc04d8989695

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54249 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34713 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73565 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61730 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/15090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3216 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43001 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->