### PR TITLE
[JSC] Optimize Compare + SShr

### DIFF
--- a/Source/JavaScriptCore/b3/B3Const32Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const32Value.cpp
@@ -258,7 +258,7 @@ TriState Const32Value::greaterEqualConstant(const Value* other) const
 
 TriState Const32Value::aboveConstant(const Value* other) const
 {
-    // UINT32_MIN > x is always false.
+    // UINT32_MIN(0) > x is always false.
     if (static_cast<uint32_t>(m_value) == std::numeric_limits<uint32_t>::min())
         return TriState::False;
     if (!other->hasInt32())
@@ -288,7 +288,7 @@ TriState Const32Value::aboveEqualConstant(const Value* other) const
 
 TriState Const32Value::belowEqualConstant(const Value* other) const
 {
-    // UINT32_MIN <= x is always true.
+    // UINT32_MIN(0) <= x is always true.
     if (static_cast<uint32_t>(m_value) == std::numeric_limits<uint32_t>::min())
         return TriState::True;
     if (!other->hasInt32())

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -252,7 +252,7 @@ public:
             case SShr:
             case ZShr:
             case RotR:
-                case RotL:
+            case RotL:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 2, ("At ", *value));
                 VALIDATE(value->type() == value->child(0)->type(), ("At ", *value));

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -379,51 +379,84 @@ Vector<B3Operand<FloatType>> floatingPointOperands()
 
 inline Vector<V128Operand> v128Operands()
 {
-    Vector<V128Operand> operands;
-    operands.append({ "0,0", v128_t { 0, 0 } });
-    operands.append({ "1,0", v128_t { 1, 0 } });
-    operands.append({ "0,1", v128_t { 0, 1 } });
-    operands.append({ "42,0", v128_t { 42, 0 } });
-    operands.append({ "0,42", v128_t { 0, 42 } });
-    operands.append({ "42,42", v128_t { 42, 42 } });
-    operands.append({ "-42,-42", v128_t { static_cast<uint64_t>(-42), static_cast<uint64_t>(-42) } });
-    operands.append({ "0,-42", v128_t { 0, static_cast<uint64_t>(-42) } });
-    operands.append({ "-42,0", v128_t { static_cast<uint64_t>(-42), 0 } });
-    operands.append({ "int64-max,int64-max", v128_t { static_cast<uint64_t>(std::numeric_limits<int64_t>::max()), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) } });
-    operands.append({ "int64-min,int64-min", v128_t { static_cast<uint64_t>(std::numeric_limits<int64_t>::min()), static_cast<uint64_t>(std::numeric_limits<int64_t>::min()) } });
-    operands.append({ "int32-max,int32-max", v128_t { static_cast<uint64_t>(std::numeric_limits<int32_t>::max()), static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) } });
-    operands.append({ "int32-min,int32-min", v128_t { static_cast<uint64_t>(std::numeric_limits<int32_t>::min()), static_cast<uint64_t>(std::numeric_limits<int32_t>::min()) } });
-    operands.append({ "uint64-max,uint64-max", v128_t { static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()), static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()) } });
-    operands.append({ "uint64-min,uint64-min", v128_t { static_cast<uint64_t>(std::numeric_limits<uint64_t>::min()), static_cast<uint64_t>(std::numeric_limits<uint64_t>::min()) } });
-    operands.append({ "uint32-max,uint32-max", v128_t { static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()), static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) } });
-    operands.append({ "uint32-min,uint32-min", v128_t { static_cast<uint64_t>(std::numeric_limits<uint32_t>::min()), static_cast<uint64_t>(std::numeric_limits<uint32_t>::min()) } });
-
-    return operands;
+    return {
+        { "0,0", v128_t { 0, 0 } },
+        { "1,0", v128_t { 1, 0 } },
+        { "0,1", v128_t { 0, 1 } },
+        { "42,0", v128_t { 42, 0 } },
+        { "0,42", v128_t { 0, 42 } },
+        { "42,42", v128_t { 42, 42 } },
+        { "-42,-42", v128_t { static_cast<uint64_t>(-42), static_cast<uint64_t>(-42) } },
+        { "0,-42", v128_t { 0, static_cast<uint64_t>(-42) } },
+        { "-42,0", v128_t { static_cast<uint64_t>(-42), 0 } },
+        { "int64-max,int64-max", v128_t { static_cast<uint64_t>(std::numeric_limits<int64_t>::max()), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) } },
+        { "int64-min,int64-min", v128_t { static_cast<uint64_t>(std::numeric_limits<int64_t>::min()), static_cast<uint64_t>(std::numeric_limits<int64_t>::min()) } },
+        { "int32-max,int32-max", v128_t { static_cast<uint64_t>(std::numeric_limits<int32_t>::max()), static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) } },
+        { "int32-min,int32-min", v128_t { static_cast<uint64_t>(std::numeric_limits<int32_t>::min()), static_cast<uint64_t>(std::numeric_limits<int32_t>::min()) } },
+        { "uint64-max,uint64-max", v128_t { static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()), static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()) } },
+        { "uint64-min,uint64-min", v128_t { static_cast<uint64_t>(std::numeric_limits<uint64_t>::min()), static_cast<uint64_t>(std::numeric_limits<uint64_t>::min()) } },
+        { "uint32-max,uint32-max", v128_t { static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()), static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) } },
+        { "uint32-min,uint32-min", v128_t { static_cast<uint64_t>(std::numeric_limits<uint32_t>::min()), static_cast<uint64_t>(std::numeric_limits<uint32_t>::min()) } },
+    };
 }
 
 inline Vector<Int64Operand> int64Operands()
 {
-    Vector<Int64Operand> operands;
-    operands.append({ "0", 0 });
-    operands.append({ "1", 1 });
-    operands.append({ "-1", -1 });
-    operands.append({ "42", 42 });
-    operands.append({ "-42", -42 });
-    operands.append({ "int64-max", std::numeric_limits<int64_t>::max() });
-    operands.append({ "int64-min", std::numeric_limits<int64_t>::min() });
-    operands.append({ "int32-max", std::numeric_limits<int32_t>::max() });
-    operands.append({ "int32-min", std::numeric_limits<int32_t>::min() });
-    operands.append({ "uint64-max", static_cast<int64_t>(std::numeric_limits<uint64_t>::max()) });
-    operands.append({ "uint64-min", static_cast<int64_t>(std::numeric_limits<uint64_t>::min()) });
-    operands.append({ "uint32-max", static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) });
-    operands.append({ "uint32-min", static_cast<int64_t>(std::numeric_limits<uint32_t>::min()) });
-    
-    return operands;
+    return {
+        { "0", 0 },
+        { "1", 1 },
+        { "-1", -1 },
+        { "42", 42 },
+        { "-42", -42 },
+        { "int64-max", std::numeric_limits<int64_t>::max() },
+        { "int64-min", std::numeric_limits<int64_t>::min() },
+        { "int32-max", std::numeric_limits<int32_t>::max() },
+        { "int32-min", std::numeric_limits<int32_t>::min() },
+        { "uint64-max", static_cast<int64_t>(std::numeric_limits<uint64_t>::max()) },
+        { "uint64-min", static_cast<int64_t>(std::numeric_limits<uint64_t>::min()) },
+        { "uint32-max", static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) },
+        { "uint32-min", static_cast<int64_t>(std::numeric_limits<uint32_t>::min()) },
+    };
+}
+
+inline Vector<Int64Operand> int64OperandsMore()
+{
+    return {
+        { "0", 0 },
+        { "1", 1 },
+        { "2", 2 },
+        { "2", 3 },
+        { "4", 4 },
+        { "24", 24 },
+        { "42", 42 },
+        { "15887", 15887 },
+        { "65534", 65534 },
+        { "65535", 65535 },
+        { "65536", 65536 },
+        { "-1", -1 },
+        { "-2", -2 },
+        { "-3", -3 },
+        { "-4", -4 },
+        { "-24", -24 },
+        { "-42", -42 },
+        { "-15887", -15887 },
+        { "-65534", -65534 },
+        { "-65535", -65535 },
+        { "-65536", -65536 },
+        { "int64-max", std::numeric_limits<int64_t>::max() },
+        { "int64-min", std::numeric_limits<int64_t>::min() },
+        { "int32-max", std::numeric_limits<int32_t>::max() },
+        { "int32-min", std::numeric_limits<int32_t>::min() },
+        { "uint64-max", static_cast<int64_t>(std::numeric_limits<uint64_t>::max()) },
+        { "uint64-min", static_cast<int64_t>(std::numeric_limits<uint64_t>::min()) },
+        { "uint32-max", static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) },
+        { "uint32-min", static_cast<int64_t>(std::numeric_limits<uint32_t>::min()) },
+    };
 }
 
 inline Vector<Int32Operand> int32Operands()
 {
-    Vector<Int32Operand> operands({
+    return {
         { "0", 0 },
         { "1", 1 },
         { "-1", -1 },
@@ -433,13 +466,43 @@ inline Vector<Int32Operand> int32Operands()
         { "int32-min", std::numeric_limits<int32_t>::min() },
         { "uint32-max", static_cast<int32_t>(std::numeric_limits<uint32_t>::max()) },
         { "uint32-min", static_cast<int32_t>(std::numeric_limits<uint32_t>::min()) }
-    });
-    return operands;
+    };
+}
+
+inline Vector<Int32Operand> int32OperandsMore()
+{
+    return {
+        { "0", 0 },
+        { "1", 1 },
+        { "2", 2 },
+        { "2", 3 },
+        { "4", 4 },
+        { "24", 24 },
+        { "42", 42 },
+        { "15887", 15887 },
+        { "65534", 65534 },
+        { "65535", 65535 },
+        { "65536", 65536 },
+        { "-1", -1 },
+        { "-2", -2 },
+        { "-3", -3 },
+        { "-4", -4 },
+        { "-24", -24 },
+        { "-42", -42 },
+        { "-15887", -15887 },
+        { "-65534", -65534 },
+        { "-65535", -65535 },
+        { "-65536", -65536 },
+        { "int32-max", std::numeric_limits<int32_t>::max() },
+        { "int32-min", std::numeric_limits<int32_t>::min() },
+        { "uint32-max", static_cast<int32_t>(std::numeric_limits<uint32_t>::max()) },
+        { "uint32-min", static_cast<int32_t>(std::numeric_limits<uint32_t>::min()) }
+    };
 }
 
 inline Vector<Int16Operand> int16Operands()
 {
-    Vector<Int16Operand> operands({
+    return {
         { "0", 0 },
         { "1", 1 },
         { "-1", -1 },
@@ -449,13 +512,12 @@ inline Vector<Int16Operand> int16Operands()
         { "int16-min", std::numeric_limits<int16_t>::min() },
         { "uint16-max", static_cast<int16_t>(std::numeric_limits<uint16_t>::max()) },
         { "uint16-min", static_cast<int16_t>(std::numeric_limits<uint16_t>::min()) }
-    });
-    return operands;
+    };
 }
 
 inline Vector<Int8Operand> int8Operands()
 {
-    Vector<Int8Operand> operands({
+    return {
         { "0", 0 },
         { "1", 1 },
         { "-1", -1 },
@@ -465,8 +527,7 @@ inline Vector<Int8Operand> int8Operands()
         { "int8-min", std::numeric_limits<int8_t>::min() },
         { "uint8-max", static_cast<int8_t>(std::numeric_limits<uint8_t>::max()) },
         { "uint8-min", static_cast<int8_t>(std::numeric_limits<uint8_t>::min()) }
-    });
-    return operands;
+    };
 }
 
 inline void add32(CCallHelpers& jit, GPRReg src1, GPRReg src2, GPRReg dest)
