### PR TITLE
[site-isolation] Send pageScaleFactor changes to all relevant processes.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/page-scale-expected.html
+++ b/LayoutTests/http/tests/site-isolation/page-scale-expected.html
@@ -1,0 +1,16 @@
+<html>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function test() {
+    if (window.testRunner) {
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
+        testRunner.notifyDone();
+    }
+}
+</script>
+<body onload="test()";>
+<div style="width:100px; height: 100px; position: absolute; left: 16px; top: 16px; background: green"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/page-scale.html
+++ b/LayoutTests/http/tests/site-isolation/page-scale.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+  body { overflow: hidden; }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+onmessage = async (event) => {
+    if (window.testRunner && event.data == "onload") {
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
+        testRunner.notifyDone();
+    }
+}
+</script>
+</head>
+<body>
+<iframe src="http://localhost:8000/site-isolation/resources/green-square.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/green-square.html
+++ b/LayoutTests/http/tests/site-isolation/resources/green-square.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+  body {
+    background: white;
+  }
+</style>
+</head>
+<body>
+<div style="width:100px; height: 100px; background: green"></div>
+<script>
+onload = () => { window.parent.postMessage("onload", "*"); }
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -160,6 +160,7 @@ void HistoryController::restoreScrollPositionAndViewState()
         RefPtr page = frame->page();
         auto desiredScrollPosition = currentItem->shouldRestoreScrollPosition() ? currentItem->scrollPosition() : view->scrollPosition();
         LOG(Scrolling, "HistoryController::restoreScrollPositionAndViewState scrolling to %d,%d", desiredScrollPosition.x(), desiredScrollPosition.y());
+        // FIXME: Page scale should be set in the UI process using WebPageProxy.
         if (page && frame->isMainFrame() && currentItem->pageScaleFactor())
             page->setPageScaleFactor(currentItem->pageScaleFactor() * page->viewScaleFactor(), desiredScrollPosition);
         else

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -226,6 +226,7 @@ RenderLayerBacking::RenderLayerBacking(RenderLayer& layer)
 {
     if (layer.isRenderViewLayer()) {
         m_isMainFrameRenderViewLayer = renderer().frame().isMainFrame();
+        m_isRootFrameRenderViewLayer = renderer().frame().isRootFrame();
         m_isFrameLayerWithTiledBacking = renderer().page().chrome().client().shouldUseTiledBackingForFrameView(renderer().view().frameView());
     }
 
@@ -543,11 +544,11 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
     }
 
 #if !PLATFORM(IOS_FAMILY)
-    if (m_isMainFrameRenderViewLayer) {
-        // Page scale is applied above the RenderView on iOS.
+    if (m_isMainFrameRenderViewLayer)
         m_graphicsLayer->setContentsOpaque(!compositor().viewHasTransparentBackground());
+    // Page scale is applied above the RenderView on iOS.
+    if (m_isRootFrameRenderViewLayer)
         m_graphicsLayer->setAppliesPageScale();
-    }
 #endif
 
 #if USE(CA)

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -449,6 +449,7 @@ private:
 
     bool m_artificiallyInflatedBounds { false }; // bounds had to be made non-zero to make transform-origin work
     bool m_isMainFrameRenderViewLayer { false };
+    bool m_isRootFrameRenderViewLayer { false };
     bool m_isFrameLayerWithTiledBacking { false };
     bool m_requiresOwnBackingStore { true };
     bool m_canCompositeFilters { false };

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4785,7 +4785,7 @@ void RenderLayerCompositor::ensureRootLayer()
 
 #if PLATFORM(IOS_FAMILY)
         // Page scale is applied above this on iOS, so we'll just say that our root layer applies it.
-        if (m_renderView.frameView().frame().isMainFrame())
+        if (m_renderView.frameView().frame().isRootFrame())
             m_rootContentsLayer->setAppliesPageScale();
 #endif
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2828,8 +2828,8 @@ void printPaintOrderTreeForLiveDocuments()
     for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
-        if (document->frame() && document->frame()->isMainFrame())
-            WTFLogAlways("----------------------main frame--------------------------\n");
+        if (document->frame() && document->frame()->isRootFrame())
+            WTFLogAlways("----------------------root frame--------------------------\n");
         WTFLogAlways("%s", document->url().string().utf8().data());
         showPaintOrderTree(document->renderView());
     }
