### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make HTTPCookieStoreObserver RefCounted

### DIFF
--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -188,8 +188,8 @@ void HTTPCookieStore::unregisterObserver(HTTPCookieStoreObserver& observer)
 
 void HTTPCookieStore::cookiesDidChange()
 {
-    for (auto& observer : m_observers)
-        observer.cookiesDidChange(*this);
+    for (Ref observer : m_observers)
+        observer->cookiesDidChange(*this);
 }
 
 WebKit::NetworkProcessProxy* HTTPCookieStore::networkProcessIfExists()

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
@@ -30,21 +30,13 @@
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 #if USE(SOUP)
 #include "SoupCookiePersistentStorageType.h"
 #endif
-
-namespace API {
-class HTTPCookieStoreObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<API::HTTPCookieStoreObserver> : std::true_type { };
-}
 
 namespace WebCore {
 struct Cookie;
@@ -60,7 +52,7 @@ namespace API {
 
 class HTTPCookieStore;
 
-class HTTPCookieStoreObserver : public CanMakeWeakPtr<HTTPCookieStoreObserver> {
+class HTTPCookieStoreObserver : public RefCountedAndCanMakeWeakPtr<HTTPCookieStoreObserver> {
 public:
     virtual ~HTTPCookieStoreObserver() { }
     virtual void cookiesDidChange(HTTPCookieStore&) = 0;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -483,7 +483,7 @@ WebsiteDataStore* WebExtensionController::websiteDataStore(std::optional<PAL::Se
 void WebExtensionController::addWebsiteDataStore(WebsiteDataStore& dataStore)
 {
     if (!m_cookieStoreObserver)
-        m_cookieStoreObserver = makeUnique<HTTPCookieStoreObserver>(*this);
+        m_cookieStoreObserver = HTTPCookieStoreObserver::create(*this);
 
     m_websiteDataStores.add(dataStore);
     dataStore.protectedCookieStore()->registerObserver(*m_cookieStoreObserver);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -225,12 +225,17 @@ private:
         WTF_MAKE_TZONE_ALLOCATED_INLINE(HTTPCookieStoreObserver);
 
     public:
+        static RefPtr<HTTPCookieStoreObserver> create(WebExtensionController& extensionController)
+        {
+            return adoptRef(new HTTPCookieStoreObserver(extensionController));
+        }
+
+    private:
         explicit HTTPCookieStoreObserver(WebExtensionController& extensionController)
             : m_extensionController(extensionController)
         {
         }
 
-    private:
         void cookiesDidChange(API::HTTPCookieStore& cookieStore) final
         {
             // FIXME: <https://webkit.org/b/267514> Add support for changeInfo.
@@ -264,7 +269,7 @@ private:
     bool m_showingActionPopup { false };
 
     std::unique_ptr<RunLoop::Timer> m_purgeOldMatchedRulesTimer;
-    std::unique_ptr<HTTPCookieStoreObserver> m_cookieStoreObserver;
+    RefPtr<HTTPCookieStoreObserver> m_cookieStoreObserver;
 };
 
 template<typename T, typename RawValue>


### PR DESCRIPTION
#### a6b0a2d42b02a548c67c94065f64799faa394cf3
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make HTTPCookieStoreObserver RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280072">https://bugs.webkit.org/show_bug.cgi?id=280072</a>

Reviewed by Geoffrey Garen.

Every CanMakeWeakPtr class should also RefCounted.

* Source/WebKit/UIProcess/API/APIHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.mm:
(HTTPCookieStore::cookiesDidChange)
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(WKHTTPCookieStoreObserver::create):
(-[WKHTTPCookieStore dealloc]):
(-[WKHTTPCookieStore addObserver:]):
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:
(CookieStoreObserver::create):
(webkitCookieManagerCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addWebsiteDataStore):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::HTTPCookieStoreObserver::create):

Canonical link: <a href="https://commits.webkit.org/284008@main">https://commits.webkit.org/284008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcb5b9775ea2cdf61d86dd7db26c8a7fe0c2eb33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12809 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40123 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17564 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15854 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61866 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3383 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43255 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44328 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->