### PR TITLE
[UnifiedPDF] There's a tile flicker after resizing has finished

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2136,6 +2136,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/TabSize.h
     platform/graphics/TextRun.h
     platform/graphics/TextTrackRepresentation.h
+    platform/graphics/TileConfigurationChangeIdentifier.h
     platform/graphics/TileGridIdentifier.h
     platform/graphics/TiledBacking.h
     platform/graphics/TrackBuffer.h

--- a/Source/WebCore/platform/graphics/TileConfigurationChangeIdentifier.h
+++ b/Source/WebCore/platform/graphics/TileConfigurationChangeIdentifier.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+enum class TileConfigurationChangeIdentifierType { };
+using TileConfigurationChangeIdentifier = ObjectIdentifier<TileConfigurationChangeIdentifierType>;
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1915,6 +1915,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
     if (affectedByTransformAnimation && m_layer->layerType() == PlatformCALayer::LayerType::LayerTypeTiledBackingLayer)
         client().notifySubsequentFlushRequired(this);
 
+    // FIXME: Can communicate with client that a scale changed. Can cancel pending update if scale didn't change.
     if (layerTypeChanged)
         client().didChangePlatformLayerForLayer(this);
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -354,7 +354,7 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
     FloatRect coverageRect = m_controller.coverageRect();
     IntRect bounds = m_controller.bounds();
 
-    LOG_WITH_STREAM(Tiling, stream << "TileGrid " << this << " (controller " << &m_controller << ") revalidateTiles: bounds " << bounds << " coverageRect" << coverageRect << " validation: " << validationPolicy);
+    LOG_WITH_STREAM(Tiling, stream << "TileGrid " << this << " (controller " << &m_controller << ") revalidateTiles: bounds " << bounds << " coverageRect " << coverageRect << " validation: " << validationPolicy);
 
     FloatRect scaledRect(coverageRect);
     scaledRect.scale(m_scale);
@@ -495,7 +495,14 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
         m_secondaryTileCoverageRects.clear();
     }
 
-    m_controller.didRevalidateTiles();
+    m_controller.didRevalidateTiles(m_tiles.keys());
+
+    for (auto& entry : m_tiles) {
+        TileIndex tileIndex = entry.key;
+        TileInfo& tileInfo = entry.value;
+        if (!tileInfo.hasStaleContent)
+            m_controller.addPendingTileToActiveTileConfigurationChangeIfNeeded(tileIndex);
+    }
 }
 
 TileGrid::TileCohort TileGrid::nextTileCohort() const

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -29,6 +29,7 @@
 #include "IntRect.h"
 #include "PlatformCALayerClient.h"
 #include "TileGridIdentifier.h"
+#include "TileGridTypes.h"
 #include "Timer.h"
 #include <wtf/Deque.h>
 #include <wtf/HashCountedSet.h>
