### PR TITLE
Discard scrolling to the saved scroll points if there is any selection done by user

### DIFF
--- a/LayoutTests/editing/input/resources/empty-document-goes-back.html
+++ b/LayoutTests/editing/input/resources/empty-document-goes-back.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<script>
+    document.body.offsetWidth;
+    setTimeout("window.history.back();", 0);
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/input/reveal-selection-having-stored-scroll-position-expected.txt
+++ b/LayoutTests/editing/input/reveal-selection-having-stored-scroll-position-expected.txt
@@ -1,0 +1,5 @@
+
+Success! The scroll position in history was not restored after navigation as input field is revealed on selection.
+
+
+

--- a/LayoutTests/editing/input/reveal-selection-having-stored-scroll-position.html
+++ b/LayoutTests/editing/input/reveal-selection-having-stored-scroll-position.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+<script>
+
+function navigate()
+{
+    if (location.hash == "") {
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        scrollTo(0,100);
+        history.pushState({ }, "", window.location + "#1");
+        setTimeout("window.location.href = 'resources/empty-document-goes-back.html'", 0);
+        return;
+    }
+    var input = document.getElementById("text-input");
+    input.focus();
+    if (window.eventSender)
+        eventSender.keyDown("a");
+
+    setTimeout(function () { 
+        var scrollPosition = document.scrollingElement.scrollTop;
+        var result = document.getElementById("result");
+        if (scrollPosition != 100)
+            result.innerHTML = "Success! The scroll position in history was not restored after navigation as input field is revealed on selection."
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+</script>
+</head>
+<body style="width:800px" onpageshow="navigate();">
+    <input id="text-input" type="text"/>
+    <div id="result">Fail. The scroll position in history was restored after navigation.</div><br/><br/>
+    <div style="width:600; height:1200; background-color:purple;"></div>
+</body>
+</htmL>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2675,6 +2676,7 @@ void FrameSelection::revealSelection(SelectionRevealMode revealMode, const Scrol
     // FIXME: This code only handles scrolling the startContainer's layer, but
     // the selection rect could intersect more than just that.
     // See <rdar://problem/4799899>.
+    m_document->frame()->view()->setWasScrolledByUser(true);
     LocalFrameView::scrollRectToVisible(rect, *start.deprecatedNode()->renderer(), insideFixed, { revealMode, alignment, alignment, ShouldAllowCrossOriginScrolling::Yes, scrollBehavior });
     updateAppearance();
 


### PR DESCRIPTION
#### 39c5756b4d9c1e4f7fa26c52046af6a0e6c32416
<pre>
Discard scrolling to the saved scroll points if there is any selection done by user

<a href="https://bugs.webkit.org/show_bug.cgi?id=280116">https://bugs.webkit.org/show_bug.cgi?id=280116</a>
<a href="https://rdar.apple.com/problem/136417261">rdar://problem/136417261</a>

Reviewed by Ryosuke Niwa.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/f0d674248b2737ea20fb62ab38e71f856a98445f">https://chromium.googlesource.com/chromium/blink/+/f0d674248b2737ea20fb62ab38e71f856a98445f</a>

This patch discards scrolling to saved points on back navigation when the
user has selection done to avoid flicker / jumpiness on back navigation.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::revealSelection):
* LayoutTests/editing/input/reveal-selection-having-stored-scroll-position.html:
* LayoutTests/editing/input/reveal-selection-having-stored-scroll-position-expected.txt:
* LayoutTests/editing/input/resources/empty-document-goes-back.html:

Canonical link: <a href="https://commits.webkit.org/284795@main">https://commits.webkit.org/284795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f337723e1de1d5fe65718fc264c228ff486054e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19353 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54470 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61946 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15619 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3485 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43401 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->