### PR TITLE
Revert 283505@main

### DIFF
--- a/Source/WebCore/page/LoginStatus.cpp
+++ b/Source/WebCore/page/LoginStatus.cpp
@@ -95,12 +95,4 @@ WallTime LoginStatus::expiry() const
     return WallTime::now() + m_timeToLive;
 }
 
-LoginStatus LoginStatus::isolatedCopy() const & {
-    return LoginStatus { m_domain.isolatedCopy(), m_username.isolatedCopy(), m_tokenType, m_authType, m_loggedInTime, m_timeToLive };
-}
-
-LoginStatus LoginStatus::isolatedCopy() && {
-    return LoginStatus { WTFMove(m_domain).isolatedCopy(), WTFMove(m_username).isolatedCopy(), m_tokenType, m_authType, m_loggedInTime, m_timeToLive };
-}
-
 }

--- a/Source/WebCore/page/LoginStatus.h
+++ b/Source/WebCore/page/LoginStatus.h
@@ -60,9 +60,6 @@ public:
     WallTime loggedInTime() const { return m_loggedInTime; }
     Seconds timeToLive() const { return m_timeToLive; }
 
-    WEBCORE_EXPORT LoginStatus isolatedCopy() const &;
-    WEBCORE_EXPORT LoginStatus isolatedCopy() &&;
-
 private:
     LoginStatus(const RegistrableDomain&, const String& username, CredentialTokenType, AuthenticationType, Seconds timeToLive);
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -52,9 +52,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ResourceLoadS
 namespace WebCore {
 class KeyedDecoder;
 class KeyedEncoder;
-class LoginStatus;
 class SQLiteStatement;
-enum class IsLoggedIn : uint8_t;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : uint8_t;
 struct ResourceLoadStatistics;
@@ -188,9 +186,6 @@ public:
     void requestStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::StorageAccessScope, CanRequestStorageAccessWithoutUserInteraction, CompletionHandler<void(StorageAccessStatus)>&&);
     void grantStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::StorageAccessPromptWasShown, WebCore::StorageAccessScope, CompletionHandler<void(WebCore::StorageAccessWasGranted)>&&);
 
-    void setLoginStatus(const RegistrableDomain&, WebCore::IsLoggedIn, std::optional<WebCore::LoginStatus>&&);
-    bool isLoggedIn(const RegistrableDomain&);
-
     void logFrameNavigation(const NavigatedToDomain&, const TopFrameDomain&, const NavigatedFromDomain&, bool isRedirect, bool isMainFrame, Seconds delayAfterMainFrameDocumentLoad, bool wasPotentiallyInitiatedByUser);
     void logCrossSiteLoadWithLinkDecoration(const NavigatedFromDomain&, const NavigatedToDomain&, DidFilterKnownLinkDecoration);
 
@@ -258,15 +253,10 @@ private:
     void merge(WebCore::SQLiteStatement*, const ResourceLoadStatistics&);
     void incrementRecordsDeletedCountForDomains(HashSet<RegistrableDomain>&&);
     bool insertObservedDomain(const ResourceLoadStatistics&) WARN_UNUSED_RETURN;
