### PR TITLE
REGRESSION(283414@main): [WPE][GTK] Network process crash when writing to pid socket

### DIFF
--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -604,8 +604,13 @@ void sendPIDToPeer(int socket)
     message.msg_iov = &iov;
     message.msg_iovlen = 1;
 
-    if (sendmsg(socket, &message, 0) == -1)
+    if (sendmsg(socket, &message, 0) == -1) {
+        // Don't crash if the parent process merely closed its pid socket.
+        // That's equivalent to canceling the process launch.
+        if (errno == EPIPE)
+            exit(1);
         g_error("sendPIDToPeer: Failed to send pid: %s", g_strerror(errno));
+    }
 }
 
 // The goal here is to receive the pid of the sandboxed child in the parent process's pid namespace.


### PR DESCRIPTION
#### 1f6c2306d3ed8a591d2e94880b7271703d1906ed
<pre>
REGRESSION(283414@main): [WPE][GTK] Network process crash when writing to pid socket
<a href="https://bugs.webkit.org/show_bug.cgi?id=280003">https://bugs.webkit.org/show_bug.cgi?id=280003</a>

Reviewed by Carlos Garcia Campos.

If the UI process closes its pid socket connection to the auxiliary
process before the auxiliary process is able to successfully write the
pid, the auxiliary process should not crash. That&apos;s sort of weird, but
since 283414@main it&apos;s now expected that this might happen if the
ProcessLauncher gets destroyed before the process launches.

In practice, I *suspect* this is actually happening for the
NetworkProcessProxy&apos;s ProcessLauncher, because I don&apos;t know how else to
explain all the network process crashes I am seeing. That&apos;s probably a
bug, and I hesitate to land a change that hides a bug, but it really is
sometimes expected and shouldn&apos;t cause a crash. E.g. If the user presses
Ctrl+T and then Ctrl+Q in quick succession, the UI process could very
plausibly quit before a web process launches. Process launching takes a
couple hundred milliseconds on my computer.

* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::sendPIDToPeer):

Canonical link: <a href="https://commits.webkit.org/283981@main">https://commits.webkit.org/283981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffe5c8ad1a96151cb03c76589bf2aef7d9140464

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19089 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54303 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12730 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58696 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34770 "Found 1 new API test failure: /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40003 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61767 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61771 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15104 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3277 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->