### PR TITLE
Test runner features are not parsed when parsing additional headers

### DIFF
--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -222,7 +222,7 @@ static std::vector<std::string> parseStringTestHeaderValueAsStringVector(const s
     return result;
 }
 
-bool parseTestHeaderFeature(TestFeatures& features, std::string key, std::string value, std::filesystem::path path, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
+static bool parseTestHeaderFeature(TestFeatures& features, std::string key, std::string value, std::filesystem::path path, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
 {
     auto keyType = [&keyTypeMap](auto& key) {
         auto it = keyTypeMap.find(key);
@@ -274,7 +274,7 @@ bool parseTestHeaderFeature(TestFeatures& features, std::string key, std::string
     return false;
 }
 
-static TestFeatures parseTestHeaderString(const std::string& pairString, std::filesystem::path path, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
+static std::optional<TestFeatures> parseTestHeaderString(const std::string& pairString, std::filesystem::path path, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
 {
     TestFeatures features;
 
@@ -331,7 +331,7 @@ static TestFeatures parseTestHeader(std::filesystem::path path, const std::unord
         return { };
     }
     std::string pairString = options.substr(beginLocation + beginString.size(), endLocation - (beginLocation + beginString.size()));
-    return parseTestHeaderString(pairString, path, keyTypeMap);
+    return parseTestHeaderString(pairString, path, keyTypeMap).value_or(TestFeatures { });
 }
 
 TestFeatures featureDefaultsFromTestHeaderForTest(const TestCommand& command, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
@@ -343,14 +343,19 @@ TestFeatures featureDefaultsFromSelfComparisonHeader(const TestCommand& command,
 {
     if (command.selfComparisonHeader.empty())
         return { };
-    return parseTestHeaderString(command.selfComparisonHeader, command.absolutePath, keyTypeMap);
+    return parseTestHeaderString(command.selfComparisonHeader, command.absolutePath, keyTypeMap).value_or(TestFeatures { });
 }
 
 TestFeatures featureFromAdditionalHeaderOption(const TestCommand& command, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
 {
     if (command.additionalHeader.empty())
         return { };
-    return parseTestHeaderString(command.additionalHeader, std::filesystem::path(), keyTypeMap);
+    return parseTestHeaderString(command.additionalHeader, std::filesystem::path(), keyTypeMap).value_or(TestFeatures { });
+}
+
+std::optional<TestFeatures> parseAdditionalHeaderString(const std::string& additionalHeader, const std::unordered_map<std::string, TestHeaderKeyType>& keyTypeMap)
+{
+    return parseTestHeaderString(additionalHeader, std::filesystem::path(), keyTypeMap);
 }
 
 } // namespace WTF

--- a/Tools/TestRunnerShared/TestFeatures.h
+++ b/Tools/TestRunnerShared/TestFeatures.h
@@ -73,5 +73,6 @@ enum class TestHeaderKeyType : uint8_t {
 TestFeatures featureDefaultsFromTestHeaderForTest(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
 TestFeatures featureDefaultsFromSelfComparisonHeader(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
 TestFeatures featureFromAdditionalHeaderOption(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
+std::optional<TestFeatures> parseAdditionalHeaderString(const std::string&, const std::unordered_map<std::string, TestHeaderKeyType>&);
 
 }

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -29,6 +29,7 @@
 #include "Options.h"
 
 #include "StringFunctions.h"
+#include "TestOptions.h"
 #include <string.h>
 
 namespace WTR {
@@ -158,7 +159,11 @@ static bool handleOptionInternalFeature(Options& options, const char*, const cha
 
 static bool handleOptionAdditionalHeader(Options& options, const char*, const char* feature)
 {
-    return parseFeature(feature, options.features);
+    auto features = parseAdditionalHeaderString(feature, TestOptions::keyTypeMapping());
+    if (!features)
+        return false;
+    merge(options.features, *features);
+    return true;
 }
 
 static bool handleOptionWebCoreLogging(Options& options, const char*, const char* channels)


### PR DESCRIPTION
#### b5544dd6df8b54100b6504044f52b66fc9f1d616
<pre>
Test runner features are not parsed when parsing additional headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=280053">https://bugs.webkit.org/show_bug.cgi?id=280053</a>
<a href="https://rdar.apple.com/136352852">rdar://136352852</a>

Reviewed by Alex Christensen.

run-webkit-tests would support passing the test header feature line
as --additional-header &quot;Feature=true&quot;

However, it was parsed with functions that stored the feature into
WebPreferences. Some features such as runInCrossOriginFrame=true
are stored in test runner features.

Fixes use-case like debugging the WebKitTestRunner directly and passing
the parameters as command line parameters instead of stdin:

```
 DYLD_FRAMEWORK_PATH=$PWD lldb -- ./WebKitTestRunner \
 <a href="http://127.0.0.1">http://127.0.0.1</a>:8000/root/webgl/webgl-allow-shared-typed-array.html
 --absolutePath $HOME/WebKit/OpenSource/LayoutTests/webgl/webgl-allow-shared-typed-array.html \
 --no-timeout \
 --additional-header runInCrossOriginFrame=true \
 --experimental-feature SiteIsolationEnabled=true \
```

* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::parseTestHeaderFeature):
(WTR::parseTestHeaderString):
(WTR::parseTestHeader):
(WTR::featureDefaultsFromSelfComparisonHeader):
(WTR::featureFromAdditionalHeaderOption):
(WTR::parseAdditionalHeaderString):
* Tools/TestRunnerShared/TestFeatures.h:
* Tools/WebKitTestRunner/Options.cpp:
(WTR::handleOptionAdditionalHeader):

Canonical link: <a href="https://commits.webkit.org/284062@main">https://commits.webkit.org/284062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d00ef60f6597532cb7afc3a95f53926f121da0d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12767 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17507 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73760 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61826 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3343 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43197 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->