### PR TITLE
Clean up ModelProcessModelPlayerProxy properly in the model process

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -157,8 +157,7 @@ void HTMLModelElement::setSourceURL(const URL& url)
         m_resource = nullptr;
     }
 
-    if (m_modelPlayer)
-        m_modelPlayer = nullptr;
+    deleteModelPlayer();
 
 #if ENABLE(MODEL_PROCESS)
     m_entityTransform = DOMMatrixReadOnly::create(TransformationMatrix::identity, DOMMatrixReadOnly::Is2D::No);
@@ -313,6 +312,13 @@ void HTMLModelElement::createModelPlayer()
     // FIXME: We need to tell the player if the size changes as well, so passing this
     // in with load probably doesn't make sense.
     m_modelPlayer->load(*m_model, size);
+}
+
+void HTMLModelElement::deleteModelPlayer()
+{
+    if (m_modelPlayer)
+        document().page()->modelPlayerProvider().deleteModelPlayer(*m_modelPlayer);
+    m_modelPlayer = nullptr;
 }
 
 bool HTMLModelElement::usesPlatformLayer() const

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -145,6 +145,7 @@ private:
     void setSourceURL(const URL&);
     void modelDidChange();
     void createModelPlayer();
+    void deleteModelPlayer();
 
     HTMLModelElement& readyPromiseResolve();
 

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -36,6 +36,10 @@
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 
+#if ENABLE(MODEL_PROCESS)
+#include "ModelPlayerIdentifier.h"
+#endif
+
 namespace WebCore {
 
 class Color;
@@ -46,6 +50,10 @@ class WEBCORE_EXPORT ModelPlayer : public RefCounted<ModelPlayer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ModelPlayer, WEBCORE_EXPORT);
 public:
     virtual ~ModelPlayer();
+
+#if ENABLE(MODEL_PROCESS)
+    virtual ModelPlayerIdentifier identifier() const = 0;
+#endif
 
     virtual void load(Model&, LayoutSize) = 0;
     virtual void sizeDidChange(LayoutSize) = 0;

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
@@ -41,6 +41,7 @@ public:
     // FIXME: Once all clients have adopted ModelPlayerProvider, this should
     // be changed to return a Ref<ModelPlayer>
     virtual RefPtr<ModelPlayer> createModelPlayer(ModelPlayerClient&) = 0;
+    virtual void deleteModelPlayer(ModelPlayer&) = 0;
 };
 
 }

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -39,9 +39,19 @@ Ref<DummyModelPlayer> DummyModelPlayer::create(ModelPlayerClient& client)
 DummyModelPlayer::DummyModelPlayer(ModelPlayerClient& client)
     : m_client { client }
 {
+#if ENABLE(MODEL_PROCESS)
+    m_id = ModelPlayerIdentifier::generate();
+#endif
 }
 
 DummyModelPlayer::~DummyModelPlayer() = default;
+
+#if ENABLE(MODEL_PROCESS)
+ModelPlayerIdentifier DummyModelPlayer::identifier() const
+{
+    return m_id;
+}
+#endif
 
 void DummyModelPlayer::load(Model& model, LayoutSize)
 {

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -41,6 +41,9 @@ private:
     DummyModelPlayer(ModelPlayerClient&);
 
     // ModelPlayer overrides.
+#if ENABLE(MODEL_PROCESS)
+    ModelPlayerIdentifier identifier() const final;
+#endif
     void load(Model&, LayoutSize) override;
     void sizeDidChange(LayoutSize) override;
     PlatformLayer* layer() override;
@@ -66,6 +69,9 @@ private:
 #endif
 
     WeakPtr<ModelPlayerClient> m_client;
+#if ENABLE(MODEL_PROCESS)
+    ModelPlayerIdentifier m_id;
+#endif
 };
 
 }

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.cpp
@@ -41,4 +41,8 @@ RefPtr<ModelPlayer> DummyModelPlayerProvider::createModelPlayer(ModelPlayerClien
     return DummyModelPlayer::create(client);
 }
 
+void DummyModelPlayerProvider::deleteModelPlayer(ModelPlayer&)
+{
+}
+
 }

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.h
@@ -38,7 +38,8 @@ public:
 
 private:
     // ModelPlayerProvider overrides.
-    virtual RefPtr<ModelPlayer> createModelPlayer(ModelPlayerClient&) override;
+    RefPtr<ModelPlayer> createModelPlayer(ModelPlayerClient&) final;
+    void deleteModelPlayer(ModelPlayer&) final;
 };
 
 }

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -68,7 +68,6 @@ public:
 
     static bool transformSupported(const simd_float4x4& transform);
 
-    WebCore::ModelPlayerIdentifier identifier() const { return m_id; }
     void invalidate();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     template<typename T> void send(T&& message);
@@ -87,6 +86,7 @@ public:
     void didFailLoading(WebCore::REModelLoader&, const WebCore::ResourceError&) final;
 
     // WebCore::ModelPlayer overrides.
+    WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
     void load(WebCore::Model&, WebCore::LayoutSize) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     PlatformLayer* layer() final;

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -104,6 +104,7 @@ bool ModelProcessModelPlayerProxy::transformSupported(const simd_float4x4& trans
 void ModelProcessModelPlayerProxy::invalidate()
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy invalidated id=%" PRIu64, this, m_id.toUInt64());
+    [m_layer setPlayer:nullptr];
 }
 
 template<typename T>

