### PR TITLE
[css-anchor-position-1] Use fallback for invalid anchor functions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-default-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor() responds to position-anchor change assert_equals: expected 50 but got 0
+FAIL Animation with anchor() responds to position-anchor change assert_equals: expected 50 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-name-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor() responds to anchor-name change assert_equals: expected 50 but got 0
+FAIL Animation with anchor() responds to anchor-name change assert_equals: expected 50 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor() assert_equals: expected 100 but got 0
+FAIL Animation with anchor() assert_equals: expected 100 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt
@@ -1,10 +1,10 @@
 X
 
 FAIL Element can be anchor positioned assert_equals: expected "50px" but got "11.5625px"
-FAIL Element can use <length> fallback if present assert_equals: expected "17px" but got "0px"
+FAIL Element can use <length> fallback if present assert_equals: expected "42px" but got "11.5625px"
 PASS Invalid anchor function, left
-FAIL Invalid anchor function, right assert_equals: left expected "0px" but got "188.4375px"
-FAIL Invalid anchor function, bottom assert_equals: top expected "0px" but got "182px"
+PASS Invalid anchor function, right
+PASS Invalid anchor function, bottom
 PASS Invalid anchor function, top
 PASS Invalid anchor function, width
 PASS Invalid anchor function, height

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-fallback-expected.txt
@@ -1,31 +1,15 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" style="left: anchor(--inexist-anchor left, 50px)" data-offset-x="50"></div>
-offsetLeft expected 50 but got 0
+PASS .target 1
 FAIL .target 2 assert_equals:
 <div class="target" style="width: anchor-size(--inexist-anchor width, 50px)" data-expected-width="50"></div>
 width expected 50 but got 0
-FAIL .target 3 assert_equals:
-<div class="target" style="left: anchor(--a1 top, 50px)" data-offset-x="50"></div>
-offsetLeft expected 50 but got 0
-FAIL .target 4 assert_equals:
-<div class="target" style="left: anchor(--a1 bottom, 50px)" data-offset-x="50"></div>
-offsetLeft expected 50 but got 0
-FAIL .target 5 assert_equals:
-<div class="target" style="top: anchor(--a1 left, 50px)" data-offset-y="50"></div>
-offsetTop expected 50 but got 0
-FAIL .target 6 assert_equals:
-<div class="target" style="top: anchor(--a1 right, 50px)" data-offset-y="50"></div>
-offsetTop expected 50 but got 0
-FAIL .target 7 assert_equals:
-<div class="target" style="left: anchor(--inexist-anchor left, 50%)" data-offset-x="150"></div>
-offsetLeft expected 150 but got 0
-FAIL .target 8 assert_equals:
-<div class="target" style="left: anchor(--inexist-anchor left, calc(20% + 20px))" data-offset-x="80"></div>
-offsetLeft expected 80 but got 0
-FAIL .target 9 assert_equals:
-<div class="target" style="top: anchor(--a1 left, anchor(--a2 top))" data-offset-y="100"></div>
-offsetTop expected 100 but got 0
+PASS .target 3
+PASS .target 4
+PASS .target 5
+PASS .target 6
+PASS .target 7
+PASS .target 8
+PASS .target 9
 FAIL .target 10 assert_equals:
 <div class="target" style="top: anchor(--a1 left, calc((anchor(--a1 bottom) + anchor(--a2 top)) / 2))" data-offset-y="75"></div>
 offsetTop expected 75 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 0
+FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 300
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in three different tree scopes assert_equals: expected 300 but got 0
+FAIL Transition with anchor names defined in three different tree scopes assert_equals: expected 300 but got 400
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-attr-expected.txt
@@ -1,5 +1,5 @@
 Anchor1
 Anchor2
 
-FAIL Transition when the anchor attribute changes assert_equals: expected 50 but got 0
+FAIL Transition when the anchor attribute changes assert_equals: expected 0 but got 140
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt
@@ -1,5 +1,5 @@
 Anchor1
 Anchor2
 
-FAIL Transition when position-anchor changes assert_equals: expected 50 but got 0
+FAIL Transition when position-anchor changes assert_equals: expected 0 but got 140
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-name-expected.txt
@@ -1,5 +1,5 @@
 Anchor1
 Anchor2
 
-FAIL Transition when the dereferenced anchor name changes assert_equals: expected 50 but got 0
+FAIL Transition when the dereferenced anchor name changes assert_equals: expected 0 but got 140
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition to a flipped state assert_equals: expected 275 but got 150
-FAIL Transition to an unflipped state assert_equals: expected 250 but got 150
+FAIL Transition to a flipped state assert_equals: expected 275 but got 0
+FAIL Transition to an unflipped state assert_equals: expected 250 but got 300
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-anchor-positioning-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-anchor-positioning-001-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL CSS Content Visibility: auto prevents existing anchors to unskipped content
-from becoming skipped assert_equals: #positioned should be anchored because it still has one more anchor. expected 208 but got 777
+PASS CSS Content Visibility: auto prevents existing anchors to unskipped content
+from becoming skipped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-002.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-002.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Layout should be updated when anchor attribute changes to another element assert_equals: expected 150 but got 0
-FAIL Layout should be updated when anchor attribute changes to a non-existent element assert_equals: expected 123 but got 0
+FAIL Layout should be updated when anchor attribute changes to another element assert_equals: expected 150 but got 123
+PASS Layout should be updated when anchor attribute changes to a non-existent element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL ::before uses originating element's implicit anchor assert_equals: expected "50px" but got "700px"
+FAIL ::before uses originating element's implicit anchor assert_equals: expected "50px" but got "0px"
 FAIL ::after uses originating element's implicit anchor assert_equals: expected "250px" but got "0px"
 FAIL ::backdrop uses originating element's implicit anchor assert_equals: expected "140px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-display-none.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-display-none.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Tests that a popover can be anchored to an unrendered element. assert_equals: expected 100 but got 0
+PASS Tests that a popover can be anchored to an unrendered element.
 

--- a/Source/WebCore/css/CSSAnchorValue.h
+++ b/Source/WebCore/css/CSSAnchorValue.h
@@ -46,6 +46,8 @@ public:
     String anchorElementString() const;
     Ref<CSSValue> anchorSide() const;
 
+    const CSSPrimitiveValue* fallback() const { return m_fallback.get(); }
+
 private:
     CSSAnchorValue(RefPtr<CSSPrimitiveValue>&& anchorElement, Ref<CSSValue>&& anchorSide, RefPtr<CSSPrimitiveValue>&& fallback)
         : CSSValue(ClassType::Anchor)


### PR DESCRIPTION
#### f5516b04862a2c4854eb8dbb643ece1357813350
<pre>
[css-anchor-position-1] Use fallback for invalid anchor functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=279975">https://bugs.webkit.org/show_bug.cgi?id=279975</a>
<a href="https://rdar.apple.com/136289037">rdar://136289037</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-anchor-position-1/#anchor-valid">https://drafts.csswg.org/css-anchor-position-1/#anchor-valid</a>

&quot;If any of these conditions are false, the anchor() function resolves to its specified fallback value.
If no fallback value is specified, it makes the declaration referencing it invalid at computed-value time.&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-dynamic-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-attr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-anchor-positioning-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-002.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-display-none.tentative-expected.txt:
* Source/WebCore/css/CSSAnchorValue.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::isInsetProperty):
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):

Return resolved fallback or unset value on failure.

Canonical link: <a href="https://commits.webkit.org/283923@main">https://commits.webkit.org/283923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f27f49f4998595cb8b6aa627e8cbca483bc6923

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12678 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70895 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16061 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17327 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58725 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9613 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/43017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->