### PR TITLE
Port WebExtension Manifest Background and Inspector Content

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "WebExtensionUtilities.h"
+
 namespace WebKit {
 
 static constexpr auto manifestVersionManifestKey = "manifest_version"_s;
@@ -68,6 +70,21 @@ static constexpr auto chromeURLOverridesManifestKey = "chrome_url_overrides"_s;
 static constexpr auto browserURLOverridesManifestKey = "browser_url_overrides"_s;
 static constexpr auto newTabManifestKey = "newtab"_s;
 
+static constexpr auto backgroundManifestKey = "background"_s;
+static constexpr auto backgroundPageManifestKey = "page"_s;
+static constexpr auto backgroundServiceWorkerManifestKey = "service_worker"_s;
+static constexpr auto backgroundScriptsManifestKey = "scripts"_s;
+static constexpr auto backgroundPersistentManifestKey = "persistent"_s;
+static constexpr auto backgroundPageTypeKey = "type"_s;
+static constexpr auto backgroundPageTypeModuleValue = "module"_s;
+static constexpr auto backgroundPreferredEnvironmentManifestKey = "preferred_environment"_s;
+static constexpr auto backgroundDocumentManifestKey = "document"_s;
+
+static constexpr auto generatedBackgroundPageFilename = "_generated_background_page.html"_s;
+static constexpr auto generatedBackgroundServiceWorkerFilename = "_generated_service_worker.js"_s;
+
+static constexpr auto devtoolsPageManifestKey = "devtools_page"_s;
+
 bool WebExtension::manifestParsedSuccessfully()
 {
     if (m_parsedManifest)
@@ -88,6 +105,12 @@ double WebExtension::manifestVersion()
         return *value;
 
     return 0;
+}
+
+bool WebExtension::hasRequestedPermission(String permission) const
+{
+    // FIXME: <https://webkit.org/b/280101> hasRequestedPermission isn't populating permission properties
+    return m_permissions.contains(permission);
 }
 
 const String& WebExtension::displayName()
@@ -196,6 +219,267 @@ void WebExtension::populateContentSecurityPolicyStringsIfNeeded()
 
     if (!m_contentSecurityPolicy)
         m_contentSecurityPolicy = "script-src 'self'"_s;
+}
+
+bool WebExtension::hasBackgroundContent()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return !m_backgroundScriptPaths.isEmpty() || !m_backgroundPagePath.isEmpty() || !m_backgroundServiceWorkerPath.isEmpty();
+}
+
+bool WebExtension::backgroundContentIsPersistent()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return hasBackgroundContent() && m_backgroundContentIsPersistent;
+}
+
+bool WebExtension::backgroundContentUsesModules()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return hasBackgroundContent() && m_backgroundContentUsesModules;
+}
+
+bool WebExtension::backgroundContentIsServiceWorker()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return m_backgroundContentEnvironment == Environment::ServiceWorker;
+}
+
+const String& WebExtension::backgroundContentPath()
+{
+    populateBackgroundPropertiesIfNeeded();
+
+    if (!m_backgroundServiceWorkerPath.isEmpty())
+        return m_backgroundServiceWorkerPath;
+
+    if (!m_backgroundScriptPaths.isEmpty()) {
+        if (backgroundContentIsServiceWorker()) {
+            static const NeverDestroyed<String> backgroundContentString = generatedBackgroundServiceWorkerFilename;
+            return backgroundContentString;
+        }
+
+        static const NeverDestroyed<String> backgroundContentString = generatedBackgroundPageFilename;
+        return backgroundContentString;
+    }
+
+    if (!m_backgroundPagePath.isEmpty())
+        return m_backgroundPagePath;
+
+    ASSERT_NOT_REACHED();
+    return nullString();
+}
+
+const String& WebExtension::generatedBackgroundContent()
+{
+    if (!m_generatedBackgroundContent.isEmpty())
+        return m_generatedBackgroundContent;
+
+    populateBackgroundPropertiesIfNeeded();
+
+    if (!m_backgroundServiceWorkerPath.isEmpty() || !m_backgroundPagePath.isEmpty())
+        return nullString();
+
+    if (m_backgroundScriptPaths.isEmpty())
+        return nullString();
+
+    bool isServiceWorker = backgroundContentIsServiceWorker();
+    bool usesModules = backgroundContentUsesModules();
+
+    Vector<String> scripts;
+    for (auto& scriptPath : m_backgroundScriptPaths) {
+        StringBuilder format;
+        if (isServiceWorker) {
+            if (usesModules) {
+                format.append("import \"./"_s, scriptPath, "\";"_s);
+
+                scripts.append(format.toString());
+                continue;
+            }
+
+            format.append("importScripts(\""_s, scriptPath, "\");"_s);
+
+            scripts.append(format.toString());
+            continue;
+        }
+
+        format.append("<script"_s);
+        if (usesModules)
+            format.append(" type=\"module\""_s);
+        format.append(" src=\""_s, scriptPath, "\"></script>"_s);
+
+        scripts.append(format.toString());
+    }
+
+    StringBuilder generatedBackgroundContent;
+    if (!isServiceWorker)
+        generatedBackgroundContent.append("<!DOCTYPE html>\n<body>\n"_s);
+
+    for (auto& scriptPath : scripts)
+        generatedBackgroundContent.append(scriptPath, "\n"_s);
+
+    if (!isServiceWorker)
+        generatedBackgroundContent.append("\n</body>"_s);
+
+    m_generatedBackgroundContent = generatedBackgroundContent.toString();
+    return m_generatedBackgroundContent;
+}
+
+void WebExtension::populateBackgroundPropertiesIfNeeded()
+{
+    if (m_parsedManifestBackgroundProperties)
+        return;
+
+    m_parsedManifestBackgroundProperties = true;
+
+    RefPtr manifestObject = this->manifestObject();
+    if (!manifestObject)
+        return;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
+
+    RefPtr backgroundManifestObject = manifestObject->getObject(backgroundManifestKey);
+    if (!backgroundManifestObject || !backgroundManifestObject->size()) {
+        if (manifestObject->getValue(backgroundManifestKey))
+            recordError(createError(Error::InvalidBackgroundContent));
+        return;
+    }
+
+    m_backgroundPagePath = backgroundManifestObject->getString(backgroundPageManifestKey);
+    m_backgroundServiceWorkerPath = backgroundManifestObject->getString(backgroundServiceWorkerManifestKey);
+    m_backgroundContentUsesModules = (backgroundManifestObject->getString(backgroundPageTypeKey) == backgroundPageTypeModuleValue);
+
+    if (RefPtr backgroundScriptPaths = backgroundManifestObject->getArray(backgroundScriptsManifestKey)) {
+        backgroundScriptPaths = filterObjects(*backgroundScriptPaths, [](auto& value) {
+            return !value.asString().isEmpty();
+        });
+
+        m_backgroundScriptPaths = makeStringVector(*backgroundScriptPaths);
+    }
+
+    Vector<String> supportedEnvironments = { backgroundDocumentManifestKey, backgroundServiceWorkerManifestKey };
+
+    Vector<String> preferredEnvironments;
+    if (auto environment = backgroundManifestObject->getString(backgroundPreferredEnvironmentManifestKey); !environment.isEmpty()) {
+        if (supportedEnvironments.contains(environment))
+            preferredEnvironments.append(environment);
+    } else if (RefPtr environments = backgroundManifestObject->getArray(backgroundPreferredEnvironmentManifestKey); environments && environments->length()) {
+        Ref filteredEnvironments = filterObjects(*environments, [supportedEnvironments](auto& value) {
+            return supportedEnvironments.contains(value.asString());
+        });
+
+        for (Ref environment : filteredEnvironments.get())
+            preferredEnvironments.append(environment->asString());
+    } else if (backgroundManifestObject->getValue(backgroundPreferredEnvironmentManifestKey))
+        recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has an empty or invalid `preferred_environment` key.", "WKWebExtensionErrorInvalidBackgroundContent description for empty or invalid preferred environment key")));
+
+    for (auto& environment : preferredEnvironments) {
+        if (environment == backgroundDocumentManifestKey) {
+            m_backgroundContentEnvironment = Environment::Document;
+            m_backgroundServiceWorkerPath = nullString();
+
+            if (!m_backgroundPagePath.isEmpty()) {
+                // Page takes precedence over scripts and service worker.
+                m_backgroundScriptPaths = { };
+                break;
+            }
+
+            if (!m_backgroundScriptPaths.isEmpty()) {
+                // Scripts takes precedence over service worker.
+                break;
+            }
+
+            recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required `page` or `scripts` key for `preferred_environment` of `document`.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background page or scripts keys")));
+            break;
+        }
+
+        if (environment == backgroundServiceWorkerManifestKey) {
+            m_backgroundContentEnvironment = Environment::ServiceWorker;
+            m_backgroundPagePath = nullString();
+
+            if (!m_backgroundServiceWorkerPath.isEmpty()) {
+                // Page takes precedence over scripts and service worker.
+                m_backgroundScriptPaths = { };
+                break;
+            }
+
+            if (!m_backgroundScriptPaths.isEmpty()) {
+                // Scripts takes precedence over service worker.
+                break;
+            }
+
+            recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required `service_worker` or `scripts` key for `preferred_environment` of `service_worker`.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background service_worker or scripts keys")));
+            break;
+        }
+    }
+
+    if (!preferredEnvironments.size()) {
+        // Page takes precedence over service worker.
+        if (!m_backgroundPagePath.isEmpty())
+            m_backgroundServiceWorkerPath = nullString();
+
+        // Scripts takes precedence over page and service worker.
+        if (!m_backgroundScriptPaths.isEmpty()) {
+            m_backgroundServiceWorkerPath = nullString();
+            m_backgroundPagePath = nullString();
+        }
+
+        m_backgroundContentEnvironment = !m_backgroundServiceWorkerPath.isEmpty() ? Environment::ServiceWorker : Environment::Document;
+
+        if (m_backgroundScriptPaths.isEmpty() && m_backgroundPagePath.isEmpty() && m_backgroundServiceWorkerPath.isEmpty())
+            recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required `scripts`, `page`, or `service_worker` key.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys")));
+    }
+
+    auto persistentBoolean = backgroundManifestObject->getBoolean(backgroundPersistentManifestKey);
+    m_backgroundContentIsPersistent = persistentBoolean ? *persistentBoolean : !(supportsManifestVersion(3) || !m_backgroundServiceWorkerPath.isEmpty());
+
+    if (m_backgroundContentIsPersistent && supportsManifestVersion(3)) {
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A `manifest_version` greater-than or equal to `3` must be non-persistent.", "WKWebExtensionErrorInvalidBackgroundPersistence description for manifest v3")));
+        m_backgroundContentIsPersistent = false;
+    }
+
+    if (m_backgroundContentIsPersistent && !m_backgroundServiceWorkerPath.isEmpty()) {
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A `service_worker` must be non-persistent.", "WKWebExtensionErrorInvalidBackgroundPersistence description for service worker")));
+        m_backgroundContentIsPersistent = false;
+    }
+
+    if (!m_backgroundContentIsPersistent && hasRequestedPermission("webRequest"_s))
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Non-persistent background content cannot listen to `webRequest` events.", "WKWebExtensionErrorInvalidBackgroundPersistence description for webRequest events")));
+
+#if PLATFORM(VISION)
+    if (m_backgroundContentIsPersistent)
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A non-persistent background is required on visionOS.", "WKWebExtensionErrorInvalidBackgroundPersistence description for visionOS")));
+#elif PLATFORM(IOS)
+    if (m_backgroundContentIsPersistent)
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS.", "WKWebExtensionErrorInvalidBackgroundPersistence description for iOS")));
+#endif
+}
+
+bool WebExtension::hasInspectorBackgroundPage()
+{
+    populateInspectorPropertiesIfNeeded();
+    return !m_inspectorBackgroundPagePath.isEmpty();
+}
+
+const String& WebExtension::inspectorBackgroundPagePath()
+{
+    populateInspectorPropertiesIfNeeded();
+    return m_inspectorBackgroundPagePath;
+}
+
+void WebExtension::populateInspectorPropertiesIfNeeded()
+{
+    if (m_parsedManifestInspectorProperties)
+        return;
+
+    m_parsedManifestInspectorProperties = true;
+
+    RefPtr manifestObject = this->manifestObject();
+    if (!manifestObject)
+        return;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page
+
+    m_inspectorBackgroundPagePath = manifestObject->getString(devtoolsPageManifestKey);
 }
 
 bool WebExtension::hasOptionsPage()

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -270,11 +270,11 @@ public:
     bool backgroundContentUsesModules();
     bool backgroundContentIsServiceWorker();
 
