### PR TITLE
Remove IsDeprecatedWeakRefSmartPointerException from already RefCounted/CheckedPtr classes in UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h
@@ -33,15 +33,6 @@
 
 OBJC_CLASS SecKeyProxy;
 
-namespace WebKit {
-class SecKeyProxyStore;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::SecKeyProxyStore> : std::true_type { };
-}
-
 namespace WebCore {
 class Credential;
 }

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -55,15 +55,6 @@
 #define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, m_connectionProxy->connection(), completion)
 
 namespace WebKit {
-class UserMediaCaptureManagerProxySourceProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::UserMediaCaptureManagerProxySourceProxy> : std::true_type { };
-}
-
-namespace WebKit {
 using namespace WebCore;
 
 class UserMediaCaptureManagerProxySourceProxy final

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -36,15 +36,6 @@
 #include "BackingStore.h"
 #endif
 
-namespace WebKit {
-class DrawingAreaProxyCoordinatedGraphics;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::DrawingAreaProxyCoordinatedGraphics> : std::true_type { };
-}
-
 namespace WebCore {
 class Region;
 }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -36,15 +36,6 @@
 #include <objc/objc.h>
 #endif
 
-namespace WebKit {
-class DownloadProxyMap;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::DownloadProxyMap> : std::true_type { };
-}
-
 namespace API {
 class DownloadClient;
 }

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -42,15 +42,6 @@
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakRef.h>
 
-namespace WebKit {
-class DrawingAreaProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::DrawingAreaProxy> : std::true_type { };
-}
-
 #if PLATFORM(COCOA)
 namespace WTF {
 class MachSendRight;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -36,15 +36,6 @@
 #include <wtf/WeakHashMap.h>
 
 namespace WebKit {
-class RemoteLayerTreeDrawingAreaProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLayerTreeDrawingAreaProxy> : std::true_type { };
-}
-
-namespace WebKit {
 
 class RemoteLayerTreeTransaction;
 class RemotePageDrawingAreaProxy;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -92,15 +92,6 @@ typedef void* PlatformScrollEvent;
 #endif
 
 namespace WebKit {
-class ViewGestureController;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ViewGestureController> : std::true_type { };
-}
-
-namespace WebKit {
 
 class ViewSnapshot;
 class WebBackForwardListItem;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -72,15 +72,6 @@
 #include "DisplayLinkProcessProxyClient.h"
 #endif
 
-namespace WebKit {
-class WebProcessProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebProcessProxy> : std::true_type { };
-}
-
 namespace API {
 class Navigation;
 class PageConfiguration;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -30,15 +30,6 @@
 #include "DrawingAreaProxy.h"
 
 namespace WebKit {
-class TiledCoreAnimationDrawingAreaProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::TiledCoreAnimationDrawingAreaProxy> : std::true_type { };
-}
-
-namespace WebKit {
 
 class TiledCoreAnimationDrawingAreaProxy final : public DrawingAreaProxy {
     WTF_MAKE_TZONE_ALLOCATED(TiledCoreAnimationDrawingAreaProxy);


### PR DESCRIPTION
#### c00c3a25d3e1159bd43c6ebf58dbe91351832212
<pre>
Remove IsDeprecatedWeakRefSmartPointerException from already RefCounted/CheckedPtr classes in UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=279995">https://bugs.webkit.org/show_bug.cgi?id=279995</a>

Reviewed by Ryosuke Niwa.

IsDeprecatedWeakRefSmartPointerException class is not required for these classes.

* Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h:

Canonical link: <a href="https://commits.webkit.org/283946@main">https://commits.webkit.org/283946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/499b0491639cc39c23a538f115865aa1cdf6dc83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18991 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18798 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12699 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39967 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17349 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/61930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11813 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15704 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-activesourcebuffers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58741 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3246 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43041 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->