@@ -45,8 +46,6 @@ namespace WebCore {
 class GraphicsContext;
 class PlatformCALayer;
 class TileController;
-
-using TileIndex = IntPoint;
 
 class TileGrid : public PlatformCALayerClient {
     WTF_MAKE_TZONE_ALLOCATED(TileGrid);
@@ -100,14 +99,10 @@ public:
     void removeUnparentedTilesNow();
 #endif
 
-    using TileCohort = unsigned;
-    static constexpr TileCohort visibleTileCohort = std::numeric_limits<TileCohort>::max();
+    using TileCohort = WebCore::TileCohort;
+    static constexpr auto visibleTileCohort = WebCore::visibleTileCohort;
 
-    struct TileInfo {
-        RefPtr<PlatformCALayer> layer;
-        TileCohort cohort { visibleTileCohort };
-        bool hasStaleContent { false };
-    };
+    using TileInfo = WebCore::TileInfo;
 
 private:
     void setTileNeedsDisplayInRect(const TileIndex&, TileInfo&, const IntRect& repaintRectInTileCoords, const IntRect& coverageRectInTileCoords);
@@ -161,7 +156,7 @@ private:
     Ref<PlatformCALayer> m_containerLayer;
 #endif
 
-    HashMap<TileIndex, TileInfo> m_tiles;
+    TileGridIndexCollectionType m_tiles;
 
     IntRect m_primaryTileCoverageRect;
     Vector<FloatRect> m_secondaryTileCoverageRects;

--- a/Source/WebCore/platform/graphics/ca/TileGridTypes.h
+++ b/Source/WebCore/platform/graphics/ca/TileGridTypes.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IntPointHash.h"
+#include <limits>
+#include <wtf/HashMap.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class IntPoint;
+class PlatformCALayer;
+
+using TileCohort = unsigned;
+static constexpr TileCohort visibleTileCohort = std::numeric_limits<TileCohort>::max();
+
+struct TileInfo {
+    RefPtr<PlatformCALayer> layer;
+    TileCohort cohort { visibleTileCohort };
+    bool hasStaleContent { false };
+};
+
+using TileIndex = IntPoint;
+using TileGridIndexCollectionType = HashMap<TileIndex, TileInfo>;
+using TileGridIndexIteratorRange = TileGridIndexCollectionType::KeysIteratorRange;
+
+} // namespace WebCore

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -71,7 +71,7 @@ private:
     void deviceOrPageScaleFactorChanged() override;
 
     void setupLayers(WebCore::GraphicsLayer& scrolledContentsLayer) override;
-    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) override;
+    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation) override;
 
     void updateIsInWindow(bool isInWindow) override;
     void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1149,7 +1149,7 @@ FloatSize PDFDiscretePresentationController::rowContainerSize(const PDFLayoutRow
     return scaledRowBounds.size();
 }
 
-void PDFDiscretePresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor)
+void PDFDiscretePresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation layoutChangeInformation)
 {
     LOG_WITH_STREAM(PDF, stream << "PDFDiscretePresentationController::updateLayersOnLayoutChange - documentSize " << documentSize << " centeringOffset " << centeringOffset);
 
@@ -1221,8 +1221,13 @@ void PDFDiscretePresentationController::updateLayersOnLayoutChange(FloatSize doc
             needsRepaint = true;
         }
 
-        if (needsRepaint)
+        if (needsRepaint) {
+            if (layoutChangeInformation.scaleFactorChangedAfterInitialLayout()) {
+                if (RefPtr asyncRenderer = asyncRendererIfExists())
+                    asyncRenderer->pdfContentScaleChanged(rowContentsLayer.get(), scaleFactor);
+            }
             rowContentsLayer->setNeedsDisplay();
+        }
 
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
         RefPtr rowSelectionLayer = row.selectionLayer;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -79,7 +79,14 @@ public:
     virtual void deviceOrPageScaleFactorChanged() = 0;
 
     virtual void setupLayers(WebCore::GraphicsLayer&) = 0;
-    virtual void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) = 0;
+
+    struct LayoutChangeInformation {
+        bool scaleFactorChanged { false };
+        bool isInitialLayout { false };
+
+        bool scaleFactorChangedAfterInitialLayout() const { return scaleFactorChanged && !isInitialLayout; }
+    };
+    virtual void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation) = 0;
 
     virtual void updateIsInWindow(bool isInWindow) = 0;
     virtual void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -60,7 +60,7 @@ private:
     void deviceOrPageScaleFactorChanged() override { }
 
     void setupLayers(WebCore::GraphicsLayer& scrolledContentsLayer) override;
-    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) override;
+    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation) override;
 
     void updateIsInWindow(bool isInWindow) override;
     void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -174,7 +174,7 @@ void PDFScrollingPresentationController::setupLayers(GraphicsLayer& scrolledCont
 #endif
 }
 
