### PR TITLE
Weak data types should not hard code WeakPtrFactory

### DIFF
--- a/Source/WTF/wtf/CanMakeWeakPtr.h
+++ b/Source/WTF/wtf/CanMakeWeakPtr.h
@@ -39,8 +39,13 @@ public:
     using WeakValueType = typename WeakPtrFactoryType::ObjectType;
     using WeakPtrImplType = typename WeakPtrFactoryType::WeakPtrImplType;
 
-    const WeakPtrFactoryType& weakPtrFactory() const { return m_weakPtrFactory; }
-    WeakPtrFactoryType& weakPtrFactory() { return m_weakPtrFactory; }
+    WeakPtrImplType* weakImplIfExists() const { return m_weakPtrFactory.impl(); }
+    WeakPtrImplType& weakImpl() const
+    {
+        initializeWeakPtrFactory();
+        return *m_weakPtrFactory.impl();
+    }
+    unsigned weakCount() const { return m_weakPtrFactory.weakPtrCount(); }
 
 protected:
     CanMakeWeakPtrBase()
@@ -57,10 +62,13 @@ protected:
 
     CanMakeWeakPtrBase& operator=(const CanMakeWeakPtrBase&) { return *this; }
 
-    void initializeWeakPtrFactory()
+    void initializeWeakPtrFactory() const
     {
-        m_weakPtrFactory.initializeIfNeeded(static_cast<WeakValueType&>(*this));
+        m_weakPtrFactory.initializeIfNeeded(static_cast<const WeakValueType&>(*this));
     }
+
+    const WeakPtrFactoryType& weakPtrFactory() const { return m_weakPtrFactory; }
+    WeakPtrFactoryType& weakPtrFactory() { return m_weakPtrFactory; }
 
 private:
     WeakPtrFactoryType m_weakPtrFactory;

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -41,6 +41,8 @@
 #include <wtf/IterationStatus.h>
 #include <wtf/TypeCasts.h>
 
+#define SINGLE_ARG(...) __VA_ARGS__ // useful when a macro argument includes a comma
+
 // Use this macro to declare and define a debug-only global variable that may have a
 // non-trivial constructor and destructor. When building with clang, this will suppress
 // warnings about global constructors and exit-time destructors.

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -369,13 +369,13 @@ private:
     template <typename T>
     static RefType makeKeyImpl(const T& key)
     {
-        return *key.weakPtrFactory().template createWeakPtr<T>(const_cast<T&>(key)).m_impl;
+        return WeakRef<T, WeakPtrImpl>(key).releaseImpl();
     }
 
     template <typename T>
     static WeakPtrImpl* keyImplIfExists(const T& key)
     {
-        if (auto* impl = key.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = key.weakImplIfExists(); impl && *impl)
             return impl;
         return nullptr;
     }

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -98,7 +98,7 @@ public:
     const_iterator find(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return WeakHashSetConstIterator(*this, m_set.find(impl));
         return end();
     }
@@ -107,7 +107,7 @@ public:
     AddResult add(const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.add(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        return m_set.add(WeakRef<T, WeakPtrImpl>(static_cast<const T&>(value)).releaseImpl());
     }
 
     T* takeAny()
@@ -122,7 +122,7 @@ public:
     bool remove(const U& value)
     {
         amortizedCleanupIfNeeded();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return m_set.remove(*impl);
         return false;
     }
@@ -144,7 +144,7 @@ public:
     bool contains(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return m_set.contains(*impl);
         return false;
     }

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -172,7 +172,7 @@ public:
     iterator find(const U& value)
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return WeakListHashSetIterator(*this, m_set.find(*impl));
         return end();
     }
@@ -181,7 +181,7 @@ public:
     const_iterator find(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return WeakListHashSetConstIterator(*this, m_set.find(*impl));
         return end();
     }
@@ -190,7 +190,7 @@ public:
     bool contains(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return m_set.contains(*impl);
         return false;
     }
