### PR TITLE
Fix PLT with site isolation enabled

### DIFF
--- a/Source/WebKit/UIProcess/FrameProcess.cpp
+++ b/Source/WebKit/UIProcess/FrameProcess.cpp
@@ -39,9 +39,10 @@ FrameProcess::FrameProcess(WebProcessProxy& process, BrowsingContextGroup& group
     , m_browsingContextGroup(group)
     , m_site(site)
 {
-    if (preferences.siteIsolationEnabled())
+    if (preferences.siteIsolationEnabled()) {
         group.addFrameProcess(*this);
-    else
+        process.markAsUsedForSiteIsolation();
+    } else
         m_browsingContextGroup = nullptr;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1541,6 +1541,12 @@ bool WebProcessProxy::canBeAddedToWebProcessCache() const
         return false;
     }
 
+    if (m_usedForSiteIsolation) {
+        // FIXME: The WebProcessCache is organized by RegistrableDomain not Site, and it is only set when the main frame loads a URL with that domain,
+        // so processes used for iframes are not correctly reused. Implement this in a way that doesn't break PLT.
+        return false;
+    }
+
     if (WebKit::isInspectorProcessPool(protectedProcessPool()))
         return false;
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -504,6 +504,8 @@ public:
     const WebCore::ProcessIdentity& processIdentity();
 #endif
 
+    void markAsUsedForSiteIsolation() { m_usedForSiteIsolation = true; }
+
 private:
     Type type() const final { return Type::WebContent; }
 
@@ -690,6 +692,7 @@ private:
 
     std::optional<WebCore::RegistrableDomain> m_registrableDomain;
     bool m_isInProcessCache { false };
+    bool m_usedForSiteIsolation { false };
 
     enum class NoOrMaybe { No, Maybe } m_isResponsive;
     Vector<CompletionHandler<void(bool webProcessIsResponsive)>> m_isResponsiveCallbacks;


### PR DESCRIPTION
#### eb9b59aba2a61af81ab34e2862f8e3cd599fe2f6
<pre>
Fix PLT with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280100">https://bugs.webkit.org/show_bug.cgi?id=280100</a>
<a href="https://rdar.apple.com/136397294">rdar://136397294</a>

Reviewed by Ryosuke Niwa.

PLT has a site in it that is loaded in the main frame and then loaded in
an iframe under a different site&apos;s main frame.  Because the WebProcessPool&apos;s
process cache is currently designed and optimized for PSON, we can&apos;t use
the process cache the same way with site isolation when looking for a
process for an iframe because otherwise the BrowsingContextGroup&apos;s process
accounting gets messed up and we end up calling WebPage::loadRequest
with a frame identifier that doesn&apos;t exist in that process and it returns
early then the test hangs.  At some point we will need to teach the
WebProcessPool&apos;s process cache about site isolation to get perf up, but
until then we need to run the test to completion.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForRegistrableDomain):

Canonical link: <a href="https://commits.webkit.org/284029@main">https://commits.webkit.org/284029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08b4d796fe6b02a058a0e965d3e98425e39bece3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19136 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58892 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40200 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17677 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73934 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15926 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61917 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9847 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43368 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->