@@ -2840,8 +2840,8 @@ void printRenderTreeForLiveDocuments()
     for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
-        if (document->frame() && document->frame()->isMainFrame())
-            WTFLogAlways("----------------------main frame--------------------------\n");
+        if (document->frame() && document->frame()->isRootFrame())
+            WTFLogAlways("----------------------root frame--------------------------\n");
         WTFLogAlways("%s", document->url().string().utf8().data());
         showRenderTree(document->renderView());
     }
@@ -2852,8 +2852,8 @@ void printLayerTreeForLiveDocuments()
     for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
-        if (document->frame() && document->frame()->isMainFrame())
-            WTFLogAlways("----------------------main frame--------------------------\n");
+        if (document->frame() && document->frame()->isRootFrame())
+            WTFLogAlways("----------------------root frame--------------------------\n");
         WTFLogAlways("%s", document->url().string().utf8().data());
         showLayerTree(document->renderView());
     }
@@ -2864,7 +2864,7 @@ void printGraphicsLayerTreeForLiveDocuments()
     for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
-        if (document->frame() && document->frame()->isMainFrame()) {
+        if (document->frame() && document->frame()->isRootFrame()) {
             WTFLogAlways("Graphics layer tree for root document %p %s", document.ptr(), document->url().string().utf8().data());
             showGraphicsLayerTreeForCompositor(document->renderView()->compositor());
         }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -672,7 +672,7 @@ void WKPageSetPageAndTextZoomFactors(WKPageRef pageRef, double pageZoomFactor, d
 void WKPageSetScaleFactor(WKPageRef pageRef, double scale, WKPoint origin)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->scalePage(scale, toIntPoint(origin));
+    toImpl(pageRef)->scalePage(scale, toIntPoint(origin), [] { });
 }
 
 double WKPageGetScaleFactor(WKPageRef pageRef)
@@ -3326,11 +3326,7 @@ void WKPageSetTopContentInsetForTesting(WKPageRef pageRef, float contentInset, v
 
 void WKPageSetPageScaleFactorForTesting(WKPageRef pageRef, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler)
 {
-    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
-    if (!pageForTesting)
-        return completionHandler(context);
-
-    pageForTesting->setPageScaleFactor(scaleFactor, toIntPoint(point), [context, completionHandler] {
+    toImpl(pageRef)->scalePage(scaleFactor, toIntPoint(point), [context, completionHandler] {
         completionHandler(context);
     });
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -174,7 +174,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_setPageScale:(CGFloat)scale withOrigin:(CGPoint)origin
 {
-    _page->scalePage(scale, WebCore::roundedIntPoint(origin));
+    _page->scalePage(scale, WebCore::roundedIntPoint(origin), [] { });
 }
 
 - (CGFloat)_pageScale

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -740,7 +740,7 @@ void ViewGestureController::applyMagnification()
         return;
 
     if (m_frameHandlesMagnificationGesture)
-        protectedWebPageProxy()->scalePage(m_magnification, roundedIntPoint(m_magnificationOrigin));
+        protectedWebPageProxy()->scalePage(m_magnification, roundedIntPoint(m_magnificationOrigin), [] { });
     else if (auto* drawingArea = m_webPageProxy->drawingArea())
         drawingArea->adjustTransientZoom(m_magnification, scaledMagnificationOrigin(m_magnificationOrigin, m_magnification));
 }
@@ -756,7 +756,7 @@ void ViewGestureController::endMagnificationGesture()
     double newMagnification = clampTo<double>(m_magnification, minMagnification, maxMagnification);
 
     if (m_frameHandlesMagnificationGesture)
-        webPageProxy->scalePage(newMagnification, roundedIntPoint(m_magnificationOrigin));
+        webPageProxy->scalePage(newMagnification, roundedIntPoint(m_magnificationOrigin), [] { });
     else {
         if (auto drawingArea = webPageProxy->drawingArea())
             drawingArea->commitTransientZoom(newMagnification, scaledMagnificationOrigin(m_magnificationOrigin, newMagnification));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1310,7 +1310,7 @@ public:
     double minPageZoomFactor() const;
     double maxPageZoomFactor() const;
 
-    void scalePage(double scale, const WebCore::IntPoint& origin);
+    void scalePage(double scale, const WebCore::IntPoint& origin, CompletionHandler<void()>&&);
     void scalePageInViewCoordinates(double scale, const WebCore::IntPoint& centerInViewCoordinates);
     void scalePageRelativeToScrollPosition(double scale, const WebCore::IntPoint& origin);
     double pageScaleFactor() const;
@@ -1427,6 +1427,7 @@ public:
 #endif
 
     void pageScaleFactorDidChange(IPC::Connection&, double);
+    void viewScaleFactorDidChange(IPC::Connection&, double);
     void pluginScaleFactorDidChange(IPC::Connection&, double);
     void pluginZoomFactorDidChange(IPC::Connection&, double);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -186,6 +186,7 @@ messages -> WebPageProxy {
 #endif
 
     PageScaleFactorDidChange(double scaleFactor)
+    ViewScaleFactorDidChange(double scaleFactor)
     PluginScaleFactorDidChange(double zoomFactor)
     PluginZoomFactorDidChange(double zoomFactor)
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -210,12 +210,4 @@ Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
     return m_page.get();
 }
 
-void WebPageProxyTesting::setPageScaleFactor(float scaleFactor, IntPoint point, CompletionHandler<void()>&& completionHandler)
-{
-    protectedPage()->forEachWebContentProcess([&](auto& process, auto pageID) {
-        process.send(Messages::WebPageTesting::SetPageScaleFactor(scaleFactor, point), pageID);
-    });
-    protectedPage()->callAfterNextPresentationUpdate(WTFMove(completionHandler));
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -77,8 +77,6 @@ public:
 #endif
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
-
-    void setPageScaleFactor(float scaleFactor, WebCore::IntPoint, CompletionHandler<void()>&&);
 private:
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
     bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -273,7 +273,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _webView.frame = NSInsetRect(contentView.bounds, 0, -_page->topContentInset());
 
     _savedScale = _page->pageScaleFactor();
-    _page->scalePage(1, WebCore::IntPoint());
+    _page->scalePage(1, WebCore::IntPoint(), [] { });
     [self _manager]->setAnimatingFullScreen(true);
     [self _manager]->willEnterFullScreen();
 }
@@ -364,7 +364,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         makeResponderFirstResponderIfDescendantOfView(_webView.window, firstResponder, _webView);
         [[_webView window] makeKeyAndOrderFront:self];
 
-        _page->scalePage(_savedScale, WebCore::IntPoint());
+        _page->scalePage(_savedScale, WebCore::IntPoint(), [] { });
         [self _manager]->restoreScrollPosition();
         _page->setTopContentInset(_savedTopContentInset);
         [self _manager]->setAnimatingFullScreen(false);
@@ -536,7 +536,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     // These messages must be sent after the swap or flashing will occur during forceRepaint:
     [self _manager]->setAnimatingFullScreen(false);
     [self _manager]->didExitFullScreen();
-    _page->scalePage(_savedScale, WebCore::IntPoint());
+    _page->scalePage(_savedScale, WebCore::IntPoint(), [] { });
     [self _manager]->restoreScrollPosition();
     _page->setTopContentInset(_savedTopContentInset);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2663,7 +2663,7 @@ double WebPage::viewScaleFactor() const
     return m_page->viewScaleFactor();
 }
 
-void WebPage::scaleView(double scale)
+void WebPage::didScaleView(double scale)
 {
     if (viewScaleFactor() == scale)
         return;
@@ -2678,7 +2678,15 @@ void WebPage::scaleView(double scale)
     }
 
     m_page->setViewScaleFactor(scale);
-    scalePage(pageScale, scrollPositionAtNewScale);
+    didScalePage(pageScale, scrollPositionAtNewScale);
+}
+
+void WebPage::scaleView(double scale)
+{
+    if (scale == viewScaleFactor())
+        return;
+    didScaleView(scale);
+    send(Messages::WebPageProxy::ViewScaleFactorDidChange(scale));
 }
 
 void WebPage::setDeviceScaleFactor(float scaleFactor)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -717,16 +717,18 @@ public:
 
     void screenPropertiesDidChange();
 
-    // FIXME(site-isolation): Calls to this should be removed in favour of setting via WebPageProxy.
+    // FIXME(site-isolation): Calls to these should be removed in favour of setting via WebPageProxy.
     void scalePage(double scale, const WebCore::IntPoint& origin);
+    void scaleView(double scale);
+
     double pageScaleFactor() const;
     double totalScaleFactor() const;
     double viewScaleFactor() const;
-    void scaleView(double scale);
 
     void didScalePage(double scale, const WebCore::IntPoint& origin);
     void didScalePageInViewCoordinates(double scale, const WebCore::IntPoint& origin);
     void didScalePageRelativeToScrollPosition(double scale, const WebCore::IntPoint& origin);
+    void didScaleView(double scale);
 
     void setUseFixedLayout(bool);
     bool useFixedLayout() const { return m_useFixedLayout; }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -301,7 +301,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidScalePage(double scale, WebCore::IntPoint origin)
     DidScalePageInViewCoordinates(double scale, WebCore::IntPoint origin)
     DidScalePageRelativeToScrollPosition(double scale, WebCore::IntPoint origin)
-    ScaleView(double scale)
+    DidScaleView(double scale)
 
     SetUseFixedLayout(bool fixed)
     SetFixedLayoutSize(WebCore::IntSize size)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -117,13 +117,6 @@ void WebPageTesting::setTopContentInset(float contentInset, CompletionHandler<vo
     completionHandler();
 }
 
-void WebPageTesting::setPageScaleFactor(double scale, IntPoint origin)
-{
-    RefPtr page = m_page->corePage();
-    if (page)
-        page->setPageScaleFactor(scale, origin);
-}
-
 Ref<WebPage> WebPageTesting::protectedPage() const
 {
     return m_page.get();

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -64,8 +64,6 @@ private:
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
 
-    void setPageScaleFactor(double scale, WebCore::IntPoint origin);
-
     void clearWheelEventTestMonitor();
     Ref<WebPage> protectedPage() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -33,5 +33,4 @@ messages -> WebPageTesting NotRefCounted {
     ClearWheelEventTestMonitor()
 
     SetTopContentInset(float contentInset) -> ()
-    SetPageScaleFactor(double scale, WebCore::IntPoint origin)
 }


### PR DESCRIPTION
#### 1e0f90c0a4748d952997071013e3836e5306dd1d
<pre>
[site-isolation] Send pageScaleFactor changes to all relevant processes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280040">https://bugs.webkit.org/show_bug.cgi?id=280040</a>
&lt;<a href="https://rdar.apple.com/136338665">rdar://136338665</a>&gt;

Reviewed by Charlie Wolfe.

Page scale changes can be initiated from both the WebProcess, as well as the UI process.
Adds mechanisms to share to all processes from the UI process, as well as sharing to all other web process when initiated from there.

Changes the TestRunner setter to use the same WebPageProxy setter as other API endpoints do, and adds a new test using a site-isolated subframe.

Also fixes Page::setPageScaleFactor to handle having multiple (and non-main) root frames.

* LayoutTests/http/tests/site-isolation/page-scale-expected.html: Added.
* LayoutTests/http/tests/site-isolation/page-scale.html: Added.
* LayoutTests/http/tests/site-isolation/resources/green-square.html: Added.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::restoreScrollPositionAndViewState):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setPageScaleFactor):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::ensureRootLayer):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::printPaintOrderTreeForLiveDocuments):
(WebCore::printRenderTreeForLiveDocuments):
(WebCore::printLayerTreeForLiveDocuments):
(WebCore::printGraphicsLayerTreeForLiveDocuments):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetScaleFactor):
(WKPageSetPageScaleFactorForTesting):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setPageScale:withOrigin:]):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::applyMagnification):
(WebKit::ViewGestureController::endMagnificationGesture):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::scalePage):
(WebKit::WebPageProxy::scalePageInViewCoordinates):
(WebKit::WebPageProxy::scalePageRelativeToScrollPosition):
(WebKit::WebPageProxy::scaleView):
(WebKit::WebPageProxy::pageScaleFactorDidChange):
(WebKit::WebPageProxy::viewScaleFactorDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::setPageScaleFactor): Deleted.
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didScaleView):
(WebKit::WebPage::scaleView):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::setPageScaleFactor): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:

Canonical link: <a href="https://commits.webkit.org/284435@main">https://commits.webkit.org/284435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b67a684ef1be4ccf99cfa29e5d20c0c91ef6d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55101 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13569 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35580 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62766 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62672 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4299 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44486 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->