### PR TITLE
[ GARDENING ] All TestWebKitAPI.SleepDisabler.* API tests are flakily timing out.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/SleepDisabler.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/SleepDisabler.mm
@@ -33,12 +33,7 @@
 
 #if WK_HAVE_C_SPI
 
-// FIXME: Remove after rdar://134545195 is resolved
-#if PLATFORM(IOS)
-TEST(WebKit, DISABLED_SleepDisabler)
-#else
 TEST(WebKit, SleepDisabler)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -118,13 +113,15 @@ public:
     }
 };
 
-TEST_F(SleepDisabler, Basic)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Basic)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
 }
 
-TEST_F(SleepDisabler, Pause)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Pause)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -133,7 +130,8 @@ TEST_F(SleepDisabler, Pause)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, Mute)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Mute)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -142,7 +140,8 @@ TEST_F(SleepDisabler, Mute)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, Unmute)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Unmute)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -154,7 +153,8 @@ TEST_F(SleepDisabler, Unmute)
     hasSleepDisablerShouldBecomeEqualTo(true);
 }
 
-TEST_F(SleepDisabler, DisableAudioTrack)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_DisableAudioTrack)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -163,7 +163,8 @@ TEST_F(SleepDisabler, DisableAudioTrack)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, Loop)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Loop)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -172,7 +173,8 @@ TEST_F(SleepDisabler, Loop)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, ChangeSrc)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_ChangeSrc)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -181,7 +183,8 @@ TEST_F(SleepDisabler, ChangeSrc)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, Load)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Load)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -192,7 +195,8 @@ TEST_F(SleepDisabler, Load)
     hasSleepDisablerShouldBecomeEqualTo(true);
 }
 
-TEST_F(SleepDisabler, Unload)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Unload)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -201,7 +205,8 @@ TEST_F(SleepDisabler, Unload)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, Navigate)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Navigate)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -222,7 +227,8 @@ TEST_F(SleepDisabler, DISABLED_NavigateBack)
     hasSleepDisablerShouldBecomeEqualTo(true);
 }
 
-TEST_F(SleepDisabler, Reload)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Reload)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -233,7 +239,8 @@ TEST_F(SleepDisabler, Reload)
     hasSleepDisablerShouldBecomeEqualTo(true);
 }
 
-TEST_F(SleepDisabler, Close)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Close)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);
@@ -242,7 +249,8 @@ TEST_F(SleepDisabler, Close)
     hasSleepDisablerShouldBecomeEqualTo(false);
 }
 
-TEST_F(SleepDisabler, Crash)
+// FIXME: Remove after rdar://134545195 is resolved
+TEST_F(SleepDisabler, DISABLED_Crash)
 {
     loadPlayingPage(@"video-with-audio");
     hasSleepDisablerShouldBecomeEqualTo(true);


### PR DESCRIPTION
#### 23533dde16009ef68e66a2b3be0adfbd1be97852
<pre>
[ GARDENING ] All TestWebKitAPI.SleepDisabler.* API tests are flakily timing out.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278552">https://bugs.webkit.org/show_bug.cgi?id=278552</a>
<a href="https://rdar.apple.com/134545195">rdar://134545195</a>

Unreviewed test gardening.

Disabling API tests.

* Tools/TestWebKitAPI/Tests/WebKit/SleepDisabler.mm:
(TEST(WebKit, SleepDisabler)):
(TEST_F(SleepDisabler, DISABLED_Basic)):
(TEST_F(SleepDisabler, DISABLED_Pause)):
(TEST_F(SleepDisabler, DISABLED_Mute)):
(TEST_F(SleepDisabler, DISABLED_Unmute)):
(TEST_F(SleepDisabler, DISABLED_DisableAudioTrack)):
(TEST_F(SleepDisabler, DISABLED_Loop)):
(TEST_F(SleepDisabler, DISABLED_ChangeSrc)):
(TEST_F(SleepDisabler, DISABLED_Load)):
(TEST_F(SleepDisabler, DISABLED_Unload)):
(TEST_F(SleepDisabler, DISABLED_Navigate)):
(TEST_F(SleepDisabler, DISABLED_Reload)):
(TEST_F(SleepDisabler, DISABLED_Close)):
(TEST_F(SleepDisabler, DISABLED_Crash)):
(TEST_F(SleepDisabler, Basic)): Deleted.
(TEST_F(SleepDisabler, Pause)): Deleted.
(TEST_F(SleepDisabler, Mute)): Deleted.
(TEST_F(SleepDisabler, Unmute)): Deleted.
(TEST_F(SleepDisabler, DisableAudioTrack)): Deleted.
(TEST_F(SleepDisabler, Loop)): Deleted.
(TEST_F(SleepDisabler, ChangeSrc)): Deleted.
(TEST_F(SleepDisabler, Load)): Deleted.
(TEST_F(SleepDisabler, Unload)): Deleted.
(TEST_F(SleepDisabler, Navigate)): Deleted.
(TEST_F(SleepDisabler, Reload)): Deleted.
(TEST_F(SleepDisabler, Close)): Deleted.
(TEST_F(SleepDisabler, Crash)): Deleted.

Canonical link: <a href="https://commits.webkit.org/284014@main">https://commits.webkit.org/284014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7abb51c1760d8588de3dfefd14c2598fbc3f42b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12811 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17573 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15860 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61873 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/15120 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9778 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3396 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10367 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43264 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->