@@ -199,50 +199,49 @@ public:
     AddResult add(const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.add(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        return m_set.add(WeakRef<T, WeakPtrImpl>(value).releaseImpl());
     }
 
     template <typename U>
     AddResult appendOrMoveToLast(const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.appendOrMoveToLast(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        return m_set.appendOrMoveToLast(WeakRef<T, WeakPtrImpl>(value).releaseImpl());
     }
 
     template <typename U>
     bool moveToLastIfPresent(const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.moveToLastIfPresent(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        return m_set.moveToLastIfPresent(WeakRef<T, WeakPtrImpl>(value).releaseImpl());
     }
 
     template <typename U>
     AddResult prependOrMoveToFirst(const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.prependOrMoveToFirst(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        return m_set.prependOrMoveToFirst(WeakRef<T, WeakPtrImpl>(value).releaseImpl());
     }
 
     template <typename U, typename V>
     AddResult insertBefore(const U& beforeValue, const V& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.insertBefore(*static_cast<const T&>(beforeValue).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(beforeValue), assertionsPolicy).m_impl,
-            *static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<V&>(value), assertionsPolicy).m_impl);
+        return m_set.insertBefore(WeakRef<T, WeakPtrImpl>(beforeValue).releaseImpl(), WeakRef<T, WeakPtrImpl>(value).releaseImpl());
     }
 
     template <typename U>
     AddResult insertBefore(iterator it, const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.insertBefore(it.m_position, *static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        return m_set.insertBefore(it.m_position, WeakRef<T, WeakPtrImpl>(value).releaseImpl());
     }
 
     template <typename U>
     bool remove(const U& value)
     {
         amortizedCleanupIfNeeded();
-        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+        if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return m_set.remove(*impl);
         return false;
     }

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -50,7 +50,7 @@ public:
     template<typename U> WeakPtr(WeakRef<U, WeakPtrImpl>&&);
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : m_impl(object ? implForObject(*object) : nullptr)
+        : m_impl(object ? &object->weakImpl() : nullptr)
 #if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
@@ -60,7 +60,7 @@ public:
     }
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>> WeakPtr(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : m_impl(implForObject(object))
+        : m_impl(&object.weakImpl())
 #if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
@@ -155,12 +155,6 @@ private:
 #endif
     {
         UNUSED_PARAM(shouldEnableAssertions);
-    }
-
-    template<typename U> static WeakPtrImpl* implForObject(const U& object)
-    {
-        object.weakPtrFactory().initializeIfNeeded(object);
-        return object.weakPtrFactory().impl();
     }
 
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -32,6 +32,13 @@
 
 namespace WTF {
 
+#define USING_CAN_MAKE_WEAKPTR(BASE) \
+    using BASE::weakImpl; \
+    using BASE::weakImplIfExists; \
+    using BASE::weakCount; \
+    using BASE::WeakValueType; \
+    using BASE::WeakPtrImplType;
+
 // Note: you probably want to inherit from CanMakeWeakPtr rather than use this directly.
 template<typename T, typename WeakPtrImpl = DefaultWeakPtrImpl>
 class WeakPtrFactory {

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -46,8 +46,8 @@ template<typename T, typename WeakPtrImpl>
 class WeakRef {
 public:
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
-    WeakRef(T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
-        : m_impl(implForObject(object))
+    WeakRef(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+        : m_impl(object.weakImpl())
 #if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
@@ -132,12 +132,6 @@ private:
             || m_impl->wasConstructedOnMainThread() == isMainThread();
     }
 #endif
-
-    template<typename U> static WeakPtrImpl& implForObject(const U& object)
-    {
-        object.weakPtrFactory().initializeIfNeeded(object);
-        return *object.weakPtrFactory().impl();
-    }
 
     Ref<WeakPtrImpl> m_impl;
 #if ASSERT_ENABLED

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -47,6 +47,7 @@ class CookieStore final : public RefCounted<CookieStore>, public EventTarget, pu
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CookieStore);
 public:
     DEFINE_VIRTUAL_REFCOUNTED;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     static Ref<CookieStore> create(ScriptExecutionContext*);
     ~CookieStore();
@@ -62,9 +63,6 @@ public:
 
     void remove(String&& name, Ref<DeferredPromise>&&);
     void remove(CookieStoreDeleteOptions&&, Ref<DeferredPromise>&&);
-
-    using EventTarget::weakPtrFactory;
-    using EventTarget::WeakValueType;
 
 private:
     explicit CookieStore(ScriptExecutionContext*);

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -70,9 +70,7 @@ public:
     static Ref<MediaKeySession> create(Document&, WeakPtr<MediaKeys>&&, MediaKeySessionType, bool useDistinctiveIdentifier, Ref<CDM>&&, Ref<CDMInstanceSession>&&);
     WEBCORE_EXPORT virtual ~MediaKeySession();
 
-    using CDMInstanceSessionClient::weakPtrFactory;
-    using CDMInstanceSessionClient::WeakValueType;
-    using CDMInstanceSessionClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CDMInstanceSessionClient);
 
     bool isClosed() const { return m_closed; }
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -57,9 +57,7 @@ class MediaControlsHost final
     , public CanMakeWeakPtr<MediaControlsHost> {
     WTF_MAKE_FAST_ALLOCATED(MediaControlsHost);
 public:
-    using CanMakeWeakPtr<MediaControlsHost>::weakPtrFactory;
-    using CanMakeWeakPtr<MediaControlsHost>::WeakValueType;
-    using CanMakeWeakPtr<MediaControlsHost>::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<MediaControlsHost>);
 
     static Ref<MediaControlsHost> create(HTMLMediaElement&);
     ~MediaControlsHost();

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -79,9 +79,7 @@ public:
 
     MediaStream& stream() { return m_stream.get(); }
 
-    using EventTarget::weakPtrFactory;
-    using EventTarget::WeakValueType;
-    using EventTarget::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
 private:
     MediaRecorder(Document&, Ref<MediaStream>&&, Options&&);

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -68,9 +68,7 @@ public:
 
     void setMediaSession(MediaSession*);
 
-    using MediaSessionCoordinatorClient::weakPtrFactory;
-    using MediaSessionCoordinatorClient::WeakValueType;
-    using MediaSessionCoordinatorClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MediaSessionCoordinatorClient);
 
     struct PlaySessionCommand {
         std::optional<double> atTime;

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -80,16 +80,13 @@ class MediaSource
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaSource);
 public:
     DEFINE_VIRTUAL_REFCOUNTED;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<MediaSource>);
 
     static void setRegistry(URLRegistry*);
     static MediaSource* lookup(const String& url) { return s_registry ? static_cast<MediaSource*>(s_registry->lookup(url)) : nullptr; }
 
     static Ref<MediaSource> create(ScriptExecutionContext&, MediaSourceInit&&);
     virtual ~MediaSource();
-
-    using CanMakeWeakPtr<MediaSource>::weakPtrFactory;
-    using CanMakeWeakPtr<MediaSource>::WeakValueType;
-    using CanMakeWeakPtr<MediaSource>::WeakPtrImplType;
 
     static bool enabledForContext(ScriptExecutionContext&);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -78,9 +78,7 @@ public:
     static Ref<SourceBuffer> create(Ref<SourceBufferPrivate>&&, MediaSource&);
     virtual ~SourceBuffer();
 
-    using CanMakeWeakPtr<SourceBuffer>::weakPtrFactory;
-    using CanMakeWeakPtr<SourceBuffer>::WeakValueType;
-    using CanMakeWeakPtr<SourceBuffer>::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<SourceBuffer>);
 
     static bool enabledForContext(ScriptExecutionContext&);
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -80,9 +80,7 @@ public:
 
     RefPtr<MediaStream> clone();
 
-    using MediaStreamPrivateObserver::weakPtrFactory;
-    using MediaStreamPrivateObserver::WeakValueType;
-    using MediaStreamPrivateObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MediaStreamPrivateObserver);
 
     bool active() const { return m_isActive; }
     bool muted() const { return m_private->muted(); }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -59,9 +59,7 @@ class HTMLModelElement final : public HTMLElement, private CachedRawResourceClie
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLModelElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLModelElement);
 public:
