### PR TITLE
[WebRTC] Allow stuns server URIs

### DIFF
--- a/LayoutTests/webrtc/stun-server-filtering.html
+++ b/LayoutTests/webrtc/stun-server-filtering.html
@@ -3,12 +3,13 @@
 <script src='../resources/testharnessreport.js'></script>
 <script>
 promise_test(async (test) => {
-    let pc = new RTCPeerConnection({iceServers:[{urls:['stun:foo.com', 'stun:blabla.local']}]});
+    let pc = new RTCPeerConnection({iceServers:[{urls:['stun:foo.com', 'stun:blabla.local', 'stuns:bar.com']}]});
     let promise = new Promise(resolve => pc.onicecandidateerror = resolve);
     let configuration = pc.getConfiguration();
 
-    assert_equals(configuration.iceServers[0].urls.length, 1);
+    assert_equals(configuration.iceServers[0].urls.length, 2);
     assert_equals(configuration.iceServers[0].urls[0], 'stun:foo.com');
+    assert_equals(configuration.iceServers[0].urls[1], 'stuns:bar.com');
 
     const event = await promise;
     assert_equals(event.url, 'stun:blabla.local');

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -539,7 +539,7 @@ ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> RTCPeerConnection
                         if (server.credential.utf8().length() > MaxTurnUsernameLength || server.username.utf8().length() > MaxTurnUsernameLength)
                             return Exception { ExceptionCode::TypeError, "TURN/TURNS username and/or credential are too long"_s };
                     }
-                } else if (!serverURL.protocolIs("stun"_s))
+                } else if (!serverURL.protocolIs("stun"_s) && !serverURL.protocolIs("stuns"_s))
                     return Exception { ExceptionCode::SyntaxError, "ICE server protocol not supported"_s };
             }
             if (serverURLs.size())


### PR DESCRIPTION
#### 66f50fba817d1d0d739dfff62f59f2b7193e17e3
<pre>
[WebRTC] Allow stuns server URIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=279976">https://bugs.webkit.org/show_bug.cgi?id=279976</a>

Reviewed by Youenn Fablet.

According to RFC 7064:

&gt; The &quot;stuns&quot; URI scheme is intended to be used by applications with
&gt; a need to identify a STUN server to be used for NAT traversal over
&gt; a secure connection.

LibWebRTC accepts this kind of URL but doesn&apos;t seem to make a difference when connecting, as
compared to stun URIs.

Based on patch from Mikolaj Staworzynski &lt;mikolaj.staworzynski@redembedded.com&gt;

* LayoutTests/webrtc/stun-server-filtering.html:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::iceServersFromConfiguration):

Canonical link: <a href="https://commits.webkit.org/284082@main">https://commits.webkit.org/284082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0459296fe8ee486eaf072d326efa8a7c7faef9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19396 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13044 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16516 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74195 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16128 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10037 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43628 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->