### PR TITLE
[JSC] Use `var` instead of `const` in `JSIteratorPrototype.js`

### DIFF
--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -37,7 +37,7 @@ function some(predicate)
     var count = 0;
     var iterator = this;
     var wrapper = { @@iterator: function () { return iterator; }};
-    for (const item of wrapper) {
+    for (var item of wrapper) {
         if (predicate(item, count++))
             return true;
     }
@@ -59,7 +59,7 @@ function every(predicate)
     var count = 0;
     var iterator = this;
     var wrapper = { @@iterator: function () { return iterator; }};
-    for (const item of wrapper) {
+    for (var item of wrapper) {
         if (!predicate(item, count++))
             return false;
     }
@@ -81,7 +81,7 @@ function find(predicate)
     var count = 0;
     var iterator = this;
     var wrapper = { @@iterator: function () { return iterator; }};
-    for (const item of wrapper) {
+    for (var item of wrapper) {
         if (predicate(item, count++))
             return item;
     }


### PR DESCRIPTION
#### 6a160a03d828d3e287190612c6e5bae544e2718a
<pre>
[JSC] Use `var` instead of `const` in `JSIteratorPrototype.js`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280106">https://bugs.webkit.org/show_bug.cgi?id=280106</a>

Reviewed by Yusuke Suzuki.

Use `var` instead of `const` in `JSIteratorPrototype.js`.

* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(some):
(every):
(find):

Canonical link: <a href="https://commits.webkit.org/284035@main">https://commits.webkit.org/284035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a075bf40920b2c46e894415fa4036cbc319251b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54445 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12857 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71248 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43536 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 13 new passes 3 flakes 7 failures; Uploaded test results; 13 new passes 4 flakes 7 failures; Compiled WebKit (warnings); layout-tests; Too many flaky failures: fast/css3-text/css3-text-decoration/text-decoration-scaled.html, fast/events/ios/activating-button-should-not-scroll-page.html, fast/events/ios/activating-checkbox-should-not-scroll-page.html, fast/events/ios/activating-radio-button-should-not-scroll-page.html, fast/events/ios/activating-reset-button-should-not-scroll-page.html, fast/events/ios/activating-submit-button-should-not-scroll-page.html, fast/events/ios/keypress-keys-in-non-editable-element.html, fast/forms/ios/focus-radio.html, fast/forms/ios/focus-reset-button.html, fast/forms/ios/focus-ring-size.html, fast/forms/ios/focus-search-field.html, fast/forms/ios/focus-submit-button.html, fast/forms/ios/focus-text-field.html, fast/scrolling/ios/key-command-scroll-to-top.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17683 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61299 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73940 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67429 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3460 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89208 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43374 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15752 "Found 9 new JSC stress test failures: wasm.yaml/wasm/fuzz/export-function.js.wasm-eager, wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit, wasm.yaml/wasm/stress/tail-call-js-inline.js.default-wasm, wasm.yaml/wasm/stress/tail-call-simple.js.wasm-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45642 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->