-    using HTMLElement::weakPtrFactory;
-    using HTMLElement::WeakValueType;
-    using HTMLElement::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     static Ref<HTMLModelElement> create(const QualifiedName&, Document&);
     virtual ~HTMLModelElement();

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -43,9 +43,7 @@ public:
 
     static Ref<SpeechRecognition> create(Document&);
 
-    using SpeechRecognitionConnectionClient::weakPtrFactory;
-    using SpeechRecognitionConnectionClient::WeakValueType;
-    using SpeechRecognitionConnectionClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(SpeechRecognitionConnectionClient);
 
     const String& lang() const { return m_lang; }
     void setLang(String&& lang) { m_lang = WTFMove(lang); }

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -46,9 +46,7 @@ public:
 
     virtual ~MediaElementAudioSourceNode();
 
-    using AudioNode::weakPtrFactory;
-    using AudioNode::WeakValueType;
-    using AudioNode::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(AudioNode);
 
     HTMLMediaElement& mediaElement() { return m_mediaElement; }
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -58,6 +58,7 @@ class WebXRSession final : public RefCounted<WebXRSession>, public EventTarget, 
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRSession);
 public:
     DEFINE_VIRTUAL_REFCOUNTED;
+    USING_CAN_MAKE_WEAKPTR(PlatformXR::TrackingAndRenderingClient);
 
     using RequestReferenceSpacePromise = DOMPromiseDeferred<IDLInterface<WebXRReferenceSpace>>;
     using EndPromise = DOMPromiseDeferred<void>;
@@ -65,10 +66,6 @@ public:
 
     static Ref<WebXRSession> create(Document&, WebXRSystem&, XRSessionMode, PlatformXR::Device&, FeatureList&&);
     virtual ~WebXRSession();
-
-    using PlatformXR::TrackingAndRenderingClient::weakPtrFactory;
-    using PlatformXR::TrackingAndRenderingClient::WeakValueType;
-    using PlatformXR::TrackingAndRenderingClient::WeakPtrImplType;
 
     XREnvironmentBlendMode environmentBlendMode() const;
     XRInteractionMode interactionMode() const;

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -53,10 +53,7 @@ class StyleRuleFontPaletteValues;
 class CSSFontSelector final : public FontSelector, public CSSFontFaceClient, public ActiveDOMObject {
 public:
     DEFINE_VIRTUAL_REFCOUNTED;
-
-    using FontSelector::weakPtrFactory;
-    using FontSelector::WeakValueType;
-    using FontSelector::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(FontSelector);
 
     using FontSelector::ref;
     using FontSelector::deref;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -435,9 +435,7 @@ class Document
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(Document, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Document);
 public:
-    using EventTarget::weakPtrFactory;
-    using EventTarget::WeakValueType;
-    using EventTarget::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     inline static Ref<Document> create(const Settings&, const URL&);
     static Ref<Document> createNonRenderedPlaceholder(LocalFrame&, const URL&);

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -35,9 +35,7 @@ class ProcessingInstruction final : public CharacterData, private CachedStyleShe
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ProcessingInstruction);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProcessingInstruction);
 public:
