### PR TITLE
[CMake] MiniBrowser fails to link in non-developer builds with USE_SKIA=ON

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -20,5 +20,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 list(APPEND WebCore_LIBRARIES
     HarfBuzz::HarfBuzz
     HarfBuzz::ICU
+)
+
+list(APPEND WebCore_PRIVATE_LIBRARIES
     Skia
 )

--- a/Source/WebKit/Platform/Skia.cmake
+++ b/Source/WebKit/Platform/Skia.cmake
@@ -15,6 +15,6 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/skia/CoreIPCSkData.serialization.in
 )
 
-list(APPEND WebKit_LIBRARIES
+list(APPEND WebKit_PRIVATE_LIBRARIES
     Skia
 )

--- a/Tools/ImageDiff/Skia.cmake
+++ b/Tools/ImageDiff/Skia.cmake
@@ -4,7 +4,7 @@ list(APPEND ImageDiff_SOURCES
 
 if (NOT USE_SYSTEM_MALLOC)
     #
-    # Skia is built to use bmalloc/fastMalloc, but ImageDiff should not
+    # Skia is built to use WTF::fastMalloc, but ImageDiff should not
     # link to WTF. Adding the malloc allocator source will make the linker
     # skip the memory allocator symbols from the Skia static library, thus
     # avoiding the need to link to WTF.

--- a/Tools/MiniBrowser/wpe/CMakeLists.txt
+++ b/Tools/MiniBrowser/wpe/CMakeLists.txt
@@ -51,6 +51,30 @@ if (DEVELOPER_MODE)
     list(APPEND MiniBrowser_PRIVATE_DEFINITIONS WEBKIT_INJECTED_BUNDLE_PATH="${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 endif ()
 
+if (USE_SKIA)
+    list(APPEND MiniBrowser_PRIVATE_LIBRARIES Skia)
+    if (NOT USE_SYSTEM_MALLOC)
+        #
+        # Skia uses WTF::fastMalloc only when built inside libWPEWebKit.
+        # Add the malloc allocator here to make the linker skil the symbols
+        # from the static library which have references to WTF.
+        #
+        list(APPEND MiniBrowser_SOURCES
+            ${THIRDPARTY_DIR}/skia/src/ports/SkMemory_malloc.cpp
+        )
+    endif ()
+
+    if (NOT DEFINED CXX_COMPILER_SUPPORTS_-Wno-unused-parameter)
+        check_cxx_compiler_flag(-Wno-unused-parameter CXX_COMPILER_SUPPORTS_-Wno-unused-parameter)
+    endif ()
+    if (CXX_COMPILER_SUPPORTS_-Wno-unused-parameter)
+        set_property(
+            SOURCE ${THIRDPARTY_DIR}/skia/src/ports/SkMemory_malloc.cpp
+            APPEND PROPERTY COMPILE_OPTIONS -Wno-unused-parameter
+        )
+    endif ()
+endif ()
+
 WEBKIT_EXECUTABLE_DECLARE(MiniBrowser)
 WEBKIT_EXECUTABLE(MiniBrowser)
 


### PR DESCRIPTION
#### bb675b5fb390bd0912c0001b5b43390ab9cecaf1
<pre>
[CMake] MiniBrowser fails to link in non-developer builds with USE_SKIA=ON
<a href="https://bugs.webkit.org/show_bug.cgi?id=280124">https://bugs.webkit.org/show_bug.cgi?id=280124</a>

Reviewed by NOBODY (OOPS!).

Make Skia use the bmalloc/fastMalloc allocator only when using inside
WebKit. In order to enforce this, apply the same technique as for
ImageDiff: add SkMemory_malloc.cpp to the list of MiniBrowser sources,
and the linker will skip pulling the symbols from libSkia.a which
reference WTF, as they have less precedence.

* Source/WebCore/platform/Skia.cmake: List Skia in WebCore_PRIVATE_LIBRARIES.
* Source/WebKit/Platform/Skia.cmake: List Skia in WebKit_PRIVATE_LIBRARIES.
* Tools/ImageDiff/Skia.cmake: Correct comment, Skia links against
  WTF::fastMalloc but not bmalloc at the moment.
* Tools/MiniBrowser/wpe/CMakeLists.txt: Add the malloc Skia allocator as
  part of the MiniBrowser build.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb675b5fb390bd0912c0001b5b43390ab9cecaf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20868 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72274 "Hash bb675b5f for PR 34036 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19170 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/72274 "Hash bb675b5f for PR 34036 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58923 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/72274 "Hash bb675b5f for PR 34036 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16692 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73968 "Hash bb675b5f for PR 34036 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15956 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/73968 "Hash bb675b5f for PR 34036 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59002 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/73968 "Hash bb675b5f for PR 34036 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3486 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->