### PR TITLE
[WPE] Upgrade our custom run-benchmark plans to use MotionMark 1.3.1

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-15FPS.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-15FPS.patch
@@ -1,0 +1,97 @@
+diff --git a/tests/resources/main.js b/tests/resources/main.js
+--- a/tests/resources/main.js
++++ b/tests/resources/main.js
+@@ -885,6 +885,7 @@
+     function(stage, options)
+     {
+         this._animateLoop = this._animateLoop.bind(this);
++        this._animateLoopProxy = this._animateLoopProxy.bind(this);
+         this._warmupLength = options["warmup-length"];
+         this._frameCount = 0;
+         this._warmupFrameCount = options["warmup-frame-count"];
+@@ -946,6 +947,7 @@
+             this._finishPromise = new SimplePromise;
+             this._previousTimestamp = undefined;
+             this._didWarmUp = false;
++            this._callbackCount = 0;
+             this._stage.tune(this._controller.initialComplexity - this._stage.complexity());
+             this._animateLoop();
+             return this._finishPromise;
+@@ -960,6 +962,15 @@
+         return promise;
+     },
+ 
++    _animateLoopProxy: function(timestamp)
++    {
++        this._callbackCount++;
++        if (this._callbackCount % 4 == 0) { // Ensure 15 FPS, only dispatch every 4th callback.
++            this._animateLoop(timestamp);
++	} else
++            requestAnimationFrame(this._animateLoopProxy);
++    },
++
+     _animateLoop: function(timestamp)
+     {
+         timestamp = (this._getTimestamp && this._getTimestamp()) || timestamp;
+@@ -986,13 +997,13 @@
+ 
+             this._stage.animate(0);
+             ++this._frameCount;
+-            requestAnimationFrame(this._animateLoop);
++            requestAnimationFrame(this._animateLoopProxy);
+             return;
+         }
+ 
+         this._controller.update(timestamp, this._stage);
+         this._stage.animate(timestamp - this._previousTimestamp);
+         this._previousTimestamp = timestamp;
+-        requestAnimationFrame(this._animateLoop);
++        requestAnimationFrame(this._animateLoopProxy);
+     }
+ });
+diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
+index a2ea114..14a9cba 100644
+--- a/resources/runner/motionmark.js
++++ b/resources/runner/motionmark.js
+@@ -477,8 +477,11 @@ window.benchmarkController = {
+         "warmup-length": 2000,
+         "warmup-frame-count": 30,
+         "first-frame-minimum-length": 0,
+-        "system-frame-rate": 60,
+-        "frame-rate": 60,
++        // Running with a target of 15FPS allows low-end devices (like the RPi)
++        // to get scores around 100-600 instead of 1-6 and that (bigger scores)
++        // is really useful for performance regression tracking.
++        "system-frame-rate": 15,
++        "frame-rate": 15,
+     },
+ 
+     initialize: async function()
+@@ -493,11 +496,12 @@ window.benchmarkController = {
+         this._startButton.disabled = true;
+         this._startButton.textContent = Strings.text.determininingFrameRate;
+ 
+-        let targetFrameRate;
++        let targetFrameRate = this.benchmarkDefaultParameters["frame-rate"];
++        /* Do no autodetect the frame-rate, use the one from benchmarkDefaultParameters.
+         try {
+             targetFrameRate = await benchmarkController.determineFrameRate();
+         } catch (e) {
+-        }
++        }*/
+         this.frameRateDeterminationComplete(targetFrameRate);
+     },
+     
+diff --git a/resources/strings.js b/resources/strings.js
+index c82e047..45d7771 100644
+--- a/resources/strings.js
++++ b/resources/strings.js
+@@ -23,7 +23,7 @@
+  * THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ var Strings = {
+-    version: "1.3.1",
++    version: "1.3.1-15fps",
+     text: {
+         testName: "Test Name",
+         score: "Score",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-60FPS.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-60FPS.patch
@@ -1,0 +1,32 @@
+diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
+index a2ea114..14a9cba 100644
+--- a/resources/runner/motionmark.js
++++ b/resources/runner/motionmark.js
+@@ -493,11 +496,12 @@ window.benchmarkController = {
+         this._startButton.disabled = true;
+         this._startButton.textContent = Strings.text.determininingFrameRate;
+ 
+-        let targetFrameRate;
++        let targetFrameRate = this.benchmarkDefaultParameters["frame-rate"];
++        /* Do no autodetect the frame-rate, use the one from benchmarkDefaultParameters (60FPS).
+         try {
+             targetFrameRate = await benchmarkController.determineFrameRate();
+         } catch (e) {
+-        }
++        }*/
+         this.frameRateDeterminationComplete(targetFrameRate);
+     },
+     
+diff --git a/resources/strings.js b/resources/strings.js
+index c82e047..45d7771 100644
+--- a/resources/strings.js
++++ b/resources/strings.js
+@@ -23,7 +23,7 @@
+  * THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ var Strings = {
+-    version: "1.3.1",
++    version: "1.3.1-60fps",
+     text: {
+         testName: "Test Name",
+         score: "Score",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-15fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-15fps.plan
@@ -1,0 +1,5 @@
+{
+    "import_plan_file": "motionmark1.3.1.plan",
+    "output_file": "motionmark1.3.1-15fps.result",
+    "extra_patches": ["data/patches/extra/MotionMark1.3.1-15FPS.patch"]
+}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-60fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-60fps.plan
@@ -1,0 +1,5 @@
+{
+    "import_plan_file": "motionmark1.3.1.plan",
+    "output_file": "motionmark1.3.1-60fps.result",
+    "extra_patches": ["data/patches/extra/MotionMark1.3.1-60FPS.patch"]
+}


### PR DESCRIPTION
#### de6e87fb4c3cce308f3326c57a2cb528241c454f
<pre>
[WPE] Upgrade our custom run-benchmark plans to use MotionMark 1.3.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=280051">https://bugs.webkit.org/show_bug.cgi?id=280051</a>

Reviewed by Simon Fraser and Carlos Garcia Campos.

Switch our custom run-benchmark plans to use MotionMark 1.3.1.
This has the main benefit that we can run individual subtests,
and get the right &apos;canvas size&apos;, which is one of the 1.3.1
fixes.

Furthermore rework the 15 FPS logic, to unbreak score computation.
The expectation is that the cadence of the rAF() callback matches the
screen refresh rate -- however we still want to run at 60 Hz refresh
rate, but artifically limit the complexity, to get higher scores on
embedded devices (e.g. a few hundred points, instead of scores between
1-4 depending on the subtest). This increases the likelihood to detect
regressions/progresses, even on low-end devices.

Realize this by injecting a rAF() proxy, which only calls the MotionMark
rAF() logic, every 4th callback, simulating 15 FPS.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-15FPS.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3.1-60FPS.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-15fps.plan: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1-60fps.plan: Added.

Canonical link: <a href="https://commits.webkit.org/284147@main">https://commits.webkit.org/284147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01dbef192a33e3551df76326d7a61081dcbb915f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21252 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19554 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13126 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43852 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/68104 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18095 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61711 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62471 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74356 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12604 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15201 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10145 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43786 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->