-    using CharacterData::weakPtrFactory;
-    using CharacterData::WeakValueType;
-    using CharacterData::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CharacterData);
 
     static Ref<ProcessingInstruction> create(Document&, String&& target, String&& data);
     virtual ~ProcessingInstruction();

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -49,9 +49,7 @@ class HTMLLinkElement final : public HTMLElement, public CachedStyleSheetClient,
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLLinkElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLinkElement);
 public:
-    using HTMLElement::weakPtrFactory;
-    using HTMLElement::WeakValueType;
-    using HTMLElement::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     static Ref<HTMLLinkElement> create(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLLinkElement();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -181,9 +181,7 @@ class HTMLMediaElement
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLMediaElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMediaElement);
 public:
-    using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::weakPtrFactory;
-    using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakValueType;
-    using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(SINGLE_ARG(CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>));
 
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -48,9 +48,8 @@ public:
     void deref() const final { HTMLElement::deref(); }
 
     using HTMLElement::scriptExecutionContext;
-    using HTMLElement::weakPtrFactory;
-    using HTMLElement::WeakValueType;
-    using HTMLElement::WeakPtrImplType;
+
+    USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     const AtomString& kind();
     void setKind(const AtomString&);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -171,9 +171,7 @@ class VideoFrame;
 class WebGLRenderingContextBase : public GraphicsContextGL::Client, public GPUBasedCanvasRenderingContext {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebGLRenderingContextBase);
 public:
-    using GPUBasedCanvasRenderingContext::weakPtrFactory;
-    using GPUBasedCanvasRenderingContext::WeakValueType;
-    using GPUBasedCanvasRenderingContext::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(GPUBasedCanvasRenderingContext);
 
     static std::unique_ptr<WebGLRenderingContextBase> create(CanvasBase&, WebGLContextAttributes, WebGLVersion);
     virtual ~WebGLRenderingContextBase();

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -70,9 +70,7 @@ public:
     void releaseCapture();
     void removeSpinButtonOwner() { m_spinButtonOwner = nullptr; }
 
-    using HTMLDivElement::weakPtrFactory;
-    using HTMLDivElement::WeakValueType;
-    using HTMLDivElement::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(HTMLDivElement);
 
     void step(int amount);
     

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -207,9 +207,7 @@ public:
         return adoptRef(*new DocumentLoader(request, data));
     }
 
-    using CachedRawResourceClient::weakPtrFactory;
-    using CachedRawResourceClient::WeakValueType;
-    using CachedRawResourceClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CachedRawResourceClient);
 
     WEBCORE_EXPORT static DocumentLoader* fromScriptExecutionContextIdentifier(ScriptExecutionContextIdentifier);
 

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -58,9 +58,7 @@ public:
     static ExceptionOr<Ref<EventSource>> create(ScriptExecutionContext&, const String& url, const Init&);
     virtual ~EventSource();
 
-    using EventTarget::weakPtrFactory;
-    using EventTarget::WeakValueType;
-    using EventTarget::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     const String& url() const;
     bool withCredentials() const;

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -46,9 +46,7 @@ public:
     static Ref<ScreenOrientation> create(Document*);
     ~ScreenOrientation();
 
-    using ScreenOrientationManagerObserver::weakPtrFactory;
-    using ScreenOrientationManagerObserver::WeakValueType;
-    using ScreenOrientationManagerObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(ScreenOrientationManagerObserver);
 
     using LockType = ScreenOrientationLockType;
     using Type = ScreenOrientationType;

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -82,9 +82,7 @@ public:
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
-    using Widget::weakPtrFactory;
-    using Widget::WeakValueType;
-    using Widget::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(Widget);
 
     // ScrollableArea functions.
     WEBCORE_EXPORT void setScrollOffset(const ScrollOffset&) final;

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -213,6 +213,8 @@ enum class AudioSessionRoutingArbitrationError : uint8_t { None, Failed, Cancell
 
 class WEBCORE_EXPORT AudioSessionRoutingArbitrationClient : public CanMakeWeakPtr<AudioSessionRoutingArbitrationClient> {
 public:
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<AudioSessionRoutingArbitrationClient>);
+
     virtual ~AudioSessionRoutingArbitrationClient() = default;
     using RoutingArbitrationError = AudioSessionRoutingArbitrationError;
 
@@ -225,8 +227,6 @@ public:
 
     virtual const void* logIdentifier() const = 0;
     virtual bool canLog() const = 0;
-
-    using WeakValueType = AudioSessionRoutingArbitrationClient;
 };
 
 WEBCORE_EXPORT String convertEnumerationToString(RouteSharingPolicy);

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -54,9 +54,7 @@ public:
     bool isMonitoringWirelessTargets() const override;
     static WEBCORE_EXPORT void providePresentingApplicationPID();
 
