### PR TITLE
Deploy more smart pointers in Source/WebKit/GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -208,13 +208,16 @@ public:
     const WebCore::ProcessIdentity& webProcessIdentity() const { return m_webProcessIdentity; }
 #if ENABLE(ENCRYPTED_MEDIA)
     RemoteCDMFactoryProxy& cdmFactoryProxy();
+    Ref<RemoteCDMFactoryProxy> protectedCdmFactoryProxy();
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
+    Ref<RemoteLegacyCDMFactoryProxy> protectedLegacyCdmFactoryProxy();
 #endif
     RemoteMediaEngineConfigurationFactoryProxy& mediaEngineConfigurationFactoryProxy();
 #if ENABLE(VIDEO)
     RemoteMediaPlayerManagerProxy& remoteMediaPlayerManagerProxy() { return m_remoteMediaPlayerManagerProxy.get(); }
+    Ref<RemoteMediaPlayerManagerProxy> protectedRemoteMediaPlayerManagerProxy();
 #endif
 #if USE(AUDIO_SESSION)
     RemoteAudioSessionProxyManager& audioSessionManager();
@@ -309,6 +312,7 @@ private:
 
 #if USE(AUDIO_SESSION)
     RemoteAudioSessionProxy& audioSessionProxy();
+    Ref<RemoteAudioSessionProxy> protectedAudioSessionProxy();
     using EnsureAudioSessionCompletion = CompletionHandler<void(const RemoteAudioSessionConfiguration&)>;
     void ensureAudioSession(EnsureAudioSessionCompletion&&);
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -585,6 +585,11 @@ RemoteAudioSessionProxyManager& GPUProcess::audioSessionManager() const
         m_audioSessionManager = RemoteAudioSessionProxyManager::create(const_cast<GPUProcess&>(*this));
     return *m_audioSessionManager;
 }
