### PR TITLE
Explicitly set the minimum TLS version to 1.0

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -516,6 +516,7 @@ Boolean _CFHostIsDomainTopLevel(CFStringRef domain);
 void _CFURLRequestCreateArchiveList(CFAllocatorRef, CFURLRequestRef, CFIndex* version, CFTypeRef** objects, CFIndex* objectCount, CFDictionaryRef* protocolProperties);
 CFMutableURLRequestRef _CFURLRequestCreateFromArchiveList(CFAllocatorRef, CFIndex version, CFTypeRef* objects, CFIndex objectCount, CFDictionaryRef protocolProperties);
 void CFURLRequestSetProxySettings(CFMutableURLRequestRef, CFDictionaryRef);
+void CFURLRequestSetSSLProperties(CFMutableURLRequestRef, CFDictionaryRef);
 
 CFN_EXPORT const CFStringRef kCFStreamPropertyCONNECTProxy;
 CFN_EXPORT const CFStringRef kCFStreamPropertyCONNECTProxyHost;

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -200,6 +200,7 @@ private:
 
 #if PLATFORM(COCOA)
     NSURLRequest *applySniffingPoliciesIfNeeded(NSURLRequest *, bool shouldContentSniff, ContentEncodingSniffingPolicy);
+    NSURLRequest *applyTLSSettings(NSURLRequest *);
 #endif
 
     friend class ResourceHandleInternal;

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -130,6 +130,17 @@ NSURLRequest *ResourceHandle::applySniffingPoliciesIfNeeded(NSURLRequest *reques
     return mutableRequest.autorelease();
 }
 
+NSURLRequest *ResourceHandle::applyTLSSettings(NSURLRequest *request)
+{
+    auto mutableRequest = adoptNS([request mutableCopy]);
+
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    CFURLRequestSetSSLProperties((__bridge CFMutableURLRequestRef)mutableRequest.get(), (__bridge CFDictionaryRef)@{@"_kCFStreamTLSMinimumVersion": @(kTLSProtocol1)});
+ALLOW_DEPRECATED_DECLARATIONS_END
+
+    return mutableRequest.autorelease();
+}
+
 #if !PLATFORM(IOS_FAMILY)
 void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, SchedulingBehavior schedulingBehavior)
 #else
@@ -166,6 +177,7 @@ void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredential
 
     auto nsRequest = retainPtr(firstRequest().nsURLRequest(HTTPBodyUpdatePolicy::UpdateHTTPBody));
     nsRequest = applySniffingPoliciesIfNeeded(nsRequest.get(), shouldContentSniff, contentEncodingSniffingPolicy);
+    nsRequest = applyTLSSettings(nsRequest.get());
 
     if (d->m_storageSession)
         nsRequest = copyRequestWithStorageSession(d->m_storageSession.get(), nsRequest.get());

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1498,6 +1498,10 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 
     cookieStorage.get()._overrideSessionCookieAcceptPolicy = YES;
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv10;
+ALLOW_DEPRECATED_DECLARATIONS_END
+
     initializeNSURLSessionsInSet(m_defaultSessionSet.get(), configuration);
 
     m_deviceManagementRestrictionsEnabled = parameters.deviceManagementRestrictionsEnabled;
@@ -1559,6 +1563,7 @@ SessionWrapper& SessionSet::initializeEphemeralStatelessSessionIfNeeded(Navigati
     configuration.URLCache = nil;
     configuration.allowsCellularAccess = existingConfiguration.allowsCellularAccess;
     configuration.connectionProxyDictionary = existingConfiguration.connectionProxyDictionary;
+    configuration.TLSMinimumSupportedProtocolVersion = existingConfiguration.TLSMinimumSupportedProtocolVersion;
 
     configuration._shouldSkipPreferredClientCertificateLookup = YES;
     configuration._sourceApplicationAuditTokenData = existingConfiguration._sourceApplicationAuditTokenData;


### PR DESCRIPTION
#### 9af3cf93cf0bbaaeeebdd3ef72c224ad2dfe6a0b
<pre>
Explicitly set the minimum TLS version to 1.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=280145">https://bugs.webkit.org/show_bug.cgi?id=280145</a>
<a href="https://rdar.apple.com/136185611">rdar://136185611</a>

Reviewed by NOBODY (OOPS!).

The system default minimum TLS version is changing to TLS 1.2.

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/platform/network/ResourceHandle.h:
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::applyTLSSettings):
(WebCore::ResourceHandle::createNSURLConnection):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::SessionSet::initializeEphemeralStatelessSessionIfNeeded):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9af3cf93cf0bbaaeeebdd3ef72c224ad2dfe6a0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68807 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13281 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16436 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62327 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/private-network-access/fetch.https.window.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62365 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3936 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43999 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45076 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->