### PR TITLE
Change UserActionElementSet to use a  WeakHashMap instead of a HashMap

### DIFF
--- a/Source/WebCore/dom/UserActionElementSet.cpp
+++ b/Source/WebCore/dom/UserActionElementSet.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 void UserActionElementSet::clear()
 {
     for (auto iterator = m_elements.begin(); iterator != m_elements.end(); ++iterator)
-        iterator->key->setUserActionElement(false);
+        iterator->key.setUserActionElement(false);
     m_elements.clear();
 }
 
@@ -44,7 +44,7 @@ bool UserActionElementSet::hasFlag(const Element& element, Flag flag) const
     // Caller has the responsibility to check isUserActionElement before calling this.
     ASSERT(element.isUserActionElement());
 
-    return m_elements.get(&const_cast<Element&>(element)).contains(flag);
+    return m_elements.get(element).contains(flag);
 }
 
 void UserActionElementSet::clearFlags(Element& element, OptionSet<Flag> flags)
@@ -54,7 +54,7 @@ void UserActionElementSet::clearFlags(Element& element, OptionSet<Flag> flags)
     if (!element.isUserActionElement())
         return;
 
-    auto iterator = m_elements.find(&element);
+    auto iterator = m_elements.find(element);
     ASSERT(iterator != m_elements.end());
     auto updatedFlags = iterator->value - flags;
     if (updatedFlags.isEmpty()) {
@@ -68,7 +68,7 @@ void UserActionElementSet::setFlags(Element& element, OptionSet<Flag> flags)
 {
     ASSERT(!flags.isEmpty());
 
-    m_elements.ensure(&element, [] {
+    m_elements.ensure(element, [] {
         return OptionSet<Flag>();
     }).iterator->value.add(flags);
 

--- a/Source/WebCore/dom/UserActionElementSet.h
+++ b/Source/WebCore/dom/UserActionElementSet.h
@@ -27,10 +27,13 @@
 
 #pragma once
 
+#include "EventTarget.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -75,7 +78,7 @@ private:
     void clearFlags(Element&, OptionSet<Flag>);
     bool hasFlag(const Element&, Flag) const;
 
-    HashMap<RefPtr<Element>, OptionSet<Flag>> m_elements;
+    WeakHashMap<Element, OptionSet<Flag>, WeakPtrImplWithEventTargetData> m_elements;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 46fb690c1b505e0a5edb8360d0f5036eaa76504f
<pre>
Change UserActionElementSet to use a  WeakHashMap instead of a HashMap
Need the bug URL (OOPS!):
Include a Radar link (OOPS!): <a href="https://rdar.apple.com/136382242">rdar://136382242</a>

Reviewed by NOBODY (OOPS!).

Make the reference to the Element a WeakPtr by using a WeakHashmap instead of a strong reference.
I observed a website where the RefPtr&lt;Element&gt; keys stored in the map were never decremented once inserted into the map even after deallocation of all Elements should have occured. The Document owns an instance of UserActionElementSet which I believe causes a reference cycle between the Nodes that reference the document and the Document itself. Break this reference cycle.

* Source/WebCore/dom/UserActionElementSet.cpp:
(WebCore::UserActionElementSet::clear):
(WebCore::UserActionElementSet::hasFlag const):
(WebCore::UserActionElementSet::clearFlags):
(WebCore::UserActionElementSet::setFlags):
* Source/WebCore/dom/UserActionElementSet.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46fb690c1b505e0a5edb8360d0f5036eaa76504f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54419 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12826 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17609 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73866 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61892 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3418 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43300 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44374 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->