### PR TITLE
[JSC] Add signposts for wasm compilers

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -264,7 +264,9 @@ std::unique_ptr<InternalFunction> BBQPlan::compileFunction(uint32_t functionInde
     Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileResult;
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
+    beginCompilerSignpost(callee);
     parseAndCompileResult = parseAndCompileBBQ(context, callee, function, signature, unlinkedWasmToWasmCalls, m_moduleInformation.get(), m_mode, functionIndex, m_hasExceptionHandlers, UINT32_MAX, tierUp);
+    endCompilerSignpost(callee);
 #endif
 
     if (UNLIKELY(!parseAndCompileResult)) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -96,8 +96,10 @@ void IPIntPlan::compileFunction(uint32_t functionIndex)
     unsigned functionIndexSpace = m_moduleInformation->importFunctionTypeIndices.size() + functionIndex;
     ASSERT_UNUSED(functionIndexSpace, m_moduleInformation->typeIndexFromFunctionIndexSpace(functionIndexSpace) == typeIndex);
 
+    beginCompilerSignpost(CompilationMode::IPIntMode, functionIndexSpace);
     m_unlinkedWasmToWasmCalls[functionIndex] = Vector<UnlinkedWasmToWasmCall>();
     auto parseAndCompileResult = parseAndCompileMetadata(function.data, signature, m_moduleInformation.get(), functionIndex);
+    endCompilerSignpost(CompilationMode::IPIntMode, functionIndexSpace);
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -98,8 +98,10 @@ void LLIntPlan::compileFunction(uint32_t functionIndex)
     unsigned functionIndexSpace = m_moduleInformation->importFunctionTypeIndices.size() + functionIndex;
     ASSERT_UNUSED(functionIndexSpace, m_moduleInformation->typeIndexFromFunctionIndexSpace(functionIndexSpace) == typeIndex);
 
+    beginCompilerSignpost(CompilationMode::LLIntMode, functionIndexSpace);
     m_unlinkedWasmToWasmCalls[functionIndex] = Vector<UnlinkedWasmToWasmCall>();
     auto parseAndCompileResult = parseAndCompileBytecode(function.data, signature, m_moduleInformation.get(), functionIndex);
+    endCompilerSignpost(CompilationMode::LLIntMode, functionIndexSpace);
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -114,9 +114,11 @@ void OMGPlan::work(CompilationEffort)
 
     Ref<OMGCallee> callee = OMGCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
 
+    beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
     auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGMode, m_functionIndex, m_hasExceptionHandlers, UINT32_MAX);
+    endCompilerSignpost(callee.get());
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -106,9 +106,11 @@ void OSREntryPlan::work(CompilationEffort)
     CompilationMode targetCompilationMode = m_callee->compilationMode() == CompilationMode::LLIntMode ? CompilationMode::BBQForOSREntryMode : CompilationMode::OMGForOSREntryMode;
     Ref<OSREntryCallee> callee = OSREntryCallee::create(targetCompilationMode, functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), m_loopIndex);
 
+    beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
     auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, targetCompilationMode, m_functionIndex, m_hasExceptionHandlers, m_loopIndex);
+    endCompilerSignpost(callee.get());
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -34,6 +34,8 @@
 #include <wtf/DataLog.h>
 #include <wtf/Locker.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/StringPrintStream.h>
+#include <wtf/SystemTracing.h>
 
 namespace JSC { namespace Wasm {
 
@@ -126,6 +128,41 @@ void Plan::fail(String&& errorMessage, Error error)
 }
 
 Plan::~Plan() = default;
+
+CString Plan::signpostMessage(CompilationMode compilationMode, uint32_t functionIndexSpace) const
+{
+    CString signpostMessage;
+    const FunctionData& function = m_moduleInformation->functions[functionIndexSpace];
+    StringPrintStream stream;
+    stream.print(compilationMode, " ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))), " instructions size = ", function.data.size());
+    return stream.toCString();
+}
+
+void Plan::beginCompilerSignpost(CompilationMode compilationMode, uint32_t functionIndexSpace) const
+{
+    if (UNLIKELY(Options::useCompilerSignpost())) {
+        auto message = signpostMessage(compilationMode, functionIndexSpace);
+        WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.data() ? message.data() : "(nullptr)");
+    }
+}
+
+void Plan::beginCompilerSignpost(const Callee& callee) const
+{
+    beginCompilerSignpost(callee.compilationMode(), callee.index());
+}
+
+void Plan::endCompilerSignpost(CompilationMode compilationMode, uint32_t functionIndexSpace) const
+{
+    if (UNLIKELY(Options::useCompilerSignpost())) {
+        auto message = signpostMessage(compilationMode, functionIndexSpace);
+        WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.data() ? message.data() : "(nullptr)");
+    }
+}
+
+void Plan::endCompilerSignpost(const Callee& callee) const
+{
+    endCompilerSignpost(callee.compilationMode(), callee.index());
+}
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -90,6 +90,12 @@ protected:
     virtual bool isComplete() const = 0;
     virtual void complete() WTF_REQUIRES_LOCK(m_lock) = 0;
 
+    CString signpostMessage(CompilationMode, uint32_t functionIndexSpace) const;
+    void beginCompilerSignpost(CompilationMode, uint32_t functionIndexSpace) const;
+    void beginCompilerSignpost(const Callee&) const;
+    void endCompilerSignpost(CompilationMode, uint32_t functionIndexSpace) const;
+    void endCompilerSignpost(const Callee&) const;
+
     MemoryMode m_mode { MemoryMode::BoundsChecking };
     Lock m_lock;
     Condition m_completed;


### PR DESCRIPTION
#### 6c2b84745d722a86cdb3da603824555cf7163f8d
<pre>
[JSC] Add signposts for wasm compilers
<a href="https://bugs.webkit.org/show_bug.cgi?id=280112">https://bugs.webkit.org/show_bug.cgi?id=280112</a>
<a href="https://rdar.apple.com/136410806">rdar://136410806</a>

Reviewed by Keith Miller.

Add signposts for wasm compilers to record compiler activities.

* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
(JSC::Wasm::Plan::signpostMessage const):
(JSC::Wasm::Plan::beginCompilerSignpost const):
(JSC::Wasm::Plan::endCompilerSignpost const):
* Source/JavaScriptCore/wasm/WasmPlan.h:

Canonical link: <a href="https://commits.webkit.org/284036@main">https://commits.webkit.org/284036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dfd32e6afd47522d4957307dd8e8ec4584748b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16331 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17697 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61313 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73954 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67443 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61934 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3474 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89222 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43388 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15760 "Found 1 new JSC binary failure: testb3, Found 925 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-bbq, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-collect-continuously, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-eager-jettison, wasm.yaml/wasm/extended-const-spec-tests/elem.wast.js.wasm-no-cjit, wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/global.wast.js.wasm-bbq ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->