### PR TITLE
Fix more smart pointer static analyzer warnings in Source/WebKit/GPUProcess/media

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -145,13 +145,13 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
 {
     String sceneIdentifier;
     std::optional<AudioSession::SoundStageSize> maxSize;
-    for (auto& proxy : m_proxies) {
-        if (!proxy.isActive())
+    for (Ref proxy : m_proxies) {
+        if (!proxy->isActive())
             continue;
 
-        if (!maxSize || proxy.soundStageSize() > *maxSize) {
-            maxSize = proxy.soundStageSize();
-            sceneIdentifier = proxy.sceneIdentifier();
+        if (!maxSize || proxy->soundStageSize() > *maxSize) {
+            maxSize = proxy->soundStageSize();
+            sceneIdentifier = proxy->sceneIdentifier();
         }
     }
 
@@ -161,8 +161,8 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
 
 bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude)
 {
-    for (auto& proxy : m_proxies) {
-        if (proxy.isActive() && &proxy != &proxyToExclude)
+    for (Ref proxy : m_proxies) {
+        if (proxy->isActive() && proxy.ptr() != &proxyToExclude)
             return true;
     }
     return false;
@@ -170,8 +170,8 @@ bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionP
 
 bool RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy()
 {
-    for (auto& proxy : m_proxies) {
-        if (proxy.isActive() && !proxy.isInterrupted())
+    for (Ref proxy : m_proxies) {
+        if (proxy->isActive() && !proxy->isInterrupted())
             return true;
     }
     return false;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -136,54 +136,41 @@ void RemoteCDMInstanceSessionProxy::storeRecordOfKeyUsage(const String& sessionI
 
 void RemoteCDMInstanceSessionProxy::updateKeyStatuses(KeyStatusVector&& keyStatuses)
 {
-    if (!m_cdm)
-        return;
-
-    auto* factory = m_cdm->factory();
-    if (!factory)
-        return;
-
-    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
-    if (!gpuConnectionToWebProcess)
-        return;
-
-    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::UpdateKeyStatuses(WTFMove(keyStatuses)), m_identifier);
+    if (RefPtr connection = this->connection())
+        connection->send(Messages::RemoteCDMInstanceSession::UpdateKeyStatuses(WTFMove(keyStatuses)), m_identifier);
 }
 
 void RemoteCDMInstanceSessionProxy::sendMessage(CDMMessageType type, Ref<SharedBuffer>&& message)
 {
-    if (!m_cdm)
-        return;
-    auto* factory = m_cdm->factory();
-    if (!factory)
-        return;
-
-    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
-    if (!gpuConnectionToWebProcess)
-        return;
-
-    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::SendMessage(type, WTFMove(message)), m_identifier);
+    if (RefPtr connection = this->connection())
+        connection->send(Messages::RemoteCDMInstanceSession::SendMessage(type, WTFMove(message)), m_identifier);
 }
 
 void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)
 {
-    if (!m_cdm)
-        return;
-
-    auto* factory = m_cdm->factory();
-    if (!factory)
-        return;
-
-    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
-    if (!gpuConnectionToWebProcess)
-        return;
-
-    gpuConnectionToWebProcess->protectedConnection()->send(Messages::RemoteCDMInstanceSession::SessionIdChanged(sessionId), m_identifier);
+    if (RefPtr connection = this->connection())
+        connection->send(Messages::RemoteCDMInstanceSession::SessionIdChanged(sessionId), m_identifier);
 }
 
 const SharedPreferencesForWebProcess& RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess() const
 {
     return protectedCdm()->sharedPreferencesForWebProcess();
+}
+
+IPC::Connection* RemoteCDMInstanceSessionProxy::connection() const
+{
+    if (!m_cdm)
+        return nullptr;
+
+    RefPtr factory = m_cdm->factory();
+    if (!factory)
+        return nullptr;
+
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
+    if (!gpuConnectionToWebProcess)
+        return nullptr;
+
+    return &gpuConnectionToWebProcess->connection();
 }
 
 RefPtr<RemoteCDMProxy> RemoteCDMInstanceSessionProxy::protectedCdm() const

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -82,6 +82,7 @@ private:
     void sessionIdChanged(const String&) final;
     PlatformDisplayID displayID() final { return m_displayID; }
 
+    IPC::Connection* connection() const;
     RefPtr<RemoteCDMProxy> protectedCdm() const;
 
     WeakPtr<RemoteCDMProxy> m_cdm;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -97,7 +97,7 @@ RefPtr<MediaPlayer> RemoteLegacyCDMProxy::cdmMediaPlayer(const LegacyCDM*) const
 
 const SharedPreferencesForWebProcess& RemoteLegacyCDMProxy::sharedPreferencesForWebProcess() const
 {
-    return m_factory->sharedPreferencesForWebProcess();
+    return protectedFactory()->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -65,6 +65,8 @@ private:
     // LegacyCDMClient
     RefPtr<WebCore::MediaPlayer> cdmMediaPlayer(const WebCore::LegacyCDM*) const final;
 
+    RefPtr<RemoteLegacyCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
+
     WeakPtr<RemoteLegacyCDMFactoryProxy> m_factory;
     WebCore::MediaPlayerIdentifier m_playerId;
     std::unique_ptr<WebCore::LegacyCDM> m_cdm;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -153,10 +153,11 @@ void RemoteLegacyCDMSessionProxy::cachedKeyForKeyID(String keyId, CachedKeyForKe
 
 void RemoteLegacyCDMSessionProxy::sendMessage(Uint8Array* message, String destinationURL)
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return;
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return;
 
@@ -165,10 +166,11 @@ void RemoteLegacyCDMSessionProxy::sendMessage(Uint8Array* message, String destin
 
 void RemoteLegacyCDMSessionProxy::sendError(MediaKeyErrorCode errorCode, uint32_t systemCode)
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return;
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return;
 
@@ -177,10 +179,11 @@ void RemoteLegacyCDMSessionProxy::sendError(MediaKeyErrorCode errorCode, uint32_
 
 String RemoteLegacyCDMSessionProxy::mediaKeysStorageDirectory() const
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return emptyString();
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return emptyString();
 


### PR DESCRIPTION
#### c73fa6cc3f95ad2f0ea8d8cbdf6d88a021d7019e
<pre>
Fix more smart pointer static analyzer warnings in Source/WebKit/GPUProcess/media
<a href="https://bugs.webkit.org/show_bug.cgi?id=280111">https://bugs.webkit.org/show_bug.cgi?id=280111</a>

Reviewed by NOBODY (OOPS!).

Deploy more smart pointers based on clang static analyzers.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateSpatialExperience):
(WebKit::RemoteAudioSessionProxyManager::hasOtherActiveProxyThan):
(WebKit::RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::updateKeyStatuses):
(WebKit::RemoteCDMInstanceSessionProxy::sendMessage):
(WebKit::RemoteCDMInstanceSessionProxy::sessionIdChanged):
(WebKit::RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteCDMInstanceSessionProxy::connection const):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
(WebKit::RemoteLegacyCDMProxy::protectedFactory const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::sendMessage):
(WebKit::RemoteLegacyCDMSessionProxy::sendError):
(WebKit::RemoteLegacyCDMSessionProxy::mediaKeysStorageDirectory const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73fa6cc3f95ad2f0ea8d8cbdf6d88a021d7019e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54456 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71260 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43546 "Found 1 new test failure: editing/input/ios/typing-with-inline-predictions.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40215 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73952 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61932 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3472 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43386 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->