-    using MediaSessionHelperClient::weakPtrFactory;
-    using MediaSessionHelperClient::WeakValueType;
-    using MediaSessionHelperClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MediaSessionHelperClient);
 
 private:
     friend class PlatformMediaSessionManager;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -92,9 +92,7 @@ public:
 
 class CDMInstanceFairPlayStreamingAVFObjC final : public CDMInstance, public AVContentKeySessionDelegateClient, public CanMakeWeakPtr<CDMInstanceFairPlayStreamingAVFObjC> {
 public:
-    using CanMakeWeakPtr<CDMInstanceFairPlayStreamingAVFObjC>::weakPtrFactory;
-    using CanMakeWeakPtr<CDMInstanceFairPlayStreamingAVFObjC>::WeakValueType;
-    using CanMakeWeakPtr<CDMInstanceFairPlayStreamingAVFObjC>::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<CDMInstanceFairPlayStreamingAVFObjC>);
 
     CDMInstanceFairPlayStreamingAVFObjC(const CDMPrivateFairPlayStreaming&);
     virtual ~CDMInstanceFairPlayStreamingAVFObjC() = default;
@@ -182,9 +180,7 @@ class CDMInstanceSessionFairPlayStreamingAVFObjC final
     , public AVContentKeySessionDelegateClient
     , private ContentKeyGroupDataSource {
 public:
-    using AVContentKeySessionDelegateClient::weakPtrFactory;
-    using AVContentKeySessionDelegateClient::WeakValueType;
-    using AVContentKeySessionDelegateClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(AVContentKeySessionDelegateClient);
 
     CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
     virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -91,9 +91,7 @@ public:
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
 
-    using MediaStreamTrackPrivateObserver::weakPtrFactory;
-    using MediaStreamTrackPrivateObserver::WeakValueType;
-    using MediaStreamTrackPrivateObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MediaStreamTrackPrivateObserver);
 
 private:
     PlatformLayer* rootLayer() const;

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -106,9 +106,7 @@ private:
     void observeSource();
     void unobserveSource();
 
-    using MediaStreamTrackPrivateObserver::weakPtrFactory;
-    using MediaStreamTrackPrivateObserver::WeakValueType;
-    using MediaStreamTrackPrivateObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MediaStreamTrackPrivateObserver);
 
     // Notifier API
     void RegisterObserver(webrtc::ObserverInterface*) final { }

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -61,10 +61,7 @@ class Worker final : public AbstractWorker, public ActiveDOMObject, private Work
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Worker);
 public:
     DEFINE_VIRTUAL_REFCOUNTED;
-
-    using AbstractWorker::weakPtrFactory;
-    using AbstractWorker::WeakValueType;
-    using AbstractWorker::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(AbstractWorker);
 
     static ExceptionOr<Ref<Worker>> create(ScriptExecutionContext&, JSC::RuntimeFlags, std::variant<RefPtr<TrustedScriptURL>, String>&&, WorkerOptions&&);
     virtual ~Worker();

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -100,9 +100,8 @@ public:
     GraphicsClient* graphicsClient() final;
 
 
-    using EventTarget::weakPtrFactory;
-    using EventTarget::WeakValueType;
-    using EventTarget::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     WorkerStorageConnection& storageConnection();
     static void postFileSystemStorageTask(Function<void()>&&);
     WorkerFileSystemStorageConnection& getFileSystemStorageConnection(Ref<FileSystemStorageConnection>&&);

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -48,9 +48,7 @@ class WorkerOrWorkletGlobalScope : public RefCounted<WorkerOrWorkletGlobalScope>
 public:
     virtual ~WorkerOrWorkletGlobalScope();
 
-    using ScriptExecutionContext::weakPtrFactory;
-    using ScriptExecutionContext::WeakValueType;
-    using ScriptExecutionContext::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(ScriptExecutionContext);
 
     bool isClosing() const { return m_isClosing; }
     WorkerOrWorkletThread* workerOrWorkletThread() const { return m_thread; }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -152,9 +152,7 @@ public:
     bool isDynamicContentScalingEnabled() const { return sharedPreferencesForWebProcess().useCGDisplayListsForDOMRendering; }
 #endif
 
-    using WebCore::NowPlayingManagerClient::weakPtrFactory;
-    using WebCore::NowPlayingManagerClient::WeakValueType;
-    using WebCore::NowPlayingManagerClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::NowPlayingManagerClient);
 
     IPC::Connection& connection() { return m_connection.get(); }
     Ref<IPC::Connection> protectedConnection() { return m_connection; }

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -46,10 +46,10 @@ class LocalAudioSessionRoutingArbitrator final
 
     friend UniqueRef<LocalAudioSessionRoutingArbitrator> WTF::makeUniqueRefWithoutFastMallocCheck<LocalAudioSessionRoutingArbitrator>(GPUConnectionToWebProcess&);
 public:
