### PR TITLE
Create GCD and XPC Pointers to call proper retain and release

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -329,7 +329,7 @@ void RemoteInspector::setupXPCConnectionIfNeeded()
         return;
     }
 
-    auto connection = adoptOSObject(xpc_connection_create_mach_service(WIRXPCMachPortName, m_xpcQueue, 0));
+    auto connection = adoptXPCObject(xpc_connection_create_mach_service(WIRXPCMachPortName, m_xpcQueue, 0));
     if (!connection) {
         WTFLogAlways("RemoteInspector failed to create XPC connection.");
         return;

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
@@ -28,9 +28,10 @@
 #if ENABLE(REMOTE_INSPECTOR)
 
 #import <dispatch/dispatch.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/Lock.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/XPCPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 OBJC_CLASS NSDictionary;
@@ -64,8 +65,8 @@ private:
     // We make sure that m_client is thread safe and immediately cleared in close().
     Lock m_mutex;
 
-    OSObjectPtr<xpc_connection_t> m_connection;
-    OSObjectPtr<dispatch_queue_t> m_queue;
+    XPCPtr<xpc_connection_t> m_connection;
+    GCDPtr<dispatch_queue_t> m_queue;
     Client* m_client;
     bool m_closed { false };
 #if PLATFORM(MAC)

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
@@ -180,12 +180,12 @@ void RemoteInspectorXPCConnection::sendMessage(NSString *messageName, NSDictiona
     if (userInfo)
         [dictionary setObject:userInfo forKey:RemoteInspectorXPCConnectionUserInfoKey];
 
-    auto xpcDictionary = adoptOSObject(_CFXPCCreateXPCMessageWithCFObject((__bridge CFDictionaryRef)dictionary.get()));
+    auto xpcDictionary = adoptXPCObject(_CFXPCCreateXPCMessageWithCFObject((__bridge CFDictionaryRef)dictionary.get()));
     ASSERT_WITH_MESSAGE(xpcDictionary && xpc_get_type(xpcDictionary.get()) == XPC_TYPE_DICTIONARY, "Unable to serialize xpc message");
     if (!xpcDictionary)
         return;
 
-    auto msg = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto msg = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_value(msg.get(), RemoteInspectorXPCConnectionSerializedMessageKey, xpcDictionary.get());
     xpc_connection_send_message(m_connection.get(), msg.get());
 }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -122,7 +122,7 @@
 
 #if PLATFORM(COCOA)
 #include <crt_externs.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #include <wtf/cocoa/CrashReporter.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
@@ -4423,7 +4423,7 @@ int jscmain(int argc, char** argv)
 #if PLATFORM(COCOA)
     auto& memoryPressureHandler = MemoryPressureHandler::singleton();
     {
-        auto queue = adoptOSObject(dispatch_queue_create("jsc shell memory pressure handler", DISPATCH_QUEUE_SERIAL));
+        auto queue = adoptGCDObject(dispatch_queue_create("jsc shell memory pressure handler", DISPATCH_QUEUE_SERIAL));
         memoryPressureHandler.setDispatchQueue(WTFMove(queue));
     }
     Box<Critical> memoryPressureCriticalState = Box<Critical>::create(Critical::No);

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -197,6 +197,8 @@
 		A8A47460151A825B004123FF /* CollatorDefault.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4734B151A825B004123FF /* CollatorDefault.cpp */; };
 		A8A47463151A825B004123FF /* CollatorICU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47350151A825B004123FF /* CollatorICU.cpp */; };
 		A8A47469151A825B004123FF /* UTF8Conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47357151A825B004123FF /* UTF8Conversion.cpp */; };
+		AAA027472C9E791800E7B3A4 /* GCDPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = AAA027462C9E791800E7B3A4 /* GCDPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AAFCED042C9E5CE100A86CAE /* XPCPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = AAFCED032C9E5CE100A86CAE /* XPCPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD89B6B71E6415080090707F /* MemoryPressureHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD89B6B51E6415080090707F /* MemoryPressureHandler.cpp */; };
 		AD89B6BA1E64150F0090707F /* MemoryPressureHandlerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = AD89B6B91E64150F0090707F /* MemoryPressureHandlerCocoa.mm */; };
 		ADF2CE671E39F106006889DB /* MemoryFootprintCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */; };
@@ -1507,6 +1509,10 @@
 		A8A47372151A825B004123FF /* VMTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMTags.h; sourceTree = "<group>"; };
 		A8A4748B151A8264004123FF /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		A9A4727F151A825A004123FF /* DisallowCType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisallowCType.h; sourceTree = "<group>"; };
+		AAA027462C9E791800E7B3A4 /* GCDPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GCDPtr.h; path = wtf/GCDPtr.h; sourceTree = "<group>"; };
+		AAA027482C9E794500E7B3A4 /* XPCPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XPCPtr.h; path = wtf/XPCPtr.h; sourceTree = "<group>"; };
+		AAFCED032C9E5CE100A86CAE /* XPCPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPCPtr.h; sourceTree = "<group>"; };
+		AAFCED052C9E5CFC00A86CAE /* GCDPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GCDPtr.h; sourceTree = "<group>"; };
 		AD653DA82006B6C200D820D7 /* RawValueTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RawValueTraits.h; sourceTree = "<group>"; };
 		AD7C434A1DD2A4A70026888B /* Expected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Expected.h; sourceTree = "<group>"; };
 		AD89B6B51E6415080090707F /* MemoryPressureHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryPressureHandler.cpp; sourceTree = "<group>"; };
@@ -1967,6 +1973,8 @@
 		5D247B5714689B8600E78B76 = {
 			isa = PBXGroup;
 			children = (
+				AAA027482C9E794500E7B3A4 /* XPCPtr.h */,
+				AAA027462C9E791800E7B3A4 /* GCDPtr.h */,
 				140ECC352C9906DF00473E19 /* RefCountedAndCanMakeWeakPtr.h */,
 				5D247B6D14689C4700E78B76 /* Configurations */,
 				DDE9931F278D0FAA00F60D26 /* Frameworks */,
@@ -2196,6 +2204,7 @@
 				1A1D8B9B173186CE00141DA4 /* FunctionDispatcher.h */,
 				FEC26BF2289DBBD300639A59 /* FunctionPtr.h */,
 				53F1D98620477B9800EBC6BF /* FunctionTraits.h */,
+				AAFCED052C9E5CFC00A86CAE /* GCDPtr.h */,
 				E3FD6D6627A1F6AD00935000 /* GenericHashKey.h */,
 				E3831F922703101A00EF5EB3 /* GenericTimeMixin.h */,
 				A8A472A8151A825A004123FF /* GetPtr.h */,
@@ -2540,6 +2549,7 @@
 				E36BA9DC29E275DB00300057 /* WTFProcess.cpp */,
 				E36BA9DD29E275DB00300057 /* WTFProcess.h */,
 				A36E16F7216FF828008DD87E /* WTFSemaphore.h */,
+				AAFCED032C9E5CE100A86CAE /* XPCPtr.h */,
 			);
 			path = wtf;
 			sourceTree = "<group>";
@@ -3274,6 +3284,7 @@
 				DD3DC8AA27A4BF8E007E5B61 /* FunctionDispatcher.h in Headers */,
 				FEC26BF3289DBBD300639A59 /* FunctionPtr.h in Headers */,
 				DD3DC94E27A4BF8E007E5B61 /* FunctionTraits.h in Headers */,
+				AAA027472C9E791800E7B3A4 /* GCDPtr.h in Headers */,
 				DDF3080227C08A77006A526F /* generate-unified-source-bundles.rb in Headers */,
 				DDF3080327C08A77006A526F /* GeneratePreferences.rb in Headers */,
 				DDCAF31D27B1E7C500C45308 /* GenericHashKey.h in Headers */,
@@ -3634,6 +3645,7 @@
 				DDF307C227C086DF006A526F /* WTFString.h in Headers */,
 				FFE39CB02B1D7472004972B0 /* wuint.h in Headers */,
 				FF41AC672A79C9BA00AC0FA5 /* WYHash.h in Headers */,
