### PR TITLE
Use xpc_dictionary_create_empty and xpc_array_create_empty to create empty dictionaries and arrays

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
@@ -185,7 +185,7 @@ void RemoteInspectorXPCConnection::sendMessage(NSString *messageName, NSDictiona
     if (!xpcDictionary)
         return;
 
-    auto msg = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto msg = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_value(msg.get(), RemoteInspectorXPCConnectionSerializedMessageKey, xpcDictionary.get());
     xpc_connection_send_message(m_connection.get(), msg.get());
 }

--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -172,6 +172,7 @@ extern const struct _xpc_type_s _xpc_type_endpoint;
 extern const struct _xpc_type_s _xpc_type_error;
 extern const struct _xpc_type_s _xpc_type_string;
 
+xpc_object_t xpc_array_create_empty(void);
 xpc_object_t xpc_array_create(const xpc_object_t*, size_t count);
 #if COMPILER_SUPPORTS(BLOCKS)
 bool xpc_array_apply(xpc_object_t, XPC_NOESCAPE xpc_array_applier_t);
@@ -193,6 +194,7 @@ void xpc_connection_send_message(xpc_connection_t, xpc_object_t);
 void xpc_connection_send_message_with_reply(xpc_connection_t, xpc_object_t, dispatch_queue_t, xpc_handler_t);
 void xpc_connection_set_event_handler(xpc_connection_t, xpc_handler_t);
 void xpc_connection_set_target_queue(xpc_connection_t, dispatch_queue_t);