-    void insertLoginStatus(const RegistrableDomain&, WebCore::IsLoggedIn loggedInStatus, const std::optional<WebCore::LoginStatus>& lastAuthentication);
-    bool loginStatusExists(const RegistrableDomain&);
-    void removeLoginStatus(const RegistrableDomain&);
     void insertDomainRelationships(const ResourceLoadStatistics&);
     void insertDomainRelationshipList(const String&, const HashSet<RegistrableDomain>&, unsigned);
     bool relationshipExists(WebCore::SQLiteStatementAutoResetScope&, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const;
     std::optional<unsigned> domainID(const RegistrableDomain&) const;
-    std::optional<unsigned> domainIDWithTable(const RegistrableDomain&, std::unique_ptr<WebCore::SQLiteStatement>&, ASCIILiteral query) const;
-    std::optional<unsigned> loginStatusDomainID(const RegistrableDomain&) const;
     bool domainExists(const RegistrableDomain&) const;
     void updateLastSeen(const RegistrableDomain&, WallTime);
     void updateDataRecordsRemoved(const RegistrableDomain&, int);
@@ -419,10 +409,6 @@ private:
     mutable std::unique_ptr<WebCore::SQLiteStatement> m_observedDomainsExistsStatement;
     mutable std::unique_ptr<WebCore::SQLiteStatement> m_removeAllDataStatement;
     mutable std::unique_ptr<WebCore::SQLiteStatement> m_checkIfTableExistsStatement;
-    mutable std::unique_ptr<WebCore::SQLiteStatement> m_loginStatusDomainIDFromStringStatement;
-    std::unique_ptr<WebCore::SQLiteStatement> m_insertLoginstatusStatement;
-    mutable std::unique_ptr<WebCore::SQLiteStatement> m_removeLoginStatusStatement;
-    mutable std::unique_ptr<WebCore::SQLiteStatement> m_loginStatusExistsStatement;
 
     Vector<CompletionHandler<void()>> m_dataRecordRemovalCompletionHandlers;
     Seconds m_timeAdvanceForTesting;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -45,6 +45,7 @@
 #include <WebCore/CookieJar.h>
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <WebCore/IsLoggedIn.h>
 #include <WebCore/LoginStatus.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/ResourceLoadStatistics.h>
@@ -448,39 +449,23 @@ void WebResourceLoadStatisticsStore::setLoginStatus(RegistrableDomain&& domain, 
 {
     ASSERT(RunLoop::isMain());
 
-    auto loginStatusToSet = lastAuthentication && lastAuthentication->hasExpired() ? std::nullopt : std::optional(WTFMove(lastAuthentication));
-    if (loginStatusToSet)
-        loginStatusToSet->setTimeToLive(WebCore::LoginStatus::TimeToLiveLong);
-
-    postTask([this, domain = WTFMove(domain).isolatedCopy(), loggedInStatus, loginStatusToSet = crossThreadCopy(WTFMove(loginStatusToSet)), completionHandler = WTFMove(completionHandler)]() mutable {
-        if (!m_statisticsStore) {
-            postTaskReply(WTFMove(completionHandler));
-            return;
-        }
-
-        m_statisticsStore->setLoginStatus(domain, loggedInStatus, WTFMove(loginStatusToSet));
-        postTaskReply(WTFMove(completionHandler));
-    });
+    if (loggedInStatus == IsLoggedIn::LoggedIn) {
+        auto loginStatusToSet = lastAuthentication && lastAuthentication->hasExpired() ? std::nullopt : std::optional(WTFMove(lastAuthentication));
+        if (loginStatusToSet)
+            loginStatusToSet->setTimeToLive(WebCore::LoginStatus::TimeToLiveLong);
+        auto pair = std::make_pair(loggedInStatus, loginStatusToSet);
+        m_loginStatus.set(domain, WTFMove(pair));
+    } else
+        m_loginStatus.remove(domain);
+    completionHandler();
 }
 
 void WebResourceLoadStatisticsStore::isLoggedIn(RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
 
-    postTask([this, domain = crossThreadCopy(WTFMove(domain)), completionHandler = WTFMove(completionHandler)]() mutable {
-        if (!m_statisticsStore) {
-            postTaskReply([completionHandler = WTFMove(completionHandler)]() mutable {
-                completionHandler(false);
-            });
-            return;
-        }
-
-        auto isloggedIn = m_statisticsStore->isLoggedIn(WTFMove(domain));
-
-        postTaskReply([isloggedIn, completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(isloggedIn);
-        });
-    });
+    auto it = m_loginStatus.find(domain);
+    completionHandler(it != m_loginStatus.end() && it->value.first == IsLoggedIn::LoggedIn);
 }
 
 void WebResourceLoadStatisticsStore::requestStorageAccessEphemeral(const RegistrableDomain& subFrameDomain, const RegistrableDomain& topFrameDomain, FrameIdentifier frameID, PageIdentifier webPageID, WebPageProxyIdentifier webPageProxyID, StorageAccessScope scope, CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction, std::optional<OrganizationStorageAccessPromptQuirk>&& storageAccessPromptQuirk, CompletionHandler<void(RequestStorageAccessResult)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -33,6 +33,7 @@
 #include "WebsiteDataType.h"
 #include <WebCore/DocumentStorageAccess.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/IsLoggedIn.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ResourceLoadObserver.h>
@@ -261,6 +262,7 @@ private:
 
     HashSet<RegistrableDomain> m_domainsWithUserInteractionQuirk;
     HashMap<TopFrameDomain, Vector<SubResourceDomain>> m_domainsWithCrossPageStorageAccessQuirk;
+    HashMap<RegistrableDomain, std::pair<IsLoggedIn, std::optional<WebCore::LoginStatus>>> m_loginStatus;
 
     bool m_hasScheduledProcessStats { false };
     bool m_firstNetworkProcessCreated { false };


### PR DESCRIPTION
#### 6ec99c556387e2582a193ff61c8fc7c664e7d736
<pre>
Revert 283505@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=279992">https://bugs.webkit.org/show_bug.cgi?id=279992</a>
<a href="https://rdar.apple.com/136162381">rdar://136162381</a>

Unreviewed.

Caused debug assertion failures in API tests.

* Source/WebCore/page/LoginStatus.cpp:
(WebCore::LoginStatus::isolatedCopy const): Deleted.
(WebCore::LoginStatus::isolatedCopy): Deleted.
* Source/WebCore/page/LoginStatus.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::expectedTableAndIndexQueries):
(WebKit::ResourceLoadStatisticsStore::sortedTables):
(WebKit::ResourceLoadStatisticsStore::createSchema):
(WebKit::ResourceLoadStatisticsStore::destroyStatements):
(WebKit::ResourceLoadStatisticsStore::domainID const):
(WebKit::ResourceLoadStatisticsStore::insertLoginStatus): Deleted.
(WebKit::ResourceLoadStatisticsStore::removeLoginStatus): Deleted.
(WebKit::ResourceLoadStatisticsStore::loginStatusExists): Deleted.
(WebKit::ResourceLoadStatisticsStore::loginStatusDomainID const): Deleted.
(WebKit::ResourceLoadStatisticsStore::domainIDWithTable const): Deleted.
(WebKit::ResourceLoadStatisticsStore::setLoginStatus): Deleted.
(WebKit::ResourceLoadStatisticsStore::isLoggedIn): Deleted.
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setLoginStatus):
(WebKit::WebResourceLoadStatisticsStore::isLoggedIn):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:

Canonical link: <a href="https://commits.webkit.org/283936@main">https://commits.webkit.org/283936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e730c9ea1b051e94f67038642405d98c07ca3483

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18788 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43287 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58660 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; 2 api tests failed or timed out; 1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16070 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17339 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73593 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11803 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/15698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58734 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3240 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43029 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->