### PR TITLE
RemoteDOMWindow::focus() and RemoteDOMWindow::blur() needs same security checks as LocalDOMWindow::focus() and LocalDOMWindow::blur()

### DIFF
--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -73,15 +73,13 @@ void RemoteDOMWindow::frameDetached()
 
 void RemoteDOMWindow::focus(LocalDOMWindow&)
 {
-    // FIXME(264713): Add security checks here equivalent to LocalDOMWindow::focus().
-    if (m_frame && m_frame->isMainFrame())
+    if (m_frame && m_frame->isMainFrame() && !m_frame->settings().windowFocusRestricted() && isSameSecurityOriginAsMainFrame())
         m_frame->client().focus();
 }
 
 void RemoteDOMWindow::blur()
 {
-    // FIXME(268121): Add security checks here equivalent to LocalDOMWindow::blur().
-    if (m_frame && m_frame->isMainFrame())
+    if (m_frame && m_frame->isMainFrame() && !m_frame->settings().windowFocusRestricted())
         m_frame->client().unfocus();
 }
 


### PR DESCRIPTION
#### 5ff93ffa4b836bc0a14af53f86cc3a32dee20887
<pre>
RemoteDOMWindow::focus() and RemoteDOMWindow::blur() needs same security checks as LocalDOMWindow::focus() and LocalDOMWindow::blur()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264713">https://bugs.webkit.org/show_bug.cgi?id=264713</a>

Reviewed by NOBODY (OOPS!).

RemoteDOMWindow::focus() and RemoteDOMWindow::blur()
needs same security checks as LocalDOMWindow::focus() and LocalDOMWindow::blur()

* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::focus):
(WebCore::RemoteDOMWindow::blur):
* Source/WebCore/page/LocalDOMWindow.h:
</pre>