### PR TITLE
testharness.js subresources use testharnessreport.js

### DIFF
--- a/LayoutTests/http/tests/lazyload/resources/lazy-load-in-iframe.html
+++ b/LayoutTests/http/tests/lazyload/resources/lazy-load-in-iframe.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="placeholder.js"></script>
 
 <body>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/resources/basic-upgrade-cors.https.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/resources/basic-upgrade-cors.https.html
@@ -1,13 +1,10 @@
 <!DOCTYPE html>
 <title>Upgrade Insecure Requests: Basics.</title>
 <script src="/js-test-resources/testharness.js"></script>
-<script src="/js-test-resources/testharnessreport.js"></script>
 
 <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 <div id="console"></div>
 <script>
-if (window.testRunner)
-    testRunner.dumpAsText();
 
 // This is a bit of a hack. UPGRADE doesn't upgrade the port number, so we
 // specify this non-existent URL ('http' over port 8443). If UPGRADE doesn't

--- a/LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html
@@ -2,7 +2,6 @@
 <html>
 <body>
     <script src=/resources/testharness.js></script>
-    <script src=/resources/testharnessreport.js></script>
     <script src="resources/webxr_util.js"></script>
     <script src="resources/webxr_test_constants_single_view.js"></script>
     <script>

--- a/LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html
@@ -2,7 +2,6 @@
 <html>
 <body>
     <script src=/resources/testharness.js></script>
-    <script src=/resources/testharnessreport.js></script>
     <script src="resources/webxr_util.js"></script>
     <script src="resources/webxr_test_constants_single_view.js"></script>
     <script>

--- a/LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html
@@ -2,7 +2,6 @@
 <html>
 <body>
     <script src=/resources/testharness.js></script>
-    <script src=/resources/testharnessreport.js></script>
     <script src="resources/webxr_util.js"></script>
     <script src="resources/webxr_test_constants_single_view.js"></script>
     <script>

