### PR TITLE
Update some model layout tests to work reliably when model process is enabled

### DIFF
--- a/LayoutTests/model-element/model-element-contents-layer-updates-expected.txt
+++ b/LayoutTests/model-element/model-element-contents-layer-updates-expected.txt
@@ -3,10 +3,9 @@
   (position 158.00 83.00)
   (bounds 300.00 150.00)
   (children
-    (contents layer (model)
+    (contents layer (hosted model)
       (position 0.00 0.00)
       (bounds 300.00 150.00)
-      (model data size 395126)
     )
   )
 )
@@ -15,10 +14,9 @@ After Changing Source:
   (position 158.00 83.00)
   (bounds 300.00 150.00)
   (children
-    (contents layer (model)
+    (contents layer (hosted model)
       (position 0.00 0.00)
       (bounds 300.00 150.00)
-      (model data size 3248)
     )
   )
 )

--- a/LayoutTests/model-element/model-element-contents-layer-updates-with-clipping-expected.txt
+++ b/LayoutTests/model-element/model-element-contents-layer-updates-with-clipping-expected.txt
@@ -7,10 +7,9 @@
       (position 0.00 0.00)
       (bounds 300.00 150.00)
       (children
-        (contents layer (model)
+        (contents layer (hosted model)
           (position 0.00 0.00)
           (bounds 300.00 150.00)
-          (model data size 395126)
         )
       )
     )
@@ -25,10 +24,9 @@ After Changing Source:
       (position 0.00 0.00)
       (bounds 300.00 150.00)
       (children
-        (contents layer (model)
+        (contents layer (hosted model)
           (position 0.00 0.00)
           (bounds 300.00 150.00)
-          (model data size 3248)
         )
       )
     )

--- a/LayoutTests/model-element/model-element-contents-layer-updates-with-clipping.html
+++ b/LayoutTests/model-element/model-element-contents-layer-updates-with-clipping.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
 <html>
 <body>
 <model id="model" style="border-radius: 5px">
@@ -13,32 +13,26 @@
     const source = document.querySelector("source");
     const model = document.getElementById("model");
 
-    const modelDidLoadFirstSource = () => {
+    source.src = "resources/heart.usdz";
+
+    model.ready.then((resolve) => {
         layers.textContent = "Before Changing Source:\n";
         layers.textContent += window.internals?.platformLayerTreeAsText(model, window.internals.PLATFORM_LAYER_TREE_INCLUDE_MODELS) ?? "This test requires testRunner.";
 
-        model.addEventListener("load", event => {
+        source.src = "resources/cube.usdz";
+
+        model.ready.then((resolve) => {
             layers.textContent += "After Changing Source:\n";
             layers.textContent += window.internals?.platformLayerTreeAsText(model, window.internals.PLATFORM_LAYER_TREE_INCLUDE_MODELS) ?? "This test requires testRunner.";
             window.testRunner?.notifyDone();
-        }, { once: true });
-
-        model.addEventListener("error", event => {
-            layers.textContent = `Failed. Second model did not load.`;
+        }, (reason) => {
+            layers.textContent = "Failed. Second model did not load: " + reason;
             window.testRunner?.notifyDone();
-        }, { once: true });
-
-        source.src = "resources/cube.usdz";
-    };
-
-    model.addEventListener("load", modelDidLoadFirstSource, { once: true });
-    model.addEventListener("error", event => {
-        layers.textContent = `Failed. First model did not load.`;
+        });
+    }, (reason) => {
+        layers.textContent = "Failed. First model did not load: " + reason;
         window.testRunner?.notifyDone();
-    }, { once: true });
-
-    source.src = "resources/heart.usdz";
-
+    });
 </script>
 </body>
 </html>

--- a/LayoutTests/model-element/model-element-contents-layer-updates.html
+++ b/LayoutTests/model-element/model-element-contents-layer-updates.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
 <html>
 <body>
 <model id="model">
@@ -13,33 +13,24 @@
     const source = document.querySelector("source");
     const model = document.getElementById("model");
 