-void PDFScrollingPresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor)
+void PDFScrollingPresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation layoutChangeInformation)
 {
     m_contentsLayer->setSize(documentSize);
     m_contentsLayer->setNeedsDisplay();
@@ -184,6 +184,10 @@ void PDFScrollingPresentationController::updateLayersOnLayoutChange(FloatSize do
     m_selectionLayer->setNeedsDisplay();
 #endif
 
+    if (layoutChangeInformation.scaleFactorChangedAfterInitialLayout()) {
+        if (RefPtr asyncRenderer = asyncRendererIfExists())
+            asyncRenderer->pdfContentScaleChanged(m_contentsLayer.get(), scaleFactor);
+    }
     TransformationMatrix transform;
     transform.scale(scaleFactor);
     transform.translate(centeringOffset.width(), centeringOffset.height());

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -268,7 +268,9 @@ private:
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;
     void setPageScaleFactor(double scale, std::optional<WebCore::IntPoint> origin) final;
-    void setScaleFactor(double scale, std::optional<WebCore::IntPoint> origin = std::nullopt);
+
+    enum class IsInitialLayout : bool { No, Yes };
+    void setScaleFactor(double scale, std::optional<WebCore::IntPoint> origin = std::nullopt, IsInitialLayout = IsInitialLayout::No);
 
     enum class CheckForMagnificationGesture : bool { No, Yes };
     void deviceOrPageScaleFactorChanged(CheckForMagnificationGesture = CheckForMagnificationGesture::No);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -130,10 +130,7 @@
 #import <UIKit/UIColor.h>
 #endif
 
-// FIXME: We should rationalize these with the values in ViewGestureController.
-// For now, we'll leave them differing as they do in PDFPlugin.
-static constexpr double minimumZoomScale = 0.2;
-static constexpr double maximumZoomScale = 6.0;
+
 static constexpr double zoomIncrement = 1.18920;
 
 namespace WebKit {
@@ -579,7 +576,7 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
     m_scrollContainerLayer->setPosition(scrollContainerRect.location());
     m_scrollContainerLayer->setSize(scrollContainerRect.size());
 
-    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
+    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor, { });
     updateSnapOffsets();
 
     didChangeSettings();
@@ -1048,7 +1045,7 @@ void UnifiedPDFPlugin::didEndMagnificationGesture()
     deviceOrPageScaleFactorChanged();
 }
 
-void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPoint> originInRootViewCoordinates)
+void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPoint> originInRootViewCoordinates, IsInitialLayout isInitialLayout)
 {
     RefPtr page = this->page();
     if (!page)
@@ -1088,7 +1085,7 @@ void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPo
 
     deviceOrPageScaleFactorChanged(CheckForMagnificationGesture::Yes);
 
-    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
+    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor,  { .scaleFactorChanged = true, .isInitialLayout = isInitialLayout == IsInitialLayout::Yes });
     updateSnapOffsets();
 
 #if PLATFORM(MAC)
