### PR TITLE
Expose cookie Partition Key in Web Inspector

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -123,7 +123,8 @@
                 { "name": "session", "type": "boolean", "description": "True in case of session cookie." },
                 { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
                 { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
-                { "name": "sameSite", "$ref": "CookieSameSitePolicy", "description": "Cookie Same-Site policy." }
+                { "name": "sameSite", "$ref": "CookieSameSitePolicy", "description": "Cookie Same-Site policy." },
+                { "name": "partitionKey", "type": "string", "optional": true, "description": "Cookie partition key. If null and partitioned property is true, then key must be computed." }
             ]
         }
     ],
@@ -191,7 +192,8 @@
             "description": "Sets a new browser cookie with the given name, domain, and path.",
             "targetTypes": ["page"],
             "parameters": [
-                { "name": "cookie", "$ref": "Cookie" }
+                { "name": "cookie", "$ref": "Cookie" },
+                { "name": "shouldPartition", "type": "boolean", "optional": true, "description": "If true, then cookie's partition key should be set." }
             ]
         },
         {

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2415,6 +2415,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/HTTPParsers.h
     platform/network/HTTPSByDefaultMode.h
     platform/network/HTTPStatusCodes.h
+    platform/network/ShouldPartitionCookie.h
     platform/network/NetworkLoadInformation.h
     platform/network/NetworkLoadMetrics.h
     platform/network/NetworkStateNotifier.h

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -105,7 +105,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> overrideSetting(Inspector::Protocol::Page::Setting, std::optional<bool>&& value);
     Inspector::Protocol::ErrorStringOr<void> overrideUserPreference(Inspector::Protocol::Page::UserPreferenceName, std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::Cookie>>> getCookies();
-    Inspector::Protocol::ErrorStringOr<void> setCookie(Ref<JSON::Object>&&);
+    Inspector::Protocol::ErrorStringOr<void> setCookie(Ref<JSON::Object>&&, std::optional<bool>&& shouldPartition);
     Inspector::Protocol::ErrorStringOr<void> deleteCookie(const String& cookieName, const String& url);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Page::FrameResourceTree>> getResourceTree();
     Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> getResourceContent(const Inspector::Protocol::Network::FrameId&, const String& url);

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -193,7 +193,7 @@ bool CookieJar::getRawCookies(Document& document, const URL& url, Vector<Cookie>
     return false;
 }
 
-void CookieJar::setRawCookie(const Document&, const Cookie& cookie)
+void CookieJar::setRawCookie(const Document&, const Cookie& cookie, ShouldPartitionCookie)
 {
     if (CheckedPtr session = protectedStorageSessionProvider()->storageSession())
         session->setCookie(cookie);

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -47,6 +47,7 @@ struct CookieStoreGetOptions;
 class NetworkStorageSession;
 class StorageSessionProvider;
 struct SameSiteInfo;
+enum class ShouldPartitionCookie : bool;
 
 class WEBCORE_EXPORT CookieJar : public RefCountedAndCanMakeWeakPtr<CookieJar> {
 public:
@@ -64,7 +65,7 @@ public:
     virtual void remoteCookiesEnabled(const Document&, CompletionHandler<void(bool)>&&) const;
     virtual std::pair<String, SecureCookiesAccessed> cookieRequestHeaderFieldValue(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies) const;
     virtual bool getRawCookies(Document&, const URL&, Vector<Cookie>&) const;
-    virtual void setRawCookie(const Document&, const Cookie&);
+    virtual void setRawCookie(const Document&, const Cookie&, ShouldPartitionCookie);
     virtual void deleteCookie(const Document&, const URL&, const String& cookieName, CompletionHandler<void()>&&);
 
     virtual void getCookiesAsync(Document&, const URL&, const CookieStoreGetOptions&, CompletionHandler<void(std::optional<Vector<Cookie>>&&)>&&) const;

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -94,6 +94,7 @@ struct SameSiteInfo;
 enum class HTTPCookieAcceptPolicy : uint8_t;
 enum class IncludeSecureCookies : bool;
 enum class IncludeHttpOnlyCookies : bool;
+enum class ShouldPartitionCookie : bool;
 enum class ThirdPartyCookieBlockingMode : uint8_t { All, AllExceptBetweenAppBoundDomains, AllExceptManagedDomains, AllOnSitesWithoutUserInteraction, OnlyAccordingToPerDomainPolicy };
 enum class ThirdPartyCookieBlockingDecision : uint8_t {
     None,
@@ -188,6 +189,9 @@ public:
 
     WEBCORE_EXPORT HTTPCookieAcceptPolicy cookieAcceptPolicy() const;
     WEBCORE_EXPORT void setCookie(const Cookie&);
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    WEBCORE_EXPORT void setCookie(const URL& firstParty, const Cookie&, ShouldPartitionCookie);
+#endif
     WEBCORE_EXPORT void setCookies(const Vector<Cookie>&, const URL&, const URL& mainDocumentURL);
     WEBCORE_EXPORT void setCookiesFromDOM(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, const String& cookieString, ShouldRelaxThirdPartyCookieBlocking) const;
     WEBCORE_EXPORT bool setCookieFromDOM(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, const Cookie&, ShouldRelaxThirdPartyCookieBlocking) const;

--- a/Source/WebCore/platform/network/ShouldPartitionCookie.h
+++ b/Source/WebCore/platform/network/ShouldPartitionCookie.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class ShouldPartitionCookie : bool { No, Yes };
+
+};

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1263,6 +1263,7 @@ localizedStrings["Paints"] = "Paints";
 localizedStrings["Paints @ Column title"] = "Paints";
 localizedStrings["Parent"] = "Parent";
 localizedStrings["Partial Garbage Collection"] = "Partial Garbage Collection";
+localizedStrings["Partition Key"] = "Partition Key";
 /* Title of icon indicating that the selected audit passed with no issues. */
 localizedStrings["Pass @ Audit Tab - Test Case"] = "Pass";
 localizedStrings["Passive"] = "Passive";

--- a/Source/WebInspectorUI/UserInterface/Views/CookiePopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CookiePopover.js
@@ -37,6 +37,8 @@ WI.CookiePopover = class CookiePopover extends WI.Popover
         this._expiresInputElement = null;
         this._httpOnlyCheckboxElement = null;
         this._secureCheckboxElement = null;
+        this._partitionedCheckboxElement = null;
+        this._partitionKeyInputElement = null;
         this._sameSiteSelectElement = null;
 
         this._serializedDataWhenShown = null;
@@ -85,6 +87,7 @@ WI.CookiePopover = class CookiePopover extends WI.Popover
             httpOnly: this._httpOnlyCheckboxElement.checked,
             secure: this._secureCheckboxElement.checked,
             sameSite: this._sameSiteSelectElement.value,
+            partitioned: this._partitionedCheckboxElement.checked,
         };
 
         if (session)
@@ -137,6 +140,8 @@ WI.CookiePopover = class CookiePopover extends WI.Popover
             data.httpOnly = cookie.httpOnly;
             data.secure = cookie.secure;
             data.sameSite = cookie.sameSite;
+            data.partitioned = cookie.partitioned;
+            data.partitionKey = cookie.partitionKey;
         } else {
             let urlComponents = WI.networkManager.mainFrame.mainResource.urlComponents;
             data.name = "";
@@ -148,6 +153,7 @@ WI.CookiePopover = class CookiePopover extends WI.Popover
             data.httpOnly = false;
             data.secure = false;
             data.sameSite = WI.Cookie.SameSiteType.None;
+            data.partitioned = false;
         }
 
         let popoverContentElement = document.createElement("div");
@@ -224,6 +230,13 @@ WI.CookiePopover = class CookiePopover extends WI.Popover
 
         this._secureCheckboxElement = createInputRow("secure", WI.unlocalizedString("Secure"), "checkbox", data.secure).inputElement;
 
+        this._partitionedCheckboxElement = createInputRow("partitioned", WI.unlocalizedString("Partitioned"), "checkbox", data.partitioned).inputElement;
+        let partitionKeyInputRow = null;
+        if (data.partitionKey) {
+            partitionKeyInputRow = createInputRow("partition-key", WI.UIString("Partition Key"), "text", data.partitionKey);
+            partitionKeyInputRow.inputElement.readOnly = true;
+        }
+
         this._sameSiteSelectElement = document.createElement("select");
         for (let sameSiteType of Object.values(WI.Cookie.SameSiteType)) {
             let optionElement = this._sameSiteSelectElement.appendChild(document.createElement("option"));
@@ -244,6 +257,20 @@ WI.CookiePopover = class CookiePopover extends WI.Popover
         });
 
         toggleExpiresRow();
+
+        if (partitionKeyInputRow) {
+            let togglePartitionKeyInput = () => {
+                partitionKeyInputRow.rowElement.hidden = !this._partitionedCheckboxElement.checked;
+
+                this.update();
+            };
+
+            this._partitionedCheckboxElement.addEventListener("change", (event) => {
+                togglePartitionKeyInput();
+            });
+
+            togglePartitionKeyInput();
+        }
 
         this._serializedDataWhenShown = this.serializedData;
 

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js
@@ -109,6 +109,9 @@ WI.ResourceCookiesContentView = class ResourceCookiesContentView extends WI.Cont
         case "httpOnly":
             cell.textContent = cookie.httpOnly ? checkmark : zeroWidthSpace;
             break;
+        case "partitioned":
+            cell.textContent = cookie.partitioned ? checkmark : zeroWidthSpace;
+            break;
         case "sameSite":
             cell.textContent = cookie.sameSite === WI.Cookie.SameSiteType.None ? emDash : WI.Cookie.displayNameForSameSiteType(cookie.sameSite);
             break;
@@ -251,6 +254,7 @@ WI.ResourceCookiesContentView = class ResourceCookiesContentView extends WI.Cont
             this._responseCookiesTable.addColumn(new WI.TableColumn("value", WI.UIString("Value"), {minWidth: 150, hideable: false}));
             this._responseCookiesTable.addColumn(new WI.TableColumn("domain", WI.unlocalizedString("Domain"), {}));
             this._responseCookiesTable.addColumn(new WI.TableColumn("path", WI.unlocalizedString("Path"), {}));
+            this._responseCookiesTable.addColumn(new WI.TableColumn("partitioned", WI.unlocalizedString("Partitioned"), {}));
             this._responseCookiesTable.addColumn(new WI.TableColumn("expires", WI.unlocalizedString("Expires"), {maxWidth: 150}));
             this._responseCookiesTable.addColumn(new WI.TableColumn("maxAge", WI.unlocalizedString("Max-Age"), {maxWidth: 90, align: "right"}));
             this._responseCookiesTable.addColumn(new WI.TableColumn("secure", WI.unlocalizedString("Secure"), {minWidth: 55, maxWidth: 65, align: "center"}));

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -834,13 +834,19 @@ void NetworkConnectionToWebProcess::getRawCookies(const URL& firstParty, const S
     completionHandler(WTFMove(result));
 }
 
-void NetworkConnectionToWebProcess::setRawCookie(const WebCore::Cookie& cookie)
+void NetworkConnectionToWebProcess::setRawCookie(const URL& firstParty, const WebCore::Cookie& cookie, ShouldPartitionCookie shouldPartitionCookie)
 {
     auto* networkStorageSession = storageSession();
     if (!networkStorageSession)
         return;
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    networkStorageSession->setCookie(firstParty, cookie, shouldPartitionCookie);
+#else
+    UNUSED_PARAM(firstParty);
+    UNUSED_PARAM(shouldPartitionCookie);
     networkStorageSession->setCookie(cookie);
+#endif
 }
 
 void NetworkConnectionToWebProcess::deleteCookie(const URL& url, const String& cookieName, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -86,6 +86,7 @@ enum class AdvancedPrivacyProtections : uint16_t;
 enum class ApplyTrackingPrevention : bool;
 enum class StorageAccessScope : bool;
 enum class IsLoggedIn : uint8_t;
+enum class ShouldPartitionCookie : bool;
 struct ClientOrigin;
 struct Cookie;
 struct CookieStoreGetOptions;
@@ -304,7 +305,7 @@ private:
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ApplyTrackingPrevention, const String& cookieString, WebCore::ShouldRelaxThirdPartyCookieBlocking);
     void cookieRequestHeaderFieldValue(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(String cookieString, bool secureCookiesAccessed)>&&);
     void getRawCookies(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
-    void setRawCookie(const WebCore::Cookie&);
+    void setRawCookie(const URL& firstParty, const WebCore::Cookie&, WebCore::ShouldPartitionCookie);
     void deleteCookie(const URL&, const String& cookieName, CompletionHandler<void()>&&);
     void cookiesEnabledSync(const URL& firstParty, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(bool enabled)>&&);
     void cookiesEnabled(const URL& firstParty, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(bool enabled)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -48,7 +48,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     CookiesEnabled(URL firstParty, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (bool enabled)
     CookieRequestHeaderFieldValue(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (String cookieString, bool didAccessSecureCookies) Synchronous
     GetRawCookies(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (Vector<WebCore::Cookie> cookies) Synchronous
-    SetRawCookie(struct WebCore::Cookie cookie)
+    SetRawCookie(URL firstParty, struct WebCore::Cookie cookie, enum:bool WebCore::ShouldPartitionCookie shouldPartitionCookie)
     DeleteCookie(URL url, String cookieName) -> ()
     DomCookiesForHost(URL host) -> (Vector<WebCore::Cookie> cookies) Synchronous
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1768,6 +1768,8 @@ struct WebCore::Cookie {
     WebCore::Cookie::SameSitePolicy sameSite;
 };
 
+enum class WebCore::ShouldPartitionCookie : bool
+
 #if ENABLE(VIDEO)
 struct WebCore::VideoFrameMetadata {
     double presentationTime;

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -322,9 +322,9 @@ bool WebCookieJar::getRawCookies(WebCore::Document& document, const URL& url, Ve
     return true;
 }
 
-void WebCookieJar::setRawCookie(const WebCore::Document& document, const Cookie& cookie)
+void WebCookieJar::setRawCookie(const WebCore::Document& document, const Cookie& cookie, ShouldPartitionCookie shouldPartitionCookie)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::SetRawCookie(cookie), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::SetRawCookie(document.firstPartyForCookies(), cookie, shouldPartitionCookie), 0);
 }
 
 void WebCookieJar::deleteCookie(const WebCore::Document& document, const URL& url, const String& cookieName, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -41,6 +41,7 @@ OBJC_CLASS NSHTTPCookieStorage;
 namespace WebCore {
 struct Cookie;
 struct CookieStoreGetOptions;
+enum class ShouldPartitionCookie : bool;
 }
 
 namespace WebKit {
@@ -57,7 +58,7 @@ public:
     void remoteCookiesEnabled(const WebCore::Document&, CompletionHandler<void(bool)>&&) const final;
     std::pair<String, WebCore::SecureCookiesAccessed> cookieRequestHeaderFieldValue(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::IncludeSecureCookies) const final;
     bool getRawCookies(WebCore::Document&, const URL&, Vector<WebCore::Cookie>&) const final;
-    void setRawCookie(const WebCore::Document&, const WebCore::Cookie&) final;
+    void setRawCookie(const WebCore::Document&, const WebCore::Cookie&, WebCore::ShouldPartitionCookie) final;
     void deleteCookie(const WebCore::Document&, const URL&, const String& cookieName, CompletionHandler<void()>&&) final;
 
     void getCookiesAsync(WebCore::Document&, const URL&, const WebCore::CookieStoreGetOptions&, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&&) const final;


### PR DESCRIPTION
#### a7fa91e9eceb1305b7b26feb1e3d55bc69b57486
<pre>
Expose cookie Partition Key in Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=279980">https://bugs.webkit.org/show_bug.cgi?id=279980</a>
<a href="https://rdar.apple.com/136293236">rdar://136293236</a>

Reviewed by BJ Burg and Devin Rousso.

This patch adds a new column in the cookie storage view that displays a
cookie&apos;s partition key. Currently, the column is hidden by default. The
partition key is also shown and can also be set in the popover. However, the
values are not currently plumbed into the underlying cookie stores, so this
change doesn&apos;t have any affect on the underlying cookie.

* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::buildObjectForCookie):
(WebCore::parseCookieObject):
(WebCore::InspectorPageAgent::setCookie):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::setRawCookie):
* Source/WebCore/loader/CookieJar.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::setCookie):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/ShouldPartitionCookie.h: Added.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/Cookie.js:
(WI.Cookie.parseSetCookieResponseHeader):
(WI.Cookie.prototype.get partitionKey):
(WI.Cookie.prototype.get partitioned):
(WI.Cookie.prototype.equals):
(WI.Cookie.prototype.toProtocol):
(WI.Cookie):
* Source/WebInspectorUI/UserInterface/Views/CookiePopover.js:
(WI.CookiePopover):
(WI.CookiePopover.prototype.get serializedData):
(WI.CookiePopover.prototype.show):
* Source/WebInspectorUI/UserInterface/Views/CookieStorageContentView.js:
(WI.CookieStorageContentView.prototype.initialLayout):
(WI.CookieStorageContentView.prototype._generateSortComparator):
(WI.CookieStorageContentView.prototype._showCookiePopover):
(WI.CookieStorageContentView.prototype.async _willDismissCookiePopover):
(WI.CookieStorageContentView.prototype._formatCookiePropertyForColumn):
(WI.CookieStorageContentView):
* Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js:
(WI.ResourceCookiesContentView.prototype.tablePopulateCell):
(WI.ResourceCookiesContentView.prototype._refreshResponseCookiesSection):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::setRawCookie):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::setRawCookie):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/288103@main">https://commits.webkit.org/288103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4775866938aca3b4229f54bea82e34e91d7c75b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63854 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21583 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28682 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31320 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74862 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87855 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80925 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71444 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14454 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103337 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14594 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25090 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->