### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make Cocoa/iOS's CanMakeWeakPtr classes RefCounted

### DIFF
--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/Forward.h>
+#import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
@@ -40,15 +41,6 @@ OBJC_CLASS UIScene;
 OBJC_CLASS WKUIWindowSceneObserver;
 
 namespace WebKit {
-class ApplicationStateTracker;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ApplicationStateTracker> : std::true_type { };
-}
-
-namespace WebKit {
 
 enum class ApplicationType : uint8_t {
     Application,
@@ -56,10 +48,14 @@ enum class ApplicationType : uint8_t {
     Extension,
 };
 
-class ApplicationStateTracker : public CanMakeWeakPtr<ApplicationStateTracker> {
+class ApplicationStateTracker : public RefCountedAndCanMakeWeakPtr<ApplicationStateTracker> {
     WTF_MAKE_TZONE_ALLOCATED(ApplicationStateTracker);
 public:
-    ApplicationStateTracker(UIView *, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector);
+    static RefPtr<ApplicationStateTracker> create(UIView *view, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector)
+    {
+        return adoptRef(new ApplicationStateTracker(view, didEnterBackgroundSelector, willEnterForegroundSelector, willBeginSnapshotSequenceSelector, didCompleteSnapshotSequenceSelector));
+    }
+
     ~ApplicationStateTracker();
 
     bool isInBackground() const { return m_isInBackground; }
@@ -68,6 +64,8 @@ public:
     void setScene(UIScene *);
 
 private:
+    ApplicationStateTracker(UIView *, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector);
+
     void setViewController(UIViewController *);
 
     void applicationDidEnterBackground();

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
@@ -29,29 +29,21 @@
 
 #include "GroupActivitiesSession.h"
 #include <wtf/HashMap.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
-#include <wtf/WeakPtr.h>
 
 OBJC_CLASS WKGroupSessionObserver;
-
-namespace WebKit {
-class GroupActivitiesSessionNotifier;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::GroupActivitiesSessionNotifier> : std::true_type { };
-}
 
 namespace WebKit {
 
 class WebPageProxy;
 
-class GroupActivitiesSessionNotifier : public CanMakeWeakPtr<GroupActivitiesSessionNotifier> {
+class GroupActivitiesSessionNotifier : public RefCountedAndCanMakeWeakPtr<GroupActivitiesSessionNotifier> {
     WTF_MAKE_TZONE_ALLOCATED(GroupActivitiesSessionNotifier);
 public:
-    static GroupActivitiesSessionNotifier& sharedNotifier();
+    static GroupActivitiesSessionNotifier& singleton();
+    static Ref<GroupActivitiesSessionNotifier> create();
 
     bool hasSessionForURL(const URL&);
     RefPtr<GroupActivitiesSession> takeSessionForURL(const URL&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -824,7 +824,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR) && HAVE(GROUP_ACTIVITIES)
     if (m_preferences->mediaSessionCoordinatorEnabled())
-        GroupActivitiesSessionNotifier::sharedNotifier().addWebPage(*this);
+        GroupActivitiesSessionNotifier::singleton().addWebPage(*this);
 #endif
 
     m_pageToCloneSessionStorageFrom = m_configuration->pageToCloneSessionStorageFrom();
@@ -876,7 +876,7 @@ WebPageProxy::~WebPageProxy()
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR) && HAVE(GROUP_ACTIVITIES)
     if (preferences->mediaSessionCoordinatorEnabled())
-        GroupActivitiesSessionNotifier::sharedNotifier().removeWebPage(*this);
+        GroupActivitiesSessionNotifier::singleton().removeWebPage(*this);
 #endif
 }
 
@@ -6775,7 +6775,7 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR) && HAVE(GROUP_ACTIVITIES)
     if (frame->isMainFrame() && m_preferences->mediaSessionCoordinatorEnabled())
-        GroupActivitiesSessionNotifier::sharedNotifier().webPageURLChanged(*this);
+        GroupActivitiesSessionNotifier::singleton().webPageURLChanged(*this);
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm
+++ b/Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm
@@ -37,7 +37,7 @@
 
 @implementation WKApplicationStateTrackingView {
     WeakObjCPtr<WKWebView> _webViewToTrack;
-    std::unique_ptr<WebKit::ApplicationStateTracker> _applicationStateTracker;
+    RefPtr<WebKit::ApplicationStateTracker> _applicationStateTracker;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame webView:(WKWebView *)webView
@@ -46,7 +46,7 @@
         return nil;
 
     _webViewToTrack = webView;
-    _applicationStateTracker = makeUnique<WebKit::ApplicationStateTracker>(self, @selector(_applicationDidEnterBackground), @selector(_applicationWillEnterForeground), @selector(_willBeginSnapshotSequence), @selector(_didCompleteSnapshotSequence));
+    _applicationStateTracker = WebKit::ApplicationStateTracker::create(self, @selector(_applicationDidEnterBackground), @selector(_applicationWillEnterForeground), @selector(_willBeginSnapshotSequence), @selector(_didCompleteSnapshotSequence));
     return self;
 }
 


### PR DESCRIPTION
#### a6d597f81b61aecdef409d0f0b805b897625a4d4
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make Cocoa/iOS&apos;s CanMakeWeakPtr classes RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280076">https://bugs.webkit.org/show_bug.cgi?id=280076</a>

Reviewed by Ryosuke Niwa.

Every CanMakeWeakPtr class should also RefCounted.

* Source/WebKit/UIProcess/ApplicationStateTracker.h:
(WebKit::ApplicationStateTracker::create):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
(WebKit::GroupActivitiesSessionNotifier::singleton):
(WebKit::GroupActivitiesSessionNotifier::sharedNotifier): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm:
(-[WKApplicationStateTrackingView initWithFrame:webView:]):

Canonical link: <a href="https://commits.webkit.org/284095@main">https://commits.webkit.org/284095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc6e28d599e519eb203a8883490b7d2b3621b0cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19401 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13051 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40399 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16134 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3656 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43633 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->