### PR TITLE
Fix ARMv7 C ABI for Int64s

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
@@ -45,8 +45,8 @@ template<typename BankInfo>
 void marshallCCallArgumentImpl(Vector<Arg>& result, unsigned& argumentCount, unsigned& stackOffset, Type childType)
 {
     const auto registerCount = cCallArgumentRegisterCount(childType);
-    if (is32Bit() && childType == Int64)
-        argumentCount = WTF::roundUpToMultipleOf<2>(argumentCount);
+    if constexpr (is32Bit())
+        ASSERT(childType != Int64);
 
     if (argumentCount < BankInfo::numberOfArgumentRegisters) {
         for (unsigned i = 0; i < registerCount; i++)
@@ -132,6 +132,16 @@ size_t cCallResultCount(Code& code, CCallValue* value)
         return 1;
 
     }
+}
+// Do register arguments of this type need to be even-aligned? (e.g. r0/r1 would
+// be even aligned, r1/r2 wouldn't).
+bool cCallArgumentEvenRegisterAlignment(Type type)
+{
+    if (!is32Bit())
+        return false;
+    if (type == Int64)
+        return true;
+    return false;
 }
 
 size_t cCallArgumentRegisterCount(Type type)

--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.h
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.h
@@ -44,6 +44,7 @@ class Code;
 Vector<Arg> computeCCallingConvention(Code&, CCallValue*);
 
 size_t cCallResultCount(Code&, CCallValue*);
+bool cCallArgumentEvenRegisterAlignment(Type);
 
 /*
  * On some platforms (well, on 32-bit platforms,) C functions can take arguments


### PR DESCRIPTION
#### 92e73bdff695fa2d3a6250ab4828a845878465b3
<pre>
Fix ARMv7 C ABI for Int64s
<a href="https://bugs.webkit.org/show_bug.cgi?id=279974">https://bugs.webkit.org/show_bug.cgi?id=279974</a>

Reviewed by Justin Michaud.

On ARMv7, Int64 arguments need to be passed on even register pairs (so,
r0/r1 or r2/r3, but not r1/r2). Pass in dummy Int32 arguments in
LowerInt64 so that AirCCallingConvention.cpp does not have to know about
the provenance of Int32 arguments and whether they were originally part
of an Int64.

* Source/JavaScriptCore/b3/B3CCallValue.h:
* Source/JavaScriptCore/b3/B3LowerInt64.cpp:
* Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp:
(JSC::B3::Air::computeCCallingConvention):
(JSC::B3::Air::computeCCallArguments):

Canonical link: <a href="https://commits.webkit.org/284451@main">https://commits.webkit.org/284451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e5d4a3e0d955f20bd346f73dc2ad932be998d84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55214 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13678 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18956 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62537 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75215 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68667 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62881 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44625 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16045 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->