+xpc_object_t xpc_dictionary_create_empty(void);
 xpc_object_t xpc_dictionary_create(const char*  const* keys, const xpc_object_t*, size_t count);
 xpc_object_t xpc_dictionary_create_reply(xpc_object_t);
 int xpc_dictionary_dup_fd(xpc_object_t, const char* key);

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -47,7 +47,7 @@ void Connection::newConnectionWasInitialized() const
 static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
     auto xpcData = encoderToXPCData(WTFMove(encoder));
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_uint64(dictionary.get(), WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -61,7 +61,7 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
 
 OSObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptOSObject(xpc_dictionary_create_empty());
     addVersionAndEncodedMessageToDictionary(WTFMove(message), dictionary.get());
     xpc_dictionary_set_uint64(dictionary.get(), protocolMessageTypeKey, static_cast<uint64_t>(messageType));
     return dictionary;

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -41,7 +41,7 @@ LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 {
 #if HAVE(LSDATABASECONTEXT) && !HAVE(SYSTEM_CONTENT_LS_DATABASE)
     m_observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptOSObject(xpc_dictionary_create_empty());
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -70,7 +70,7 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
     [LSDatabaseContext.sharedDatabaseContext getSystemContentDatabaseObject4WebKit:makeBlockPtr([connection = connection] (xpc_object_t _Nullable object, NSError * _Nullable error) {
         if (!object)
             return;
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptOSObject(xpc_dictionary_create_empty());
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, object);
 
@@ -79,7 +79,7 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
     }).get()];
 #elif HAVE(LSDATABASECONTEXT)
     RetainPtr<id> observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptOSObject(xpc_dictionary_create_empty());
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -88,7 +88,7 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
 
     [LSDatabaseContext.sharedDatabaseContext removeDatabaseChangeObserver4WebKit:observer.get()];
 #else
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
     xpc_connection_send_message(connection.get(), message.get());
 #endif

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -228,7 +228,7 @@ OSObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 
 RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::createHostingUpdateCoordinator(mach_port_t sendRight)
 {
-    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_mach_send(xpcRepresentation.get(), machPortKey, sendRight);
     NSError* error = nil;
     auto coordinator = [getBELayerHierarchyHostingTransactionCoordinatorClass() coordinatorWithXPCRepresentation:xpcRepresentation.get() error:&error];
@@ -239,7 +239,7 @@ RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::cr
 
 RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(uint64_t pid, uint64_t contextID)
 {
-    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_uint64(xpcRepresentation.get(), processIDKey, pid);
     xpc_dictionary_set_uint64(xpcRepresentation.get(), contextIDKey, contextID);
     NSError* error = nil;

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -50,7 +50,7 @@ void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
 
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
     // Give the process a chance to exit cleanly by sending a XPC message to request termination, then try xpc_connection_kill.
-    auto exitMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto exitMessage = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(exitMessage.get(), messageNameKey, exitProcessMessage.characters());
     xpc_connection_send_message(connection, exitMessage.get());
 #endif

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -65,7 +65,7 @@ VideoReceiverEndpointMessage VideoReceiverEndpointMessage::decode(xpc_object_t m
 
 OSObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
 {
-    OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    OSObjectPtr message = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
     xpc_dictionary_set_uint64(message.get(), mediaElementIdentifierKey.characters(), m_mediaElementIdentifier.toUInt64());

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -83,7 +83,7 @@ void XPCEndpoint::sendEndpointToConnection(xpc_connection_t connection)
     if (!connection)
         return;
 
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(message.get(), xpcEndpointMessageNameKey(), xpcEndpointMessageName());
     xpc_dictionary_set_value(message.get(), xpcEndpointNameKey(), m_endpoint.get());
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
@@ -83,7 +83,7 @@ bool DaemonConnectionSet::debugModeEnabled() const
 
 void DaemonConnectionSet::broadcastConsoleMessage(JSC::MessageLevel messageLevel, const String& message)
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_uint64(dictionary.get(), protocolDebugMessageLevelKey, static_cast<uint64_t>(messageLevel));
     xpc_dictionary_set_string(dictionary.get(), protocolDebugMessageKey, message.utf8().data());
     for (auto& connection : m_connections.keys())

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -40,11 +40,11 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
 {
     ASSERT(secKeyProxyStore.isInitialized());
 
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(message.get(), ClientCertificateAuthentication::XPCMessageNameKey, ClientCertificateAuthentication::XPCMessageNameValue);
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCChallengeIDKey, challengeID.toUInt64());
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, secKeyProxyStore.get().endpoint._endpoint);
-    auto certificateDataArray = adoptOSObject(xpc_array_create(nullptr, 0));
+    auto certificateDataArray = adoptOSObject(xpc_array_create_empty());
     for (id certificate in credential.nsCredential().certificates) {
         auto data = adoptCF(SecCertificateCopyData((SecCertificateRef)certificate));
         xpc_array_append_value(certificateDataArray.get(), adoptOSObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -322,7 +322,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     // 1.1. An important case is WebKitTestRunner, where we should use English localizations for all system frameworks.
     // 2. When AppleLanguages is passed as command line argument for UI process, or set in its preferences, we should respect it in child processes.
 #if !USE(EXTENSIONKIT)
-    auto initializationMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto initializationMessage = adoptOSObject(xpc_dictionary_create_empty());
     _CFBundleSetupXPCBootstrap(initializationMessage.get());
     xpc_connection_set_bootstrap(m_xpcConnection.get(), initializationMessage.get());
 #endif
@@ -355,7 +355,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
         clientIdentifier = [[NSBundle mainBundle] bundleIdentifier];
 
     // FIXME: Switch to xpc_connection_set_bootstrap once it's available everywhere we need.
-    auto bootstrapMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto bootstrapMessage = adoptOSObject(xpc_dictionary_create_empty());
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     xpc_dictionary_set_string(bootstrapMessage.get(), "WebKitBundleVersion", WEBKIT_BUNDLE_VERSION);
@@ -364,7 +364,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     auto languagesIterator = m_launchOptions.extraInitializationData.find<HashTranslatorASCIILiteral>("OverrideLanguages"_s);
     if (languagesIterator != m_launchOptions.extraInitializationData.end()) {
         LOG_WITH_STREAM(Language, stream << "Process Launcher is copying OverrideLanguages into initialization message: " << languagesIterator->value);
-        auto languages = adoptOSObject(xpc_array_create(nullptr, 0));
+        auto languages = adoptOSObject(xpc_array_create_empty());
         for (auto language : StringView(languagesIterator->value).split(','))
             xpc_array_set_string(languages.get(), XPC_ARRAY_APPEND, language.utf8().data());
         xpc_dictionary_set_value(bootstrapMessage.get(), "OverrideLanguages", languages.get());
@@ -372,7 +372,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 
 #if PLATFORM(IOS_FAMILY)
     // Clients that set these environment variables explicitly do not have the values automatically forwarded by libxpc.
-    auto containerEnvironmentVariables = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto containerEnvironmentVariables = adoptOSObject(xpc_dictionary_create_empty());
     if (const char* environmentHOME = getenv("HOME"))
         xpc_dictionary_set_string(containerEnvironmentVariables.get(), "HOME", environmentHOME);
     if (const char* environmentCFFIXED_USER_HOME = getenv("CFFIXED_USER_HOME"))
@@ -423,7 +423,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     auto sdkBehaviors = sdkAlignedBehaviors();
     xpc_dictionary_set_data(bootstrapMessage.get(), "client-sdk-aligned-behaviors", sdkBehaviors.storage(), sdkBehaviors.storageLengthInBytes());
 
-    auto extraInitializationData = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto extraInitializationData = adoptOSObject(xpc_dictionary_create_empty());
 
     for (const auto& keyValuePair : m_launchOptions.extraInitializationData)
         xpc_dictionary_set_string(extraInitializationData.get(), keyValuePair.key.utf8().data(), keyValuePair.value.utf8().data());

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -65,7 +65,7 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 
 void LaunchServicesDatabaseManager::didConnect()
 {
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName);
 
     auto connection = this->connection();

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -151,7 +151,7 @@ void Connection::sendAuditToken()
 static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
     auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptOSObject(xpc_dictionary_create_empty());
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -111,25 +111,25 @@ static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestS
 
     const char* serviceName = (preferTestService == WebPushTool::PreferTestService::Yes) ? "org.webkit.webpushtestdaemon.service" : "com.apple.webkit.webpushd.service";
 
-    auto plist = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto plist = adoptNS(xpc_dictionary_create_empty());
     xpc_dictionary_set_string(plist.get(), "_ManagedBy", "webpushtool");
     xpc_dictionary_set_string(plist.get(), "Label", "org.webkit.webpushtestdaemon");
     xpc_dictionary_set_bool(plist.get(), "LaunchOnlyOnce", true);
     xpc_dictionary_set_bool(plist.get(), "RootedSimulatorPath", true);
 
     {
-        auto environmentVariables = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto environmentVariables = adoptNS(xpc_dictionary_create_empty());
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_FRAMEWORK_PATH", currentExecutableDirectoryURL.fileSystemRepresentation);
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_LIBRARY_PATH", currentExecutableDirectoryURL.fileSystemRepresentation);
         xpc_dictionary_set_value(plist.get(), "EnvironmentVariables", environmentVariables.get());
     }
     {
-        auto machServices = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto machServices = adoptNS(xpc_dictionary_create_empty());
         xpc_dictionary_set_bool(machServices.get(), serviceName, true);
         xpc_dictionary_set_value(plist.get(), "MachServices", machServices.get());
     }
     {
-        auto programArguments = adoptNS(xpc_array_create(nullptr, 0));
+        auto programArguments = adoptNS(xpc_array_create_empty());
 #if PLATFORM(MAC)
         xpc_array_set_string(programArguments.get(), XPC_ARRAY_APPEND, daemonExecutablePathURL.fileSystemRepresentation);
 #else

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -57,7 +57,7 @@ private:
         if (messageName && !strcmp(messageName, testMessageFromClient)) {
             endpointReceivedMessageFromClient = true;
 
-            auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            auto message = adoptOSObject(xpc_dictionary_create_empty());
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromEndpoint);
             xpc_connection_send_message(connection, message.get());
         }
@@ -74,7 +74,7 @@ private:
     }
     void didConnect() final
     {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptOSObject(xpc_dictionary_create_empty());
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromClient);
         xpc_connection_send_message(connection().get(), message.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -504,7 +504,7 @@ static void attemptConnectionInProcessWithoutEntitlement()
         done = true;
     });
     xpc_connection_activate(connection.get());
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptNS(xpc_dictionary_create_empty());
     xpc_connection_send_message(connection.get(), dictionary.get());
     TestWebKitAPI::Util::run(&done);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -242,7 +242,7 @@ private:
 
 OSObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder) const
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptOSObject(xpc_dictionary_create_empty());
 
     uint64_t protocolVersion = WebKit::WebPushD::protocolVersionValue;
     if (m_shouldIncrementProtocolVersionForTesting)

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -68,7 +68,7 @@ RetainPtr<NSURL> currentExecutableDirectory()
 #if PLATFORM(IOS) || PLATFORM(VISION)
 static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 {
-    auto xpc = adoptNS(xpc_array_create(nullptr, 0));
+    auto xpc = adoptNS(xpc_array_create_empty());
     for (id value in array) {
         if ([value isKindOfClass:NSString.class])
             xpc_array_set_string(xpc.get(), XPC_ARRAY_APPEND, [value UTF8String]);
@@ -80,7 +80,7 @@ static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 
 static RetainPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
 {
-    auto xpc = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto xpc = adoptNS(xpc_dictionary_create_empty());
     for (NSString *key in dictionary) {
         ASSERT([key isKindOfClass:NSString.class]);
         const char* keyUTF8 = key.UTF8String;


### PR DESCRIPTION
<pre>Use xpc_dictionary_create_empty and xpc_array_create_empty to create empty dictionaries and arrays
https://bugs.webkit.org/show_bug.cgi?id=280086

Reviewed by NOBODY (OOPS!).

xpc_dictionary_create_empty is clearer.

Every case of xpc_dictionary_create(nullptr, nullptr, 0) just replace with xpc_dictionary_create_empty, and every case of xpc_array_create(nullptr, 0) just replace with xpc_array_create_empty.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm: (Inspector::RemoteInspectorXPCConnection::sendMessage):
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm: (WebKit::WebPushD::messageDictionaryFromEncoder):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm: (WebKit::PCM::Connection::dictionaryFromMessage const):
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm: (WebKit::LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver): (WebKit::LaunchServicesDatabaseObserver::startObserving):
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm: (WebKit::LayerHostingContext::createHostingUpdateCoordinator): (WebKit::LayerHostingContext::createHostingHandle):
* Source/WebKit/Platform/cocoa/XPCUtilities.mm: (WebKit::terminateWithReason):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm: (WebKit::VideoReceiverEndpointMessage::encode const):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm: (WebKit::XPCEndpoint::sendEndpointToConnection):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm: (WebKit::PCM::DaemonConnectionSet::broadcastConsoleMessage):
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm: (WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm: (WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm: (WebKit::LaunchServicesDatabaseManager::didConnect):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm: (WebPushTool::messageDictionaryFromEncoder):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm: (registerDaemonWithLaunchD):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm: (TestWebKitAPI::attemptConnectionInProcessWithoutEntitlement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm: (TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm: (TestWebKitAPI::convertDictionaryToXPC):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cfea5959ece22264771a9df1bda9fc0ad90ebdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18337 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23507 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26503 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70084 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82881 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76178 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68533 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67787 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9856 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98433 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7037 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21541 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->