+
+Ref<RemoteAudioSessionProxyManager> GPUProcess::protectedAudioSessionManager() const
+{
+    return audioSessionManager();
+}
 #endif
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
@@ -621,13 +626,13 @@ void GPUProcess::processIsStartingToCaptureAudio(GPUConnectionToWebProcess& proc
 #if ENABLE(VIDEO)
 void GPUProcess::requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier processIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completion)
 {
-    auto iterator = m_webProcessConnections.find(processIdentifier);
-    if (iterator == m_webProcessConnections.end()) {
+    RefPtr connection = m_webProcessConnections.get(processIdentifier);
+    if (!connection) {
         completion(std::nullopt);
         return;
     }
 
-    completion(iterator->value->remoteMediaPlayerManagerProxy().bitmapImageForCurrentTime(playerIdentifier));
+    completion(connection->protectedRemoteMediaPlayerManagerProxy()->bitmapImageForCurrentTime(playerIdentifier));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -99,6 +99,7 @@ public:
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     RemoteAudioSessionProxyManager& audioSessionManager() const;
+    Ref<RemoteAudioSessionProxyManager> protectedAudioSessionManager() const;
 #endif
 
     WebCore::NowPlayingManager& nowPlayingManager();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -100,6 +100,7 @@ private:
     bool allowTestOnlyIPC();
 
     RemoteAudioSessionProxyManager& audioSessionManager();
+    Ref<RemoteAudioSessionProxyManager> protectedAudioSessionManager();
     Ref<IPC::Connection> protectedConnection() const;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -83,10 +83,10 @@ void RemoteAudioSessionProxyManager::updateCategory()
     HashCountedSet<AudioSession::CategoryType, WTF::IntHash<AudioSession::CategoryType>, WTF::StrongEnumHashTraits<AudioSession::CategoryType>> categoryCounts;
     HashCountedSet<AudioSession::Mode, WTF::IntHash<AudioSession::Mode>, WTF::StrongEnumHashTraits<AudioSession::Mode>> modeCounts;
     HashCountedSet<RouteSharingPolicy, WTF::IntHash<RouteSharingPolicy>, WTF::StrongEnumHashTraits<RouteSharingPolicy>> policyCounts;
-    for (auto& otherProxy : m_proxies) {
-        categoryCounts.add(otherProxy.category());
-        modeCounts.add(otherProxy.mode());
-        policyCounts.add(otherProxy.routeSharingPolicy());
+    for (Ref otherProxy : m_proxies) {
+        categoryCounts.add(otherProxy->category());
+        modeCounts.add(otherProxy->mode());
+        policyCounts.add(otherProxy->routeSharingPolicy());
     }
 
     AudioSession::CategoryType category = AudioSession::CategoryType::None;
@@ -132,9 +132,9 @@ void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()
     }
 #endif
     size_t preferredBufferSize = std::numeric_limits<size_t>::max();
-    for (auto& proxy : m_proxies) {
-        if (proxy.preferredBufferSize() && proxy.preferredBufferSize() < preferredBufferSize)
-            preferredBufferSize = proxy.preferredBufferSize();
+    for (Ref proxy : m_proxies) {
+        if (proxy->preferredBufferSize() && proxy->preferredBufferSize() < preferredBufferSize)
+            preferredBufferSize = proxy->preferredBufferSize();
     }
 
     if (preferredBufferSize != std::numeric_limits<size_t>::max())

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -95,7 +95,7 @@ void RemoteCDMFactoryProxy::supportsKeySystem(const String& keySystem, Completio
 
 void RemoteCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
+    if (RefPtr proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
         proxy->didReceiveMessage(connection, decoder);
 }
 
@@ -113,7 +113,7 @@ void RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage(IPC::Connection&
 
 bool RemoteCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
+    if (RefPtr proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
         return proxy->didReceiveSyncMessage(connection, decoder, encoder);
     return false;
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -70,7 +70,7 @@ void RemoteCDMInstanceProxy::unrequestedInitializationDataReceived(const String&
     if (!m_cdm)
         return;
 
-    auto* factory = m_cdm->factory();
+    RefPtr factory = m_cdm->factory();
     if (!factory)
         return;
 
@@ -96,7 +96,7 @@ void RemoteCDMInstanceProxy::setStorageDirectory(const String& directory)
     if (!m_cdm)
         return;
 
-    auto* factory = m_cdm->factory();
+    RefPtr factory = m_cdm->factory();
     if (!factory)
         return;
 
@@ -122,7 +122,7 @@ void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHan
 
     auto identifier = RemoteCDMInstanceSessionIdentifier::generate();
     auto session = RemoteCDMInstanceSessionProxy::create(m_cdm.get(), privSession.releaseNonNull(), logIdentifier, identifier);
-    m_cdm->factory()->addSession(identifier, WTFMove(session));
+    protectedCdm()->protectedFactory()->addSession(identifier, WTFMove(session));
     completion(identifier);
 }
 
@@ -133,7 +133,12 @@ Ref<WebCore::CDMInstance> RemoteCDMInstanceProxy::protectedInstance() const
 
 const SharedPreferencesForWebProcess& RemoteCDMInstanceProxy::sharedPreferencesForWebProcess() const
 {
-    return m_cdm->sharedPreferencesForWebProcess();
+    return protectedCdm()->sharedPreferencesForWebProcess();
+}
+
+RefPtr<RemoteCDMProxy> RemoteCDMInstanceProxy::protectedCdm() const
+{
+    return m_cdm.get();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -89,6 +89,8 @@ private:
     void setStorageDirectory(const String&);
     void createSession(uint64_t logIdentifier, CompletionHandler<void(const RemoteCDMInstanceSessionIdentifier&)>&&);
 
+    RefPtr<RemoteCDMProxy> protectedCdm() const;
+
     WeakPtr<RemoteCDMProxy> m_cdm;
     Ref<WebCore::CDMInstance> m_instance;
     UniqueRef<RemoteCDMInstanceConfiguration> m_configuration;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -74,7 +74,7 @@ void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGrouping
     }
 
     // Implement the CDMPrivate::supportsInitData() check here:
-    if (!m_cdm->supportsInitData(initDataType, *initData)) {
+    if (!protectedCdm()->supportsInitData(initDataType, *initData)) {
         completion({ }, emptyString(), false, false);
         return;
     }
@@ -92,7 +92,7 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
     }
 
     // Implement the CDMPrivate::sanitizeResponse() check here:
-    auto sanitizedResponse = m_cdm->sanitizeResponse(*response);
+    auto sanitizedResponse = protectedCdm()->sanitizeResponse(*response);
     if (!sanitizedResponse) {
         completion(false, { }, std::nullopt, std::nullopt, false);
         return;
@@ -106,7 +106,7 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
 void RemoteCDMInstanceSessionProxy::loadSession(LicenseType type, String sessionId, String origin, LoadSessionCallback&& completion)
 {
     // Implement the CDMPrivate::sanitizeSessionId() check here:
-    auto sanitizedSessionId = m_cdm->sanitizeSessionId(sessionId);
+    auto sanitizedSessionId = protectedCdm()->sanitizeSessionId(sessionId);
     if (!sanitizedSessionId) {
         completion(std::nullopt, std::nullopt, std::nullopt, false, CDMInstanceSession::SessionLoadFailure::MismatchedSessionType);
         return;
@@ -183,7 +183,12 @@ void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)
 
 const SharedPreferencesForWebProcess& RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess() const
 {
-    return m_cdm->sharedPreferencesForWebProcess();
+    return protectedCdm()->sharedPreferencesForWebProcess();
+}
+
+RefPtr<RemoteCDMProxy> RemoteCDMInstanceSessionProxy::protectedCdm() const
+{
+    return m_cdm.get();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -82,6 +82,8 @@ private:
     void sessionIdChanged(const String&) final;
     PlatformDisplayID displayID() final { return m_displayID; }
 
+    RefPtr<RemoteCDMProxy> protectedCdm() const;
+
     WeakPtr<RemoteCDMProxy> m_cdm;
     Ref<WebCore::CDMInstanceSession> m_session;
     RemoteCDMInstanceSessionIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -96,7 +96,7 @@ void RemoteCDMProxy::createInstance(CompletionHandler<void(RemoteCDMInstanceIden
     auto identifier = RemoteCDMInstanceIdentifier::generate();
     auto instance = RemoteCDMInstanceProxy::create(*this, privateInstance.releaseNonNull(), identifier);
     RemoteCDMInstanceConfiguration configuration = instance->configuration();
-    m_factory->addInstance(identifier, WTFMove(instance));
+    protectedFactory()->addInstance(identifier, WTFMove(instance));
     completion(identifier, WTFMove(configuration));
 }
 
@@ -118,7 +118,7 @@ void RemoteCDMProxy::setLogIdentifier(uint64_t logIdentifier)
 
 const SharedPreferencesForWebProcess& RemoteCDMProxy::sharedPreferencesForWebProcess() const
 {
-    return m_factory->sharedPreferencesForWebProcess();
+    return protectedFactory()->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -58,6 +58,7 @@ public:
     const RemoteCDMConfiguration& configuration() const { return m_configuration.get(); }
 
     RemoteCDMFactoryProxy* factory() const { return m_factory.get(); }
+    RefPtr<RemoteCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
 
     bool supportsInitData(const AtomString&, const WebCore::SharedBuffer&);
     RefPtr<WebCore::SharedBuffer> sanitizeResponse(const WebCore::SharedBuffer& response);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -63,14 +63,15 @@ void RemoteLegacyCDMProxy::supportsMIMEType(const String& mimeType, SupportsMIME
 
 void RemoteLegacyCDMProxy::createSession(const String& keySystem, uint64_t logIdentifier, CreateSessionCallback&& callback)
 {
-    if (!m_cdm || !m_factory) {
+    RefPtr factory = m_factory.get();
+    if (!m_cdm || !factory) {
         callback({ });
         return;
     }
 
     auto sessionIdentifier = RemoteLegacyCDMSessionIdentifier::generate();
-    auto session = RemoteLegacyCDMSessionProxy::create(*m_factory, logIdentifier, sessionIdentifier, *m_cdm);
-    m_factory->addSession(sessionIdentifier, WTFMove(session));
+    auto session = RemoteLegacyCDMSessionProxy::create(*factory, logIdentifier, sessionIdentifier, *m_cdm);
+    factory->addSession(sessionIdentifier, WTFMove(session));
     callback(WTFMove(sessionIdentifier));
 }
 
@@ -83,14 +84,15 @@ void RemoteLegacyCDMProxy::setPlayerId(std::optional<MediaPlayerIdentifier>&& pl
 
 RefPtr<MediaPlayer> RemoteLegacyCDMProxy::cdmMediaPlayer(const LegacyCDM*) const
 {
-    if (!m_playerId || !m_factory)
+    RefPtr factory = m_factory.get();
+    if (!m_playerId || !factory)
         return nullptr;
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return nullptr;
 
-    return gpuConnectionToWebProcess->remoteMediaPlayerManagerProxy().mediaPlayer(m_playerId);
+    return gpuConnectionToWebProcess->protectedRemoteMediaPlayerManagerProxy()->mediaPlayer(m_playerId);
 }
 
 const SharedPreferencesForWebProcess& RemoteLegacyCDMProxy::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -138,19 +138,19 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMed
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, IPC::Semaphore&& semaphore)
 {
-    if (auto* unit = m_units.get(identifier))
+    if (RefPtr unit = m_units.get(identifier))
         unit->start(WTFMove(handle), WTFMove(semaphore));
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 {
-    if (auto* unit = m_units.get(identifier))
+    if (RefPtr unit = m_units.get(identifier))
         unit->stop();
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::setAudioOutputDevice(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, const String& deviceId)
 {
-    if (auto* unit = m_units.get(identifier))
+    if (RefPtr unit = m_units.get(identifier))
         unit->setAudioOutputDevice(deviceId);
 }
 


### PR DESCRIPTION
#### f87f22ee4341d1455e88fcb08b3f414bc8c36e37
<pre>
Deploy more smart pointers in Source/WebKit/GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=280087">https://bugs.webkit.org/show_bug.cgi?id=280087</a>

Reviewed by Basuke Suzuki.

Deployed more smart pointers based on clang static analyzer warnings.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::allowsExitUnderMemoryPressure const):
(WebKit::GPUConnectionToWebProcess::protectedCdmFactoryProxy):
(WebKit::GPUConnectionToWebProcess::audioSessionProxy):
(WebKit::GPUConnectionToWebProcess::protectedAudioSessionProxy):
(WebKit::GPUConnectionToWebProcess::protectedRemoteMediaPlayerManagerProxy):
(WebKit::GPUConnectionToWebProcess::performWithMediaPlayerOnMainThread):
(WebKit::GPUConnectionToWebProcess::ensureAudioSession):
(WebKit::GPUConnectionToWebProcess::protectedLegacyCdmFactoryProxy):
(WebKit::GPUConnectionToWebProcess::dispatchMessage):
(WebKit::GPUConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::protectedAudioSessionManager const):
(WebKit::GPUProcess::requestBitmapImageForCurrentTime):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::configuration):
(WebKit::RemoteAudioSessionProxy::setCategory):
(WebKit::RemoteAudioSessionProxy::setPreferredBufferSize):
(WebKit::RemoteAudioSessionProxy::tryToSetActive):
(WebKit::RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride):
(WebKit::RemoteAudioSessionProxy::beginInterruptionRemote):
(WebKit::RemoteAudioSessionProxy::endInterruptionRemote):
(WebKit::RemoteAudioSessionProxy::setSceneIdentifier):
(WebKit::RemoteAudioSessionProxy::setSoundStageSize):
(WebKit::RemoteAudioSessionProxy::protectedAudioSessionManager):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateCategory):
(WebKit::RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMMessage):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::unrequestedInitializationDataReceived):
(WebKit::RemoteCDMInstanceProxy::setStorageDirectory):
(WebKit::RemoteCDMInstanceProxy::createSession):
(WebKit::RemoteCDMInstanceProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteCDMInstanceProxy::protectedCdm const):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::requestLicense):
(WebKit::RemoteCDMInstanceSessionProxy::updateLicense):
(WebKit::RemoteCDMInstanceSessionProxy::loadSession):
(WebKit::RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteCDMInstanceSessionProxy::protectedCdm const):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp:
(WebKit::RemoteCDMProxy::createInstance):
(WebKit::RemoteCDMProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
(WebKit::RemoteCDMProxy::protectedFactory const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::createSession):
(WebKit::RemoteLegacyCDMProxy::cdmMediaPlayer const):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::stopUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::setAudioOutputDevice):

Canonical link: <a href="https://commits.webkit.org/284027@main">https://commits.webkit.org/284027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d67d29d9d7346cc0fd48ac699c36f6da214998c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54423 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12830 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40153 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73870 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61874 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3419 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89138 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43304 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/89138 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->