@@ -1221,7 +1218,7 @@ void UnifiedPDFPlugin::updateLayout(AdjustScaleAfterLayout shouldAdjustScale, st
     if (shouldAdjustScale == AdjustScaleAfterLayout::Yes && m_view) {
         auto initialScaleFactor = initialScale();
         LOG_WITH_STREAM(PDF, stream << "UnifiedPDFPlugin::updateLayout - on first layout, chose scale for actual size " << initialScaleFactor);
-        setScaleFactor(initialScaleFactor);
+        setScaleFactor(initialScaleFactor, std::nullopt, IsInitialLayout::Yes);
 
         m_shouldUpdateAutoSizeScale = ShouldUpdateAutoSizeScale::No;
     }

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -98,6 +98,11 @@ public:
     void setClient(TiledBackingClient*) final { }
     PlatformLayerIdentifier layerIdentifier() const final { return *m_owner.primaryLayerID(); }
     TileGridIdentifier primaryGridIdentifier() const final { return TileGridIdentifier { 0 }; }
+    std::optional<TileConfigurationChangeIdentifier> activeConfigurationChange() const final { return { }; }
+    TileConfigurationChangeIdentifier initiateTileConfigurationChange(CompletionHandler<void(TileGridIdentifier oldGrid, const std::optional<TileGridIdentifier>& newGrid)>&&) final;
+    void didPrepareContentForTile(TileIndex) final { }
+    void commitTileConfigurationChange(TileGridIdentifier, TileGridIdentifier) final { };
+
     std::optional<TileGridIdentifier> secondaryGridIdentifier() const final { return { }; }
     void setVisibleRect(const FloatRect&) final { }
     FloatRect visibleRect() const final { return { }; };
@@ -754,6 +759,12 @@ void GraphicsLayerWC::recursiveCommitChanges(const TransformState& state)
         static_cast<GraphicsLayerWC*>(replica)->recursiveCommitChanges(localState);
     for (auto& child : children())
         static_cast<GraphicsLayerWC*>(child.ptr())->recursiveCommitChanges(localState);
+}
+
+TileConfigurationChangeIdentifier GraphicsLayerWC::initiateTileConfigurationChange(CompletionHandler<void(TileGridIdentifier oldGrid, const std::optional<TileGridIdentifier>& newGrid)>&&)
+{
+    completionHandler(TileGridIdentifier { 0 }, TileGridIdentifier { 0 });
+    return TileConfigurationChangeIdentifier { 0 };
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### cbececab5e693864a42115694e555306845a55ab
<pre>
[UnifiedPDF] There&apos;s a tile flicker after resizing has finished
<a href="https://bugs.webkit.org/show_bug.cgi?id=270041">https://bugs.webkit.org/show_bug.cgi?id=270041</a>
<a href="https://rdar.apple.com/123566595">rdar://123566595</a>

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/TileConfigurationChangeIdentifier.h: Added.
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::activeConfigurationChange const):
(WebCore::TileController::destroyExistingTileConfigurationChange):
(WebCore::TileController::addPendingTilesToActiveTileConfigurationChangeIfNeeded):
(WebCore::TileController::makeTileConfigurationChange):
(WebCore::TileController::didPrepareContentForTile):
(WebCore::TileController::swapPrimaryGridWithPendingTileGrid):
(WebCore::TileController::setNeedsDisplay):
(WebCore::TileController::setNeedsDisplayInRect):
(WebCore::TileController::setContentsScale):
(WebCore::TileController::revalidateTiles):
(WebCore::TileController::tileSize const):
(WebCore::TileController::rectForTile const):
(WebCore::TileController::computeTileSize):
(WebCore::TileController::didRevalidateTiles):
(WebCore::TileController::tileGridExtent const):
(WebCore::TileController::retainedTileBackingStoreMemory const):
(WebCore::TileController::tileCoverageRect const):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::revalidateTiles):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/graphics/ca/TileGridTypes.h: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::willRepaintAllTiles):
(WebKit::AsyncPDFRenderer::tilingScaleFactorDidChange):
(WebKit::AsyncPDFRenderer::prepareContentForTile):
(WebKit::AsyncPDFRenderer::didPrepareContentForTile):
(WebKit::AsyncPDFRenderer::cancelPrepareContentForTile):
(WebKit::AsyncPDFRenderer::didCancelTileConfigurationChange):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::tileConfigurationChangeCompletionHandler):
(WebKit::AsyncPDFRenderer::pdfContentScaleChanged):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::applyWheelEventDelta):
(WebKit::PDFDiscretePresentationController::updateLayersOnLayoutChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
(WebKit::PDFPresentationController::LayoutChangeInformation::scaleFactorChangedAfterInitialLayout const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateLayersOnLayoutChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::updateLayout):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbececab5e693864a42115694e555306845a55ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75277 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22375 "Hash cbececab for PR 34010 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56261 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/22375 "Hash cbececab for PR 34010 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18806 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63983 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63956 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5734 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46383 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1162 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Checked out pull request; Found 47098 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47454 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->