### PR TITLE
[iOS] voice activity detection is not working

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -128,6 +128,7 @@ protected:
     virtual bool migrateToNewDefaultDevice(const CaptureDevice&) { return false; }
 
     void setVoiceActivityListenerCallback(Function<void()>&& callback) { m_voiceActivityCallback = WTFMove(callback); }
+    bool hasVoiceActivityListenerCallback() const { return !!m_voiceActivityCallback; }
     void voiceActivityDetected();
 
     void disableVoiceActivityThrottleTimerForTesting() { m_voiceActivityThrottleTimer.stop(); }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedInternalUnit.h
@@ -49,7 +49,7 @@ private:
     OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32, AudioBufferList*) final;
     OSStatus defaultInputDevice(uint32_t*) final;
     OSStatus defaultOutputDevice(uint32_t*) final;
-    void setVoiceActivityDetection(bool) final;
+    bool setVoiceActivityDetection(bool) final;
 
     CoreAudioSharedUnit::StoredAudioUnit m_audioUnit;
     bool m_shouldUseVPIO { false };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -82,7 +82,7 @@ public:
         virtual OSStatus defaultOutputDevice(uint32_t*) = 0;
         virtual void delaySamples(Seconds) { }
         virtual Seconds verifyCaptureInterval(bool isProducingSamples) const { return isProducingSamples ? 20_s : 2_s; }
-        virtual void setVoiceActivityDetection(bool) = 0;
+        virtual bool setVoiceActivityDetection(bool) = 0;
     };
 
     WEBCORE_EXPORT static CoreAudioSharedUnit& unit();
@@ -168,6 +168,9 @@ private:
 
     void verifyIsCapturing();
 
+    void updateVoiceActiveDetection();
+    bool shouldEnableVoiceActivityDetection() const;
+
     CreationCallback m_creationCallback;
     GetSampleRateCallback m_getSampleRateCallback;
     std::unique_ptr<InternalUnit> m_ioUnit;
@@ -215,6 +218,7 @@ private:
 
     bool m_shouldUseVPIO { true };
     bool m_shouldSetVoiceActivityListener { false };
+    bool m_voiceActivityDetectionEnabled { false };
 #if PLATFORM(MAC)
     StoredAudioUnit m_storedVPIOUnit { nullptr };
     Timer m_storedVPIOUnitDeallocationTimer;

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -127,7 +127,7 @@ private:
     OSStatus defaultOutputDevice(uint32_t*) final;
     void delaySamples(Seconds) final;
     Seconds verifyCaptureInterval(bool) const final { return 1_s; }
-    void setVoiceActivityDetection(bool);
+    bool setVoiceActivityDetection(bool) final;
 
     int sampleRate() const { return m_streamFormat.mSampleRate; }
     void tick();
@@ -263,14 +263,15 @@ void MockAudioSharedInternalUnit::delaySamples(Seconds delta)
     m_timer.startOneShot(delta);
 }
 
-void MockAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
+bool MockAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
 {
     m_voiceActivityDetectionEnabled = shouldEnable;
-    if (!m_voiceActivityDetectionEnabled || !m_isOutputMuted) {
+    if (!m_voiceActivityDetectionEnabled || !m_isOutputMuted)
         m_voiceDetectionTimer.stop();
-        return;
-    }
-    m_voiceDetectionTimer.startRepeating(100_ms);
+    else
+        m_voiceDetectionTimer.startRepeating(100_ms);
+
+    return true;
 }
 
 void MockAudioSharedInternalUnit::voiceDetected()


### PR DESCRIPTION
#### 154de6967e0b4ec901fe8e2fe6843622664e6c45
<pre>
[iOS] voice activity detection is not working
<a href="https://rdar.apple.com/135942656">rdar://135942656</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280056">https://bugs.webkit.org/show_bug.cgi?id=280056</a>

Reviewed by Eric Carlson.

On iOS, we first need to mute the VPIO unit and then set the voice activity listener.
We rework the listener enablement/disablement code so that it works for both macOS and iOS.

We introduce CoreAudioSharedUnit::shouldEnableVoiceActivityDetection which tells whether voice activity listener should be on.
On iOS, it will return true if VPIO is started, muted and the voice activity callback is set.
On macOS, we do not check whether VPIO is muted as this is not necessary.
This allows tabs that have been muted due to another page capturing to receive notifications of voice activity if the tab is visible.

We introduce CoreAudioSharedUnit::updateVoiceActiveDetection which will call CoreAudioSharedInternalUnit::setVoiceActivityDetection according CoreAudioSharedUnit::shouldEnableVoiceActivityDetection.
CoreAudioSharedUnit::updateVoiceActiveDetection is called from various places when some capture states change.

Tested on macOS and iOS devices.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::hasVoiceActivityListenerCallback const):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedInternalUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::~CoreAudioSharedUnit):
(WebCore::CoreAudioSharedUnit::cleanupAudioUnit):
(WebCore::CoreAudioSharedUnit::startInternal):
(WebCore::CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged):
(WebCore::CoreAudioSharedUnit::stopInternal):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(WebCore::CoreAudioSharedUnit::shouldEnableVoiceActivityDetection const):
(WebCore::CoreAudioSharedUnit::updateVoiceActiveDetection):
(WebCore::CoreAudioSharedInternalUnit::setVoiceActivityDetection):
(WebCore::CoreAudioSharedUnit::enableMutedSpeechActivityEventListener):
(WebCore::CoreAudioSharedUnit::disableMutedSpeechActivityEventListener):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::setVoiceActivityDetection):

Canonical link: <a href="https://commits.webkit.org/284084@main">https://commits.webkit.org/284084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c27b76b044acc8e62d7d5cc1864d21798d057895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54369 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12776 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16195 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73772 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61834 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15173 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9736 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3349 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43206 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->