### PR TITLE
[JSC] Support BranchSub32/64 3 operands

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1620,9 +1620,21 @@ BranchSub32 U:G:32, U:G:32, UZD:G:32 /branch
     x86: ResCond, Tmp, Addr
     x86: ResCond, Addr, Tmp
 
+# Say EZD, so that it does not alias with any of the input.
+# This is necessary to undo sub operation when speculation fails.
+arm64: BranchSub32 U:G:32, U:G:32, U:G:32, EZD:G:32 /branch
+    ResCond, Tmp, Tmp, Tmp
+    ResCond, Tmp, Imm, Tmp
+
 64: BranchSub64 U:G:32, U:G:64, UD:G:64 /branch
     ResCond, Imm, Tmp
     ResCond, Tmp, Tmp
+
+# Say EZD, so that it does not alias with any of the input.
+# This is necessary to undo sub operation when speculation fails.
+arm64: BranchSub64 U:G:32, U:G:64, U:G:64, EZD:G:64 /branch
+    ResCond, Tmp, Tmp, Tmp
+    ResCond, Tmp, Imm, Tmp
 
 BranchNeg32 U:G:32, UZD:G:32 /branch
     ResCond, Tmp


### PR DESCRIPTION
#### 1bef55fa7ec3a5c431f24bc731e2ecaa01d97785
<pre>
[JSC] Support BranchSub32/64 3 operands
<a href="https://bugs.webkit.org/show_bug.cgi?id=279991">https://bugs.webkit.org/show_bug.cgi?id=279991</a>
<a href="https://rdar.apple.com/problem/136300288">rdar://problem/136300288</a>

Reviewed by Yijia Huang.

This patch extends CheckSpecial to handle 3-operands BranchSub32 /
BranchSub64. BranchSub32 / BranchSub64 need to have undo behavior
when speculation fails. But if it is emitted like

    BranchSub32 %x0, %x0, %x0

There is no way to recover %x0 after this sub32 gets done. To avoid
this, we use EarlyDef for the destination register, which ensures that
we will never have conflicting register assginment with Use and Def.
Def is always not Use. So in the worst case,

    BranchSub32 %x0, %x0, %x1

will be generated. And at that time, we can undo the behavior by doing

    Add32 %x0, %x1

Also, EarlyDef ensures that any Use in stackmap for this patchpoint does
not get clobbered.

* Source/JavaScriptCore/b3/B3CheckSpecial.cpp:
(JSC::B3::CheckSpecial::forEachArg):
(JSC::B3::CheckSpecial::generate):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3StackmapSpecial.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:

Canonical link: <a href="https://commits.webkit.org/283978@main">https://commits.webkit.org/283978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8e3e6b141d4caef772a4fb44633f20bf051a48b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19091 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54319 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17448 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61064 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73701 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67194 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15763 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61791 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3294 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/88973 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10345 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/43138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15703 "Found 7 new JSC stress test failures: wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-eager, wasm.yaml/wasm/stress/tail-call.js.default-wasm, wasm.yaml/wasm/stress/tail-call.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->