### PR TITLE
[ITP] Refactor logic for managing the lifetimes of script-written third party cookies and local storage

### DIFF
--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -179,7 +179,7 @@ String CookieJar::cookieRequestHeaderFieldValue(Document& document, const URL& u
     return result.first;
 }
 
-bool CookieJar::getRawCookies(const Document& document, const URL& url, Vector<Cookie>& cookies) const
+bool CookieJar::getRawCookies(Document& document, const URL& url, Vector<Cookie>& cookies) const
 {
     auto pageID = document.pageID();
     std::optional<FrameIdentifier> frameID;

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -62,7 +62,7 @@ public:
     virtual bool cookiesEnabled(Document&);
     virtual void remoteCookiesEnabled(const Document&, CompletionHandler<void(bool)>&&) const;
     virtual std::pair<String, SecureCookiesAccessed> cookieRequestHeaderFieldValue(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies) const;
-    virtual bool getRawCookies(const Document&, const URL&, Vector<Cookie>&) const;
+    virtual bool getRawCookies(Document&, const URL&, Vector<Cookie>&) const;
     virtual void setRawCookie(const Document&, const Cookie&);
     virtual void deleteCookie(const Document&, const URL&, const String& cookieName, CompletionHandler<void()>&&);
 

--- a/Source/WebCore/storage/Storage.h
+++ b/Source/WebCore/storage/Storage.h
@@ -57,6 +57,8 @@ public:
 private:
     Storage(LocalDOMWindow&, Ref<StorageArea>&&);
 
+    bool requiresScriptExecutionTelemetry() const;
+
     const Ref<StorageArea> m_storageArea;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -56,7 +56,7 @@ public:
     bool cookiesEnabled(WebCore::Document&) final;
     void remoteCookiesEnabled(const WebCore::Document&, CompletionHandler<void(bool)>&&) const final;
     std::pair<String, WebCore::SecureCookiesAccessed> cookieRequestHeaderFieldValue(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::IncludeSecureCookies) const final;
-    bool getRawCookies(const WebCore::Document&, const URL&, Vector<WebCore::Cookie>&) const final;
+    bool getRawCookies(WebCore::Document&, const URL&, Vector<WebCore::Cookie>&) const final;
     void setRawCookie(const WebCore::Document&, const WebCore::Cookie&) final;
     void deleteCookie(const WebCore::Document&, const URL&, const String& cookieName, CompletionHandler<void()>&&) final;
 

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -108,6 +108,7 @@ struct AutocorrectionContext {
 - (void)synchronouslyLoadHTMLString:(NSString *)html baseURL:(NSURL *)url;
 - (void)synchronouslyLoadHTMLString:(NSString *)html preferences:(WKWebpagePreferences *)preferences;
 - (void)synchronouslyLoadRequest:(NSURLRequest *)request;
+- (void)synchronouslyLoadSimulatedRequest:(NSURLRequest *)request responseHTMLString:(NSString *)htmlString;
 - (void)synchronouslyLoadRequest:(NSURLRequest *)request preferences:(WKWebpagePreferences *)preferences;
 - (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request;
 - (void)synchronouslyLoadTestPageNamed:(NSString *)pageName;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -106,6 +106,12 @@ static NSString *overrideBundleIdentifier(id, SEL)
     [self _test_waitForDidFinishNavigationWithPreferences:preferences];
 }
 
+- (void)synchronouslyLoadSimulatedRequest:(NSURLRequest *)request responseHTMLString:(NSString *)htmlString
+{
+    [self loadSimulatedRequest:request responseHTMLString:htmlString];
+    [self _test_waitForDidFinishNavigation];
+}
+
 - (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request
 {
     [self loadRequest:request];


### PR DESCRIPTION
#### 8defcbeb9bbafc2a135b9b5cd4703fdccb289335
<pre>
[ITP] Refactor logic for managing the lifetimes of script-written third party cookies and local storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=280099">https://bugs.webkit.org/show_bug.cgi?id=280099</a>
<a href="https://rdar.apple.com/136378432">rdar://136378432</a>

Reviewed by Charlie Wolfe.

Add checks for script telemetry underneath calls to read from or write to `localStorage` or
`document.cookie`.

* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::getRawCookies const):
* Source/WebCore/loader/CookieJar.h:
* Source/WebCore/storage/Storage.cpp:
(WebCore::Storage::length const):
(WebCore::Storage::key const):
(WebCore::Storage::getItem const):
(WebCore::Storage::setItem):
(WebCore::Storage::removeItem):
(WebCore::Storage::requiresScriptExecutionTelemetry const):
* Source/WebCore/storage/Storage.h:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::requiresScriptExecutionTelemetry):
(WebKit::WebCookieJar::cookies const):
(WebKit::WebCookieJar::setCookies):
(WebKit::WebCookieJar::cookiesEnabled):
(WebKit::WebCookieJar::cookieRequestHeaderFieldValue const):
(WebKit::WebCookieJar::getRawCookies const):
(WebKit::WebCookieJar::getCookiesAsync const):
(WebKit::WebCookieJar::setCookieAsync const):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView synchronouslyLoadSimulatedRequest:responseHTMLString:]):

Add a helper method to synchronously load a simulated `NSURLRequest`.

Canonical link: <a href="https://commits.webkit.org/284135@main">https://commits.webkit.org/284135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f52e5d60675743abcf202446ff4d1be509e250a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18040 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16207 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59260 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3725 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->