### PR TITLE
[GStreamer] Do not access a null GstStructure

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1023,6 +1023,11 @@ std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILiteral key
 template<typename T>
 std::optional<T> gstStructureGet(const GstStructure* structure, StringView key)
 {
+    if (!structure) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
+        return std::nullopt;
+    }
+
     T value;
     auto strKey = key.toStringWithoutCopying();
     if constexpr(std::is_same_v<T, int>) {
@@ -1067,16 +1072,31 @@ template std::optional<bool> gstStructureGet(const GstStructure*, StringView key
 
 StringView gstStructureGetString(const GstStructure* structure, ASCIILiteral key)
 {
+    if (!structure) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
+        return { };
+    }
+
     return gstStructureGetString(structure, StringView { key });
 }
 
 StringView gstStructureGetString(const GstStructure* structure, StringView key)
 {
+    if (!structure) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
+        return { };
+    }
+
     return StringView::fromLatin1(gst_structure_get_string(structure, static_cast<const char*>(key.rawCharacters())));
 }
 
 StringView gstStructureGetName(const GstStructure* structure)
 {
+    if (!structure) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
+        return { };
+    }
+
     return StringView::fromLatin1(gst_structure_get_name(structure));
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3911,6 +3911,9 @@ bool MediaPlayerPrivateGStreamer::updateVideoSinkStatistics()
 
     GUniqueOutPtr<GstStructure> stats;
     g_object_get(m_videoSink.get(), "stats", &stats.outPtr(), nullptr);
+    if (!stats)
+        return false;
+
     auto totalVideoFrames = gstStructureGet<uint64_t>(stats.get(), "rendered"_s);
     auto droppedVideoFrames = gstStructureGet<uint64_t>(stats.get(), "dropped"_s);
 


### PR DESCRIPTION
#### 4f4db5aea9b8871ed9daff946b54bf200c84e193
<pre>
[GStreamer] Do not access a null GstStructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=279972">https://bugs.webkit.org/show_bug.cgi?id=279972</a>

Reviewed by Philippe Normand.

Stats can be null in some sinks so we avoid accessing them in that case. For the same prize we protect the access to
null structures in the GstStructure accessors.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureGet):
(WebCore::gstStructureGetString):
(WebCore::gstStructureGetName):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSinkStatistics):

Canonical link: <a href="https://commits.webkit.org/283974@main">https://commits.webkit.org/283974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a7345dcb04244b29ceae584896a19231b008ccf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12660 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16044 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73562 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61703 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61776 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3214 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->