-    const modelDidLoadFirstSource = () => {
+    model.ready.then((resolve) => {
         layers.textContent = "Before Changing Source:\n";
         layers.textContent += window.internals?.platformLayerTreeAsText(model, window.internals.PLATFORM_LAYER_TREE_INCLUDE_MODELS) ?? "This test requires testRunner.";
 
-        model.addEventListener("load", event => {
+        source.src = "resources/cube.usdz";
+
+        model.ready.then((resolve) => {
             layers.textContent += "After Changing Source:\n";
             layers.textContent += window.internals?.platformLayerTreeAsText(model, window.internals.PLATFORM_LAYER_TREE_INCLUDE_MODELS) ?? "This test requires testRunner.";
             window.testRunner?.notifyDone();
-        }, { once: true });
-
-        model.addEventListener("error", event => {
-            layers.textContent = `Failed. Second model did not load.`;
+        }, (reason) => {
+            layers.textContent = "Failed. Second model did not load: " + reason;
             window.testRunner?.notifyDone();
-        }, { once: true });
-
-        source.src = "resources/cube.usdz";
-    }
-
-    if (model.complete)
-        modelDidLoadFirstSource();
-    else {
-        model.addEventListener("load", modelDidLoadFirstSource, { once: true });
-        model.addEventListener("error", event => {
-            layers.textContent = `Failed. First model did not load.`;
-            window.testRunner?.notifyDone();
-        }, { once: true });
-    }
+        });
+    }, (reason) => {
+        layers.textContent = "Failed. First model did not load: " + reason;
+        window.testRunner?.notifyDone();
+    });
 </script>
 </body>
 </html>

--- a/LayoutTests/model-element/model-element-graphics-layers-opacity-expected.txt
+++ b/LayoutTests/model-element/model-element-graphics-layers-opacity-expected.txt
@@ -3,10 +3,9 @@
   (bounds 300.00 150.00)
   (opacity 0.50)
   (children
-    (contents layer (model)
+    (contents layer (hosted model)
       (position 0.00 0.00)
       (bounds 300.00 150.00)
-      (opacity 0.50)
     )
   )
 )

--- a/LayoutTests/model-element/model-element-graphics-layers-opacity.html
+++ b/LayoutTests/model-element/model-element-graphics-layers-opacity.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
 <html>
 <head>
     <style>
@@ -19,21 +19,14 @@
     const layers = document.getElementById("layers");
     const model = document.getElementById("model");
 
-    const modelDidLoad = () => {
-        layers.innerText = window.internals?.platformLayerTreeAsText(model) ?? "This test requires testRunner.";
+    model.ready.then((resolve) => {
+        layers.textContent = window.internals?.platformLayerTreeAsText(model) ?? "This test requires testRunner.";
         model.remove();
         window.testRunner?.notifyDone();
-    };
-
-    if (model.complete)
-        modelDidLoad();
-    else {
-        model.addEventListener("load", modelDidLoad);
-        model.addEventListener("error", event => {
-            layers.textContent = `Failed. Model did not load.`;
-            window.testRunner?.notifyDone();
-        });
-    }
+    }, (reason) => {
+        layers.textContent = "Failed model load: " + reason;
+        window.testRunner?.notifyDone();
+    });
 </script>
 </body>
 </html>

--- a/LayoutTests/model-element/model-element-graphics-layers.html
+++ b/LayoutTests/model-element/model-element-graphics-layers.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
 <html>
 <body>
 <model id="model">
@@ -12,21 +12,14 @@
     const layers = document.getElementById("layers");
     const model = document.getElementById("model");
 
-    const modelDidLoad = () => {
+    model.ready.then((resolve) => {
         layers.innerText = window.internals?.layerTreeAsText(document) ?? "This test requires testRunner.";
         model.remove();
         window.testRunner?.notifyDone();
-    }
-
-    if (model.complete)
-        modelDidLoad();
-    else {
-        model.addEventListener("load", modelDidLoad);
-        model.addEventListener("error", event => {
-            layers.textContent = `Failed. Model did not load.`;
-            window.testRunner?.notifyDone();
-        });
-    }
+    }, (reason) => {
+        layers.textContent = `Failed. Model did not load.`;
+        window.testRunner?.notifyDone();
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### 755b4edbfbdda72d5538d7ffea4e9f78e57eca3e
<pre>
Update some model layout tests to work reliably when model process is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280042">https://bugs.webkit.org/show_bug.cgi?id=280042</a>
<a href="https://rdar.apple.com/136342920">rdar://136342920</a>

Reviewed by Mike Wyrzykowski.

Explicitly enable model process for these tests that output layer content.
Update the tests such that we check the layer tree after the model has been
loaded in the model process via the model.ready API.
Update the expected layer tree to include hosted model layers.

* LayoutTests/model-element/model-element-contents-layer-updates-expected.txt:
* LayoutTests/model-element/model-element-contents-layer-updates-with-clipping-expected.txt:
* LayoutTests/model-element/model-element-contents-layer-updates-with-clipping.html:
* LayoutTests/model-element/model-element-contents-layer-updates.html:
* LayoutTests/model-element/model-element-graphics-layers-opacity-expected.txt:
* LayoutTests/model-element/model-element-graphics-layers-opacity.html:
* LayoutTests/model-element/model-element-graphics-layers.html:

Canonical link: <a href="https://commits.webkit.org/283995@main">https://commits.webkit.org/283995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00b79def84895e86ada0618016c721c44a1dc341

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19130 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54340 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16168 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73740 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61800 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3323 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43177 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->