--- a/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
+++ b/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
@@ -28,14 +28,16 @@
 {
     [super setOpacity:opacity];
 
-    _player->updateOpacity();
+    if (_player)
+        _player->updateOpacity();
 }
 
 - (void)layoutSublayers
 {
     [super layoutSublayers];
 
-    _player->updateTransform();
+    if (_player)
+        _player->updateTransform();
 }
 
 @end

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -51,7 +51,6 @@ public:
 private:
     explicit ModelProcessModelPlayer(WebCore::ModelPlayerIdentifier, WebPage&, WebCore::ModelPlayerClient&);
 
-    WebCore::ModelPlayerIdentifier identifier() { return m_id; }
     WebPage* page() { return m_page.get(); }
     WebCore::ModelPlayerClient* client() { return m_client.get(); }
 
@@ -63,6 +62,7 @@ private:
     void didUpdateEntityTransform(const WebCore::TransformationMatrix&);
 
     // WebCore::ModelPlayer overrides.
+    WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
     void load(WebCore::Model&, WebCore::LayoutSize) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     PlatformLayer* layer() final;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -32,6 +32,7 @@
 #include "ModelProcessModelPlayerManagerProxyMessages.h"
 #include "WebPage.h"
 #include "WebProcess.h"
+#include <WebCore/ModelPlayer.h>
 #include <WebCore/ModelPlayerClient.h>
 #include <WebCore/ModelPlayerIdentifier.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -73,8 +74,9 @@ Ref<ModelProcessModelPlayer> ModelProcessModelPlayerManager::createModelProcessM
     return player;
 }
 
-void ModelProcessModelPlayerManager::deleteModelProcessModelPlayer(WebCore::ModelPlayerIdentifier identifier)
+void ModelProcessModelPlayerManager::deleteModelProcessModelPlayer(WebCore::ModelPlayer& modelPlayer)
 {
+    WebCore::ModelPlayerIdentifier identifier = modelPlayer.identifier();
     m_players.take(identifier);
     modelProcessConnection().connection().send(Messages::ModelProcessModelPlayerManagerProxy::DeleteModelPlayer(identifier), 0);
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
@@ -32,6 +32,7 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class ModelPlayer;
 class ModelPlayerClient;
 }
 
@@ -51,7 +52,7 @@ public:
     ModelProcessConnection& modelProcessConnection();
 
     Ref<ModelProcessModelPlayer> createModelProcessModelPlayer(WebPage&, WebCore::ModelPlayerClient&);
-    void deleteModelProcessModelPlayer(WebCore::ModelPlayerIdentifier);
+    void deleteModelProcessModelPlayer(WebCore::ModelPlayer&);
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -85,4 +85,15 @@ RefPtr<WebCore::ModelPlayer> WebModelPlayerProvider::createModelPlayer(WebCore::
     return nullptr;
 }
 
+void WebModelPlayerProvider::deleteModelPlayer(WebCore::ModelPlayer& modelPlayer)
+{
+#if ENABLE(MODEL_PROCESS)
+    Ref page = m_page.get();
+    if (page->corePage()->settings().modelProcessEnabled())
+        return WebProcess::singleton().modelProcessModelPlayerManager().deleteModelProcessModelPlayer(modelPlayer);
+#else
+    UNUSED_PARAM(modelPlayer);
+#endif
+}
+
 }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
@@ -41,7 +41,8 @@ public:
 
 private:
     // WebCore::ModelPlayerProvider overrides.
-    virtual RefPtr<WebCore::ModelPlayer> createModelPlayer(WebCore::ModelPlayerClient&) final;
+    RefPtr<WebCore::ModelPlayer> createModelPlayer(WebCore::ModelPlayerClient&) final;
+    void deleteModelPlayer(WebCore::ModelPlayer&) final;
 
     WeakRef<WebPage> m_page;
 };


### PR DESCRIPTION
#### 24abd21e0c1118fa539b2fbbd45796c110ec01da
<pre>
Clean up ModelProcessModelPlayerProxy properly in the model process
<a href="https://bugs.webkit.org/show_bug.cgi?id=280128">https://bugs.webkit.org/show_bug.cgi?id=280128</a>
<a href="https://rdar.apple.com/136424138">rdar://136424138</a>

Reviewed by Mike Wyrzykowski.

There are two reasons why ModelProcessModelPlayerProxy can’t get
released properly:

- ModelProcessModelPlayerManagerProxy never removes it from the
m_proxies hashmap
- There’s a strong reference cycle between ModelProcessModelPlayerProxy
and WKModelProcessModelLayer

When the HTMLModelElement is done with the ModelProcessModelPlayer, we need
to notify the model process to clean up the corresponding ModelProcessModelPlayerProxy.
HTMLModelElement::deleteModelPlayer() is added to handle that cleanup.
It calls ModelPlayerProvider::deleteModelPlayer(), which for the model process
case, calls ModelProcessModelPlayerManager::deleteModelProcessModelPlayer().
That cleans up the model player on the web process side and sends a message
to the model process to clean up the corresponding ModelProcessModelPlayerProxy.
ModelProcessModelPlayerProxy::invalidate() then sets the WKModelProcessModelLayer&apos;s
player to be null to break the reference cycle.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setSourceURL):
(WebCore::HTMLModelElement::deleteModelPlayer):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerProvider.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::identifier const):
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.cpp:
(WebCore::DummyModelPlayerProvider::deleteModelPlayer):
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::invalidate):
* Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm:
(-[WKModelProcessModelLayer setOpacity:]):
(-[WKModelProcessModelLayer layoutSublayers]):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
(WebKit::ModelProcessModelPlayer::identifier): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::deleteModelProcessModelPlayer):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h:
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:
(WebKit::WebModelPlayerProvider::deleteModelPlayer):
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h:

Canonical link: <a href="https://commits.webkit.org/284048@main">https://commits.webkit.org/284048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c6acfbe49907e13f48788a561d45dc60a167ed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54501 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74007 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61951 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3508 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43441 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->