+				AAFCED042C9E5CE100A86CAE /* XPCPtr.h in Headers */,
 				DDF306EA27C08654006A526F /* XPCSPI.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -94,6 +94,7 @@ set(WTF_PUBLIC_HEADERS
     FunctionDispatcher.h
     FunctionPtr.h
     FunctionTraits.h
+    GCDPtr.h
     GenericHashKey.h
     GenericTimeMixin.h
     GetPtr.h
@@ -361,6 +362,7 @@ set(WTF_PUBLIC_HEADERS
     WordLock.h
     WorkQueue.h
     WorkerPool.h
+    XPCPtr.h
     dtoa.h
 
     dragonbox/dragonbox.h

--- a/Source/WTF/wtf/GCDPtr.h
+++ b/Source/WTF/wtf/GCDPtr.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <os/object.h>
+#include <wtf/StdLibExtras.h>
+
+// Because ARC enablement is a compile-time choice, and we compile this header
+// both ways, we need a separate copy of our code when ARC is enabled.
+#if __has_feature(objc_arc)
+#define adoptGCDObject adoptGCDObjectArc
+#define retainGCDObject retainGCDObjectArc
+#define releaseGCDObject releaseGCDObject
+#endif
+
+namespace WTF {
+
+template<typename> class GCDPtr;
+template<typename T> GCDPtr<T> adoptGCDObject(T) WARN_UNUSED_RETURN;
+
+template<typename T> static inline void retainGCDObject(T ptr)
+{
+#if __has_feature(objc_arc)
+    UNUSED_PARAM(ptr);
+#else
+    dispatch_retain(ptr);
+#endif
+}
+
+template<typename T> static inline void releaseGCDObject(T ptr)
+{
+#if __has_feature(objc_arc)
+    UNUSED_PARAM(ptr);
+#else
+    dispatch_release(ptr);
+#endif
+}
+
+template<typename T> class GCDPtr {
+public:
+    GCDPtr()
+        : m_ptr(nullptr)
+    {
+    }
+
+    ~GCDPtr()
+    {
+        if (m_ptr)
+            releaseGCDObject(m_ptr);
+    }
+
+    T get() const { return m_ptr; }
+
+    explicit operator bool() const { return m_ptr; }
+    bool operator!() const { return !m_ptr; }
+
+    GCDPtr(const GCDPtr& other)
+        : m_ptr(other.m_ptr)
+    {
+        if (m_ptr)
+            retainGCDObject(m_ptr);
+    }
+
+    GCDPtr(GCDPtr&& other)
+        : m_ptr(WTFMove(other.m_ptr))
+    {
+        other.m_ptr = nullptr;
+    }
+
+    GCDPtr(T ptr)
+        : m_ptr(WTFMove(ptr))
+    {
+        if (m_ptr)
+            retainGCDObject(m_ptr);
+    }
+
+    GCDPtr& operator=(const GCDPtr& other)
+    {
+        GCDPtr ptr = other;
+        swap(ptr);
+        return *this;
+    }
+
+    GCDPtr& operator=(GCDPtr&& other)
+    {
+        GCDPtr ptr = WTFMove(other);
+        swap(ptr);
+        return *this;
+    }
+
+    GCDPtr& operator=(std::nullptr_t)
+    {
+        if (m_ptr)
+            releaseGCDObject(m_ptr);
+        m_ptr = nullptr;
+        return *this;
+    }
+
+    GCDPtr& operator=(T other)
+    {
+        GCDPtr ptr = WTFMove(other);
+        swap(ptr);
+        return *this;
+    }
+
+    void swap(GCDPtr& other)
+    {
+        std::swap(m_ptr, other.m_ptr);
+    }
+
+    T leakRef() WARN_UNUSED_RETURN
+    {
+        return std::exchange(m_ptr, nullptr);
+    }
+
+    friend GCDPtr adoptGCDObject<T>(T) WARN_UNUSED_RETURN;
+
+private:
+    struct AdoptGCDObject { };
+    GCDPtr(AdoptGCDObject, T ptr)
+        : m_ptr(WTFMove(ptr))
+    {
+    }
+
+    T m_ptr;
+};
+
+template<typename T> inline GCDPtr<T> adoptGCDObject(T ptr)
+{
+    return GCDPtr<T> { typename GCDPtr<T>::AdoptGCDObject { }, WTFMove(ptr) };
+}
+
+} // namespace WTF
+
+using WTF::adoptGCDObject;
+using WTF::GCDPtr;

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -38,7 +38,7 @@
 #endif
 
 #if PLATFORM(COCOA)
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #endif
 
 namespace WTF {
@@ -131,7 +131,7 @@ public:
     WTF_EXPORT_PRIVATE MemoryUsagePolicy currentMemoryUsagePolicy();
 
 #if PLATFORM(COCOA)
-    void setDispatchQueue(OSObjectPtr<dispatch_queue_t>&& queue)
+    void setDispatchQueue(GCDPtr<dispatch_queue_t>&& queue)
     {
         RELEASE_ASSERT(!m_installed);
         m_dispatchQueue = WTFMove(queue);
@@ -268,7 +268,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    OSObjectPtr<dispatch_queue_t> m_dispatchQueue;
+    GCDPtr<dispatch_queue_t> m_dispatchQueue;
 #endif
 };
 

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -194,8 +194,8 @@ template<typename T> RetainPtr<typename RetainPtr<T>::HelperPtrType> retainPtr(T
 
 template<typename T> inline RetainPtr<T>::~RetainPtr()
 {
-    if (auto ptr = std::exchange(m_ptr, nullptr))
-        CFRelease(ptr);
+    if (m_ptr)
+        CFRelease(m_ptr);
 }
 
 template<typename T> inline RetainPtr<T>::RetainPtr(PtrType ptr)

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -34,7 +34,7 @@
 
 #if USE(COCOA_EVENT_LOOP)
 #include <dispatch/dispatch.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #else
 #include <wtf/RunLoop.h>
 #endif
@@ -63,13 +63,13 @@ protected:
     };
     WorkQueueBase(ASCIILiteral name, Type, QOS);
 #if USE(COCOA_EVENT_LOOP)
-    explicit WorkQueueBase(OSObjectPtr<dispatch_queue_t>&&);
+    explicit WorkQueueBase(GCDPtr<dispatch_queue_t>&&);
 #else
     explicit WorkQueueBase(RunLoop&);
 #endif
 
 #if USE(COCOA_EVENT_LOOP)
-    OSObjectPtr<dispatch_queue_t> m_dispatchQueue;
+    GCDPtr<dispatch_queue_t> m_dispatchQueue;
 #else
     RunLoop* m_runLoop;
 #endif

--- a/Source/WTF/wtf/XPCPtr.h
+++ b/Source/WTF/wtf/XPCPtr.h
@@ -151,26 +151,6 @@ private:
     T m_ptr;
 };
 
-template<typename T> inline void swap(RetainPtr<T>& a, RetainPtr<T>& b)
-{
-    a.swap(b);
-}
-
-template<typename T, typename U> constexpr bool operator==(const RetainPtr<T>& a, const RetainPtr<U>& b)
-{ 
-    return a.get() == b.get(); 
-}
-
-template<typename T, typename U> constexpr bool operator==(const RetainPtr<T>& a, U* b)
-{
-    return a.get() == b; 
-}
-
-template<typename T, typename U> constexpr bool operator==(T* a, const RetainPtr<U>& b)
-{
-    return a == b.get(); 
-}
-
 template<typename T> struct IsSmartPtr<XPCPtr<T>> {
     static constexpr bool value = true;
     static constexpr bool isNullable = true;

--- a/Source/WTF/wtf/XPCPtr.h
+++ b/Source/WTF/wtf/XPCPtr.h
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <os/object.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/HashTraits.h>
+#include <wtf/NeverDestroyed.h>
+
+// Because ARC enablement is a compile-time choice, and we compile this header
+// both ways, we need a separate copy of our code when ARC is enabled.
+#if __has_feature(objc_arc)
+#define adoptXPCObject adoptXPCObjectArc
+#define retainXPCObject retainXPCObjectArc
+#define releaseXPCObject releaseXPCObject
+#endif
+
+namespace WTF {
+
+template<typename> class XPCPtr;
+template<typename T> XPCPtr<T> adoptXPCObject(T) WARN_UNUSED_RETURN;
+
+template<typename T> static inline void retainXPCObject(T ptr)
+{
+#if __has_feature(objc_arc)
+    UNUSED_PARAM(ptr);
+#else
+    xpc_retain(ptr);
+#endif
+}
+
+template<typename T> static inline void releaseXPCObject(T ptr)
+{
+#if __has_feature(objc_arc)
+    UNUSED_PARAM(ptr);
+#else
+    xpc_release(ptr);
+#endif
+}
+
+template<typename T> class XPCPtr {
+public:
+    XPCPtr()
+        : m_ptr(nullptr)
+    {
+    }
+
+    ~XPCPtr()
+    {
+        if (m_ptr)
+            releaseXPCObject(m_ptr);
+    }
+
+    T get() const { return m_ptr; }
+
+    explicit operator bool() const { return m_ptr; }
+    bool operator!() const { return !m_ptr; }
+
+    XPCPtr(const XPCPtr& other)
+        : m_ptr(other.m_ptr)
+    {
+        if (m_ptr)
+            retainXPCObject(m_ptr);
+    }
+
+    XPCPtr(XPCPtr&& other)
+        : m_ptr(WTFMove(other.m_ptr))
+    {
+        other.m_ptr = nullptr;
+    }
+
+    XPCPtr(T ptr)
+        : m_ptr(WTFMove(ptr))
+    {
+        if (m_ptr)
+            retainXPCObject(m_ptr);
+    }
+
+    XPCPtr& operator=(const XPCPtr& other)
+    {
+        XPCPtr ptr = other;
+        swap(ptr);
+        return *this;
+    }
+
+    XPCPtr& operator=(XPCPtr&& other)
+    {
+        XPCPtr ptr = WTFMove(other);
+        swap(ptr);
+        return *this;
+    }
+
+    XPCPtr& operator=(std::nullptr_t)
+    {
+        if (m_ptr)
+            releaseXPCObject(m_ptr);
+        m_ptr = nullptr;
+        return *this;
+    }
+
+    XPCPtr& operator=(T other)
+    {
+        XPCPtr ptr = WTFMove(other);
+        swap(ptr);
+        return *this;
+    }
+
+    void swap(XPCPtr& other)
+    {
+        std::swap(m_ptr, other.m_ptr);
+    }
+
+    T leakRef() WARN_UNUSED_RETURN
+    {
+        return std::exchange(m_ptr, nullptr);
+    }
+
+    friend XPCPtr adoptXPCObject<T>(T) WARN_UNUSED_RETURN;
+
+private:
+    struct AdoptXPCObject { };
+    XPCPtr(AdoptXPCObject, T ptr)
+        : m_ptr(WTFMove(ptr))
+    {
+    }
+
+    T m_ptr;
+};
+
+template<typename T> inline void swap(RetainPtr<T>& a, RetainPtr<T>& b)
+{
+    a.swap(b);
+}
+
+template<typename T, typename U> constexpr bool operator==(const RetainPtr<T>& a, const RetainPtr<U>& b)
+{ 
+    return a.get() == b.get(); 
+}
+
+template<typename T, typename U> constexpr bool operator==(const RetainPtr<T>& a, U* b)
+{
+    return a.get() == b; 
+}
+
+template<typename T, typename U> constexpr bool operator==(T* a, const RetainPtr<U>& b)
+{
+    return a == b.get(); 
+}
+
+template<typename T> struct IsSmartPtr<XPCPtr<T>> {
+    static constexpr bool value = true;
+    static constexpr bool isNullable = true;
+};
+
+template<typename P> struct HashTraits<XPCPtr<P>> : SimpleClassHashTraits<XPCPtr<P>> {
+};
+
+template<typename P> struct DefaultHash<XPCPtr<P>> : PtrHash<XPCPtr<P>> { };
+
+template<typename P> struct XPCPtrObjectHashTraits : SimpleClassHashTraits<XPCPtr<P>> {
+    static const XPCPtr<P>& emptyValue()
+    {
+        static NeverDestroyed<XPCPtr<P>> null;
+        return null;
+    }
+
+    static bool isEmptyValue(const XPCPtr<P>& value) { return !value; }
+};
+
+template<typename P> struct XPCPtrObjectHash {
+    static size_t hash(const XPCPtr<P>& o)
+    {
+        ASSERT_WITH_MESSAGE(o.get(), "attempt to use null XPCPtr in HashTable");
+        return xpc_hash(o.get());
+    }
+    static bool equal(const XPCPtr<P>& a, const XPCPtr<P>& b)
+    {
+        return xpc_equal(a.get(), b.get());
+    }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+inline bool safeXPCEqual(xpc_object_t a, xpc_object_t b)
+{
+    return (!a && !b) || (a && b && xpc_equal(a, b));
+}
+
+inline size_t safeXPCHash(xpc_object_t a)
+{
+    return a ? xpc_hash(a) : 0;
+}
+
+} // namespace WTF
+
+using WTF::adoptXPCObject;
+using WTF::XPCPtr;
+using WTF::safeXPCEqual;
+using WTF::safeXPCHash;

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -26,8 +26,8 @@
 #import "config.h"
 #import <wtf/cocoa/Entitlements.h>
 
-#import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/XPCPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/WTFString.h>
 
@@ -48,13 +48,13 @@ bool hasEntitlement(audit_token_t token, ASCIILiteral entitlement)
 
 bool hasEntitlement(xpc_connection_t connection, StringView entitlement)
 {
-    auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
+    auto value = adoptXPCObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 
 bool hasEntitlement(xpc_connection_t connection, ASCIILiteral entitlement)
 {
-    auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
+    auto value = adoptXPCObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -49,15 +49,15 @@ void MemoryPressureHandler::platformReleaseMemory(Critical critical)
     }
 }
 
-static OSObjectPtr<dispatch_source_t>& memoryPressureEventSource()
+static GCDPtr<dispatch_source_t> &memoryPressureEventSource()
 {
-    static NeverDestroyed<OSObjectPtr<dispatch_source_t>> source;
+    static NeverDestroyed<GCDPtr<dispatch_source_t>> source;
     return source.get();
 }
 
-static OSObjectPtr<dispatch_source_t>& timerEventSource()
+static GCDPtr<dispatch_source_t> &timerEventSource()
 {
-    static NeverDestroyed<OSObjectPtr<dispatch_source_t>> source;
+    static NeverDestroyed<GCDPtr<dispatch_source_t>> source;
     return source.get();
 }
 
@@ -84,7 +84,7 @@ void MemoryPressureHandler::install()
 
     dispatch_async(m_dispatchQueue.get(), ^{
         auto memoryStatusFlags = DISPATCH_MEMORYPRESSURE_NORMAL | DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL;
-        memoryPressureEventSource() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, memoryStatusFlags, m_dispatchQueue.get()));
+        memoryPressureEventSource() = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, memoryStatusFlags, m_dispatchQueue.get()));
 
         dispatch_source_set_event_handler(memoryPressureEventSource().get(), ^{
             auto status = dispatch_source_get_data(memoryPressureEventSource().get());
@@ -197,7 +197,7 @@ void MemoryPressureHandler::uninstall()
 void MemoryPressureHandler::holdOff(Seconds seconds)
 {
     dispatch_async(m_dispatchQueue.get(), ^{
-        timerEventSource() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_dispatchQueue.get()));
+        timerEventSource() = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_dispatchQueue.get()));
         if (timerEventSource()) {
             dispatch_set_context(timerEventSource().get(), this);
             // FIXME: The final argument `s_minimumHoldOffTime.seconds()` seems wrong.

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -76,7 +76,7 @@ void WorkQueueBase::dispatchSync(Function<void()>&& function)
     dispatch_sync_f(m_dispatchQueue.get(), new Function<void()> { WTFMove(function) }, dispatchWorkItem<Function<void()>>);
 }
 
-WorkQueueBase::WorkQueueBase(OSObjectPtr<dispatch_queue_t>&& dispatchQueue)
+WorkQueueBase::WorkQueueBase(GCDPtr<dispatch_queue_t>&& dispatchQueue)
     : m_dispatchQueue(WTFMove(dispatchQueue))
     , m_threadID(mainThreadID)
 {
@@ -86,7 +86,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type type, QOS qos)
 {
     dispatch_queue_attr_t attr = type == Type::Concurrent ? DISPATCH_QUEUE_CONCURRENT : DISPATCH_QUEUE_SERIAL;
     attr = dispatch_queue_attr_make_with_qos_class(attr, Thread::dispatchQOSClass(qos), 0);
-    m_dispatchQueue = adoptOSObject(dispatch_queue_create(name, attr));
+    m_dispatchQueue = adoptGCDObject(dispatch_queue_create(name, attr));
     dispatch_set_context(m_dispatchQueue.get(), this);
     // We use &s_uid for the key, since it's convenient. Dispatch does not dereference it.
     // We use s_uid to generate the id so that WorkQueues and Threads share the id namespace.

--- a/Source/WebCore/platform/FileMonitor.h
+++ b/Source/WebCore/platform/FileMonitor.h
@@ -32,7 +32,7 @@
 
 #if USE(COCOA_EVENT_LOOP)
 #include <dispatch/dispatch.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #endif
 
 #if USE(GLIB)
@@ -52,7 +52,7 @@ public:
 
 private:
 #if USE(COCOA_EVENT_LOOP)
-    OSObjectPtr<dispatch_source_t> m_platformMonitor;
+    GCDPtr<dispatch_source_t> m_platformMonitor;
 #endif
 #if USE(GLIB)
     static void fileChangedCallback(GFileMonitor*, GFile*, GFile*, GFileMonitorEvent, FileMonitor*);

--- a/Source/WebCore/platform/VideoReceiverEndpoint.h
+++ b/Source/WebCore/platform/VideoReceiverEndpoint.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-using VideoReceiverEndpoint = OSObjectPtr<xpc_object_t>;
+using VideoReceiverEndpoint = XPCPtr<xpc_object_t>;
 #else
 using VideoReceiverEndpoint = void*;
 #endif

--- a/Source/WebCore/platform/cocoa/FileMonitorCocoa.mm
+++ b/Source/WebCore/platform/cocoa/FileMonitorCocoa.mm
@@ -50,7 +50,7 @@ FileMonitor::FileMonitor(const String& path, Ref<WorkQueue>&& handlerQueue, WTF:
     }
 
     // The source (platformMonitor) retains the dispatch queue.
-    m_platformMonitor = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE, handle, monitorMask, handlerQueue->dispatchQueue()));
+    m_platformMonitor = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE, handle, monitorMask, handlerQueue->dispatchQueue()));
 
     LOG(ResourceLoadStatistics, "Creating monitor %p", m_platformMonitor.get());
 

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
@@ -30,10 +30,11 @@
 #include "PlatformContentFilter.h"
 #include <objc/NSObjCRuntime.h>
 #include <wtf/Compiler.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/XPCPtr.h>
 
 enum NEFilterSourceStatus : NSInteger;
 
@@ -65,7 +66,7 @@ private:
     void initialize(const URL* = nullptr);
     void handleDecision(NEFilterSourceStatus, NSData *replacementData);
 
-    OSObjectPtr<dispatch_queue_t> m_queue;
+    GCDPtr<dispatch_queue_t> m_queue;
     RetainPtr<NSData> m_replacementData;
     RetainPtr<NEFilterSource> m_neFilterSource;
 };

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -65,7 +65,7 @@ void NetworkExtensionContentFilter::initialize(const URL* url)
 {
     ASSERT(!m_queue);
     ASSERT(!m_neFilterSource);
-    m_queue = adoptOSObject(dispatch_queue_create("WebKit NetworkExtension Filtering", DISPATCH_QUEUE_SERIAL));
+    m_queue = adoptGCDObject(dispatch_queue_create("WebKit NetworkExtension Filtering", DISPATCH_QUEUE_SERIAL));
     ASSERT_UNUSED(url, !url);
     m_neFilterSource = adoptNS([[NEFilterSource alloc] initWithDecisionQueue:m_queue.get()]);
     [m_neFilterSource setSourceAppIdentifier:applicationBundleIdentifier()];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -103,13 +103,14 @@
 #import <pal/text/TextCodecUTF8.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/FileSystem.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/ListHashSet.h>
 #import <wtf/NativePromise.h>
 #import <wtf/NeverDestroyed.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/XPCPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/CString.h>
 #import <wtf/threads/BinarySemaphore.h>
@@ -1267,7 +1268,7 @@ void MediaPlayerPrivateAVFoundationObjC::beginLoadingMetadata()
 {
     INFO_LOG(LOGIDENTIFIER);
 
-    OSObjectPtr<dispatch_group_t> metadataLoadingGroup = adoptOSObject(dispatch_group_create());
+    GCDPtr<dispatch_group_t> metadataLoadingGroup = adoptGCDObject(dispatch_group_create());
     dispatch_group_enter(metadataLoadingGroup.get());
     ThreadSafeWeakPtr weakThis { *this };
     [m_avAsset loadValuesAsynchronouslyForKeys:assetMetadataKeyNames() completionHandler:^{

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -40,6 +40,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WorkQueue.h>
+#include <wtf/XPCPtr.h>
 
 typedef CFTypeRef CMBufferRef;
 typedef const struct __CFArray * CFArrayRef;
@@ -141,7 +142,7 @@ private:
     RetainPtr<CMTimebaseRef> m_timebase WTF_GUARDED_BY_LOCK(m_lock);
     const Ref<WorkQueue> m_decompressionQueue;
     const Ref<WorkQueue> m_enqueingQueue;
-    OSObjectPtr<dispatch_source_t> m_timerSource WTF_GUARDED_BY_LOCK(m_lock);
+    GCDPtr<dispatch_source_t> m_timerSource WTF_GUARDED_BY_LOCK(m_lock);
     Function<void()> m_notificationCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
     Function<void()> m_hasAvailableFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
     Function<void(RetainPtr<CMSampleBufferRef>&&)> m_newDecodedFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -105,7 +105,7 @@ void WebCoreDecompressionSession::setTimebaseWithLockHeld(CMTimebaseRef timebase
 
     if (m_timebase) {
         if (!m_timerSource) {
-            m_timerSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue()));
+            m_timerSource = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue()));
             dispatch_source_set_event_handler(m_timerSource.get(), [this] {
                 automaticDequeue();
             });

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -37,12 +37,12 @@
 #import <UIKit/UIColor.h>
 #import <UIKit/UIImage.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-#import <pal/ios/UIKitSoftLink.h>
 #import <pal/spi/ios/UIKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/FileSystem.h>
-#import <wtf/OSObjectPtr.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/RetainPtr.h>
+#import <pal/ios/UIKitSoftLink.h>
 
 typedef void(^ItemProviderDataLoadCompletionHandler)(NSData *, NSError *);
 typedef void(^ItemProviderFileLoadCompletionHandler)(NSURL *, BOOL, NSError *);
@@ -829,8 +829,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     auto setFileURLsLock = adoptNS([[NSLock alloc] init]);
-    auto synchronousFileLoadingGroup = adoptOSObject(dispatch_group_create());
-    auto fileLoadingGroup = adoptOSObject(dispatch_group_create());
+    auto synchronousFileLoadingGroup = adoptGCDObject(dispatch_group_create());
+    auto fileLoadingGroup = adoptGCDObject(dispatch_group_create());
     for (WebItemProviderLoadResult *loadResult in loadResults.get()) {
         for (NSString *typeToLoad in loadResult.typesToLoad) {
             dispatch_group_enter(fileLoadingGroup.get());

--- a/Source/WebCore/platform/mac/PowerObserverMac.cpp
+++ b/Source/WebCore/platform/mac/PowerObserverMac.cpp
@@ -38,7 +38,7 @@ PowerObserver::PowerObserver(Function<void()>&& powerOnHander)
     , m_powerConnection(0)
     , m_notificationPort(nullptr)
     , m_notifierReference(0)
-    , m_dispatchQueue(adoptOSObject(dispatch_queue_create("com.apple.WebKit.PowerObserver", 0)))
+    , m_dispatchQueue(adoptGCDObject(dispatch_queue_create("com.apple.WebKit.PowerObserver", 0)))
 {
     m_powerConnection = IORegisterForSystemPower(this, &m_notificationPort, [](void* context, io_service_t service, uint32_t messageType, void* messageArgument) {
         static_cast<PowerObserver*>(context)->didReceiveSystemPowerNotification(service, messageType, messageArgument);

--- a/Source/WebCore/platform/mac/PowerObserverMac.h
+++ b/Source/WebCore/platform/mac/PowerObserverMac.h
@@ -29,8 +29,8 @@
 #import <IOKit/IOMessage.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 #import <wtf/Function.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/Noncopyable.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
@@ -60,7 +60,7 @@ private:
     io_connect_t m_powerConnection;
     IONotificationPortRef m_notificationPort;
     io_object_t m_notifierReference;
-    OSObjectPtr<dispatch_queue_t> m_dispatchQueue;
+    GCDPtr<dispatch_queue_t> m_dispatchQueue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -33,7 +33,7 @@
 #include <wtf/BlockPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSDictionary;
@@ -119,7 +119,7 @@ private:
     RetainPtr<CMSampleBufferRef> m_currentFrame;
     RefPtr<ScreenCaptureSessionSource> m_sessionSource;
     RetainPtr<SCStreamConfiguration> m_streamConfiguration;
-    OSObjectPtr<dispatch_queue_t> m_captureQueue;
+    GCDPtr<dispatch_queue_t> m_captureQueue;
     CaptureDevice m_captureDevice;
     uint32_t m_deviceID { 0 };
     mutable std::optional<IntSize> m_intrinsicSize;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -609,7 +609,7 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
 dispatch_queue_t ScreenCaptureKitCaptureSource::captureQueue()
 {
     if (!m_captureQueue)
-        m_captureQueue = adoptOSObject(dispatch_queue_create("CGDisplayStreamCaptureSource Capture Queue", DISPATCH_QUEUE_SERIAL));
+        m_captureQueue = adoptGCDObject(dispatch_queue_create("CGDisplayStreamCaptureSource Capture Queue", DISPATCH_QUEUE_SERIAL));
 
     return m_captureQueue.get();
 }

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class GPUServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    GPUServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    GPUServiceInitializerDelegate(XPCPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class ModelServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    ModelServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    ModelServiceInitializerDelegate(XPCPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class NetworkServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    NetworkServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    NetworkServiceInitializerDelegate(XPCPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTFMove(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -568,7 +568,7 @@ private:
     // FIXME: We'd like to be able to do this without the #ifdef, but WorkQueue + BinarySemaphore isn't good enough since
     // multiple requests to clear the cache can come in before previous requests complete, and we need to wait for all of them.
     // In the future using WorkQueue and a counting semaphore would work, as would WorkQueue supporting the libdispatch concept of "work groups".
-    OSObjectPtr<dispatch_group_t> m_clearCacheDispatchGroup;
+    GCDPtr<dispatch_group_t> m_clearCacheDispatchGroup;
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -44,10 +44,10 @@ void Connection::newConnectionWasInitialized() const
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(m_configuration));
 }
 
-static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+static XPCPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder> &&encoder)
 {
     auto xpcData = encoderToXPCData(WTFMove(encoder));
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -60,7 +60,7 @@ public:
 private:
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)
-    OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
+    XPCPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
     void connectionReceivedEvent(xpc_object_t) final { }
 #endif
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
@@ -50,7 +50,7 @@ public:
 private:
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)
-    OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
+    XPCPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
     void connectionReceivedEvent(xpc_object_t) final;
 #endif
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -59,9 +59,9 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
     m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), MessageSource::PrivateClickMeasurement, messageLevel, String::fromUTF8(debugMessage));
 }
 
-OSObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
+XPCPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage &&message) const
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     addVersionAndEncodedMessageToDictionary(WTFMove(message), dictionary.get());
     xpc_dictionary_set_uint64(dictionary.get(), protocolMessageTypeKey, static_cast<uint64_t>(messageType));
     return dictionary;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -32,7 +32,7 @@
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #endif
 
 #if USE(GLIB)
@@ -64,7 +64,7 @@ public:
 
 #if PLATFORM(COCOA)
     enum class Backing { Buffer, Map };
-    Data(OSObjectPtr<dispatch_data_t>&&, Backing = Backing::Buffer);
+    Data(GCDPtr<dispatch_data_t>&&, Backing = Backing::Buffer);
 #endif
 #if USE(GLIB)
     Data(GRefPtr<GBytes>&&, FileSystem::PlatformFileHandle fd = FileSystem::invalidPlatformFileHandle);
@@ -95,7 +95,7 @@ public:
 #endif
 private:
 #if PLATFORM(COCOA)
-    mutable OSObjectPtr<dispatch_data_t> m_dispatchData;
+    mutable GCDPtr<dispatch_data_t> m_dispatchData;
     mutable std::span<const uint8_t> m_data;
 #endif
 #if USE(GLIB)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
@@ -74,7 +74,7 @@ private:
 #endif
     std::atomic<bool> m_wasDeleted { false }; // Try to narrow down a crash, https://bugs.webkit.org/show_bug.cgi?id=165659
 #if PLATFORM(COCOA)
-    OSObjectPtr<dispatch_io_t> m_dispatchIO;
+    GCDPtr<dispatch_io_t> m_dispatchIO;
 #endif
 #if USE(GLIB)
     GRefPtr<GInputStream> m_inputStream;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -82,7 +82,7 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
     int fd = ::open(path.data(), oflag, mode);
     m_fileDescriptor = fd;
 
-    m_dispatchIO = adoptOSObject(dispatch_io_create(DISPATCH_IO_RANDOM, fd, dispatch_get_global_queue(dispatchQueueIdentifier(dispatchQOS), 0), [fd](int) {
+    m_dispatchIO = adoptGCDObject(dispatch_io_create(DISPATCH_IO_RANDOM, fd, dispatch_get_global_queue(dispatchQueueIdentifier(dispatchQOS), 0), [fd](int) {
         close(fd);
     }));
     ASSERT(m_dispatchIO.get());
@@ -104,7 +104,7 @@ void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Func
         ASSERT_UNUSED(done, done || !didCallCompletionHandler);
         if (didCallCompletionHandler)
             return;
-        Data data { OSObjectPtr<dispatch_data_t> { fileData } };
+        Data data { GCDPtr<dispatch_data_t> { fileData } };
         auto callback = WTFMove(completionHandler);
         callback(data, error);
         didCallCompletionHandler = true;

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -44,7 +44,7 @@ public:
     static ASCIILiteral supplementName();
 
 private:
-    void startObserving(OSObjectPtr<xpc_connection_t>);
+    void startObserving(XPCPtr<xpc_connection_t>);
 
     // XPCEndpoint
     ASCIILiteral xpcEndpointMessageNameKey() const override;
@@ -57,7 +57,7 @@ private:
 
     RetainPtr<id> m_observer;
     Lock m_connectionsLock;
-    Vector<OSObjectPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
+    Vector<XPCPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
 };
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -41,7 +41,7 @@ LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 {
 #if HAVE(LSDATABASECONTEXT) && !HAVE(SYSTEM_CONTENT_LS_DATABASE)
     m_observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -59,7 +59,7 @@ ASCIILiteral LaunchServicesDatabaseObserver::supplementName()
     return "LaunchServicesDatabaseObserverSupplement"_s;
 }
 
-void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t> connection)
+void LaunchServicesDatabaseObserver::startObserving(XPCPtr<xpc_connection_t> connection)
 {
     {
         Locker locker { m_connectionsLock };
@@ -70,7 +70,7 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
     [LSDatabaseContext.sharedDatabaseContext getSystemContentDatabaseObject4WebKit:makeBlockPtr([connection = connection] (xpc_object_t _Nullable object, NSError * _Nullable error) {
         if (!object)
             return;
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, object);
 
@@ -79,7 +79,7 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
     }).get()];
 #elif HAVE(LSDATABASECONTEXT)
     RetainPtr<id> observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -88,7 +88,7 @@ void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t
 
     [LSDatabaseContext.sharedDatabaseContext removeDatabaseChangeObserver4WebKit:observer.get()];
 #else
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
     xpc_connection_send_message(connection.get(), message.get());
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -169,7 +169,7 @@ void NetworkProcess::clearHSTSCache(PAL::SessionID sessionID, WallTime modifiedS
 void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)
 {
     if (!m_clearCacheDispatchGroup)
-        m_clearCacheDispatchGroup = adoptOSObject(dispatch_group_create());
+        m_clearCacheDispatchGroup = adoptGCDObject(dispatch_group_create());
 
     auto group = m_clearCacheDispatchGroup.get();
     dispatch_group_async(group, dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -52,7 +52,8 @@
 
 #if OS(DARWIN)
 #include <mach/mach_port.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #endif
 
@@ -278,14 +279,14 @@ public:
             : port(port)
         {
         }
-        Identifier(mach_port_t port, OSObjectPtr<xpc_connection_t> xpcConnection)
+        Identifier(mach_port_t port, XPCPtr<xpc_connection_t> xpcConnection)
             : port(port)
             , xpcConnection(WTFMove(xpcConnection))
         {
         }
         explicit operator bool() const { return MACH_PORT_VALID(port); }
         mach_port_t port { MACH_PORT_NULL };
-        OSObjectPtr<xpc_connection_t> xpcConnection;
+        XPCPtr<xpc_connection_t> xpcConnection;
 #endif
     };
 
@@ -669,14 +670,14 @@ private:
     void cancelSendSource();
 
     mach_port_t m_sendPort { MACH_PORT_NULL };
-    OSObjectPtr<dispatch_source_t> m_sendSource;
+    GCDPtr<dispatch_source_t> m_sendSource;
 
     mach_port_t m_receivePort { MACH_PORT_NULL };
-    OSObjectPtr<dispatch_source_t> m_receiveSource;
+    GCDPtr<dispatch_source_t> m_receiveSource;
 
     std::unique_ptr<MachMessage> m_pendingOutgoingMachMessage;
 
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCPtr<xpc_connection_t> m_xpcConnection;
     std::atomic<bool> m_didRequestProcessTermination { false };
 #elif OS(WINDOWS)
     // Called on the connection queue.

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -31,7 +31,7 @@
 #include <wtf/text/CString.h>
 
 #if PLATFORM(COCOA)
-#include <wtf/OSObjectPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #endif
 
@@ -60,13 +60,15 @@ public:
     virtual ~Connection() = default;
 
 #if PLATFORM(COCOA)
-    explicit Connection(OSObjectPtr<xpc_connection_t>&& connection)
-        : m_connection(WTFMove(connection)) { }
+    explicit Connection(XPCPtr<xpc_connection_t>&& connection)
+        : m_connection(WTFMove(connection))
+    {
+    }
     xpc_connection_t get() const { return m_connection.get(); }
     void send(xpc_object_t) const;
     void sendWithReply(xpc_object_t, CompletionHandler<void(xpc_object_t)>&&) const;
 protected:
-    mutable OSObjectPtr<xpc_connection_t> m_connection;
+    mutable XPCPtr<xpc_connection_t> m_connection;
 #endif
     virtual void initializeConnectionIfNeeded() const { }
 };
@@ -83,7 +85,7 @@ public:
 
     virtual void newConnectionWasInitialized() const = 0;
 #if PLATFORM(COCOA)
-    virtual OSObjectPtr<xpc_object_t> dictionaryFromMessage(typename Traits::MessageType, EncodedMessage&&) const = 0;
+    virtual XPCPtr<xpc_object_t> dictionaryFromMessage(typename Traits::MessageType, EncodedMessage&&) const = 0;
     virtual void connectionReceivedEvent(xpc_object_t) = 0;
 #endif
 

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -197,7 +197,7 @@ void Connection::platformOpen()
     // Change the message queue length for the receive port.
     setMachPortQueueLength(m_receivePort, largeOutgoingMessageQueueCountThreshold);
 
-    m_receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, m_connectionQueue->dispatchQueue()));
+    m_receiveSource = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, m_connectionQueue->dispatchQueue()));
     dispatch_source_set_event_handler(m_receiveSource.get(), [this, protectedThis = Ref { *this }] {
         receiveSourceEventHandler();
     });
@@ -341,7 +341,7 @@ void Connection::initializeSendSource()
         return;
     RELEASE_ASSERT(m_sendPort != MACH_PORT_NULL);
 
-    m_sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, m_connectionQueue->dispatchQueue()));
+    m_sendSource = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, m_connectionQueue->dispatchQueue()));
     dispatch_source_set_registration_handler(m_sendSource.get(), [this, protectedThis = Ref { *this }] {
         if (!m_sendSource)
             return;

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -64,7 +64,7 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
 {
     if (m_connection)
         return;
-    m_connection = adoptOSObject(xpc_connection_create_mach_service(m_machServiceName.data(), dispatch_get_main_queue(), 0));
+    m_connection = adoptXPCObject(xpc_connection_create_mach_service(m_machServiceName.data(), dispatch_get_main_queue(), 0));
     xpc_connection_set_event_handler(m_connection.get(), [weakThis = WeakPtr { *this }](xpc_object_t event) {
         if (!weakThis)
             return;

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -27,9 +27,9 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/XPCPtr.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS CAContext;
@@ -115,7 +115,7 @@ public:
     LayerHostingContextID cachedContextID();
 
 #if USE(EXTENSIONKIT)
-    OSObjectPtr<xpc_object_t> xpcRepresentation() const;
+    XPCPtr<xpc_object_t> xpcRepresentation() const;
     RetainPtr<BELayerHierarchy> hostable() const { return m_hostable; }
 
     static RetainPtr<BELayerHierarchyHandle> createHostingHandle(uint64_t pid, uint64_t contextID);

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -219,7 +219,7 @@ LayerHostingContextID LayerHostingContext::cachedContextID()
 }
 
 #if USE(EXTENSIONKIT)
-OSObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
+XPCPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 {
     if (!m_hostable)
         return nullptr;
@@ -228,7 +228,7 @@ OSObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 
 RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::createHostingUpdateCoordinator(mach_port_t sendRight)
 {
-    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto xpcRepresentation = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_mach_send(xpcRepresentation.get(), machPortKey, sendRight);
     NSError* error = nil;
     auto coordinator = [getBELayerHierarchyHostingTransactionCoordinatorClass() coordinatorWithXPCRepresentation:xpcRepresentation.get() error:&error];
@@ -239,7 +239,7 @@ RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::cr
 
 RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(uint64_t pid, uint64_t contextID)
 {
-    auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto xpcRepresentation = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(xpcRepresentation.get(), processIDKey, pid);
     xpc_dictionary_set_uint64(xpcRepresentation.get(), contextIDKey, contextID);
     NSError* error = nil;

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -50,7 +50,7 @@ void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
 
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
     // Give the process a chance to exit cleanly by sending a XPC message to request termination, then try xpc_connection_kill.
-    auto exitMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto exitMessage = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(exitMessage.get(), messageNameKey, exitProcessMessage.characters());
     xpc_connection_send_message(connection, exitMessage.get());
 #endif

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
@@ -42,7 +42,7 @@ public:
 
     static ASCIILiteral messageName() { return "video-receiver-endpoint"_s; }
     static VideoReceiverEndpointMessage decode(xpc_object_t);
-    OSObjectPtr<xpc_object_t> encode() const;
+    XPCPtr<xpc_object_t> encode() const;
 
     const WebCore::ProcessIdentifier& processIdentifier() const { return m_processIdentifier; }
     const WebCore::HTMLMediaElementIdentifier& mediaElementIdentifier() const { return m_mediaElementIdentifier; }

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -63,9 +63,9 @@ VideoReceiverEndpointMessage VideoReceiverEndpointMessage::decode(xpc_object_t m
     };
 }
 
-OSObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
+XPCPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
 {
-    OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    OSObjectPtr message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier.toUInt64());
     xpc_dictionary_set_uint64(message.get(), mediaElementIdentifierKey.characters(), m_mediaElementIdentifier.toUInt64());

--- a/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -54,7 +54,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
         handleXPCExitMessage(event);
 #endif
-        callOnMainRunLoop([event = OSObjectPtr(event), weakThis = weakThis] {
+        callOnMainRunLoop([event = XPCPtr(event), weakThis = weakThis] {
             RELEASE_ASSERT(isMainRunLoop());
 
             xpc_type_t type = xpc_get_type(event.get());

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
@@ -28,7 +28,7 @@
 #ifdef __cplusplus
 
 #include <WebKit/WKBase.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #include <wtf/text/ASCIILiteral.h>
 
@@ -41,7 +41,7 @@ public:
 
     WK_EXPORT void sendEndpointToConnection(xpc_connection_t);
 
-    WK_EXPORT OSObjectPtr<xpc_endpoint_t> endpoint() const;
+    WK_EXPORT XPCPtr<xpc_endpoint_t> endpoint() const;
 
     static constexpr auto xpcMessageNameKey = "message-name"_s;
 
@@ -51,8 +51,8 @@ private:
     virtual ASCIILiteral xpcEndpointNameKey() const = 0;
     virtual void handleEvent(xpc_connection_t, xpc_object_t) = 0;
 
-    OSObjectPtr<xpc_connection_t> m_connection;
-    OSObjectPtr<xpc_endpoint_t> m_endpoint;
+    XPCPtr<xpc_connection_t> m_connection;
+    XPCPtr<xpc_endpoint_t> m_endpoint;
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -40,8 +40,8 @@ namespace WebKit {
 
 XPCEndpoint::XPCEndpoint()
 {
-    m_connection = adoptOSObject(xpc_connection_create(nullptr, nullptr));
-    m_endpoint = adoptOSObject(xpc_endpoint_create(m_connection.get()));
+    m_connection = adoptXPCObject(xpc_connection_create(nullptr, nullptr));
+    m_endpoint = adoptXPCObject(xpc_endpoint_create(m_connection.get()));
 
     xpc_connection_set_target_queue(m_connection.get(), dispatch_get_main_queue());
     xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
@@ -50,7 +50,7 @@ XPCEndpoint::XPCEndpoint()
         handleXPCExitMessage(message);
 #endif
         if (type == XPC_TYPE_CONNECTION) {
-            OSObjectPtr<xpc_connection_t> connection = message;
+            XPCPtr<xpc_connection_t> connection = message;
 #if USE(APPLE_INTERNAL_SDK)
             auto pid = xpc_connection_get_pid(connection.get());
 
@@ -83,14 +83,14 @@ void XPCEndpoint::sendEndpointToConnection(xpc_connection_t connection)
     if (!connection)
         return;
 
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), xpcEndpointMessageNameKey(), xpcEndpointMessageName());
     xpc_dictionary_set_value(message.get(), xpcEndpointNameKey(), m_endpoint.get());
 
     xpc_connection_send_message(connection, message.get());
 }
 
-OSObjectPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const
+XPCPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const
 {
     return m_endpoint;
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.h
@@ -29,7 +29,7 @@
 
 #include <WebKit/WKBase.h>
 #include <wtf/Lock.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit {
@@ -41,14 +41,14 @@ public:
     WK_EXPORT void setEndpoint(xpc_endpoint_t);
 
 protected:
-    WK_EXPORT OSObjectPtr<xpc_connection_t> connection();
+    WK_EXPORT XPCPtr<xpc_connection_t> connection();
 
 private:
     virtual void handleEvent(xpc_object_t) = 0;
     virtual void didConnect() = 0;
 
     Lock m_connectionLock;
-    OSObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
+    XPCPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
@@ -41,7 +41,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
         if (m_connection)
             return;
 
-        m_connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));
+        m_connection = adoptXPCObject(xpc_connection_create_from_endpoint(endpoint));
 
         xpc_connection_set_target_queue(m_connection.get(), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
         xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
@@ -75,7 +75,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
     didConnect();
 }
 
-OSObjectPtr<xpc_connection_t> XPCEndpointClient::connection()
+XPCPtr<xpc_connection_t> XPCEndpointClient::connection()
 {
     Locker locker { m_connectionLock };
     return m_connection;

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.h
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace IPC {
@@ -37,7 +37,7 @@ class Encoder;
 namespace WebKit {
 
 void startListeningForMachServiceConnections(const char* serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t));
-RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
-OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
+XPCPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
+XPCPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/HashMap.h>
-#include <wtf/RetainPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace JSC {
@@ -52,7 +52,7 @@ public:
     
 private:
     enum class DebugModeEnabled : bool { No, Yes };
-    HashMap<RetainPtr<xpc_connection_t>, DebugModeEnabled> m_connections;
+    HashMap<XPCPtr<xpc_connection_t>, DebugModeEnabled> m_connections;
     size_t m_connectionsWithDebugModeEnabled { 0 };
 };
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
@@ -83,7 +83,7 @@ bool DaemonConnectionSet::debugModeEnabled() const
 
 void DaemonConnectionSet::broadcastConsoleMessage(JSC::MessageLevel messageLevel, const String& message)
 {
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), protocolDebugMessageLevelKey, static_cast<uint64_t>(messageLevel));
     xpc_dictionary_set_string(dictionary.get(), protocolDebugMessageKey, message.utf8().data());
     for (auto& connection : m_connections.keys())

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -46,12 +46,12 @@
 
 namespace WebKit {
 
-static CompletionHandler<void(PCM::EncodedMessage&&)> replySender(PCM::MessageType messageType, OSObjectPtr<xpc_object_t>&& request)
+static CompletionHandler<void(PCM::EncodedMessage &&)> replySender(PCM::MessageType messageType, XPCPtr<xpc_object_t> &&request)
 {
     if (!PCM::messageTypeSendsReply(messageType))
         return nullptr;
-    return [request = WTFMove(request)] (PCM::EncodedMessage&& message) {
-        auto reply = adoptOSObject(xpc_dictionary_create_reply(request.get()));
+    return [request = WTFMove(request)](PCM::EncodedMessage &&message) {
+        auto reply = adoptXPCObject(xpc_dictionary_create_reply(request.get()));
         PCM::addVersionAndEncodedMessageToDictionary(WTFMove(message), reply.get());
         xpc_connection_send_message(xpc_dictionary_get_remote_connection(request.get()), reply.get());
     };
@@ -81,7 +81,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     xpc_activity_register("com.apple.webkit.adattributiond.activity", XPC_ACTIVITY_CHECK_IN, ^(xpc_activity_t activity) {
         if (xpc_activity_get_state(activity) == XPC_ACTIVITY_STATE_CHECK_IN) {
             NSLog(@"Activity checking in");
-            auto criteria = adoptOSObject(xpc_activity_copy_criteria(activity));
+            auto criteria = adoptXPCObject(xpc_activity_copy_criteria(activity));
 
             // These values should align with values from com.apple.webkit.adattributiond.plist
             constexpr auto oneHourSeconds = 3600;

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -52,7 +52,7 @@ namespace WebKit {
 
 class XPCServiceInitializerDelegate {
 public:
-    XPCServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    XPCServiceInitializerDelegate(XPCPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : m_connection(WTFMove(connection))
         , m_initializerMessage(initializerMessage)
     {
@@ -74,7 +74,7 @@ protected:
     bool hasEntitlement(ASCIILiteral entitlement);
     bool isClientSandboxed();
 
-    OSObjectPtr<xpc_connection_t> m_connection;
+    XPCPtr<xpc_connection_t> m_connection;
     xpc_object_t m_initializerMessage;
 };
 
@@ -93,7 +93,7 @@ enum class EnableLockdownMode: bool { No, Yes };
 void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode, bool isWebContentProcess);
 
 template<typename XPCServiceType, typename XPCServiceInitializerDelegateType, bool isWebContentProcess = false>
-void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+void XPCServiceInitializer(XPCPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
 {
     XPCServiceInitializerDelegateType delegate(WTFMove(connection), initializerMessage);
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -162,7 +162,7 @@ bool XPCServiceInitializerDelegate::isClientSandboxed()
 void setOSTransaction(OSObjectPtr<os_transaction_t>&& transaction)
 {
     static NeverDestroyed<OSObjectPtr<os_transaction_t>> globalTransaction;
-    static NeverDestroyed<OSObjectPtr<dispatch_source_t>> globalSource;
+    static NeverDestroyed<GCDPtr<dispatch_source_t>> globalSource;
 
     // Because we don't use RunningBoard on macOS, we leak an OS transaction to control the lifetime of our XPC
     // services ourselves. However, one of the side effects of leaking this transaction is that the default SIGTERM
@@ -172,7 +172,7 @@ void setOSTransaction(OSObjectPtr<os_transaction_t>&& transaction)
     // control our lifetime via process assertions instead of leaking this OS transaction.
     static dispatch_once_t flag;
     dispatch_once(&flag, ^{
-        globalSource.get() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue()));
+        globalSource.get() = adoptGCDObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue()));
         dispatch_source_set_event_handler(globalSource.get().get(), ^{
             exitProcess(0);
         });

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -124,7 +124,7 @@ static void checkFrameworkVersion(xpc_object_t message)
 
 void XPCServiceEventHandler(xpc_connection_t peer)
 {
-    OSObjectPtr<xpc_connection_t> retainedPeerConnection(peer);
+    XPCPtr<xpc_connection_t> retainedPeerConnection(peer);
 
     xpc_connection_set_target_queue(peer, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
     xpc_connection_set_event_handler(peer, ^(xpc_object_t event) {
@@ -211,7 +211,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 return;
             }
 
-            auto reply = adoptOSObject(xpc_dictionary_create_reply(event));
+            auto reply = adoptXPCObject(xpc_dictionary_create_reply(event));
             xpc_dictionary_set_string(reply.get(), "message-name", "process-finished-launching");
             xpc_connection_send_message(xpc_dictionary_get_remote_connection(event), reply.get());
 
@@ -223,7 +223,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             if (fd != -1)
                 dup2(fd, STDERR_FILENO);
 
-            WorkQueue::main().dispatchSync([initializerFunctionPtr, event = OSObjectPtr<xpc_object_t>(event), retainedPeerConnection] {
+            WorkQueue::main().dispatchSync([initializerFunctionPtr, event = XPCPtr<xpc_object_t>(event), retainedPeerConnection] {
                 WTF::initializeMainThread();
 
                 initializeCFPrefs();
@@ -246,7 +246,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 
 int XPCServiceMain(int, const char**)
 {
-    auto bootstrap = adoptOSObject(xpc_copy_bootstrap());
+    auto bootstrap = adoptXPCObject(xpc_copy_bootstrap());
 
     if (bootstrap) {
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -40,14 +40,14 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
 {
     ASSERT(secKeyProxyStore.isInitialized());
 
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), ClientCertificateAuthentication::XPCMessageNameKey, ClientCertificateAuthentication::XPCMessageNameValue);
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCChallengeIDKey, challengeID.toUInt64());
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, secKeyProxyStore.get().endpoint._endpoint);
-    auto certificateDataArray = adoptOSObject(xpc_array_create(nullptr, 0));
+    auto certificateDataArray = adoptXPCObject(xpc_array_create(nullptr, 0));
     for (id certificate in credential.nsCredential().certificates) {
         auto data = adoptCF(SecCertificateCopyData((SecCertificateRef)certificate));
-        xpc_array_append_value(certificateDataArray.get(), adoptOSObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());
+        xpc_array_append_value(certificateDataArray.get(), adoptXPCObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());
     }
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCCertificatesKey, certificateDataArray.get());
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCPersistenceKey, static_cast<uint64_t>(credential.nsCredential().persistence));

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1355,7 +1355,7 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
     if (view && view->_hostingView) {
         auto hostingUpdateCoordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithError:nil];
         [hostingUpdateCoordinator addLayerHierarchyHostingView:view->_hostingView.get()];
-        OSObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
+        XPCPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
         fenceSendRight = MachSendRight::adopt(xpc_dictionary_copy_mach_send(xpcRepresentationHostingCoordinator.get(), machPortKey));
         page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::SetVideoLayerFrameFenced(contextId, frame, WTFMove(fenceSendRight)), page->webPageIDInMainFrameProcess());
         [hostingUpdateCoordinator commit];

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#import <wtf/OSObjectPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/Seconds.h>
+#import <wtf/XPCPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 #if USE(EXTENSIONKIT_PROCESS_TERMINATION)
@@ -60,7 +60,7 @@ private:
 #if USE(EXTENSIONKIT_PROCESS_TERMINATION)
     std::optional<ExtensionProcess> m_process;
 #else
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCPtr<xpc_connection_t> m_xpcConnection;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -167,7 +167,7 @@ private:
     Client* m_client;
 
 #if PLATFORM(COCOA)
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCPtr<xpc_connection_t> m_xpcConnection;
 #endif
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -29,8 +29,8 @@
 #include "ExtensionCapabilityGrant.h"
 
 #include <wtf/BlockPtr.h>
-#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/XPCPtr.h>
 
 #if USE(EXTENSIONKIT)
 OBJC_CLASS BEWebContentProcess;
@@ -59,7 +59,7 @@ public:
 #endif
 
     void invalidate() const;
-    OSObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
+    XPCPtr<xpc_connection_t> makeLibXPCConnection() const;
     PlatformGrant grantCapability(const PlatformCapability&, BlockPtr<void()>&& invalidationHandler = ^{ }) const;
     RetainPtr<UIInteraction> createVisibilityPropagationInteraction() const;
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -67,10 +67,10 @@ void ExtensionProcess::invalidate() const
     });
 }
 
-OSObjectPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
+XPCPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
 {
     NSError *error = nil;
-    OSObjectPtr<xpc_connection_t> xpcConnection;
+    XPCPtr<xpc_connection_t> xpcConnection;
     WTF::switchOn(m_process, [&] (auto& process) {
         xpcConnection = [process makeLibXPCConnectionError:&error];
     });

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -455,7 +455,7 @@ private:
     private:
         WeakPtr<NetworkProcessProxy> m_networkProcess;
     };
-    OSObjectPtr<xpc_object_t> m_endpointMessage;
+    XPCPtr<xpc_object_t> m_endpointMessage;
 #endif
 
     WeakHashSet<WebsiteDataStore> m_websiteDataStores;

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -34,7 +34,7 @@
 #import <Metal/Metal.h>
 #import <WebCore/PlatformXR.h>
 #import <WebCore/PlatformXRPose.h>
-#import <wtf/OSObjectPtr.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/WeakObjCPtr.h>
 
@@ -384,7 +384,7 @@ id<WKARPresentationSession> createPresentationSession(ARSession *session, WKARPr
 #pragma mark - _WKTransientGestureRecognizer implementation
 
 @implementation _WKTransientGestureRecognizer {
-    OSObjectPtr<dispatch_queue_t> _accessQueue;
+    GCDPtr<dispatch_queue_t> _accessQueue;
     WeakObjCPtr<_WKARPresentationSession> _session;
     RetainPtr<NSMutableDictionary<NSNumber *, _WKTransientAction *>> _transientActions;
 }
@@ -393,7 +393,7 @@ id<WKARPresentationSession> createPresentationSession(ARSession *session, WKARPr
 {
     self = [super init];
     if (self) {
-        _accessQueue = adoptOSObject(dispatch_queue_create("com.apple.WebContent._WKTransientGestureRecognizer.AccessQueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL));
+        _accessQueue = adoptGCDObject(dispatch_queue_create("com.apple.WebContent._WKTransientGestureRecognizer.AccessQueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL));
         _session = session;
         _transientActions = adoptNS([NSMutableDictionary new]);
     }

--- a/Source/WebKit/UIProcess/ios/WKMouseDeviceObserver.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseDeviceObserver.mm
@@ -30,15 +30,15 @@
 
 #import "WebProcessProxy.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/MainThread.h>
-#import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
 
 @implementation WKMouseDeviceObserver {
     BOOL _hasMouseDevice;
     size_t _startCount;
     RetainPtr<id<BSInvalidatable>> _token;
-    OSObjectPtr<dispatch_queue_t> _deviceObserverTokenQueue;
+    GCDPtr<dispatch_queue_t> _deviceObserverTokenQueue;
 }
 
 + (WKMouseDeviceObserver *)sharedInstance
@@ -52,7 +52,7 @@
     if (!(self = [super init]))
         return nil;
 
-    _deviceObserverTokenQueue = adoptOSObject(dispatch_queue_create("WKMouseDeviceObserver _deviceObserverTokenQueue", DISPATCH_QUEUE_SERIAL));
+    _deviceObserverTokenQueue = adoptGCDObject(dispatch_queue_create("WKMouseDeviceObserver _deviceObserverTokenQueue", DISPATCH_QUEUE_SERIAL));
 
     return self;
 }

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -36,6 +36,7 @@
 #import <WebCore/SecurityOrigin.h>
 #import <pal/spi/cocoa/NSFileManagerSPI.h>
 #import <wtf/Deque.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
@@ -106,7 +107,7 @@ struct PermissionRequest {
 
 @implementation WKWebGeolocationPolicyDecider {
 @private
-    RetainPtr<dispatch_queue_t> _diskDispatchQueue;
+    GCDPtr<dispatch_queue_t> _diskDispatchQueue;
     RetainPtr<NSMutableDictionary> _sites;
     Deque<std::unique_ptr<PermissionRequest>> _challenges;
     std::unique_ptr<PermissionRequest> _activeChallenge;
@@ -126,7 +127,7 @@ struct PermissionRequest {
     if (!self)
         return nil;
 
-    _diskDispatchQueue = adoptNS(dispatch_queue_create("com.apple.WebKit.WKWebGeolocationPolicyDecider", DISPATCH_QUEUE_SERIAL));
+    _diskDispatchQueue = adoptGCDObject(dispatch_queue_create("com.apple.WebKit.WKWebGeolocationPolicyDecider", DISPATCH_QUEUE_SERIAL));
 
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), self, clearGeolocationCache, CLAppResetChangedNotification, NULL, CFNotificationSuspensionBehaviorCoalesce);
 

--- a/Source/WebKit/UIProcess/mac/ServicesController.mm
+++ b/Source/WebKit/UIProcess/mac/ServicesController.mm
@@ -84,7 +84,7 @@ void ServicesController::refreshExistingServices(bool refreshImmediately)
 
     auto refreshTime = dispatch_time(DISPATCH_TIME_NOW, refreshImmediately ? 0 : (int64_t)(1 * NSEC_PER_SEC));
     dispatch_after(refreshTime, m_refreshQueue, ^{
-        auto serviceLookupGroup = adoptOSObject(dispatch_group_create());
+        auto serviceLookupGroup = adoptGCDObject(dispatch_group_create());
 
         static NSImage *image { [[NSImage alloc] init] };
         hasCompatibleServicesForItems(serviceLookupGroup.get(), @[ image ], [this] (bool hasServices) {

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -65,7 +65,7 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 
 void LaunchServicesDatabaseManager::didConnect()
 {
-    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName);
 
     auto connection = this->connection();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -363,13 +363,13 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
 #if HAVE(VIDEO_RESTRICTED_DECODING)
 #if (PLATFORM(MAC) || PLATFORM(MACCATALYST)) && !ENABLE(TRUSTD_BLOCKING_IN_WEBCONTENT)
-    OSObjectPtr<dispatch_semaphore_t> codeCheckSemaphore;
+    GCDPtr<dispatch_semaphore_t> codeCheckSemaphore;
     if (SandboxExtension::consumePermanently(parameters.trustdExtensionHandle)) {
         // Open up a Mach connection to trustd by doing a code check validation on the main bundle.
         // This is required since launchd will be blocked after process launch, which prevents new Mach connections to be created.
         // FIXME: remove this once <rdar://90127163> is fixed.
         // Dispatch this work on a thread to avoid blocking the main thread. We will wait for this to complete at the end of this method.
-        codeCheckSemaphore = adoptOSObject(dispatch_semaphore_create(0));
+        codeCheckSemaphore = adoptGCDObject(dispatch_semaphore_create(0));
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), [codeCheckSemaphore = codeCheckSemaphore] {
             auto bundleURL = adoptCF(CFBundleCopyBundleURL(CFBundleGetMainBundle()));
             SecStaticCodeRef code = nullptr;

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -45,6 +45,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #include <wtf/text/WTFString.h>
 
@@ -117,7 +118,7 @@ private:
     void setAppBadge(WebCore::SecurityOriginData&&, std::optional<uint64_t>);
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
 
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    XPCPtr<xpc_connection_t> m_xpcConnection;
     String m_hostAppCodeSigningIdentifier;
     bool m_hostAppHasPushInjectEntitlement { false };
     String m_pushPartitionString;

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -350,7 +350,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
     }
 #endif
 
-    auto reply = adoptOSObject(xpc_dictionary_create_reply(request));
+    auto reply = adoptXPCObject(xpc_dictionary_create_reply(request));
     auto replyHandler = [xpcConnection = WTFMove(xpcConnection), reply = WTFMove(reply)] (UniqueRef<IPC::Encoder>&& encoder) {
         RELEASE_ASSERT(RunLoop::isMain());
         auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -30,10 +30,10 @@
 #include <WebCore/PushPermissionState.h>
 #include <memory>
 #include <wtf/CompletionHandler.h>
-#include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/XPCPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 using WebKit::WebPushD::PushMessageForTesting;
@@ -86,7 +86,7 @@ private:
     String m_bundleIdentifier;
     String m_pushPartition;
 
-    RetainPtr<xpc_connection_t> m_connection;
+    XPCPtr<xpc_connection_t> m_connection;
     ASCIILiteral m_serviceName;
 };
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -76,8 +76,7 @@ Connection::Connection(PreferTestService preferTestService, String bundleIdentif
 
 void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 {
-
-    m_connection = adoptNS(xpc_connection_create_mach_service(m_serviceName, dispatch_get_main_queue(), 0));
+    m_connection = adoptXPCObject(xpc_connection_create_mach_service(m_serviceName, dispatch_get_main_queue(), 0));
 
     xpc_connection_set_event_handler(m_connection.get(), [](xpc_object_t event) {
         if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_CONNECTION_INTERRUPTED) {
@@ -148,10 +147,10 @@ void Connection::sendAuditToken()
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTFMove(configuration)));
 }
 
-static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+static XPCPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder> &&encoder)
 {
     auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -111,25 +111,25 @@ static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestS
 
     const char* serviceName = (preferTestService == WebPushTool::PreferTestService::Yes) ? "org.webkit.webpushtestdaemon.service" : "com.apple.webkit.webpushd.service";
 
-    auto plist = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto plist = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(plist.get(), "_ManagedBy", "webpushtool");
     xpc_dictionary_set_string(plist.get(), "Label", "org.webkit.webpushtestdaemon");
     xpc_dictionary_set_bool(plist.get(), "LaunchOnlyOnce", true);
     xpc_dictionary_set_bool(plist.get(), "RootedSimulatorPath", true);
 
     {
-        auto environmentVariables = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto environmentVariables = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_FRAMEWORK_PATH", currentExecutableDirectoryURL.fileSystemRepresentation);
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_LIBRARY_PATH", currentExecutableDirectoryURL.fileSystemRepresentation);
         xpc_dictionary_set_value(plist.get(), "EnvironmentVariables", environmentVariables.get());
     }
     {
-        auto machServices = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto machServices = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_bool(machServices.get(), serviceName, true);
         xpc_dictionary_set_value(plist.get(), "MachServices", machServices.get());
     }
     {
-        auto programArguments = adoptNS(xpc_array_create(nullptr, 0));
+        auto programArguments = adoptXPCObject(xpc_array_create(nullptr, 0));
 #if PLATFORM(MAC)
         xpc_array_set_string(programArguments.get(), XPC_ARRAY_APPEND, daemonExecutablePathURL.fileSystemRepresentation);
 #else

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -52,6 +52,7 @@
 #import <pal/text/TextEncodingRegistry.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/Compiler.h>
+#import <wtf/GCDPtr.h>
 #import <wtf/MainThread.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>
@@ -200,13 +201,13 @@ struct WebPreferencesPrivate
 public:
     WebPreferencesPrivate()
 #if PLATFORM(IOS_FAMILY)
-        : readWriteQueue { adoptNS(dispatch_queue_create("com.apple.WebPreferences.ReadWriteQueue", DISPATCH_QUEUE_CONCURRENT)) }
+        : readWriteQueue { adoptGCDObject(dispatch_queue_create("com.apple.WebPreferences.ReadWriteQueue", DISPATCH_QUEUE_CONCURRENT)) }
 #endif
     {
     }
 
 #if PLATFORM(IOS_FAMILY)
-    RetainPtr<dispatch_queue_t> readWriteQueue;
+    GCDPtr<dispatch_queue_t> readWriteQueue;
 #endif
     RetainPtr<NSMutableDictionary> values;
     RetainPtr<NSString> identifier;

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1859,7 +1859,7 @@ static void resetWebViewToConsistentState(const WTR::TestOptions& options, Reset
 // lock to prevent potentially re-entering WebCore.
 static void WebThreadLockAfterDelegateCallbacksHaveCompleted()
 {
-    auto delegateSemaphore = adoptOSObject(dispatch_semaphore_create(0));
+    auto delegateSemaphore = adoptGCDObject(dispatch_semaphore_create(0));
     WebThreadRun(^{
         dispatch_semaphore_signal(delegateSemaphore.get());
     });

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/OSObjectPtr.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <wtf/GCDPtr.h>
 #include <wtf/OSObjectPtr.h>
 
 #include <CoreFoundation/CoreFoundation.h>
@@ -47,7 +48,7 @@ namespace TestWebKitAPI {
 
 TEST(OS_OBJECT_PTR_TEST_NAME, AdoptOSObject)
 {
-    OSObjectPtr<dispatch_queue_t> foo = adoptOSObject(dispatch_queue_create(0, DISPATCH_QUEUE_SERIAL));
+    GCDPtr<dispatch_queue_t> foo = adoptGCDObject(dispatch_queue_create(0, DISPATCH_QUEUE_SERIAL));
     uintptr_t fooPtr;
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
         fooPtr = reinterpret_cast<uintptr_t>(foo.get());
@@ -76,7 +77,7 @@ TEST(OS_OBJECT_PTR_TEST_NAME, RetainRelease)
 
 TEST(OS_OBJECT_PTR_TEST_NAME, LeakRef)
 {
-    OSObjectPtr<dispatch_queue_t> foo = adoptOSObject(dispatch_queue_create(0, DISPATCH_QUEUE_SERIAL));
+    GCDPtr<dispatch_queue_t> foo = adoptGCDObject(dispatch_queue_create(0, DISPATCH_QUEUE_SERIAL));
     uintptr_t fooPtr;
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
         fooPtr = reinterpret_cast<uintptr_t>(foo.get());
@@ -90,7 +91,7 @@ TEST(OS_OBJECT_PTR_TEST_NAME, LeakRef)
     EXPECT_EQ(nullptr, foo.get());
     EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)fooPtr));
 
-    WTF::releaseOSObject(queue);
+    WTF::releaseGCDObject(queue);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -57,7 +57,7 @@ private:
         if (messageName && !strcmp(messageName, testMessageFromClient)) {
             endpointReceivedMessageFromClient = true;
 
-            auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromEndpoint);
             xpc_connection_send_message(connection, message.get());
         }
@@ -74,7 +74,7 @@ private:
     }
     void didConnect() final
     {
-        auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromClient);
         xpc_connection_send_message(connection().get(), message.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -498,13 +498,13 @@ static void attemptConnectionInProcessWithoutEntitlement()
 {
 #if USE(APPLE_INTERNAL_SDK)
     __block bool done = false;
-    auto connection = adoptNS(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", dispatch_get_main_queue(), 0));
+    auto connection = adoptXPCObject(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", dispatch_get_main_queue(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
         EXPECT_EQ(event, XPC_ERROR_CONNECTION_INTERRUPTED);
         done = true;
     });
     xpc_connection_activate(connection.get());
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_connection_send_message(connection.get(), dictionary.get());
     TestWebKitAPI::Util::run(&done);
 #endif

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.h
@@ -28,6 +28,7 @@
 #if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 #import <wtf/RetainPtr.h>
+#import <wtf/XPCPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 @class NSDictionary;

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -66,9 +66,9 @@ RetainPtr<NSURL> currentExecutableDirectory()
 }
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
+static XPCPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 {
-    auto xpc = adoptNS(xpc_array_create(nullptr, 0));
+    auto xpc = adoptXPCObject(xpc_array_create(nullptr, 0));
     for (id value in array) {
         if ([value isKindOfClass:NSString.class])
             xpc_array_set_string(xpc.get(), XPC_ARRAY_APPEND, [value UTF8String]);
@@ -78,9 +78,9 @@ static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
     return xpc;
 }
 
-static RetainPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
+static XPCPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
 {
-    auto xpc = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
+    auto xpc = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
     for (NSString *key in dictionary) {
         ASSERT([key isKindOfClass:NSString.class]);
         const char* keyUTF8 = key.UTF8String;

--- a/Tools/TestWebKitAPI/mac/VirtualGamepad.h
+++ b/Tools/TestWebKitAPI/mac/VirtualGamepad.h
@@ -29,7 +29,7 @@
 
 #include <dispatch/dispatch.h>
 #include <wtf/FastMalloc.h>
-#include <wtf/OSObjectPtr.h>
+#include <wtf/GCDPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 
@@ -114,7 +114,7 @@ private:
     RetainPtr<NSString> m_uniqueID;
     RetainPtr<HIDUserDevice> m_userDevice;
     RetainPtr<HIDDevice> m_device;
-    OSObjectPtr<dispatch_queue_t> m_dispatchQueue;
+    GCDPtr<dispatch_queue_t> m_dispatchQueue;
 
     Vector<float> m_buttonValues;
     Vector<float> m_axisValues;

--- a/Tools/TestWebKitAPI/mac/VirtualGamepad.mm
+++ b/Tools/TestWebKitAPI/mac/VirtualGamepad.mm
@@ -42,7 +42,7 @@ namespace TestWebKitAPI {
 VirtualGamepad::VirtualGamepad(const GamepadMapping& gamepadMapping)
     : m_gamepadMapping(gamepadMapping)
 {
-    m_dispatchQueue = adoptOSObject(dispatch_queue_create(0, DISPATCH_QUEUE_SERIAL));
+    m_dispatchQueue = adoptGCDObject(dispatch_queue_create(0, DISPATCH_QUEUE_SERIAL));
     m_uniqueID = NSUUID.UUID.UUIDString;
 
     m_buttonValues = Vector<float>(m_gamepadMapping.buttonCount, 0.0);


### PR DESCRIPTION
<pre>Create GCD and XPC Pointers to call proper retain and release
https://bugs.webkit.org/show_bug.cgi?id=280108

Reviewed by NOBODY (OOPS!).

Otherwise, it will call the wrong retain + release.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5777e195870da71f8a744504b776f00644f4c145

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68272 "3 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47664 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20931 "Hash 5777e195 for PR 34021 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70389 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55460 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19233 "Hash 5777e195 for PR 34021 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/12922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71339 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/55460 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/20931 "Hash 5777e195 for PR 34021 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/34975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/55460 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/20931 "Hash 5777e195 for PR 34021 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17774 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/61390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/55460 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/20931 "Hash 5777e195 for PR 34021 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74031 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67520 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12243 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/19233 "Hash 5777e195 for PR 34021 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/61964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12282 "Hash 5777e195 for PR 34021 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/20931 "Hash 5777e195 for PR 34021 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/20931 "Hash 5777e195 for PR 34021 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89299 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43465 "Hash 5777e195 for PR 34021 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15787 "Found 9 new JSC stress test failures: wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-double.js.wasm-eager, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-collect-continuously, wasm.yaml/wasm/stress/tail-call.js.default-wasm, wasm.yaml/wasm/stress/tail-call.js.wasm-eager, wasm.yaml/wasm/stress/throw-null-ref.js.wasm-collect-continuously, wasm.yaml/wasm/v8/many-parameters.js.wasm-bbq (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44539 "Hash 5777e195 for PR 34021 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45733 "Hash 5777e195 for PR 34021 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44281 "Hash 5777e195 for PR 34021 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->