--- a/LayoutTests/http/wpt/loading/early-hints/resources/preconnect.html
+++ b/LayoutTests/http/wpt/loading/early-hints/resources/preconnect.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
 async function loadImage(url) {

--- a/LayoutTests/http/wpt/resource-timing/resources/rt-iframe-1.html
+++ b/LayoutTests/http/wpt/resource-timing/resources/rt-iframe-1.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>Frame 1</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="rt-utilities.sub.js"></script>
 </head>
 <body>

--- a/LayoutTests/http/wpt/resource-timing/resources/rt-iframe-2.html
+++ b/LayoutTests/http/wpt/resource-timing/resources/rt-iframe-2.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>Frame 2</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="rt-utilities.sub.js"></script>
 </head>
 <body>

--- a/LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html
+++ b/LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html
@@ -1,7 +1,6 @@
 <html>
 <head>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html
+++ b/LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>Web Authentication API: Tests that a frame that is cross-origin with feature policy can access the API.</title>
     <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
     <script src="/common/get-host-info.sub.js"></script>
     <script src="./util.js"></script>

--- a/LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html
+++ b/LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <title>Web Authentication API: Invoke PublicKeyCredential in ip addresses.</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="util.js"></script>
 <script>
     // Default mock configuration. Tests need to override if they need different configuration.

--- a/LayoutTests/http/wpt/workers/modules/resources/new-shared-worker-window.html
+++ b/LayoutTests/http/wpt/workers/modules/resources/new-shared-worker-window.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <title>SharedWorker: new SharedWorker()</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 let worker;
 

--- a/LayoutTests/http/wpt/workers/modules/resources/new-worker-window.html
+++ b/LayoutTests/http/wpt/workers/modules/resources/new-worker-window.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <title>DedicatedWorker: new Worker()</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 let worker;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-embed.html
@@ -3,7 +3,6 @@
 <meta name="timeout" content="long">
 <title>Test site embedded in a cross-site context</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/cookies/resources/cookie-helper.sub.js"></script>
 <script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/observer-in-iframe-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/observer-in-iframe-subframe.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="./intersection-observer-test-utils.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup with Promise-returning functions</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_bad_return.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_bad_return.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup with non-thenable-returning function</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_rejection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_rejection.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup with Promise-returning functions (rejection handling)</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_rejection_after_load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_rejection_after_load.html
@@ -9,7 +9,6 @@
 Promise support. Some failures are expected.</p>
 <div id="log"></div>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 <script>
 promise_test(function(t) {
   t.add_cleanup(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_timeout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_timeout.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup with Promise-returning functions (timeout handling)</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_bad_return.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_bad_return.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup with value-returning function</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_count.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup reported count</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_err.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_err.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup: error</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_err_multi.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_err_multi.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup: multiple functions with one in error</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_sync_queue.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_sync_queue.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test#add_cleanup: queuing tests</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/api-tests-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/api-tests-1.html
@@ -8,7 +8,6 @@
 <h1>Sample HTML5 API Tests</h1>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
     setup_run = false;
     setup(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/api-tests-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/api-tests-2.html
@@ -8,7 +8,6 @@
 <p>There should be two results</p>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 setup({explicit_done:true})
 test(function() {assert_true(true)}, "Test defined before onload");

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/assert-array-equals.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/assert-array-equals.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <title>assert_array_equals</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/force_timeout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/force_timeout.html
@@ -7,7 +7,6 @@
 <h1>Test#force_timeout</h1>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ explicit_timeout: true });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/generate-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/generate-callback.html
@@ -3,7 +3,6 @@
 <head>
 <title>Sample for using generate_tests to create a series of tests that share the same callback.</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
@@ -7,7 +7,6 @@
   <title>idlharness: Partial dictionary</title>
   <script src="/resources/test/variants.js"></script>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_exposed_wildcard.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_exposed_wildcard.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>idlharness: Exposed=*</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>idlharness: Immutable prototypes</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_interface_mixin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_interface_mixin.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <title>idlharness: interface mixins</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -7,7 +7,6 @@
   <title>idlharness: Partial interface</title>
   <script src="/resources/test/variants.js"></script>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>idlharness: Primary interface</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_to_json_operation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_to_json_operation.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>IdlInterface.prototype.test_to_json_operation()</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
   <script src="../../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>idlharness: namespace attribute</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <title>idlharness: namespace operation</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <title>idlharness: Partial namespace</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-callback.html
@@ -3,7 +3,6 @@
 <head>
 <title>Example with iframe that notifies containing document via callbacks</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body onload="start_test_in_iframe()">
 <h1>Callbacks From Tests Running In An IFRAME</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-consolidate-errors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-consolidate-errors.html
@@ -3,7 +3,6 @@
 <head>
 <title>Example with iframe that consolidates errors via fetch_tests_from_window</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 var parent_test = async_test("Test executing in parent context");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-consolidate-tests.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-consolidate-tests.html
@@ -3,7 +3,6 @@
 <head>
 <title>Example with iframe that consolidates tests via fetch_tests_from_window</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 var parent_test = async_test("Test executing in parent context");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-msg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-msg.html
@@ -3,7 +3,6 @@
 <head>
 <title>Example with iframe that notifies containing document via cross document messaging</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <h1>Notifications From Tests Running In An IFRAME</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/log-insertion.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/log-insertion.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <title>Log insertion</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 test(function(t) {
   assert_equals(document.body, null);

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/order.html
@@ -7,7 +7,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 test(function() {}, 'second');
 test(function() {}, 'first');

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise-async.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise-async.html
@@ -8,7 +8,6 @@
 <p>This test assumes ECMAScript 6 Promise support. Some failures are expected.</p>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 
 test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise-with-sync.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise-with-sync.html
@@ -8,7 +8,6 @@
 <p>This test demonstrates the use of <tt>promise_test</tt> alongside synchronous tests.</p>
 <div id="log"></div>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 <script>
 "use strict";
 var sequence = [];

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise.html
@@ -9,7 +9,6 @@
 Promise support. Some failures are expected.</p>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 test(
     function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/queue.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/queue.html
@@ -3,7 +3,6 @@
 <head>
 <title>Test queuing synchronous tests</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/setup-worker-service.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/setup-worker-service.html
@@ -3,7 +3,6 @@
 <head>
 <title>Setup function in a service worker</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <h1>Setup function in a service worker</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-fail.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-fail.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example with file_is_test (should fail)</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ single_test: true });
 onload = function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-no-assertions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-no-assertions.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example single page test with no asserts</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ single_test: true });
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-no-body.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-no-body.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example single page test with no body</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ single_test: true });
 assert_true(true);

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-pass.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-pass.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example with file_is_test</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ single_test: true });
 onload = function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/step_wait.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/step_wait.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <title>Tests for step_wait</title>
 <script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
 <div id=log></div>
 <script>
 promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/step_wait_func.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/step_wait_func.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <title>Tests for step_wait_func and step_wait_func_done</title>
 <script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
 <div id=log></div>
 <script>
 async_test(t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/task-scheduling-promise-test.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/task-scheduling-promise-test.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <title>testharness.js - task scheduling</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 <script>
 var sameTask = null;
 var sameMicrotask = null;

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/task-scheduling-test.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/task-scheduling-test.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <title>testharness.js - task scheduling</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 <script>
 var sameMicrotask = null;
 var expectedError = new Error('This error is expected');

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated-uncaught-allow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated-uncaught-allow.html
@@ -3,7 +3,6 @@
 <head>
 <title>Dedicated Worker Tests - Allowed Uncaught Exception</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <h1>Dedicated Web Worker Tests - Allowed Uncaught Exception</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated-uncaught-single.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated-uncaught-single.html
@@ -3,7 +3,6 @@
 <head>
 <title>Dedicated Worker Tests - Uncaught Exception in Single-Page Test</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <h1>Dedicated Web Worker Tests - Uncaught Exception in Single-Page Test</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated.sub.html
@@ -3,7 +3,6 @@
 <head>
 <title>Dedicated Worker Tests</title>
 <script src="../../../testharness.js"></script>
-<script src="../../../testharnessreport.js"></script>
 </head>
 <body>
 <h1>Dedicated Web Worker Tests</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-service.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-service.html
@@ -3,7 +3,6 @@
 <head>
 <title>Example with a service worker</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <h1>Service Worker Tests</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-shared.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-shared.html
@@ -3,7 +3,6 @@
 <head>
 <title>Example with a shared worker</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <h1>Shared Web Worker Tests</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlArray/is_json_type.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlArray/is_json_type.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlDictionary/get_reverse_inheritance_stack.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlDictionary/get_reverse_inheritance_stack.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlDictionary/test_partial_dictionary.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlDictionary/test_partial_dictionary.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <title>idlharness: partial dictionaries</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
   <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/constructors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/constructors.html
@@ -2,7 +2,6 @@
 <title>IdlInterface.prototype.constructors()</title>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/default_to_json_operation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/default_to_json_operation.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_interface_object.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_interface_object.html
@@ -2,7 +2,6 @@
 <title>IdlInterface.prototype.get_interface_object()</title>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_interface_object_owner.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_interface_object_owner.html
@@ -2,7 +2,6 @@
 <title>IdlInterface.prototype.get_interface_object_owner()</title>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_legacy_namespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_legacy_namespace.html
@@ -2,7 +2,6 @@
 <title>IdlInterface.prototype.get_legacy_namespace()</title>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_qualified_name.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_qualified_name.html
@@ -2,7 +2,6 @@
 <title>IdlInterface.prototype.get_qualified_name()</title>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_reverse_inheritance_stack.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_reverse_inheritance_stack.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/has_default_to_json_regular_operation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/has_default_to_json_regular_operation.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/has_to_json_regular_operation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/has_to_json_regular_operation.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/should_have_interface_object.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/should_have_interface_object.html
@@ -2,7 +2,6 @@
 <title>IdlInterface.prototype.should_have_interface_object()</title>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterfaceMember/is_to_json_regular_operation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterfaceMember/is_to_json_regular_operation.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterfaceMember/toString.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterfaceMember/toString.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_implements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_implements.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/test/tests/unit/helpers.js"></script>
 <title>assert_implements unittests</title>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_implements_optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_implements_optional.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/test/tests/unit/helpers.js"></script>
 <title>assert_implements_optional unittests</title>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_object_equals.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_object_equals.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/test/tests/unit/helpers.js"></script>
 <title>Assertion functions</title>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/basic.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/format-value.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/format-value.html
@@ -7,7 +7,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/late-test.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/late-test.html
@@ -6,7 +6,6 @@
 <body>
 <div id="log"></div>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <p>This test simulates an automated test running scenario, where the test
 results emitted by testharness.js may be interpreted after some delay. It is
 intended to demonstrate that in such cases, any additional tests which are
@@ -20,7 +19,6 @@ async_test(function(t) {
     var source = [
         "<div id='log'></div>",
         "<script src='/resources/testharness.js'></" + "script>",
-        "<script src='/resources/testharnessreport.js'></" + "script>",
         "<script>",
         "parent.childReady(window);",
         "setup({ explicit_done: true });",

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/claim-with-redirect-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/claim-with-redirect-iframe.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="test-helpers.sub.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/clients-get-cross-origin-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/clients-get-cross-origin-frame.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js"></script>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/resources/new-shared-worker-window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/resources/new-shared-worker-window.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <title>SharedWorker: new SharedWorker()</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 let worker;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/resources/new-worker-window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/resources/new-worker-window.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <title>DedicatedWorker: new Worker()</title>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script>
 let worker;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/worklets/resources/addmodule-window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/worklets/resources/addmodule-window.html
@@ -3,7 +3,6 @@
 <head>
   <title>Worklet: Referrer</title>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="worklet-test-utils.js"></script>
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/worklets/resources/referrer-window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/worklets/resources/referrer-window.html
@@ -4,7 +4,6 @@
   <title>Worklet: Referrer</title>
   <script src="/common/get-host-info.sub.js"></script>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
   <script src="worklet-test-utils.js"></script>
 </head>
 <body>

--- a/LayoutTests/resize-observer/resources/frame4.html
+++ b/LayoutTests/resize-observer/resources/frame4.html
@@ -1,5 +1,4 @@
 <script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
 <script src="./resizeTestHelper.js"></script>
 
 <h1>frame4</h1>

--- a/LayoutTests/resources/testharnessreport.js
+++ b/LayoutTests/resources/testharnessreport.js
@@ -66,13 +66,6 @@ if (self.testRunner) {
     *   manner that allows dumpAsText to produce readable test results
     */
     add_completion_callback(function (tests, harness_status) {
-        // Only pay attention to results at the top-level window.
-        // Ideally testharness.js would allow us to only attach a completion handler in this case:
-        // https://github.com/web-platform-tests/rfcs/pull/168
-        if (window !== window.top || (orig_opener !== null && orig_opener !== window)) {
-            return;
-        }
-
         var resultStr = "\n";
 
         // Sanitizes the given text for display in test results.


### PR DESCRIPTION
#### 35d84689606a71f6fe892bbbbd0fadb9789b2416
<pre>
testharness.js subresources use testharnessreport.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=280050">https://bugs.webkit.org/show_bug.cgi?id=280050</a>
<a href="https://rdar.apple.com/136348953">rdar://136348953</a>

Reviewed by NOBODY (OOPS!).

The testharness.js main document should use testharnessreport.js.

The docs say:
    `fetch_tests_from_window` will aggregate tests from separate windows or iframes
    into the current document as if they were all part of the same test suite. The
    document of the second window (or iframe) should include `testharness.js`, but
    not `testharnessreport.js`, and use `test`, `async_test`, and `promise_test` in
    the usual manner.

Fix all .html files that exist in **/resources/**

Remove the testharnessreport.js hack where we skip reporting test completion
if the test is run in a subframe.

* LayoutTests/http/tests/lazyload/resources/lazy-load-in-iframe.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/resources/basic-upgrade-cors.https.html:
* LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html:
* LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html:
* LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html:
* LayoutTests/http/wpt/loading/early-hints/resources/preconnect.html:
* LayoutTests/http/wpt/resource-timing/resources/rt-iframe-1.html:
* LayoutTests/http/wpt/resource-timing/resources/rt-iframe-2.html:
* LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html:
* LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html:
* LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html:
* LayoutTests/http/wpt/workers/modules/resources/new-shared-worker-window.html:
* LayoutTests/http/wpt/workers/modules/resources/new-worker-window.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-embed.html:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/observer-in-iframe-subframe.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_bad_return.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_rejection.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_rejection_after_load.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_async_timeout.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_bad_return.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_count.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_err.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_err_multi.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/add_cleanup_sync_queue.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/api-tests-1.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/api-tests-2.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/assert-array-equals.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/force_timeout.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/generate-callback.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_exposed_wildcard.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_interface_mixin.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlInterface/test_to_json_operation.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-callback.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-consolidate-errors.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-consolidate-tests.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/iframe-msg.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/log-insertion.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/order.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise-async.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise-with-sync.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/promise.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/queue.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/setup-worker-service.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-fail.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-no-assertions.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-no-body.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/single-page-test-pass.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/step_wait.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/step_wait_func.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/task-scheduling-promise-test.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/task-scheduling-test.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated-uncaught-allow.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated-uncaught-single.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-dedicated.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-service.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/functional/worker-shared.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlArray/is_json_type.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlDictionary/get_reverse_inheritance_stack.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlDictionary/test_partial_dictionary.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/constructors.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/default_to_json_operation.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_interface_object.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_interface_object_owner.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_legacy_namespace.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_qualified_name.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/get_reverse_inheritance_stack.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/has_default_to_json_regular_operation.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/has_to_json_regular_operation.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterface/should_have_interface_object.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterfaceMember/is_to_json_regular_operation.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/IdlInterfaceMember/toString.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_implements.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_implements_optional.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/assert_object_equals.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/format-value.html:
* LayoutTests/imported/w3c/web-platform-tests/resources/test/tests/unit/late-test.html:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/claim-with-redirect-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/clients-get-cross-origin-frame.html:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/resources/new-shared-worker-window.html:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/resources/new-worker-window.html:
* LayoutTests/imported/w3c/web-platform-tests/worklets/resources/addmodule-window.html:
* LayoutTests/imported/w3c/web-platform-tests/worklets/resources/referrer-window.html:
* LayoutTests/resize-observer/resources/frame4.html:
* LayoutTests/resources/testharnessreport.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d84689606a71f6fe892bbbbd0fadb9789b2416

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18957 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54347 "Found 1 new test failure: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12761 "Found 1 new test failure: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71063 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43406 "Found 5 new test failures: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html http/wpt/loading/early-hints/preconnect-csp-allowed.h2.window.html http/wpt/loading/early-hints/preconnect-csp-blocked.h2.window.html http/wpt/loading/early-hints/preconnect.h2.window.html http/wpt/webauthn/public-key-credential-ip-address.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16187 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62047 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16528 "Found 5 new test failures: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html http/wpt/loading/early-hints/preconnect-csp-allowed.h2.window.html http/wpt/loading/early-hints/preconnect-csp-blocked.h2.window.html http/wpt/loading/early-hints/preconnect.h2.window.html http/wpt/webauthn/public-key-credential-ip-address.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73751 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11967 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15804 "Found 5 new test failures: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html http/wpt/loading/early-hints/preconnect-csp-allowed.h2.window.html http/wpt/loading/early-hints/preconnect-csp-blocked.h2.window.html http/wpt/loading/early-hints/preconnect.h2.window.html http/wpt/webauthn/public-key-credential-ip-address.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61807 "Found 1 new test failure: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61821 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9721 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3341 "Found 5 new test failures: http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html http/wpt/loading/early-hints/preconnect-csp-allowed.h2.window.html http/wpt/loading/early-hints/preconnect-csp-blocked.h2.window.html http/wpt/loading/early-hints/preconnect.h2.window.html http/wpt/webauthn/public-key-credential-ip-address.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->