### PR TITLE
Regression(280938.63@safari-7619-branch) WeChat may hang in callOnGlobalObjectRunLoopAndWait()

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
@@ -66,10 +66,7 @@ public:
 private:
     JSGlobalObjectDebuggable(JSGlobalObject&);
 
-    void callOnGlobalObjectRunLoopAndWait(Function<void()>&&) const;
-
     JSGlobalObject* m_globalObject;
-    Ref<RunLoop> m_globalObjectRunLoop;
     Inspector::RemoteControllableTarget::Type m_type { Inspector::RemoteControllableTarget::Type::JavaScript };
 };
 


### PR DESCRIPTION
#### 1946d2619f35c5ad9ff6505a3a79fb06fb94a53b
<pre>
Regression(280938.63@safari-7619-branch) WeChat may hang in callOnGlobalObjectRunLoopAndWait()
<a href="https://bugs.webkit.org/show_bug.cgi?id=277435">https://bugs.webkit.org/show_bug.cgi?id=277435</a>
<a href="https://rdar.apple.com/132773444">rdar://132773444</a>

Reviewed by Ryosuke Niwa.

Just doing a partial revert of 280938.63@safari-7619-branch for now to resolve the issue.
We no longer try to dispatch to the JSGlobalObject&apos;s runloop before using the JSGlobalObject.
This should restore shipping behavior.

Based on initial investigation, the app seems to sometimes create a JSGlobalObject on thread
A, then later use that JSGlobalObject on the main thread. This causes us to call
`callOnGlobalObjectRunLoopAndWait()`, which tries to dispatch on thread A&apos;s runloop, and waits
on a BinarySemaphore until the task has been processed on the other runloop. However, this task
is sometimes not executed and we just hang on the BinarySemaphore. I suspect thread A may have
exited. Since `callOnGlobalObjectRunLoopAndWait()` seems unreliable, we now stop using it.

* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
(JSC::JSGlobalObjectDebuggable::JSGlobalObjectDebuggable):
(JSC::JSGlobalObjectDebuggable::name const):
(JSC::JSGlobalObjectDebuggable::connect):
(JSC::JSGlobalObjectDebuggable::disconnect):
(JSC::JSGlobalObjectDebuggable::dispatchMessageFromRemote):
(JSC::JSGlobalObjectDebuggable::pauseWaitingForAutomaticInspection):
(JSC::JSGlobalObjectDebuggable::callOnGlobalObjectRunLoopAndWait const): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h:

Originally-landed-as: 6fc69ba54d92. <a href="https://rdar.apple.com/136108635">rdar://136108635</a>
Canonical link: <a href="https://commits.webkit.org/285066@main">https://commits.webkit.org/285066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11c36463c482f9adb329d53974ae1c0ce623c60d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20910 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64489 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77194 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70613 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64106 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64095 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5873 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92399 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46577 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20377 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->