+    USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionRoutingArbitrationClient);
+
     static UniqueRef<LocalAudioSessionRoutingArbitrator> create(GPUConnectionToWebProcess&);
     virtual ~LocalAudioSessionRoutingArbitrator();
-
-    using WeakValueType = WebCore::AudioSessionRoutingArbitrationClient;
 
     void processDidTerminate();
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -68,9 +68,7 @@ public:
 
     void updatePresentingProcesses();
 
-    using WebCore::AudioSessionInterruptionObserver::weakPtrFactory;
-    using WebCore::AudioSessionInterruptionObserver::WeakValueType;
-    using WebCore::AudioSessionInterruptionObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionInterruptionObserver);
 
 private:
     RemoteAudioSessionProxyManager(GPUProcess&);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -52,9 +52,7 @@ class RemoteCDMInstanceSessionProxy;
 
 class RemoteCDMInstanceProxy : public WebCore::CDMInstanceClient, private IPC::MessageReceiver  {
 public:
-    using WebCore::CDMInstanceClient::weakPtrFactory;
-    using WebCore::CDMInstanceClient::WeakValueType;
-    using WebCore::CDMInstanceClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::CDMInstanceClient);
 
     static std::unique_ptr<RemoteCDMInstanceProxy> create(RemoteCDMProxy&, Ref<WebCore::CDMInstance>&&, RemoteCDMInstanceIdentifier);
     ~RemoteCDMInstanceProxy();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -112,9 +112,7 @@ class RemoteMediaPlayerProxy final
     , private IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaPlayerProxy);
 public:
-    using WebCore::MediaPlayerClient::WeakPtrImplType;
-    using WebCore::MediaPlayerClient::WeakValueType;
-    using WebCore::MediaPlayerClient::weakPtrFactory;
+    USING_CAN_MAKE_WEAKPTR(WebCore::MediaPlayerClient);
 
     static Ref<RemoteMediaPlayerProxy> create(RemoteMediaPlayerManagerProxy&, WebCore::MediaPlayerIdentifier, WebCore::MediaPlayerClientIdentifier, Ref<IPC::Connection>&&, WebCore::MediaPlayerEnums::MediaEngineIdentifier, RemoteMediaPlayerProxyConfiguration&&, RemoteVideoFrameObjectHeap&, const WebCore::ProcessIdentity&);
     ~RemoteMediaPlayerProxy();

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -70,9 +70,7 @@ public:
 
     void setShouldRegisterAsSpeakerSamplesProducer(bool);
 
-    using WebCore::AudioSessionInterruptionObserver::weakPtrFactory;
-    using WebCore::AudioSessionInterruptionObserver::WeakValueType;
-    using WebCore::AudioSessionInterruptionObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionInterruptionObserver);
 
 private:
     RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, Ref<IPC::Connection>&&, bool shouldRegisterAsSpeakerSamplesProducer, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&&);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -56,9 +56,7 @@ public:
     static RefPtr<RemoteSampleBufferDisplayLayer> create(GPUConnectionToWebProcess&, SampleBufferDisplayLayerIdentifier, Ref<IPC::Connection>&&);
     ~RemoteSampleBufferDisplayLayer();
 
-    using WebCore::SampleBufferDisplayLayerClient::weakPtrFactory;
-    using WebCore::SampleBufferDisplayLayerClient::WeakValueType;
-    using WebCore::SampleBufferDisplayLayerClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::SampleBufferDisplayLayerClient);
 
     using LayerInitializationCallback = CompletionHandler<void(std::optional<LayerHostingContextID>)>;
     void initialize(bool hideRootLayer, WebCore::IntSize, bool shouldMaintainAspectRatio, bool canShowWhileLocked, LayerInitializationCallback&&);

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -73,9 +73,7 @@ public:
     static Ref<ModelConnectionToWebProcess> create(ModelProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, ModelProcessConnectionParameters&&);
     virtual ~ModelConnectionToWebProcess();
 
-    using CanMakeWeakPtr<ModelConnectionToWebProcess>::weakPtrFactory;
-    using CanMakeWeakPtr<ModelConnectionToWebProcess>::WeakValueType;
-    using CanMakeWeakPtr<ModelConnectionToWebProcess>::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<ModelConnectionToWebProcess>);
 
     IPC::Connection& connection() { return m_connection.get(); }
     Ref<IPC::Connection> protectedConnection() { return m_connection; }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -137,9 +137,8 @@ class NetworkConnectionToWebProcess final
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkConnectionToWebProcess);
 public:
-    using MessageReceiver::weakPtrFactory;
-    using MessageReceiver::WeakValueType;
-    using MessageReceiver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MessageReceiver);
+
     using RegistrableDomain = WebCore::RegistrableDomain;
 
     static Ref<NetworkConnectionToWebProcess> create(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -79,9 +79,7 @@ public:
     WebSWServerConnection(const WebSWServerConnection&) = delete;
     ~WebSWServerConnection() final;
 
-    using WebCore::SWServer::Connection::weakPtrFactory;
-    using WebCore::SWServer::Connection::WeakValueType;
-    using WebCore::SWServer::Connection::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::SWServer::Connection);
 
     IPC::Connection& ipcConnection() const { return m_contentConnection.get(); }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -61,9 +61,7 @@ class WebSWServerToContextConnection final: public WebCore::SWServerToContextCon
     WTF_MAKE_TZONE_ALLOCATED(WebSWServerToContextConnection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSWServerToContextConnection);
 public:
-    using WebCore::SWServerToContextConnection::weakPtrFactory;
-    using WebCore::SWServerToContextConnection::WeakValueType;
-    using WebCore::SWServerToContextConnection::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::SWServerToContextConnection);
 
     WebSWServerToContextConnection(NetworkConnectionToWebProcess&, WebPageProxyIdentifier, WebCore::RegistrableDomain&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, WebCore::SWServer&);
     ~WebSWServerToContextConnection();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -685,9 +685,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
             return adoptRef(*new WKMediaSessionCoordinatorForTesting(privateCoordinator));
         }
 
-        using WebCore::MediaSessionCoordinatorClient::weakPtrFactory;
-        using WebCore::MediaSessionCoordinatorClient::WeakValueType;
-        using WebCore::MediaSessionCoordinatorClient::WeakPtrImplType;
+        USING_CAN_MAKE_WEAKPTR(WebCore::MediaSessionCoordinatorClient);
 
     private:
         explicit WKMediaSessionCoordinatorForTesting(id <_WKMediaSessionCoordinator> clientCoordinator)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -74,9 +74,7 @@ protected:
     AuxiliaryProcessProxy(ShouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority = AlwaysRunsAtBackgroundPriority::No, Seconds responsivenessTimeout = ResponsivenessTimer::defaultResponsivenessTimeout);
 
 public:
-    using ResponsivenessTimer::Client::weakPtrFactory;
-    using ResponsivenessTimer::Client::WeakValueType;
-    using ResponsivenessTimer::Client::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(ResponsivenessTimer::Client);
 
     virtual ~AuxiliaryProcessProxy();
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -229,9 +229,7 @@ class PlaybackSessionManagerProxy
     , public CanMakeWeakPtr<PlaybackSessionManagerProxy>
     , private IPC::MessageReceiver {
 public:
-    using CanMakeWeakPtr<PlaybackSessionManagerProxy>::WeakPtrImplType;
-    using CanMakeWeakPtr<PlaybackSessionManagerProxy>::WeakValueType;
-    using CanMakeWeakPtr<PlaybackSessionManagerProxy>::weakPtrFactory;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<PlaybackSessionManagerProxy>);
 
     static Ref<PlaybackSessionManagerProxy> create(WebPageProxy&);
     virtual ~PlaybackSessionManagerProxy();

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -162,9 +162,7 @@ class VideoPresentationManagerProxy
     , public CanMakeWeakPtr<VideoPresentationManagerProxy>
     , private IPC::MessageReceiver {
 public:
-    using CanMakeWeakPtr<VideoPresentationManagerProxy>::WeakPtrImplType;
-    using CanMakeWeakPtr<VideoPresentationManagerProxy>::WeakValueType;
-    using CanMakeWeakPtr<VideoPresentationManagerProxy>::weakPtrFactory;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<VideoPresentationManagerProxy>);
 
     static Ref<VideoPresentationManagerProxy> create(WebPageProxy&, PlaybackSessionManagerProxy&);
     virtual ~VideoPresentationManagerProxy();

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -58,9 +58,7 @@ public:
     void pause(CompletionHandler<void(bool)>&&);
     void setTrack(const String&, CompletionHandler<void(bool)>&&);
 
-    using MediaSessionCoordinatorClient::weakPtrFactory;
-    using MediaSessionCoordinatorClient::WeakValueType;
-    using MediaSessionCoordinatorClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(MediaSessionCoordinatorClient);
 
 private:
     explicit RemoteMediaSessionCoordinatorProxy(WebPageProxy&, Ref<MediaSessionCoordinatorProxyPrivate>&&);

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -65,9 +65,7 @@ public:
     using Callback = CompletionHandler<void(Respond&&)>;
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;
 