-    NSString *backgroundContentPath();
-    NSString *generatedBackgroundContent();
+    const String& backgroundContentPath();
+    const String& generatedBackgroundContent();
 
     bool hasInspectorBackgroundPage();
-    NSString *inspectorBackgroundPagePath();
+    const String& inspectorBackgroundPagePath();
 
     bool hasOptionsPage();
     bool hasOverrideNewTabPage();
@@ -298,7 +298,7 @@ public:
     const PermissionsSet& requestedPermissions();
     const PermissionsSet& optionalPermissions();
 
-    bool hasRequestedPermission(NSString *) const;
+    bool hasRequestedPermission(String) const;
 
     // Match patterns requested by the extension in their manifest.
     // These are not the currently allowed permission patterns.
@@ -394,13 +394,13 @@ private:
 
     String m_contentSecurityPolicy;
 
-    RetainPtr<NSArray> m_backgroundScriptPaths;
-    RetainPtr<NSString> m_backgroundPagePath;
-    RetainPtr<NSString> m_backgroundServiceWorkerPath;
-    RetainPtr<NSString> m_generatedBackgroundContent;
+    Vector<String> m_backgroundScriptPaths;
+    String m_backgroundPagePath;
+    String m_backgroundServiceWorkerPath;
+    String m_generatedBackgroundContent;
     Environment m_backgroundContentEnvironment { Environment::Document };
 
