### PR TITLE
REGRESSION(247615@main): [WPE][GTK] Suspended cached web processes remain forever after UI process terminates uncleanly

### DIFF
--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -29,6 +29,7 @@
 #include "UserMessage.h"
 #include "WebProcessPool.h"
 #include "WebsiteDataStore.h"
+#include <WebCore/NotImplemented.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <wtf/FileSystem.h>
@@ -74,22 +75,14 @@ void WebProcessProxy::sendMessageToWebContext(UserMessage&& message)
 
 void WebProcessProxy::platformSuspendProcess()
 {
-    auto id = processID();
-    if (!id)
-        return;
-
-    RELEASE_LOG(Process, "%p - [PID=%i] WebProcessProxy::platformSuspendProcess", this, id);
-    kill(id, SIGSTOP);
+    // FIXME: https://webkit.org/b/280014
+    notImplemented();
 }
 
 void WebProcessProxy::platformResumeProcess()
 {
-    auto id = processID();
-    if (!id)
-        return;
-
-    RELEASE_LOG(Process, "%p - [PID=%i] WebProcessProxy::platformResumeProcess", this, id);
-    kill(id, SIGCONT);
+    // FIXME: https://webkit.org/b/280014
+    notImplemented();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### a585b00cb55e2ef5c0fb3d897618214f42f33d82
<pre>
REGRESSION(247615@main): [WPE][GTK] Suspended cached web processes remain forever after UI process terminates uncleanly
<a href="https://bugs.webkit.org/show_bug.cgi?id=280014">https://bugs.webkit.org/show_bug.cgi?id=280014</a>

Reviewed by Carlos Garcia Campos.

Give up on suspending cached web processes. Hopefully the impact on
battery life is not too great. :(

Resume relies on the UI process to not crash, and UI process crashes are
unfortunately common. My suggestion is to introduce a new process
monitor auxiliary process to manage terminating and reaping all other
auxiliary processes when the UI process terminates, but that requires
effort. In the meantime, Ctrl+C is all it takes to test what happens
when the UI process &quot;crashes&quot; or quits uncleanly. We need to make sure
all subprocesses are reliably terminated even when this happens. The
auxiliary process is normally able to notice when its IPC connection to
the UI process is closed, and then quit. But it cannot notice if it is
suspended!

* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformSuspendProcess):
(WebKit::WebProcessProxy::platformResumeProcess):

Canonical link: <a href="https://commits.webkit.org/284462@main">https://commits.webkit.org/284462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eb8e4b2d340d484e434a67de39c9a45197fd8ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13704 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41243 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16972 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/69144 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15420 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10839 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4458 "Passed tests") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/10604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->