### PR TITLE
Fix assertion in WebSWClientConnection::matchRegistration after network process crash

### DIFF
--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -172,8 +172,11 @@ void WebSWClientConnection::matchRegistration(SecurityOriginData&& topOrigin, co
         return;
     }
 
-    runOrDelayTaskForImport([this, callback = WTFMove(callback), topOrigin = WTFMove(topOrigin), clientURL]() mutable {
-        sendWithAsyncReply(Messages::WebSWServerConnection::MatchRegistration { topOrigin, clientURL }, WTFMove(callback));
+    CompletionHandlerWithFinalizer<void(std::optional<ServiceWorkerRegistrationData>)> completionHandler(WTFMove(callback), [] (auto& callback) {
+        callback(std::nullopt);
+    });
+    runOrDelayTaskForImport([this, completionHandler = WTFMove(completionHandler), topOrigin = WTFMove(topOrigin), clientURL]() mutable {
+        sendWithAsyncReply(Messages::WebSWServerConnection::MatchRegistration { topOrigin, clientURL }, WTFMove(completionHandler));
     });
 }
 


### PR DESCRIPTION
#### 8ff9aac9dafb83663ae8f82da58a742ce5d270ea
<pre>
Fix assertion in WebSWClientConnection::matchRegistration after network process crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=280005">https://bugs.webkit.org/show_bug.cgi?id=280005</a>
<a href="https://rdar.apple.com/136310625">rdar://136310625</a>

Reviewed by Youenn Fablet.

This fixes an assertion I saw on a bot with this stack trace:

ASSERTION FAILED: Completion handler should always be called
!m_function
.../WebKitBuild/Debug/usr/local/include/wtf/CompletionHandler.h(66) : WTF::CompletionHandler&lt;void (std::optional&lt;WebCore::ServiceWorkerRegistrationData&gt; &amp;&amp;)&gt;::~CompletionHandler()
1   WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;::~CompletionHandler()
2   WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;::~CompletionHandler()
3   WebKit::WebSWClientConnection::matchRegistration(WebCore::SecurityOriginData&amp;&amp;, WTF::URL const&amp;, WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;&amp;&amp;)::$_10::~$_10()
4   WebKit::WebSWClientConnection::matchRegistration(WebCore::SecurityOriginData&amp;&amp;, WTF::URL const&amp;, WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;&amp;&amp;)::$_10::~$_10()
5   WTF::Detail::CallableWrapper&lt;WebKit::WebSWClientConnection::matchRegistration(WebCore::SecurityOriginData&amp;&amp;, WTF::URL const&amp;, WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;&amp;&amp;)::$_10, void&gt;::~CallableWrapper()
6   WTF::Detail::CallableWrapper&lt;WebKit::WebSWClientConnection::matchRegistration(WebCore::SecurityOriginData&amp;&amp;, WTF::URL const&amp;, WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;&amp;&amp;)::$_10, void&gt;::~CallableWrapper()
7   WTF::Detail::CallableWrapper&lt;WebKit::WebSWClientConnection::matchRegistration(WebCore::SecurityOriginData&amp;&amp;, WTF::URL const&amp;, WTF::CompletionHandler&lt;void (std::__1::optional&lt;WebCore::ServiceWorkerRegistrationData&gt;&amp;&amp;)&gt;&amp;&amp;)::$_10, void&gt;::~CallableWrapper()
8   std::__1::default_delete&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;&gt;::operator()[abi:sn170006](WTF::Detail::CallableWrapperBase&lt;void&gt;*) const
9   std::__1::unique_ptr&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;, std::__1::default_delete&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;&gt;&gt;::reset[abi:sn170006](WTF::Detail::CallableWrapperBase&lt;void&gt;*)
10  std::__1::unique_ptr&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;, std::__1::default_delete&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;&gt;&gt;::~unique_ptr[abi:sn170006]()
11  std::__1::unique_ptr&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;, std::__1::default_delete&lt;WTF::Detail::CallableWrapperBase&lt;void&gt;&gt;&gt;::~unique_ptr[abi:sn170006]()
12  WTF::Function&lt;void ()&gt;::~Function()
13  WTF::Function&lt;void ()&gt;::~Function()
14  WTF::VectorDestructor&lt;true, WTF::Function&lt;void ()&gt;&gt;::destruct(WTF::Function&lt;void ()&gt;*, WTF::Function&lt;void ()&gt;*)
15  WTF::VectorTypeOperations&lt;WTF::Function&lt;void ()&gt;&gt;::destruct(WTF::Function&lt;void ()&gt;*, WTF::Function&lt;void ()&gt;*)
16  WTF::Deque&lt;WTF::Function&lt;void ()&gt;, 0ul&gt;::destroyAll()
17  WTF::Deque&lt;WTF::Function&lt;void ()&gt;, 0ul&gt;::~Deque()
18  WTF::Deque&lt;WTF::Function&lt;void ()&gt;, 0ul&gt;::~Deque()
19  WebKit::WebSWClientConnection::~WebSWClientConnection()
20  WebKit::WebSWClientConnection::~WebSWClientConnection()
21  WebKit::WebSWClientConnection::~WebSWClientConnection()
22  WTF::RefCounted&lt;WebCore::SWClientConnection&gt;::deref() const
23  WTF::DefaultRefDerefTraits&lt;WebKit::WebSWClientConnection&gt;::derefIfNotNull(WebKit::WebSWClientConnection*)
24  WTF::RefPtr&lt;WebKit::WebSWClientConnection, WTF::RawPtrTraits&lt;WebKit::WebSWClientConnection&gt;, WTF::DefaultRefDerefTraits&lt;WebKit::WebSWClientConnection&gt;&gt;::~RefPtr()
25  WTF::RefPtr&lt;WebKit::WebSWClientConnection, WTF::RawPtrTraits&lt;WebKit::WebSWClientConnection&gt;, WTF::DefaultRefDerefTraits&lt;WebKit::WebSWClientConnection&gt;&gt;::~RefPtr()
26  WebKit::NetworkProcessConnection::didClose(IPC::Connection&amp;)
27  IPC::Connection::dispatchDidCloseAndInvalidate()::$_14::operator()() const
28  WTF::Detail::CallableWrapper&lt;IPC::Connection::dispatchDidCloseAndInvalidate()::$_14, void&gt;::call()
29  WTF::Function&lt;void ()&gt;::operator()() const
30  WTF::RunLoop::performWork()
31  WTF::RunLoop::performWork(void*)

* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::matchRegistration):

Canonical link: <a href="https://commits.webkit.org/283969@main">https://commits.webkit.org/283969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/881ea0bfb2d5e6adeff5f78eeba376ff6f3fff82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39986 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17388 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61744 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3267 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43080 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->