### PR TITLE
Fix Clang 19 warnings in Windows

### DIFF
--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -30,6 +30,10 @@
 #include "VM.h"
 #include <wtf/EnumClassOperatorOverloads.h>
 
+#if OS(WINDOWS)
+#include <intrin.h>
+#endif
+
 namespace JSC  {
 
 class JSWebAssemblyInstance;

--- a/Source/WebCore/platform/win/SystemInfo.cpp
+++ b/Source/WebCore/platform/win/SystemInfo.cpp
@@ -117,7 +117,7 @@ static bool isWOW64()
         if (!kernel32Module)
             return wow64;
         typedef BOOL (WINAPI* IsWow64ProcessFunc)(HANDLE, PBOOL);
-        IsWow64ProcessFunc isWOW64Process = reinterpret_cast<IsWow64ProcessFunc>(GetProcAddress(kernel32Module, "IsWow64Process"));
+        IsWow64ProcessFunc isWOW64Process = reinterpret_cast<IsWow64ProcessFunc>((void*)GetProcAddress(kernel32Module, "IsWow64Process"));
         if (isWOW64Process) {
             BOOL result = FALSE;
             wow64 = isWOW64Process(GetCurrentProcess(), &result) && result;
@@ -138,7 +138,7 @@ static WORD processorArchitecture()
         if (!kernel32Module)
             return architecture;
         typedef VOID (WINAPI* GetNativeSystemInfoFunc)(LPSYSTEM_INFO);
-        GetNativeSystemInfoFunc getNativeSystemInfo = reinterpret_cast<GetNativeSystemInfoFunc>(GetProcAddress(kernel32Module, "GetNativeSystemInfo"));
+        GetNativeSystemInfoFunc getNativeSystemInfo = reinterpret_cast<GetNativeSystemInfoFunc>((void*)::GetProcAddress(kernel32Module, "GetNativeSystemInfo"));
         if (getNativeSystemInfo) {
             SYSTEM_INFO systemInfo;
             ZeroMemory(&systemInfo, sizeof(systemInfo));

--- a/Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp
@@ -37,7 +37,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters&, RefPtr<API:
     if (!lib)
         return false;
 
-    WKBundleInitializeFunctionPtr proc = reinterpret_cast<WKBundleInitializeFunctionPtr>(::GetProcAddress(lib, "WKBundleInitialize"));
+    WKBundleInitializeFunctionPtr proc = reinterpret_cast<WKBundleInitializeFunctionPtr>((void*)::GetProcAddress(lib, "WKBundleInitialize"));
     if (!proc)
         return false;
 


### PR DESCRIPTION
#### d42b3b93458b1a1e7e7ac2ebcd407aa992f1f3de
<pre>
Fix Clang 19 warnings in Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=280071">https://bugs.webkit.org/show_bug.cgi?id=280071</a>

Reviewed by Fujii Hironori.

Fixes any warnings generated while doing a non-unified build with Clang 19.1.0.

* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/WebCore/platform/win/SystemInfo.cpp:
(WebCore::isWOW64):
(WebCore::processorArchitecture):
* Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp:
(WebKit::InjectedBundle::initialize):

Canonical link: <a href="https://commits.webkit.org/284013@main">https://commits.webkit.org/284013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51fc945ee4c1b9aabb6e69a97570fe792affca62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54391 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34853 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17550 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73807 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67296 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15841 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61843 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/exit-transition-with-anonymous-layout-object.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-root-scrollbar-with-fixed-background.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61859 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3375 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43241 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15724 "Found 9 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison, wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-bbq, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-eager, wasm.yaml/wasm/stress/tail-call.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->