### PR TITLE
[Subgrid] Implicitly named lines can be empty due to inherited named lines

### DIFF
--- a/LayoutTests/fast/grid/subgrid-inherited-line-names-crash-expected.txt
+++ b/LayoutTests/fast/grid/subgrid-inherited-line-names-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/grid/subgrid-inherited-line-names-crash.html
+++ b/LayoutTests/fast/grid/subgrid-inherited-line-names-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="display: grid;">
+    <div style="display: grid; grid-template-areas: 'header content'; grid-template-columns: subgrid;">
+        <div style="grid-area: content;">Test passes if it does not crash.</div>
+    </div>
+</body>
+</html>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -310,7 +310,7 @@ bool NamedLineCollectionBase::hasExplicitNamedLines() const
 
 bool NamedLineCollectionBase::hasNamedLines() const
 {
-    return hasExplicitNamedLines() || m_implicitNamedLinesIndices;
+    return hasExplicitNamedLines() || (m_implicitNamedLinesIndices && !m_implicitNamedLinesIndices->isEmpty());
 }
 
 unsigned NamedLineCollection::lastLine() const


### PR DESCRIPTION
#### 65ecac43a67afede24a8367f35853c2ec7d521c6
<pre>
[Subgrid] Implicitly named lines can be empty due to inherited named lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=280068">https://bugs.webkit.org/show_bug.cgi?id=280068</a>
<a href="https://rdar.apple.com/136174078">rdar://136174078</a>

Reviewed by Alan Baradlay.

For subgrids when we try to resolve a grid-area to line names we will first generate the
implicit lines associated with that area. If we end up actually generating these implicit
line names we will then override these line names with the line names that we inherited
from the actual grid. During this process we not actually end up inheriting any lines for
the particular name we are looking for (the one specified by the grid-area property)
because that track may be beyond the bounds specified for the subgrid. As a result, this
could end up in an empty Vector for the implicitly named lines.

In the testcase the subgrid attempts to create two named columns but that does not work
because the subgrid is only contained within the first column of the parent grid. As a
result, the subgrid&apos;s item cannot resolve the names of the lines associated with the
grid-area.

* LayoutTests/fast/grid/subgrid-inherited-line-names-crash-expected.txt: Added.
* LayoutTests/fast/grid/subgrid-inherited-line-names-crash.html: Added.
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::NamedLineCollectionBase::hasNamedLines const):

Canonical link: <a href="https://commits.webkit.org/283998@main">https://commits.webkit.org/283998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5080d0316895f5d3b0d07882406cb2a2a2068f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54386 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12795 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17545 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61839 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3371 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/43235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->