-    using AuthenticatorTransportServiceObserver::weakPtrFactory;
-    using AuthenticatorTransportServiceObserver::WeakValueType;
-    using AuthenticatorTransportServiceObserver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(AuthenticatorTransportServiceObserver);
 
     const static size_t maxTransportNumber;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -599,9 +599,7 @@ public:
     static Ref<WebPageProxy> create(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     virtual ~WebPageProxy();
 
-    using IPC::MessageReceiver::weakPtrFactory;
-    using IPC::MessageReceiver::WeakValueType;
-    using IPC::MessageReceiver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(IPC::MessageReceiver);
 
     static void forMostVisibleWebPageIfAny(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(WebPageProxy*)>&&);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -160,9 +160,7 @@ class WebProcessPool final
 #endif
 {
 public:
-    using IPC::MessageReceiver::weakPtrFactory;
-    using IPC::MessageReceiver::WeakValueType;
-    using IPC::MessageReceiver::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(IPC::MessageReceiver);
 
     static Ref<WebProcessPool> create(API::ProcessPoolConfiguration&);
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -64,9 +64,7 @@ public:
 
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
-    using PlatformXRCoordinatorSessionEventClient::weakPtrFactory;
-    using PlatformXRCoordinatorSessionEventClient::WeakValueType;
-    using PlatformXRCoordinatorSessionEventClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(PlatformXRCoordinatorSessionEventClient);
 
     void invalidate();
 

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -53,9 +53,7 @@ class UserMediaPermissionRequestManager : public WebCore::MediaCanStartListener
 {
     WTF_MAKE_TZONE_ALLOCATED(UserMediaPermissionRequestManager);
 public:
-    using WebCore::MediaCanStartListener::weakPtrFactory;
-    using WebCore::MediaCanStartListener::WeakValueType;
-    using WebCore::MediaCanStartListener::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebCore::MediaCanStartListener);
 
     explicit UserMediaPermissionRequestManager(WebPage&);
     ~UserMediaPermissionRequestManager() = default;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -106,9 +106,7 @@ public:
     void incrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementPtrCount(); }
 
-    using WebKit::PDFScriptEvaluatorClient::weakPtrFactory;
-    using WebKit::PDFScriptEvaluatorClient::WeakValueType;
-    using WebKit::PDFScriptEvaluatorClient::WeakPtrImplType;
+    USING_CAN_MAKE_WEAKPTR(WebKit::PDFScriptEvaluatorClient);
 
     void startLoading();
     void destroy();

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -41,12 +41,12 @@ class AudioSessionRoutingArbitrator final
     , public WebCore::AudioSessionRoutingArbitrationClient {
     WTF_MAKE_TZONE_ALLOCATED(AudioSessionRoutingArbitrator);
 public:
+    USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionRoutingArbitrationClient);
+
     explicit AudioSessionRoutingArbitrator(WebProcess&);
     virtual ~AudioSessionRoutingArbitrator();
 
     static ASCIILiteral supplementName();
-
-    using WeakValueType = WebCore::AudioSessionRoutingArbitrationClient;
 
     // AudioSessionRoutingAbritrator
     void beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&&) final;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -133,9 +133,7 @@ class VideoPresentationManager
     , public CanMakeWeakPtr<VideoPresentationManager>
     , private IPC::MessageReceiver {
 public:
-    using CanMakeWeakPtr<VideoPresentationManager>::WeakPtrImplType;
-    using CanMakeWeakPtr<VideoPresentationManager>::WeakValueType;
-    using CanMakeWeakPtr<VideoPresentationManager>::weakPtrFactory;
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<VideoPresentationManager>);
 
     static Ref<VideoPresentationManager> create(WebPage&, PlaybackSessionManager&);
     virtual ~VideoPresentationManager();


### PR DESCRIPTION
#### 7c2599f8defb332d27a04e95dc5eca101af4042e
<pre>
Weak data types should not hard code WeakPtrFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=280131">https://bugs.webkit.org/show_bug.cgi?id=280131</a>
<a href="https://rdar.apple.com/136431404">rdar://136431404</a>

Reviewed by Ryosuke Niwa.

This is work toward implementing a more efficient weak pointer.

* Source/WTF/wtf/CanMakeWeakPtr.h:
(WTF::CanMakeWeakPtrBase::weakImplIfExists const):
(WTF::CanMakeWeakPtrBase::weakImpl const):
(WTF::CanMakeWeakPtrBase::initializeWeakPtrFactory const):
(WTF::CanMakeWeakPtrBase::weakPtrFactory const): Deleted.
(WTF::CanMakeWeakPtrBase::weakPtrFactory): Deleted.
(WTF::CanMakeWeakPtrBase::initializeWeakPtrFactory): Deleted.
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::WeakPtr):
(WTF::WeakPtr::implForObject): Deleted.
* Source/WTF/wtf/WeakPtrFactory.h:
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::WeakRef):
(WTF::WeakRef::implForObject): Deleted.
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/shadow/SpinButtonElement.h:
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:

Canonical link: <a href="https://commits.webkit.org/284162@main">https://commits.webkit.org/284162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37986ef6cbc174bb352c3b836658586a22694200

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54510 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12919 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17767 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74024 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67513 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61957 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61978 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3516 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89292 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43458 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15783 "Found 11 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.default-wasm, wasm.yaml/wasm/fuzz/memory.js.wasm-eager, wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-to-wasm-many-i64.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.default-wasm, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/tail-call-double.js.wasm-eager, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-eager ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->