-    RetainPtr<NSString> m_inspectorBackgroundPagePath;
+    String m_inspectorBackgroundPagePath;
 
     String m_optionsPagePath;
     String m_overrideNewTabPagePath;


### PR DESCRIPTION
#### 728527cd9838203667cd707899aa4b87c6462175
<pre>
Port WebExtension Manifest Background and Inspector Content
<a href="https://webkit.org/b/280041">https://webkit.org/b/280041</a>

Reviewed by Timothy Hatcher.

Ports the WebExtension manifest background content and inspector content to C++.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceStringForPath):
(WebKit::WebExtension::resourceDataForPath):
(WebKit::WebExtension::hasRequestedPermission const): Deleted.
(WebKit::WebExtension::hasBackgroundContent): Deleted.
(WebKit::WebExtension::backgroundContentIsPersistent): Deleted.
(WebKit::WebExtension::backgroundContentUsesModules): Deleted.
(WebKit::WebExtension::backgroundContentIsServiceWorker): Deleted.
(WebKit::WebExtension::backgroundContentPath): Deleted.
(WebKit::WebExtension::generatedBackgroundContent): Deleted.
(WebKit::WebExtension::populateBackgroundPropertiesIfNeeded): Deleted.
(WebKit::WebExtension::hasInspectorBackgroundPage): Deleted.
(WebKit::WebExtension::inspectorBackgroundPagePath): Deleted.
(WebKit::WebExtension::populateInspectorPropertiesIfNeeded): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::hasRequestedPermission const):
(WebKit::WebExtension::hasBackgroundContent):
(WebKit::WebExtension::backgroundContentIsPersistent):
(WebKit::WebExtension::backgroundContentUsesModules):
(WebKit::WebExtension::backgroundContentIsServiceWorker):
(WebKit::WebExtension::backgroundContentPath):
(WebKit::WebExtension::generatedBackgroundContent):
(WebKit::WebExtension::populateBackgroundPropertiesIfNeeded):
(WebKit::WebExtension::hasInspectorBackgroundPage):
(WebKit::WebExtension::inspectorBackgroundPagePath):
(WebKit::WebExtension::populateInspectorPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:

Canonical link: <a href="https://commits.webkit.org/284078@main">https://commits.webkit.org/284078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7ed3c7bacd1dc34174ff9965d7e5f2d943a5049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19538 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54607 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13012 "Passed tests") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40358 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17895 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62059 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62080 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3617 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43586 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->