### PR TITLE
Adopt smart pointers in TextUnderElementMode

### DIFF
--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -309,6 +309,15 @@ TextStream& operator<<(TextStream& ts, const Ref<T>& item)
     return ts << item.get();
 }
 
+template<typename T>
+TextStream& operator<<(TextStream& ts, const CheckedPtr<T>& item)
+{
+    if (item)
+        return ts << *item;
+
+    return ts << "null";
+}
+
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg>
 TextStream& operator<<(TextStream& ts, const HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg>& map)
 {

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -673,7 +673,7 @@ struct TextUnderElementMode {
     bool considerHiddenState { true };
     bool inHiddenSubtree { false };
     TrimWhitespace trimWhitespace { TrimWhitespace::Yes };
-    Node* ignoredChildNode { nullptr };
+    CheckedPtr<Node> ignoredChildNode { nullptr };
 
     bool isHidden() { return considerHiddenState && inHiddenSubtree; }
 };


### PR DESCRIPTION
#### 47dcfd1e9e490ff866563d4abae1ccc9503d765b
<pre>
Adopt smart pointers in TextUnderElementMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=280054">https://bugs.webkit.org/show_bug.cgi?id=280054</a>

Reviewed by Tyler Wilcock.

Use a smart pointer to store the node, preventing static analyizer warnings
of uncounted members.

* Source/WTF/wtf/text/TextStream.h:
(WTF::operator&lt;&lt;):
* Source/WebCore/accessibility/AXCoreObject.h:

Canonical link: <a href="https://commits.webkit.org/284094@main">https://commits.webkit.org/284094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81cf22558044548233f64e8412d3a5c8651b733a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54356 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17510 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61126 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67256 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15176 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3346 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89035 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43200 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15718 "Found 928 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-bbq, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-collect-continuously, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-eager-jettison, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-no-cjit, wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.wasm-bbq ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->