### PR TITLE
Adopt smart pointers in AccessibilityObjectAtspi

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -729,7 +729,7 @@ OptionSet<Atspi::State> AccessibilityObjectAtspi::states() const
         return states;
     }
 
-    auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
+    auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject.get());
 
     if (m_coreObject->isEnabled()) {
         states.add(Atspi::State::Enabled);
@@ -891,13 +891,12 @@ HashMap<String, String> AccessibilityObjectAtspi::attributes() const
     if (columnIndex != -1)
         map.add("colindex"_s, String::number(columnIndex));
 
-    if (is<AccessibilityTableCell>(m_coreObject)) {
-        auto& cell = downcast<AccessibilityTableCell>(*m_coreObject);
-        int rowSpan = cell.axRowSpan();
+    if (auto* cell = dynamicDowncast<AccessibilityTableCell>(m_coreObject.get())) {
+        int rowSpan = cell->axRowSpan();
         if (rowSpan != -1)
             map.add("rowspan"_s, String::number(rowSpan));
 
-        int columnSpan = cell.axColumnSpan();
+        int columnSpan = cell->axColumnSpan();
         if (columnSpan != -1)
             map.add("colspan"_s, String::number(columnSpan));
     }
@@ -922,7 +921,7 @@ HashMap<String, String> AccessibilityObjectAtspi::attributes() const
         map.add("setsize"_s, String::number(m_coreObject->setSize()));
 
     // The Core AAM states that an explicitly-set value should be exposed, including "none".
-    if (static_cast<AccessibilityObject*>(m_coreObject)->hasAttribute(HTMLNames::aria_sortAttr)) {
+    if (static_cast<AccessibilityObject*>(m_coreObject.get())->hasAttribute(HTMLNames::aria_sortAttr)) {
         switch (m_coreObject->sortDirection()) {
         case AccessibilitySortDirection::Invalid:
             break;
@@ -954,7 +953,7 @@ HashMap<String, String> AccessibilityObjectAtspi::attributes() const
     // In the case of ATSPI, the mechanism to do so is an object attribute pair (xml-roles:"string").
     // We cannot use the computedRoleString for this purpose because it is not limited to elements
     // with ARIA roles, and it might not contain the actual ARIA role value (e.g. DPub ARIA).
-    String roleString = static_cast<AccessibilityObject*>(m_coreObject)->getAttribute(HTMLNames::roleAttr);
+    String roleString = static_cast<AccessibilityObject*>(m_coreObject.get())->getAttribute(HTMLNames::roleAttr);
     if (!roleString.isEmpty())
         map.add("xml-roles"_s, roleString);
 
@@ -974,7 +973,7 @@ HashMap<String, String> AccessibilityObjectAtspi::attributes() const
     if (!roleDescription.isEmpty())
         map.add("roledescription"_s, roleDescription);
 
-    String dropEffect = static_cast<AccessibilityObject*>(m_coreObject)->getAttribute(HTMLNames::aria_dropeffectAttr);
+    String dropEffect = static_cast<AccessibilityObject*>(m_coreObject.get())->getAttribute(HTMLNames::aria_dropeffectAttr);
     if (!dropEffect.isEmpty())
         map.add("dropeffect"_s, dropEffect);
 
@@ -1047,7 +1046,7 @@ RelationMap AccessibilityObjectAtspi::relationMap() const
                 ariaLabelledByElements.append(m_coreObject->axObjectCache()->getOrCreate(renderFieldset));
         }
     } else {
-        auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
+        auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject.get());
         if (liveObject && !liveObject->controlForLabelElement())
             ariaLabelledByElements = m_coreObject->labeledByObjects();
     }

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -23,6 +23,7 @@
 #include "AXCoreObject.h"
 #include "AccessibilityAtspi.h"
 #include "AccessibilityAtspiEnums.h"
+#include "AccessibilityRootAtspi.h"
 #include "IntRect.h"
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
@@ -33,8 +34,6 @@ typedef struct _GVariant GVariant;
 typedef struct _GVariantBuilder GVariantBuilder;
 
 namespace WebCore {
-class AXCoreObject;
-class AccessibilityRootAtspi;
 
 using RelationMap = HashMap<Atspi::Relation, Vector<RefPtr<AccessibilityObjectAtspi>>, IntHash<Atspi::Relation>, WTF::StrongEnumHashTraits<Atspi::Relation>>;
 
@@ -280,9 +279,9 @@ private:
     static GDBusInterfaceVTable s_tableCellFunctions;
     static GDBusInterfaceVTable s_collectionFunctions;
 
-    AXCoreObject* m_coreObject { nullptr };
+    RefPtr<AXCoreObject> m_coreObject;
     OptionSet<Interface> m_interfaces;
-    AccessibilityRootAtspi* m_root { nullptr };
+    RefPtr<AccessibilityRootAtspi> m_root;
     std::optional<RefPtr<AccessibilityObjectAtspi>> m_parent;
     bool m_isRegistered { false };
     String m_path;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -164,7 +164,7 @@ float AccessibilityObjectAtspi::opacity() const
 
 void AccessibilityObjectAtspi::scrollToMakeVisible(Atspi::ScrollType scrollType) const
 {
-    auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
+    auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject.get());
     if (!liveObject)
         return;
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTableCellAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTableCellAtspi.cpp
@@ -63,7 +63,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_tableCellFunctions = {
         if (!g_strcmp0(propertyName, "RowSpan"))
             return g_variant_new_int32(atspiObject->rowSpan());
         if (!g_strcmp0(propertyName, "Table")) {
-            auto* axObject = atspiObject->m_coreObject;
+            auto* axObject = atspiObject->m_coreObject.get();
             if (!axObject || !axObject->isExposedTableCell())
                 return AccessibilityAtspi::singleton().nullReference();
 
@@ -74,7 +74,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_tableCellFunctions = {
                     break;
 
                 wrapper->updateBackingStore();
-                axObject = wrapper->m_coreObject;
+                axObject = wrapper->m_coreObject.get();
                 if (axObject && axObject->isTable())
                     break;
             }

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -701,7 +701,7 @@ bool AccessibilityObjectAtspi::selectionBounds(int& startOffset, int& endOffset)
 
 void AccessibilityObjectAtspi::setSelectedRange(unsigned utf16Offset, unsigned length)
 {
-    auto* axObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
+    auto* axObject = dynamicDowncast<AccessibilityObject>(m_coreObject.get());
     if (!axObject)
         return;
 
@@ -829,7 +829,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         return attributes;
     };
 
-    auto defaultAttributes = accessibilityTextAttributes(m_coreObject, { });
+    auto defaultAttributes = accessibilityTextAttributes(m_coreObject.get(), { });
     if (!utf16Offset)
         return { WTFMove(defaultAttributes), -1, -1 };
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp
@@ -97,7 +97,7 @@ double AccessibilityObjectAtspi::minimumIncrement() const
     if (!m_coreObject)
         return 0;
 
-    auto stepAttribute = static_cast<AccessibilityObject*>(m_coreObject)->getAttribute(HTMLNames::stepAttr);
+    auto stepAttribute = static_cast<AccessibilityObject*>(m_coreObject.get())->getAttribute(HTMLNames::stepAttr);
     if (!stepAttribute.isEmpty())
         return stepAttribute.toFloat();
 


### PR DESCRIPTION
#### 586941e5c41743ff7ebb0d46eb9bda6504b09775
<pre>
Adopt smart pointers in AccessibilityObjectAtspi
<a href="https://bugs.webkit.org/show_bug.cgi?id=279983">https://bugs.webkit.org/show_bug.cgi?id=279983</a>

Reviewed by Adrian Perez de Castro.

AccessibilityRootAtspi and AXCoreObject are ref-counted, so
using raw pointers triggers static analyzer warnings. Use RefPtr&apos;s
instead.

* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::states const):
(WebCore::AccessibilityObjectAtspi::attributes const):
(WebCore::AccessibilityObjectAtspi::relationMap const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::scrollToMakeVisible const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTableCellAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::setSelectedRange):
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::minimumIncrement const):

Canonical link: <a href="https://commits.webkit.org/284075@main">https://commits.webkit.org/284075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed73bf8b4c09617db07b93e6959a2833779f2f18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58645 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34722 "Found 1 new API test failure: /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-style-sheet (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61735 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3225 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10398 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43012 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->