### PR TITLE
Adopt more smart pointers in WebExtensionContext-related files

### DIFF
--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -55,7 +55,7 @@ namespace API {
 using namespace WebKit::NetworkCache;
 using namespace FileSystem;
 
-ContentRuleListStore& ContentRuleListStore::defaultStore()
+ContentRuleListStore& ContentRuleListStore::defaultStoreSingleton()
 {
     static NeverDestroyed<Ref<ContentRuleListStore>> defaultStore = adoptRef(*new ContentRuleListStore());
     return defaultStore->get();

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -56,7 +56,7 @@ public:
     // to prevent crashing while loading old data.
     static constexpr uint32_t CurrentContentRuleListFileVersion = 17;
 
-    static ContentRuleListStore& defaultStore();
+    static ContentRuleListStore& defaultStoreSingleton();
     static Ref<ContentRuleListStore> storeWithPath(const WTF::String& storePath);
 
     explicit ContentRuleListStore();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -71,7 +71,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 + (instancetype)defaultStore
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return wrapper(API::ContentRuleListStore::defaultStore());
+    return wrapper(API::ContentRuleListStore::defaultStoreSingleton());
 #else
     return nil;
 #endif
@@ -191,7 +191,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 + (instancetype)defaultStoreWithLegacyFilename
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return wrapper(API::ContentRuleListStore::defaultStore());
+    return wrapper(API::ContentRuleListStore::defaultStoreSingleton());
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -83,7 +83,8 @@ static Expected<Ref<WebExtensionAction>, WebExtensionError> getOrCreateActionWit
 
 bool WebExtensionContext::isActionMessageAllowed()
 {
-    return isLoaded() && (extension().hasAction() || extension().hasBrowserAction() || extension().hasPageAction());
+    Ref extension = *m_extension;
+    return isLoaded() && (extension->hasAction() || extension->hasBrowserAction() || extension->hasPageAction());
 }
 
 void WebExtensionContext::actionGetTitle(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
@@ -96,7 +97,7 @@ void WebExtensionContext::actionGetTitle(std::optional<WebExtensionWindowIdentif
         return;
     }
 
-    completionHandler(action.value()->label(WebExtensionAction::FallbackWhenEmpty::No));
+    completionHandler(Ref { action.value() }->label(WebExtensionAction::FallbackWhenEmpty::No));
 }
 
 void WebExtensionContext::actionSetTitle(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& title, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
@@ -151,7 +152,7 @@ void WebExtensionContext::actionGetPopup(std::optional<WebExtensionWindowIdentif
         return;
     }
 
-    completionHandler(action.value()->popupPath());
+    completionHandler(Ref { action.value() }->popupPath());
 }
 
 void WebExtensionContext::actionSetPopup(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& popupPath, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
@@ -173,7 +174,7 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
 {
     static NSString * const apiName = @"action.openPopup()";
 
-    if (!defaultAction().canProgrammaticallyPresentPopup()) {
+    if (!protectedDefaultAction()->canProgrammaticallyPresentPopup()) {
         completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
@@ -238,7 +239,7 @@ void WebExtensionContext::actionGetBadgeText(std::optional<WebExtensionWindowIde
         return;
     }
 
-    completionHandler(action.value()->badgeText());
+    completionHandler(Ref { action.value() }->badgeText());
 }
 
 void WebExtensionContext::actionSetBadgeText(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& text, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
@@ -266,7 +267,7 @@ void WebExtensionContext::actionGetEnabled(std::optional<WebExtensionWindowIdent
         return;
     }
 
-    completionHandler(action.value()->isEnabled());
+    completionHandler(Ref { action.value() }->isEnabled());
 }
 
 void WebExtensionContext::actionSetEnabled(std::optional<WebExtensionTabIdentifier> tabIdentifier, bool enabled, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
@@ -43,7 +43,7 @@ namespace WebKit {
 
 bool WebExtensionContext::isCommandsMessageAllowed()
 {
-    return isLoaded() && extension().hasCommands();
+    return isLoaded() && protectedExtension()->hasCommands();
 }
 
 void WebExtensionContext::commandsGetAll(CompletionHandler<void(Vector<WebExtensionCommandParameters>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -108,9 +108,9 @@ void WebExtensionContext::fetchCookies(WebsiteDataStore& dataStore, const URL& u
     };
 
     if (url.isValid())
-        dataStore.cookieStore().cookiesForURL(url.isolatedCopy(), WTFMove(internalCompletionHandler));
+        dataStore.protectedCookieStore()->cookiesForURL(url.isolatedCopy(), WTFMove(internalCompletionHandler));
     else
-        dataStore.cookieStore().cookies(WTFMove(internalCompletionHandler));
+        dataStore.protectedCookieStore()->cookies(WTFMove(internalCompletionHandler));
 }
 
 void WebExtensionContext::cookiesGet(std::optional<PAL::SessionID> sessionID, const String& name, const URL& url, CompletionHandler<void(Expected<std::optional<WebExtensionCookieParameters>, WebExtensionError>&&)>&& completionHandler)
@@ -223,7 +223,7 @@ void WebExtensionContext::cookiesGetAllCookieStores(CompletionHandler<void(Expec
 {
     HashMap<PAL::SessionID, Vector<WebExtensionTabIdentifier>> stores;
 
-    auto defaultSessionID = extensionController()->configuration().defaultWebsiteDataStore().sessionID();
+    auto defaultSessionID = extensionController()->protectedConfiguration()->defaultWebsiteDataStore().sessionID();
     stores.set(defaultSessionID, Vector<WebExtensionTabIdentifier> { });
 
     for (Ref tab : openTabs()) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -67,7 +67,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage()
     auto *savedRulesetState = objectForKey<NSDictionary>(m_state, declarativeNetRequestRulesetStateKey);
     if (!savedRulesetState.count) {
         // Populate with the default enabled state.
-        for (auto& ruleset : extension().declarativeNetRequestRulesets()) {
+        for (auto& ruleset : protectedExtension()->declarativeNetRequestRulesets()) {
             if (ruleset.enabled)
                 m_enabledStaticRulesetIDs.add(ruleset.rulesetID);
         }
@@ -75,8 +75,9 @@ void WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage()
         return;
     }
 
+    RefPtr extension = m_extension;
     for (NSString *savedIdentifier in savedRulesetState) {
-        auto ruleset = extension().declarativeNetRequestRuleset(savedIdentifier);
+        auto ruleset = extension->declarativeNetRequestRuleset(savedIdentifier);
         if (!ruleset)
             continue;
 
@@ -108,8 +109,9 @@ WebExtensionContext::DeclarativeNetRequestValidatedRulesets WebExtensionContext:
 {
     WebExtension::DeclarativeNetRequestRulesetVector validatedRulesets;
 
+    RefPtr extension = m_extension;
     for (auto& identifier : rulesetIdentifiers) {
-        auto ruleset = extension().declarativeNetRequestRuleset(identifier);
+        auto ruleset = extension->declarativeNetRequestRuleset(identifier);
         if (!ruleset)
             return toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules. Invalid ruleset id: %@.", (NSString *)identifier);
 
@@ -121,8 +123,9 @@ WebExtensionContext::DeclarativeNetRequestValidatedRulesets WebExtensionContext:
 
 void WebExtensionContext::declarativeNetRequestToggleRulesets(const Vector<String>& rulesetIdentifiers, bool newValue, NSMutableDictionary *rulesetIdentifiersToEnabledState)
 {
+    RefPtr extension = m_extension;
     for (auto& identifier : rulesetIdentifiers) {
-        auto ruleset = extension().declarativeNetRequestRuleset(identifier);
+        auto ruleset = extension->declarativeNetRequestRuleset(identifier);
         if (!ruleset)
             continue;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -49,7 +49,7 @@ void WebExtensionContext::addListener(WebPageProxyIdentifier identifier, WebExte
 
     RELEASE_LOG_DEBUG(Extensions, "Registered event listener for type %{public}hhu in %{public}@ world", enumToUnderlyingType(type), (NSString *)toDebugString(contentWorldType));
 
-    if (!extension().backgroundContentIsPersistent() && isBackgroundPage(identifier))
+    if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(identifier))
         m_backgroundContentEventListeners.add(type);
 
     auto result = m_eventListenerPages.add({ type, contentWorldType }, WeakPageCountedSet { });
@@ -66,7 +66,7 @@ void WebExtensionContext::removeListener(WebPageProxyIdentifier identifier, WebE
 
     RELEASE_LOG_DEBUG(Extensions, "Unregistered %{public}zu event listener(s) for type %{public}hhu in %{public}@ world", removedCount, enumToUnderlyingType(type), (NSString *)toDebugString(contentWorldType));
 
-    if (!extension().backgroundContentIsPersistent() && isBackgroundPage(identifier)) {
+    if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(identifier)) {
         for (size_t i = 0; i < removedCount; ++i)
             m_backgroundContentEventListeners.remove(type);
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -220,7 +220,7 @@ void WebExtensionContext::firePortMessageEventsIfNeeded(WebExtensionContentWorld
         return;
 
     case WebExtensionContentWorldType::Native:
-        if (auto nativePort = m_nativePortMap.get(channelIdentifier))
+        if (RefPtr nativePort = m_nativePortMap.get(channelIdentifier))
             nativePort->receiveMessage(parseJSON(messageJSON, JSONOptions::FragmentsAllowed), std::nullopt);
         return;
 
@@ -253,7 +253,7 @@ void WebExtensionContext::sendQueuedNativePortMessagesIfNeeded(WebExtensionPortC
     if (messages.isEmpty())
         return;
 
-    auto nativePort = m_nativePortMap.get(channelIdentifier);
+    RefPtr nativePort = m_nativePortMap.get(channelIdentifier);
     if (!nativePort)
         return;
 
@@ -306,7 +306,7 @@ void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWor
         return;
 
     case WebExtensionContentWorldType::Native:
-        if (auto nativePort = m_nativePortMap.get(channelIdentifier))
+        if (RefPtr nativePort = m_nativePortMap.get(channelIdentifier))
             nativePort->reportDisconnection(std::nullopt);
         return;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -434,7 +434,7 @@ void WebExtensionContext::runtimeWebPageSendMessage(const String& extensionID, c
     completeSenderParameters.tabParameters = tab->parameters();
 
     auto url = completeSenderParameters.url;
-    auto validMatchPatterns = destinationExtension->extension().externallyConnectableMatchPatterns();
+    auto validMatchPatterns = destinationExtension->protectedExtension()->externallyConnectableMatchPatterns();
     if (!hasPermission(url, tab.get()) || !WebExtensionMatchPattern::patternsMatchURL(validMatchPatterns, url)) {
         callAfterRandomDelay([completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler({ });
@@ -490,7 +490,7 @@ void WebExtensionContext::runtimeWebPageConnect(const String& extensionID, WebEx
     completeSenderParameters.tabParameters = tab->parameters();
 
     auto url = completeSenderParameters.url;
-    auto validMatchPatterns = destinationExtension->extension().externallyConnectableMatchPatterns();
+    auto validMatchPatterns = destinationExtension->protectedExtension()->externallyConnectableMatchPatterns();
     if (!hasPermission(url, tab.get()) || !WebExtensionMatchPattern::patternsMatchURL(validMatchPatterns, url)) {
         callAfterRandomDelay([=, this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -117,7 +117,7 @@ void WebExtensionContext::scriptingInsertCSS(const WebExtensionScriptInjectionPa
         auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
         auto styleSheetPairs = getSourcePairsForParameters(parameters, *this);
-        injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, parameters.styleLevel, injectedFrames, *this);
+        injectStyleSheets(styleSheetPairs, webView, Ref { *m_contentScriptWorld }, parameters.styleLevel, injectedFrames, *this);
 
         completionHandler({ });
     });
@@ -359,9 +359,10 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
             return !!string.length;
         });
 
+        RefPtr extension = m_extension;
         for (NSString *scriptPath in scriptPaths) {
             NSError *error;
-            if (!extension().resourceStringForPath(scriptPath, &error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)) {
+            if (!extension->resourceStringForPath(scriptPath, &error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)) {
                 recordError(error);
                 *errorMessage = toErrorString(callingAPIName, nil, @"invalid resource '%@'", scriptPath);
                 return false;
@@ -376,7 +377,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
 
         for (NSString *styleSheetPath in styleSheetPaths) {
             NSError *error;
-            if (!extension().resourceStringForPath(styleSheetPath, &error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)) {
+            if (!extension->resourceStringForPath(styleSheetPath, &error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)) {
                 recordError(error);
                 *errorMessage = toErrorString(callingAPIName, nil, @"invalid resource '%@'", styleSheetPath);
                 return false;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -635,7 +635,7 @@ void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdent
         auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
         auto styleSheetPairs = getSourcePairsForParameters(parameters, *this);
-        injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, parameters.styleLevel, injectedFrames, *this);
+        injectStyleSheets(styleSheetPairs, webView, Ref { *m_contentScriptWorld }, parameters.styleLevel, injectedFrames, *this);
 
         completionHandler({ });
     });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -58,15 +58,17 @@ WebExtensionContext::WebExtensionContext()
 
 WebExtensionContextParameters WebExtensionContext::parameters() const
 {
+    RefPtr extension = m_extension;
+
     return {
         identifier(),
         baseURL(),
         uniqueIdentifier(),
         unsupportedAPIs(),
         m_grantedPermissions,
-        extension().serializeLocalization(),
-        extension().serializeManifest(),
-        extension().manifestVersion(),
+        extension->serializeLocalization(),
+        extension->serializeManifest(),
+        extension->manifestVersion(),
         isSessionStorageAllowedInContentScripts(),
         backgroundPageIdentifier(),
 #if ENABLE(INSPECTOR_EXTENSIONS)
@@ -142,10 +144,11 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
                 continue;
 
             for (auto entry : pagesEntry->value) {
-                if (!hasAccessToPrivateData() && entry.key.sessionID().isEphemeral())
+                Ref page = entry.key;
+                if (!hasAccessToPrivateData() && page->sessionID().isEphemeral())
                     continue;
 
-                Ref process = entry.key.legacyMainFrameProcess();
+                Ref process = page->legacyMainFrameProcess();
                 if (process->canSendMessage())
                     result.add(WTFMove(process));
             }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -446,6 +446,7 @@ public:
 #endif
 
     WebExtensionAction& defaultAction();
+    Ref<WebExtensionAction> protectedDefaultAction() { return defaultAction(); }
     Ref<WebExtensionAction> getAction(WebExtensionWindow*);
     Ref<WebExtensionAction> getAction(WebExtensionTab*);
     Ref<WebExtensionAction> getOrCreateAction(WebExtensionWindow*);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -835,6 +835,13 @@ void WebInspectorUIProxy::evaluateInFrontendForTesting(const String& expression)
     inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::EvaluateInFrontendForTesting(expression), inspectorPage->webPageIDInMainFrameProcess());
 }
 
+#if ENABLE(INSPECTOR_EXTENSIONS)
+RefPtr<WebInspectorUIExtensionControllerProxy> WebInspectorUIProxy::protectedExtensionController() const
+{
+    return extensionController();
+}
+#endif
+
 // Unsupported configurations can use the stubs provided here.
 
 #if !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN) && !ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -118,6 +118,7 @@ public:
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WebInspectorUIExtensionControllerProxy* extensionController() const { return m_extensionController.get(); }
+    RefPtr<WebInspectorUIExtensionControllerProxy> protectedExtensionController() const;
 #endif
 
     bool isConnected() const { return !!m_inspectorPage; }

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -179,12 +179,12 @@ WebCore::DOMWrapperWorld& WebExtensionContextProxy::toDOMWrapperWorld(WebExtensi
 #if ENABLE(INSPECTOR_EXTENSIONS)
     case WebExtensionContentWorldType::Inspector:
 #endif
-        return mainWorld();
+        return mainWorldSingleton();
     case WebExtensionContentWorldType::ContentScript:
         return contentScriptWorld();
     case WebExtensionContentWorldType::Native:
         ASSERT_NOT_REACHED();
-        return mainWorld();
+        return mainWorldSingleton();
     }
 }
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -127,7 +127,7 @@ Vector<Ref<WebPage>> WebExtensionContextProxy::popupPages(std::optional<WebExten
         if (windowIdentifier && entry.value.second && entry.value.second.value() != windowIdentifier.value())
             continue;
 
-        result.append(entry.key);
+        result.append(Ref { entry.key });
     }
 
     return result;
@@ -149,7 +149,7 @@ Vector<Ref<WebPage>> WebExtensionContextProxy::tabPages(std::optional<WebExtensi
         if (windowIdentifier && entry.value.second && entry.value.second.value() != windowIdentifier.value())
             continue;
 
-        result.append(entry.key);
+        result.append(Ref { entry.key });
     }
 
     return result;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -91,7 +91,7 @@ public:
     bool hasDOMWrapperWorld(WebExtensionContentWorldType contentWorldType) const { return contentWorldType != WebExtensionContentWorldType::ContentScript || hasContentScriptWorld(); }
     WebCore::DOMWrapperWorld& toDOMWrapperWorld(WebExtensionContentWorldType) const;
 
-    static WebCore::DOMWrapperWorld& mainWorld() { return WebCore::mainThreadNormalWorld(); }
+    static WebCore::DOMWrapperWorld& mainWorldSingleton() { return WebCore::mainThreadNormalWorld(); }
 
     bool hasContentScriptWorld() const { return !!m_contentScriptWorld; }
     WebCore::DOMWrapperWorld& contentScriptWorld() const { RELEASE_ASSERT(hasContentScriptWorld()); return *m_contentScriptWorld; }
@@ -124,9 +124,9 @@ public:
     Vector<Ref<WebPage>> tabPages(std::optional<WebExtensionTabIdentifier> = std::nullopt, std::optional<WebExtensionWindowIdentifier> = std::nullopt) const;
     void addTabPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
 
-    void enumerateFramesAndNamespaceObjects(const Function<void(WebFrame&, WebExtensionAPINamespace&)>&, WebCore::DOMWrapperWorld& = mainWorld());
+    void enumerateFramesAndNamespaceObjects(const Function<void(WebFrame&, WebExtensionAPINamespace&)>&, WebCore::DOMWrapperWorld& = mainWorldSingleton());
 
-    void enumerateNamespaceObjects(const Function<void(WebExtensionAPINamespace&)>& function, WebCore::DOMWrapperWorld& = mainWorld())
+    void enumerateNamespaceObjects(const Function<void(WebExtensionAPINamespace&)>& function)
     {
         enumerateFramesAndNamespaceObjects([&](auto&, auto& namespaceObject) {
             function(namespaceObject);


### PR DESCRIPTION
#### 39736fe29ef8f60b794a701ff647e764dfa58911
<pre>
Adopt more smart pointers in WebExtensionContext-related files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280093">https://bugs.webkit.org/show_bug.cgi?id=280093</a>
<a href="https://rdar.apple.com/136391189">rdar://136391189</a>

Reviewed by Timothy Hatcher.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::ContentRuleListStore::defaultStoreSingleton):
(API::ContentRuleListStore::defaultStore): Deleted.
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(+[WKContentRuleListStore defaultStore]):
(+[WKContentRuleListStore defaultStoreWithLegacyFilename]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::isActionMessageAllowed):
(WebKit::WebExtensionContext::actionGetTitle):
(WebKit::WebExtensionContext::actionGetPopup):
(WebKit::WebExtensionContext::actionOpenPopup):
(WebKit::WebExtensionContext::actionGetBadgeText):
(WebKit::WebExtensionContext::actionGetEnabled):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm:
(WebKit::WebExtensionContext::isCommandsMessageAllowed):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::fetchCookies):
(WebKit::WebExtensionContext::cookiesGetAllCookieStores):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage):
(WebKit::WebExtensionContext::declarativeNetRequestValidateRulesetIdentifiers):
(WebKit::WebExtensionContext::declarativeNetRequestToggleRulesets):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::firePortMessageEventsIfNeeded):
(WebKit::WebExtensionContext::sendQueuedNativePortMessagesIfNeeded):
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeWebPageSendMessage):
(WebKit::WebExtensionContext::runtimeWebPageConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsInsertCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::errors):
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::localization):
(WebKit::WebExtensionContext::setInspectable):
(WebKit::WebExtensionContext::optionsPageURL const):
(WebKit::WebExtensionContext::overrideNewTabPageURL const):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::didCommitLoadForFrame):
(WebKit::WebExtensionContext::getOrCreateSidebar):
(WebKit::WebExtensionContext::commands):
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
(WebKit::WebExtensionContext::backgroundPageIdentifier const):
(WebKit::WebExtensionContext::addPopupPage):
(WebKit::WebExtensionContext::enumerateExtensionPages):
(WebKit::WebExtensionContext::processDisplayName):
(WebKit::WebExtensionContext::webViewConfiguration):
(WebKit::WebExtensionContext::backgroundContentURL):
(WebKit::WebExtensionContext::loadBackgroundContent):
(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad):
(WebKit::WebExtensionContext::loadBackgroundWebViewIfNeeded):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::backgroundWebViewInspectionName):
(WebKit::WebExtensionContext::scheduleBackgroundContentToUnload):
(WebKit::WebExtensionContext::unloadBackgroundContentIfPossible):
(WebKit::WebExtensionContext::determineInstallReasonDuringLoad):
(WebKit::WebExtensionContext::loadBackgroundPageListenersFromStorage):
(WebKit::WebExtensionContext::saveBackgroundPageListenersToStorage):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessary):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents):
(WebKit::WebExtensionContext::didFinishDocumentLoad):
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate):
(WebKit::WebExtensionContext::inspectorBackgroundPageURL const):
(WebKit::WebExtensionContext::openInspectors const):
(WebKit::WebExtensionContext::loadedInspectors const):
(WebKit::WebExtensionContext::inspectorExtension const):
(WebKit::WebExtensionContext::inspector const):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::isInspectorBackgroundPage const):
(WebKit::WebExtensionContext::isDevToolsMessageAllowed):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesDuringLoad):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPages):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesForPrivateBrowsing):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPagesForPrivateBrowsing):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPage):
(WebKit::WebExtensionContext::inspectorWillOpen):
(WebKit::WebExtensionContext::inspectorWillClose):
(WebKit::WebExtensionContext::addInjectedContent):
(WebKit::WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentControllers):
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
(WebKit::WebExtensionContext::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::protectedDefaultAction):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::protectedExtensionController const):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::toDOMWrapperWorld const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::popupPages const):
(WebKit::WebExtensionContextProxy::tabPages const):
(WebKit::WebExtensionContextProxy::enumerateFramesAndNamespaceObjects):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/284043@main">https://commits.webkit.org/284043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/280a128a901d9982d30ee054935702aca7be75a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54464 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34929 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40223 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61940 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15147 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3479 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43395 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44469 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->