### PR TITLE
GradientImage::drawPattern() can trigger read back from the GPU process

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -160,12 +160,8 @@ void BitmapImage::drawLuminanceMaskPattern(GraphicsContext& context, const Float
     setImageObserver(WTFMove(observer));
     buffer->convertToLuminanceMask();
 
-    auto image = ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
-    if (!image)
-        return;
-
     context.setDrawLuminanceMask(false);
-    context.drawPattern(Ref { *image }, destinationRect, bufferRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });
+    context.drawPattern(*buffer, destinationRect, bufferRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });
 }
 
 void BitmapImage::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/GradientImage.cpp
+++ b/Source/WebCore/platform/graphics/GradientImage.cpp
@@ -86,7 +86,7 @@ void GradientImage::drawPattern(GraphicsContext& destContext, const FloatRect& d
         if (destContext.drawLuminanceMask())
             imageBuffer->convertToLuminanceMask();
 
-        m_cachedImage = ImageBuffer::sinkIntoNativeImage(WTFMove(imageBuffer));
+        m_cachedImage = WTFMove(imageBuffer);
         if (!m_cachedImage)
             return;
     }

--- a/Source/WebCore/platform/graphics/GradientImage.h
+++ b/Source/WebCore/platform/graphics/GradientImage.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 class Gradient;
-class NativeImage;
+class ImageBuffer;
 
 class GradientImage final : public GeneratedImage {
 public:
@@ -52,7 +52,7 @@ private:
     void dump(WTF::TextStream&) const final;
     
     Ref<Gradient> m_gradient;
-    RefPtr<NativeImage> m_cachedImage;
+    RefPtr<ImageBuffer> m_cachedImage;
     FloatSize m_cachedAdjustedSize;
     unsigned m_cachedGeneratorHash { 0 };
     FloatSize m_cachedScaleFactor;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -254,15 +254,12 @@ void SVGImage::drawPatternForContainer(GraphicsContext& context, const FloatSize
     imageBufferSize.scale(imageBufferScale.width(), imageBufferScale.height());
 
     RefPtr buffer = context.createImageBuffer(expandedIntSize(imageBufferSize.size()));
-    if (!buffer) // Failed to allocate buffer.
+    if (!buffer)
         return;
+
     drawForContainer(buffer->context(), containerSize, containerZoom, initialFragmentURL, imageBufferSize, zoomedContainerRect);
     if (context.drawLuminanceMask())
         buffer->convertToLuminanceMask();
-
-    RefPtr image = ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
-    if (!image)
-        return;
 
     // Adjust the source rect and transform due to the image buffer's scaling.
     FloatRect scaledSrcRect = srcRect;
@@ -271,7 +268,7 @@ void SVGImage::drawPatternForContainer(GraphicsContext& context, const FloatSize
     unscaledPatternTransform.scale(1 / imageBufferScale.width(), 1 / imageBufferScale.height());
 
     context.setDrawLuminanceMask(false);
-    context.drawPattern(*image, dstRect, scaledSrcRect, unscaledPatternTransform, phase, spacing, options);
+    context.drawPattern(*buffer, dstRect, scaledSrcRect, unscaledPatternTransform, phase, spacing, options);
 }
 
 ImageDrawResult SVGImage::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)


### PR DESCRIPTION
#### 0c562a47ae674a636e4a682a61f976305c5b292f
<pre>
GradientImage::drawPattern() can trigger read back from the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=280083">https://bugs.webkit.org/show_bug.cgi?id=280083</a>
<a href="https://rdar.apple.com/111943095">rdar://111943095</a>

Reviewed by Said Abou-Hallawa.

Creating a NativeImage from an ImageBuffer in the WebContent process, with GPU rendering enabled,
requires readback from the GPU process, which is blocking.

We can fix this easily in `GradientImage::drawPattern()` by simply caching the ImageBuffer we&apos;ve
already created. We make the same change in `SVGImage::drawPatternForContainer()` and
`BitmapImage::drawLuminanceMaskPattern()`

* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::drawLuminanceMaskPattern):
* Source/WebCore/platform/graphics/GradientImage.cpp:
(WebCore::GradientImage::drawPattern):
* Source/WebCore/platform/graphics/GradientImage.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::drawPatternForContainer):

Canonical link: <a href="https://commits.webkit.org/284047@main">https://commits.webkit.org/284047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eff8b5e55411f2434c771c39474129f509fa95b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72327 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54497 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12913 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16373 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74020 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15985 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61958 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-scale.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-fill.html webanimations/accelerated-animation-with-delay.html webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3514 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43454 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->