### PR TITLE
Adopt more smart pointers in miscellaneous files

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -116,7 +116,7 @@ void RemoteImageDecoderAVFProxy::setData(ImageDecoderIdentifier identifier, cons
         return;
     }
 
-    auto imageDecoder = m_imageDecoders.get(identifier);
+    RefPtr imageDecoder = m_imageDecoders.get(identifier);
     imageDecoder->setData(data.isNull() ? SharedBuffer::create() : data.unsafeBuffer().releaseNonNull(), allDataReceived);
 
     auto frameCount = imageDecoder->frameCount();

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -36,7 +36,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(UIRemoteObjectRegistry);
 
 std::unique_ptr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
-    return protectedPage()->legacyMainFrameProcess().protectedThrottler()->backgroundActivity(name).moveToUniquePtr();
+    return protectedPage()->protectedLegacyMainFrameProcess()->protectedThrottler()->backgroundActivity(name).moveToUniquePtr();
 }
 
 UIRemoteObjectRegistry::UIRemoteObjectRegistry(_WKRemoteObjectRegistry *remoteObjectRegistry, WebPageProxy& page)

--- a/Source/WebKit/UIProcess/WebContextSupplement.h
+++ b/Source/WebKit/UIProcess/WebContextSupplement.h
@@ -48,7 +48,8 @@ public:
     {
     }
 
-    WebProcessPool* processPool() const { return m_processPool.get(); }
+    WebProcessPool* processPool() { return m_processPool.get(); }
+    RefPtr<WebProcessPool> protectedProcessPool() { return processPool(); }
     void clearProcessPool() { m_processPool = nullptr; }
 
     void ref() { refWebContextSupplement(); }

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -59,7 +59,7 @@ Ref<WebGeolocationManagerProxy> WebGeolocationManagerProxy::create(WebProcessPoo
 WebGeolocationManagerProxy::WebGeolocationManagerProxy(WebProcessPool* processPool)
     : WebContextSupplement(processPool)
 {
-    WebContextSupplement::processPool()->addMessageReceiver(Messages::WebGeolocationManagerProxy::messageReceiverName(), *this);
+    WebContextSupplement::protectedProcessPool()->addMessageReceiver(Messages::WebGeolocationManagerProxy::messageReceiverName(), *this);
 }
 
 WebGeolocationManagerProxy::~WebGeolocationManagerProxy() = default;
@@ -106,16 +106,16 @@ void WebGeolocationManagerProxy::providerDidChangePosition(WebGeolocationPositio
 {
     for (auto& [registrableDomain, perDomainData] : m_perDomainData) {
         perDomainData->lastPosition = position->corePosition();
-        for (auto& process : perDomainData->watchers)
-            process.send(Messages::WebGeolocationManager::DidChangePosition(registrableDomain, perDomainData->lastPosition.value()), 0);
+        for (Ref process : perDomainData->watchers)
+            process->send(Messages::WebGeolocationManager::DidChangePosition(registrableDomain, perDomainData->lastPosition.value()), 0);
     }
 }
 
 void WebGeolocationManagerProxy::providerDidFailToDeterminePosition(const String& errorMessage)
 {
     for (auto& [registrableDomain, perDomainData] : m_perDomainData) {
-        for (auto& proxy : perDomainData->watchers)
-            proxy.send(Messages::WebGeolocationManager::DidFailToDeterminePosition(registrableDomain, errorMessage), 0);
+        for (Ref proxy : perDomainData->watchers)
+            proxy->send(Messages::WebGeolocationManager::DidFailToDeterminePosition(registrableDomain, errorMessage), 0);
     }
 }
 
@@ -124,8 +124,8 @@ void WebGeolocationManagerProxy::resetPermissions()
 {
     ASSERT(m_clientProvider);
     for (auto& [registrableDomain, perDomainData] : m_perDomainData) {
-        for (auto& proxy : perDomainData->watchers)
-            proxy.send(Messages::WebGeolocationManager::ResetPermissions(registrableDomain), 0);
+        for (Ref proxy : perDomainData->watchers)
+            proxy->send(Messages::WebGeolocationManager::ResetPermissions(registrableDomain), 0);
     }
 }
 #endif


### PR DESCRIPTION
#### 0f54db92edc6de5cb6dc96335ecfafcb6329169d
<pre>
Adopt more smart pointers in miscellaneous files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280026">https://bugs.webkit.org/show_bug.cgi?id=280026</a>
<a href="https://rdar.apple.com/136328218">rdar://136328218</a>

Reviewed by Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
(WebKit::RemoteImageDecoderAVFProxy::setData):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
* Source/WebKit/UIProcess/WebContextSupplement.h:
(WebKit::WebContextSupplement::processPool):
(WebKit::WebContextSupplement::protectedProcessPool):
(WebKit::WebContextSupplement::processPool const): Deleted.
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::WebGeolocationManagerProxy):
(WebKit::WebGeolocationManagerProxy::providerDidChangePosition):
(WebKit::WebGeolocationManagerProxy::providerDidFailToDeterminePosition):
(WebKit::WebGeolocationManagerProxy::resetPermissions):

Canonical link: <a href="https://commits.webkit.org/284006@main">https://commits.webkit.org/284006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1365123112eb3c4da85d65e2140de9e0129549ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19095 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12738 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71017 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43358 "Found 1 new test failure: editing/text-iterator/hidden-textarea-selection-quirk.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/58833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40025 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17452 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61997 "Found 509 new API test failures: TestWebKitAPI.ProcessSwap.NavigatingSameOriginToCOOPAndCOEPSameOrigin, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOriginAllowPopup2, TestWebKitAPI.ProcessSwap.GetUserMediaCaptureState, TestWebKitAPI.ResourceLoadStatistics.EnableResourceLoadStatisticsAfterNetworkProcessCreation, TestWebKitAPI.ResourceLoadStatistics.MigrateDataFromMissingTopFrameUniqueRedirectSameSiteStrictTableSchema, TestWebKitAPI.URLSchemeHandler.HandleURLRewrittenByPlugIn, TestWebKitAPI.Coding.WKProcessPool, TestWebKitAPI.ParserYieldTokenTests.DeferredScriptExecutesBeforeDocumentLoadWhenTakingParserYieldToken, TestWebKitAPI.ProcessSwap.ProcessSwapInRelatedView, TestWebKitAPI.DragAndDropTests.InjectedBundleOverridePerformTwoStepDrop ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73705 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61780 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61792 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3300 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10362 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43142 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->