### PR TITLE
Add SVG SMIL `repeatCount` caching

### DIFF
--- a/Source/WebCore/svg/animation/SMILRepeatCount.h
+++ b/Source/WebCore/svg/animation/SMILRepeatCount.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+namespace WebCore {
+// Representation of the value from the 'repeatCount' SMIL attribute.
+// "Unspecified" is used to indicate that the attribute is not specified.
+// "Invalid" is used to indicate that the attribute may have changed and needs
+// to be reparsed.
+class SMILRepeatCount {
+public:
+    static SMILRepeatCount unspecified() { return SMILRepeatCount(std::numeric_limits<double>::quiet_NaN()); }
+    static SMILRepeatCount indefinite() { return SMILRepeatCount(std::numeric_limits<double>::infinity()); }
+    static SMILRepeatCount numeric(double value)
+    {
+        ASSERT(std::isfinite(value));
+        ASSERT(value > 0);
+        return SMILRepeatCount(value);
+    }
+
+    static SMILRepeatCount invalid() { return SMILRepeatCount(-std::numeric_limits<double>::infinity()); }
+
+    bool isValid() const { return m_value != -std::numeric_limits<double>::infinity(); }
+    bool isUnspecified() const
+    {
+        ASSERT(isValid());
+        return std::isnan(m_value);
+    }
+
+    bool isIndefinite() const
+    {
+        ASSERT(isValid());
+        return std::isinf(m_value);
+    }
+
+    double numericValue() const
+    {
+        ASSERT(!isUnspecified());
+        ASSERT(!isIndefinite());
+        ASSERT(isValid());
+        return m_value;
+    }
+
+private:
+    explicit SMILRepeatCount(double value)
+        : m_value(value) { }
+    double m_value;
+};
+
+} // WebCore namespace

--- a/Source/WebCore/svg/animation/SMILTime.cpp
+++ b/Source/WebCore/svg/animation/SMILTime.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "SMILTime.h"
 
-#include <float.h>
+#include "SMILRepeatCount.h"
 
 namespace WebCore {
 
@@ -52,15 +52,12 @@ SMILTime operator-(const SMILTime& a, const SMILTime& b)
     return a.value() - b.value();
 }
 
-SMILTime operator*(const SMILTime& a,  const SMILTime& b)
+SMILTime SMILTime::repeat(SMILRepeatCount repeatCount) const
 {
-    if (a.isUnresolved() || b.isUnresolved())
-        return SMILTime::unresolved();
-    if (!a.value() || !b.value())
-        return SMILTime(0);
-    if (a.isIndefinite() || b.isIndefinite())
+    ASSERT(repeatCount.isValid());
+    if (repeatCount.isIndefinite() || repeatCount.isUnspecified())
         return SMILTime::indefinite();
-    return a.value() * b.value();
+    return SMILTime(m_time * repeatCount.numericValue());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/animation/SMILTime.h
+++ b/Source/WebCore/svg/animation/SMILTime.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class SMILRepeatCount;
 class SMILTime {
 public:
     SMILTime() : m_time(0) { }
@@ -47,6 +48,9 @@ public:
     bool isFinite() const { return m_time < indefiniteValue; }
     bool isIndefinite() const { return m_time == indefiniteValue; }
     bool isUnresolved() const { return m_time == unresolvedValue; }
+
+    SMILTime repeat(SMILRepeatCount) const;
+    SMILTime operator-() const { return -m_time; }
     
 private:
     static const double unresolvedValue;
@@ -91,7 +95,5 @@ inline bool operator<(const SMILTimeWithOrigin& a, const SMILTimeWithOrigin& b) 
 
 SMILTime operator+(const SMILTime&, const SMILTime&);
 SMILTime operator-(const SMILTime&, const SMILTime&);
-// So multiplying times does not make too much sense but SMIL defines it for duration * repeatCount
-SMILTime operator*(const SMILTime&, const SMILTime&);
 
 } // namespace WebCore

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "SMILRepeatCount.h"
 #include "SMILTime.h"
 #include "SVGElement.h"
 #include <wtf/HashSet.h>
@@ -74,7 +75,7 @@ public:
 
     SMILTime dur() const;
     SMILTime repeatDur() const;
-    SMILTime repeatCount() const;
+    SMILRepeatCount repeatCount() const;
     SMILTime maxValue() const;
     SMILTime minValue() const;
 
@@ -215,7 +216,7 @@ private:
 
     mutable SMILTime m_cachedDur;
     mutable SMILTime m_cachedRepeatDur;
-    mutable SMILTime m_cachedRepeatCount;
+    mutable SMILRepeatCount m_cachedRepeatCount;
     mutable SMILTime m_cachedMin;
     mutable SMILTime m_cachedMax;
 


### PR DESCRIPTION
#### 4780c57f0a8251d12da7a68ba378003ff52c92a8
<pre>
Add SVG SMIL `repeatCount` caching
<a href="https://bugs.webkit.org/show_bug.cgi?id=280138">https://bugs.webkit.org/show_bug.cgi?id=280138</a>
<a href="https://rdar.apple.com/136437667">rdar://136437667</a>

Reviewed by NOBODY (OOPS!).

In past [1], Blink / Chromium added SVG SMIL `repeatCount` caching but
it was later reworked in [2], which is merge here:

Per [2], repeatCount&apos; was previously shoehorned into a SMILTime since it was a
reasonable match semantically. This makes less sense when storing
SMILTimes as integers though, so rework it to use a small helper class
that stores a double and exposes the various states that repeat count
can have.

Add a SMILTime::repeat(SMILRepeatCount) helper to compute the repeated
duration. SVGSMILElement::parseCondition is reworked to use negation to
add the sign to an offset value. With this operator* on SMILTime can be
eliminated. operator-() (unary -) is added to be able to implement the
negation.

[1] <a href="https://github.com/chromium/chromium/commit/7f6d808516ed96430682e71be4fe4d73f9cc9501">https://github.com/chromium/chromium/commit/7f6d808516ed96430682e71be4fe4d73f9cc9501</a>
[2] <a href="https://github.com/chromium/chromium/commit/623e59c3ce345009e6ec4a978ed03e3cfa43d4ef">https://github.com/chromium/chromium/commit/623e59c3ce345009e6ec4a978ed03e3cfa43d4ef</a>

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/svg/animation/SMILRepeatCount.h:
(WebCore::SMILRepeatCount::SMILRepeatCount):
* Source/WebCore/svg/animation/SMILTime.cpp:
(WebCore::SMILTime::repeat const):
(WebCore::operator*): Deleted.
* Source/WebCore/svg/animation/SMILTime.h:
(WebCore::SMILTime::operator- const):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::SVGSMILElement):
(WebCore::SVGSMILElement::parseCondition):
(WebCore::SVGSMILElement::svgAttributeChanged):
(WebCore::parseRepeatCount):
(WebCore::SVGSMILElement::repeatCount const):
(WebCore::SVGSMILElement::repeatingDuration const):
(WebCore::SVGSMILElement::resolveActiveEnd const):
* Source/WebCore/svg/animation/SVGSMILElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49e3485885277e1873191ff37545a3929fb1669

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19460 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54545 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74074 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62000 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62020 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3557 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43508 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->