@@ -1307,5 +1368,8 @@ void testVectorExtractLane0Double();
 
 void testConstDoubleMove();
 void testConstFloatMove();
+
+void testSShrCompare32(int32_t);
+void testSShrCompare64(int64_t);
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -867,6 +867,9 @@ void run(const TestConfig* config)
     RUN(testConstDoubleMove());
     RUN(testConstFloatMove());
 
+    RUN_UNARY(testSShrCompare32, int32OperandsMore());
+    RUN_UNARY(testSShrCompare64, int64OperandsMore());
+
     if (isX86()) {
         RUN(testBranchBitAndImmFusion(Identity, Int64, 1, Air::BranchTest32, Air::Arg::Tmp));
         RUN(testBranchBitAndImmFusion(Identity, Int64, 0xff, Air::BranchTest32, Air::Arg::Tmp));


### PR DESCRIPTION
#### 4d69e9711e0914814e5f680812aff39356cc1f6f
<pre>
[JSC] Optimize Compare + SShr
<a href="https://bugs.webkit.org/show_bug.cgi?id=280046">https://bugs.webkit.org/show_bug.cgi?id=280046</a>
<a href="https://rdar.apple.com/136347499">rdar://136347499</a>

Reviewed by Yijia Huang.

We found that particular pattern like AboveEqual(SShr(@x, 2), constant)
is frequently emitted in some JavaScript code. This patch attempts to
convert it to AboveEqual(@x, constant &lt;&lt; 2) when constant and
shift-amount are within the safe range.

For now, we only support Above/Below/AboveEqual/BelowEqual. In the
future, we would like to expand it to GreaterThan etc. Also we would
like to support other shift operations too.

* Source/JavaScriptCore/b3/B3Const32Value.cpp:
(JSC::B3::Const32Value::aboveConstant const):
(JSC::B3::Const32Value::belowEqualConstant const):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
(v128Operands):
(int64Operands):
(int64OperandsMore):
(int32Operands):
(int32OperandsMore):
(int16Operands):
(int8Operands):
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testSShrCompare32):
(testSShrCompare64):

Canonical link: <a href="https://commits.webkit.org/283990@main">https://commits.webkit.org/283990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50b58b3d8a541e86d17e2ece51143f7f94214ea3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67997 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17499 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61115 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73752 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67245 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61808 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61822 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3337 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89024 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10350 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43189 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15714 "Found 1 new JSC binary failure: testb3, Found 8 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-bbq, wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-collect-continuously, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-eager, wasm.yaml/wasm/stress/tail-call.js.wasm-collect-continuously, wasm.yaml/wasm/stress/tail-call.js.wasm-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44263 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->