### PR TITLE
getDisplayMedia video track getSettings() is not returning correct results until getting the first video frame

### DIFF
--- a/LayoutTests/fast/mediastream/resources/getDisplayMedia-utils.js
+++ b/LayoutTests/fast/mediastream/resources/getDisplayMedia-utils.js
@@ -7,17 +7,7 @@ async function callGetDisplayMedia(options)
     window.internals.withUserGesture(() => {
         promise = navigator.mediaDevices.getDisplayMedia(options);
     });
-    const stream = await promise; 
-    const track = stream.getVideoTracks()[0];
-
-    // getSettings is not computing the correct parameters right away. We should probably fix this.
-    while (true) {
-        const settings = track.getSettings();
-        if (settings.width && settings.height)
-            break;
-        await new Promise(resolve => setTimeout(resolve, 50));
-    }
-    return stream;
+    return await promise;
 }
 
 async function waitForHeight(track, value) {

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -203,6 +203,11 @@ void DisplayCaptureSourceCocoa::endProducingData()
     m_capturer->end();
 }
 
+void DisplayCaptureSourceCocoa::whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback)
+{
+    m_capturer->whenReady(WTFMove(callback));
+}
+
 Seconds DisplayCaptureSourceCocoa::elapsedTime()
 {
     if (m_startTime.isNaN())

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -94,6 +94,7 @@ public:
         virtual DisplaySurfaceType surfaceType() const = 0;
         virtual void commitConfiguration(const RealtimeMediaSourceSettings&) = 0;
         virtual IntSize intrinsicSize() const = 0;
+        virtual void whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback) { callback({ }); }
 
         virtual void setLogger(const Logger&, const void*);
         const Logger* loggerPtr() const { return m_logger.get(); }
@@ -153,6 +154,7 @@ private:
     IntSize computeResizedVideoFrameSize(IntSize desiredSize, IntSize actualSize) final;
     void setSizeFrameRateAndZoom(const VideoPresetConstraints&) final;
     double observedFrameRate() const final;
+    void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
 
     ASCIILiteral logClassName() const final { return "DisplayCaptureSourceCocoa"_s; }
     void setLogger(const Logger&, const void*) final;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -92,6 +92,7 @@ private:
     DisplaySurfaceType surfaceType() const final;
     void commitConfiguration(const RealtimeMediaSourceSettings&) final;
     IntSize intrinsicSize() const final;
+    void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
 
     // LoggerHelper
     ASCIILiteral logClassName() const final { return "ScreenCaptureKitCaptureSource"_s; }
@@ -131,6 +132,8 @@ private:
     float m_frameRate { 0 };
     bool m_isRunning { false };
     bool m_isVideoEffectEnabled { false };
+    bool m_didReceiveVideoFrame { false };
+    CompletionHandler<void(CaptureSourceError&&)> m_whenReadyCallback;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0a9bdfd79fa76af5dc4cc4689a34ea2db2fe086f
<pre>
getDisplayMedia video track getSettings() is not returning correct results until getting the first video frame
<a href="https://rdar.apple.com/136359711">rdar://136359711</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280058">https://bugs.webkit.org/show_bug.cgi?id=280058</a>

Reviewed by Eric Carlson.

Our display capturer is only able to compute the right width/height settings when receiving the first video frame.
Before the patch, we would return the display stream and wait for starting to capture to get the video frame and compute the right settings.

We are now capturing one frame to be able to compute the size settings.
We then stop capture and resolve the getDisplayMedia promise with the track having the correct settings.
We then start capture for real this time.

We implement this by having UserMediaCaptureManagerProxy wait on the track to be ready via RealtimeMediaSource::whenReady.
RealtimeMediaSource::whenReady is only implemented by DisplayCaptureSourceCocoa which will ask its capturer to be ready.
When capturer is ready, UserMediaCaptureManagerProxy can then signal to the WebProcess that it can proceed with getDisplayMedia promise resolution.

Tested by removing the workaround added in callGetDisplayMedia test routine.

* LayoutTests/fast/mediastream/resources/getDisplayMedia-utils.js:
(async callGetDisplayMedia):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::whenReady):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::~ScreenCaptureKitCaptureSource):
(WebCore::ScreenCaptureKitCaptureSource::whenReady):
(WebCore::ScreenCaptureKitCaptureSource::start):
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::m_readyTimer):
(WebCore::MockDisplayCapturer::start):
(WebCore::MockDisplayCapturer::stop):
(WebCore::MockDisplayCapturer::whenReady):
(WebCore::MockDisplayCapturer::readyTimerFired):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):

Canonical link: <a href="https://commits.webkit.org/284080@main">https://commits.webkit.org/284080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36823671aac36c5c98181345bf161b8045d05f58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19385 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13038 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16505 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16120 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59163 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15170 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3642 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43617 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->