### PR TITLE
Remove unnecessary uses of reinterpret_cast

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -62,7 +62,7 @@ CFStringRef JSStringCopyCFString(CFAllocatorRef allocator, JSStringRef string)
 
     if (string->is8Bit()) {
         auto characters = string->span8();
-        return CFStringCreateWithBytes(allocator, reinterpret_cast<const UInt8*>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false);
+        return CFStringCreateWithBytes(allocator, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false);
     }
     auto characters = string->span16();
     return CFStringCreateWithCharacters(allocator, reinterpret_cast<const UniChar*>(characters.data()), characters.size());

--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -64,7 +64,7 @@ public:
     template<typename T>
     T get(void* logicalBaseAddress, ptrdiff_t offset)
     {
-        return get<T>(reinterpret_cast<uint8_t*>(logicalBaseAddress) + offset);
+        return get<T>(static_cast<uint8_t*>(logicalBaseAddress) + offset);
     }
 
     template<typename T>
@@ -74,7 +74,7 @@ public:
             m_dirtyBits |= dirtyBitFor(logicalAddress);
         else {
             size_t numberOfChunks = roundUpToMultipleOf<sizeof(T)>(s_chunkSize) / s_chunkSize;
-            uint8_t* dirtyAddress = reinterpret_cast<uint8_t*>(logicalAddress);
+            uint8_t* dirtyAddress = static_cast<uint8_t*>(logicalAddress);
             for (size_t i = 0; i < numberOfChunks; ++i, dirtyAddress += s_chunkSize)
                 m_dirtyBits |= dirtyBitFor(dirtyAddress);
         }
@@ -84,7 +84,7 @@ public:
     template<typename T>
     void set(void* logicalBaseAddress, ptrdiff_t offset, T value)
     {
-        set<T>(reinterpret_cast<uint8_t*>(logicalBaseAddress) + offset, value);
+        set<T>(static_cast<uint8_t*>(logicalBaseAddress) + offset, value);
     }
 
     bool hasWritesToFlush() const { return !!m_dirtyBits; }
@@ -105,7 +105,7 @@ private:
 
     void* physicalAddressFor(void* logicalAddress)
     {
-        return reinterpret_cast<uint8_t*>(logicalAddress) + m_physicalAddressOffset;
+        return static_cast<uint8_t*>(logicalAddress) + m_physicalAddressOffset;
     }
 
     void flushWrites();
@@ -169,7 +169,7 @@ public:
     template<typename T>
     T get(void* logicalBaseAddress, ptrdiff_t offset)
     {
-        return get<T>(reinterpret_cast<uint8_t*>(logicalBaseAddress) + offset);
+        return get<T>(static_cast<uint8_t*>(logicalBaseAddress) + offset);
     }
 
     template<typename T>
@@ -182,7 +182,7 @@ public:
     template<typename T>
     void set(void* logicalBaseAddress, ptrdiff_t offset, T value)
     {
-        set<T>(reinterpret_cast<uint8_t*>(logicalBaseAddress) + offset, value);
+        set<T>(static_cast<uint8_t*>(logicalBaseAddress) + offset, value);
     }
 
     JS_EXPORT_PRIVATE Page* ensurePageFor(void* address);

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1624,21 +1624,21 @@ public:
 
     static void repatchPointer(void* where, void* valuePtr)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(where);
+        uint32_t* location = static_cast<uint32_t*>(where);
         PatchPointerImpl::apply(location, valuePtr);
         cacheFlush(location, sizeof(uint32_t) * 8);
     }
 
     static void relinkJump(void* from, void* to)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(from);
+        uint32_t* location = static_cast<uint32_t*>(from);
         LinkJumpImpl::apply(location, to);
         cacheFlush(location, sizeof(uint32_t) * 2);
     }
 
     static void relinkCall(void* from, void* to)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(from);
+        uint32_t* location = static_cast<uint32_t*>(from);
         LinkCallImpl::apply(location, to);
         cacheFlush(location, sizeof(uint32_t) * 2);
     }
@@ -1650,14 +1650,14 @@ public:
 
     static void replaceWithVMHalt(void* where)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(where);
+        uint32_t* location = static_cast<uint32_t*>(where);
         location[0] = RISCV64Instructions::SD::construct(RISCV64Registers::zero, RISCV64Registers::zero, SImmediate::v<SImmediate, 0>());
         cacheFlush(location, sizeof(uint32_t));
     }
 
     static void replaceWithJump(void* from, void* to)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(from);
+        uint32_t* location = static_cast<uint32_t*>(from);
         intptr_t offset = uintptr_t(to) - uintptr_t(from);
 
         if (JImmediate::isValid(offset)) {
@@ -1682,14 +1682,14 @@ public:
 
     static void revertJumpReplacementToPatch(void* from, void* valuePtr)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(from);
+        uint32_t* location = static_cast<uint32_t*>(from);
         PatchPointerImpl::apply(location, RISCV64Registers::x30, valuePtr);
         cacheFlush(location, sizeof(uint32_t) * 8);
     }
 
     static void* readCallTarget(void* from)
     {
-        uint32_t* location = reinterpret_cast<uint32_t*>(from);
+        uint32_t* location = static_cast<uint32_t*>(from);
         return PatchPointerImpl::read(location);
     }
 
@@ -1698,13 +1698,13 @@ public:
     static void cacheFlush(void* code, size_t size)
     {
         intptr_t end = reinterpret_cast<intptr_t>(code) + size;
-        __builtin___clear_cache(reinterpret_cast<char*>(code), reinterpret_cast<char*>(end));
+        __builtin___clear_cache(static_cast<char*>(code), reinterpret_cast<char*>(end));
     }
 
     template<MachineCodeCopyMode copy>
     static void fillNops(void* base, size_t size)
     {
-        uint32_t* ptr = reinterpret_cast<uint32_t*>(base);
+        uint32_t* ptr = static_cast<uint32_t*>(base);
         RELEASE_ASSERT(roundUpToMultipleOf<sizeof(uint32_t)>(ptr) == ptr);
         RELEASE_ASSERT(!(size % sizeof(uint32_t)));
 

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -3891,7 +3891,7 @@ public:
     
     static bool isInt3(void* address)
     {
-        uint8_t candidateInstruction = *reinterpret_cast<uint8_t*>(address);
+        uint8_t candidateInstruction = *static_cast<uint8_t*>(address);
         return candidateInstruction == OP_INT3;
     }
 
@@ -6037,7 +6037,7 @@ public:
         ASSERT(from.isSet());
         ASSERT(to.isSet());
 
-        char* code = reinterpret_cast<char*>(m_formatter.data());
+        char* code = static_cast<char*>(m_formatter.data());
         ASSERT(!WTF::unalignedLoad<int32_t>(bitwise_cast<int32_t*>(code + from.offset()) - 1));
         setRel32(code + from.offset(), code + to.offset());
     }
@@ -6046,21 +6046,21 @@ public:
     {
         ASSERT(from.isSet());
 
-        setRel32(reinterpret_cast<char*>(code) + from.offset(), to);
+        setRel32(static_cast<char*>(code) + from.offset(), to);
     }
 
     static void linkCall(void* code, AssemblerLabel from, void* to)
     {
         ASSERT(from.isSet());
 
-        setRel32(reinterpret_cast<char*>(code) + from.offset(), to);
+        setRel32(static_cast<char*>(code) + from.offset(), to);
     }
 
     static void linkPointer(void* code, AssemblerLabel where, void* value)
     {
         ASSERT(where.isSet());
 
-        setPointer(reinterpret_cast<char*>(code) + where.offset(), value);
+        setPointer(static_cast<char*>(code) + where.offset(), value);
     }
 
     static void relinkJump(void* from, void* to)
@@ -6138,8 +6138,8 @@ public:
         constexpr unsigned instructionSize = 10; // REX.W MOV IMM64
         constexpr int rexBytes = 1;
         constexpr int opcodeBytes = 1;
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
-        
+        uint8_t* ptr = static_cast<uint8_t*>(instructionStart);
+
         union {
             uint64_t asWord;
             uint8_t asBytes[8];
@@ -6168,8 +6168,8 @@ public:
         constexpr unsigned instructionSize = 6; // REX MOV IMM32
         constexpr int rexBytes = 1;
         constexpr int opcodeBytes = 1;
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
-        
+        uint8_t* ptr = static_cast<uint8_t*>(instructionStart);
+
         union {
             uint32_t asWord;
             uint8_t asBytes[4];
@@ -6194,7 +6194,7 @@ public:
         constexpr int opcodeBytes = 1;
         constexpr int modRMBytes = 1;
         ASSERT(opcodeBytes + modRMBytes <= maxJumpReplacementSize());
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
+        uint8_t* ptr = static_cast<uint8_t*>(instructionStart);
         union {
             uint32_t asWord;
             uint8_t asBytes[4];
@@ -6220,7 +6220,7 @@ public:
         constexpr int opcodeBytes = 1;
         constexpr int modRMBytes = 1;
         ASSERT(opcodeBytes + modRMBytes <= maxJumpReplacementSize());
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
+        uint8_t* ptr = static_cast<uint8_t*>(instructionStart);
         union {
             uint32_t asWord;
             uint8_t asBytes[4];
@@ -6291,7 +6291,7 @@ public:
             {0x66, 0x2e, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x02, 0x00, 0x00}
         };
 
-        uint8_t* where = reinterpret_cast<uint8_t*>(base);
+        uint8_t* where = static_cast<uint8_t*>(base);
         while (size) {
             unsigned nopSize = static_cast<unsigned>(std::min<size_t>(size, 15));
             unsigned numPrefixes = nopSize <= 10 ? 0 : nopSize - 10;

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -4949,7 +4949,7 @@ void testProbeModifiesStackPointerToInsideProbeStateOnStack()
 #endif
     for (size_t offset = 0; offset < sizeof(Probe::State); offset += increment) {
         testProbeModifiesStackPointer([=] (Probe::Context& context) -> void* {
-            return reinterpret_cast<uint8_t*>(probeStateForContext(context)) + offset;
+            return static_cast<uint8_t*>(probeStateForContext(context)) + offset;
 
         });
     }
@@ -5053,16 +5053,16 @@ void testProbeModifiesStackValues()
 
             // Ensure that we'll be writing over the regions of the stack where the Probe::State is.
             originalSP = cpu.sp();
-            newSP = reinterpret_cast<uintptr_t*>(probeStateForContext(context)) - numberOfExtraEntriesToWrite;
+            newSP = static_cast<uintptr_t*>(probeStateForContext(context)) - numberOfExtraEntriesToWrite;
             cpu.sp() = newSP;
 
             // Fill the stack with values.
-            uintptr_t* p = reinterpret_cast<uintptr_t*>(newSP);
+            uintptr_t* p = static_cast<uintptr_t*>(newSP);
             int count = 0;
             stack.set<double>(p++, 1.234567);
             if (is32Bit())
                 p++; // On 32-bit targets, a double takes up 2 uintptr_t.
-            while (p < reinterpret_cast<uintptr_t*>(originalSP))
+            while (p < static_cast<uintptr_t*>(originalSP))
                 stack.set<uintptr_t>(p++, testWord(count++));
         });
 
@@ -5090,12 +5090,12 @@ void testProbeModifiesStackValues()
             CHECK_EQ(cpu.sp(), newSP);
 
             // Validate the stack values.
-            uintptr_t* p = reinterpret_cast<uintptr_t*>(newSP);
+            uintptr_t* p = static_cast<uintptr_t*>(newSP);
             int count = 0;
             CHECK_EQ(stack.get<double>(p++), 1.234567);
             if (is32Bit())
                 p++; // On 32-bit targets, a double takes up 2 uintptr_t.
-            while (p < reinterpret_cast<uintptr_t*>(originalSP))
+            while (p < static_cast<uintptr_t*>(originalSP))
                 CHECK_EQ(stack.get<uintptr_t>(p++), testWord(count++));
         });
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -210,7 +210,7 @@ void CodeBlock::dumpSource(PrintStream& out)
 {
     ScriptExecutable* executable = ownerExecutable();
     if (executable->isFunctionExecutable()) {
-        FunctionExecutable* functionExecutable = reinterpret_cast<FunctionExecutable*>(executable);
+        auto functionExecutable = static_cast<FunctionExecutable*>(executable);
         StringView source = functionExecutable->source().provider()->getRange(
             functionExecutable->parametersStartOffset(),
             functionExecutable->functionEnd() + 1); // Type profiling end offset is the character before the '}'.

--- a/Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp
@@ -51,7 +51,7 @@ bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, vo
         else
             snprintf(pcInfo, sizeof(pcInfo) - 1, "%#llx", static_cast<unsigned long long>(bitwise_cast<uintptr_t>(currentPC)));
         out.printf("%s%24s: %s", prefix, pcInfo, arm64Opcode.disassemble(currentPC));
-        if (auto str = AssemblyCommentRegistry::singleton().comment(reinterpret_cast<void*>(currentPC)))
+        if (auto str = AssemblyCommentRegistry::singleton().comment(currentPC))
             out.printf("; %s\n", str->ascii().data());
         else
             out.printf("\n");

--- a/Source/JavaScriptCore/disassembler/X86Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/X86Disassembler.cpp
@@ -57,7 +57,7 @@ bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, vo
             out.printf("%s%#16llx: %s", prefix, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)), formatted);
         else
             out.printf("%s%#16llx: failed-to-format", prefix, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)));
-        if (auto str = AssemblyCommentRegistry::singleton().comment(reinterpret_cast<void*>(static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)))))
+        if (auto str = AssemblyCommentRegistry::singleton().comment(reinterpret_cast<void*>(bitwise_cast<uintptr_t>(data + offset))))
             out.printf("; %s\n", str->ascii().data());
         else
             out.printf("\n");

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -47,7 +47,7 @@ StackVisitor::StackVisitor(CallFrame* startFrame, VM& vm, bool skipFirstFrame)
     m_frame.m_wasmDistanceFromDeepestInlineFrame = 0;
     CallFrame* topFrame;
     if (startFrame) {
-        ASSERT(!vm.topCallFrame || reinterpret_cast<void*>(vm.topCallFrame) != vm.topEntryFrame);
+        ASSERT(!vm.topCallFrame || static_cast<void*>(vm.topCallFrame) != vm.topEntryFrame);
 
         m_frame.m_entryFrame = vm.topEntryFrame;
         topFrame = vm.topCallFrame;

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -438,7 +438,7 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
         }
 #endif
 
-        void* reservationEnd = reinterpret_cast<uint8_t*>(reservation.base) + reservation.size;
+        void* reservationEnd = static_cast<uint8_t*>(reservation.base) + reservation.size;
         g_jscConfig.startExecutableMemory = reservation.base;
         g_jscConfig.endExecutableMemory = reservationEnd;
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -128,7 +128,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 #endif
     if (isJITPC(dst)) {
         RELEASE_ASSERT(!Gigacage::contains(src));
-        RELEASE_ASSERT(reinterpret_cast<uint8_t*>(dst) + n <= endOfFixedExecutableMemoryPool());
+        RELEASE_ASSERT(static_cast<uint8_t*>(dst) + n <= endOfFixedExecutableMemoryPool());
 
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
         auto checkForZeroes = [n] (const void* buffer_v) {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -837,7 +837,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
 
     auto forEachActiveDataSegment = [&] (auto fn) {
         auto& wasmMemory = m_instance->memory()->memory();
-        uint8_t* memory = reinterpret_cast<uint8_t*>(wasmMemory.basePointer());
+        uint8_t* memory = static_cast<uint8_t*>(wasmMemory.basePointer());
         uint64_t sizeInBytes = wasmMemory.size();
 
         for (const Wasm::Segment::Ptr& segment : data) {

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -428,11 +428,11 @@ static int findMonth(std::span<const LChar> monthStr)
 static bool parseInt(std::span<const LChar>& string, int base, int* result)
 {
     char* stopPosition;
-    long longResult = strtol(reinterpret_cast<const char*>(string.data()), &stopPosition, base);
+    long longResult = strtol(byteCast<char>(string.data()), &stopPosition, base);
     // Avoid the use of errno as it is not available on Windows CE
-    if (string.data() == reinterpret_cast<const LChar*>(stopPosition) || longResult <= std::numeric_limits<int>::min() || longResult >= std::numeric_limits<int>::max())
+    if (byteCast<char>(string.data()) == stopPosition || longResult <= std::numeric_limits<int>::min() || longResult >= std::numeric_limits<int>::max())
         return false;
-    string = string.subspan(reinterpret_cast<const LChar*>(stopPosition) - string.data());
+    string = string.subspan(stopPosition - byteCast<char>(string.data()));
     *result = longResult;
     return true;
 }
@@ -440,11 +440,11 @@ static bool parseInt(std::span<const LChar>& string, int base, int* result)
 static bool parseLong(std::span<const LChar>& string, int base, long* result)
 {
     char* stopPosition;
-    *result = strtol(reinterpret_cast<const char*>(string.data()), &stopPosition, base);
+    *result = strtol(byteCast<char>(string.data()), &stopPosition, base);
     // Avoid the use of errno as it is not available on Windows CE
-    if (string.data() == reinterpret_cast<const LChar*>(stopPosition) || *result == std::numeric_limits<long>::min() || *result == std::numeric_limits<long>::max())
+    if (byteCast<char>(string.data()) == stopPosition || *result == std::numeric_limits<long>::min() || *result == std::numeric_limits<long>::max())
         return false;
-    string = string.subspan(reinterpret_cast<const LChar*>(stopPosition) - string.data());
+    string = string.subspan(stopPosition - byteCast<char>(string.data()));
     return true;
 }
 

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -716,7 +716,7 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
 {
     for (unsigned i = 0; i < size; ++i)
         table[i].~ValueType();
-    HashTableMalloc::free(reinterpret_cast<char*>(table));
+    HashTableMalloc::free(table);
 }
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy>
@@ -789,7 +789,7 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     }
 
     if (oldTable)
-        HashTableMalloc::free(reinterpret_cast<char*>(oldTable));
+        HashTableMalloc::free(oldTable);
 
     internalCheckTableConsistency();
 }

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -326,7 +326,7 @@ BOOL isUserVisibleURL(NSString *string)
     // This function is used to optimize all the most common cases where we don't need the userVisibleString algorithm.
 
     char buffer[1024];
-    auto success = CFStringGetCString(bridge_cast(string), reinterpret_cast<char*>(buffer), sizeof(buffer) - 1, kCFStringEncodingUTF8);
+    auto success = CFStringGetCString(bridge_cast(string), buffer, sizeof(buffer) - 1, kCFStringEncodingUTF8);
     auto characters = success ? buffer : [string UTF8String];
 
     // Check for control characters, %-escape sequences that are non-ASCII, and xn--: these

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -414,7 +414,7 @@ static void imageBytesForSource(const auto& sourceDescriptor, const auto& destin
             return callback({ }, 0, 0);
 
         auto sizeInBytes = height * CGImageGetBytesPerRow(platformImage.get());
-        auto bytePointer = reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(pixelDataCfData.get()));
+        auto bytePointer = CFDataGetBytePtr(pixelDataCfData.get());
         auto requiredSize = width * height * 4;
         auto alphaInfo = CGImageGetAlphaInfo(platformImage.get());
         bool channelLayoutIsRGB = false;

--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -132,7 +132,7 @@ bool FileHandle::printf(const char* format, ...)
 
     va_end(args);
 
-    return write({ reinterpret_cast<const uint8_t*>(buffer.data()), stringLength }) >= 0;
+    return write({ byteCast<uint8_t>(buffer.data()), stringLength }) >= 0;
 }
 
 void FileHandle::close()

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -466,7 +466,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
     if (!m_pixelData)
         return false;
 
-    m_imagePixelData = reinterpret_cast<const void*>(CFDataGetBytePtr(m_pixelData.get()));
+    m_imagePixelData = CFDataGetBytePtr(m_pixelData.get());
 
     unsigned srcUnpackAlignment = 0;
     size_t bytesPerRow = CGImageGetBytesPerRow(decodedImage->platformImage().get());
@@ -492,7 +492,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
             source += srcStrideInElements;
             destination += dstStrideInElements;
         }
-        m_imagePixelData = reinterpret_cast<const void*>(m_formalizedRGBA8Data.get());
+        m_imagePixelData = m_formalizedRGBA8Data.get();
         m_imageSourceFormat = DataFormat::RGBA8;
         m_imageSourceUnpackAlignment = 1;
     }

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -96,7 +96,7 @@ void UnrealizedCoreTextFont::addAttributesForOpticalSizing(CFMutableDictionaryRe
 
 static inline void appendOpenTypeFeature(CFMutableArrayRef features, const FontFeature& feature)
 {
-    auto featureKey = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(feature.tag().data()), feature.tag().size() * sizeof(FontTag::value_type), kCFStringEncodingASCII, false));
+    auto featureKey = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, byteCast<UInt8>(feature.tag().data()), feature.tag().size() * sizeof(FontTag::value_type), kCFStringEncodingASCII, false));
     int rawFeatureValue = feature.value();
     auto featureValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawFeatureValue));
     CFTypeRef featureDictionaryKeys[] = { kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue };

--- a/Source/WebCore/platform/network/create-http-header-name-table
+++ b/Source/WebCore/platform/network/create-http-header-name-table
@@ -137,7 +137,7 @@ bool findHTTPHeaderName(StringView stringView, HTTPHeaderName& headerName)
         return false;
 
     if (stringView.is8Bit()) {
-        if (auto nameAndString = HTTPHeaderNamesHash::findHeaderNameImpl(reinterpret_cast<const char*>(stringView.span8().data()), length)) {
+        if (auto nameAndString = HTTPHeaderNamesHash::findHeaderNameImpl(byteCast<char>(stringView.span8().data()), length)) {
             headerName = nameAndString->headerName;
             return true;
         }

--- a/Source/WebCore/platform/text/mac/TextBoundaries.mm
+++ b/Source/WebCore/platform/text/mac/TextBoundaries.mm
@@ -63,7 +63,7 @@ static CFStringTokenizerRef tokenizerForString(CFStringRef str)
 {
     static const NeverDestroyed locale = [] {
         const char* localID = currentTextBreakLocaleID();
-        auto currentLocaleID = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(localID), strlen(localID), kCFStringEncodingASCII, false, kCFAllocatorNull));
+        auto currentLocaleID = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, byteCast<UInt8>(localID), strlen(localID), kCFStringEncodingASCII, false, kCFAllocatorNull));
         return adoptCF(CFLocaleCreate(kCFAllocatorDefault, currentLocaleID.get()));
     }();
 

--- a/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -90,7 +90,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
                 certificates = [NSMutableArray arrayWithCapacity:total];
                 for (size_t i = 0; i < total; i++) {
                     auto certificateData = xpc_array_get_value(certificateDataArray, i);
-                    auto cfData = adoptCF(CFDataCreate(nullptr, reinterpret_cast<const UInt8*>(xpc_data_get_bytes_ptr(certificateData)), xpc_data_get_length(certificateData)));
+                    auto cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(xpc_data_get_bytes_ptr(certificateData)), xpc_data_get_length(certificateData)));
                     auto certificate = adoptCF(SecCertificateCreateWithData(nullptr, cfData.get()));
                     if (!certificate)
                         return;

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -480,7 +480,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         filenames.append(String::fromUTF8(fileURL.fileSystemRepresentation));
 
     NSData *png = UIImagePNGRepresentation(iconImage);
-    RefPtr<API::Data> iconImageDataRef = adoptRef(WebKit::toImpl(WKDataCreate(reinterpret_cast<const unsigned char*>([png bytes]), [png length])));
+    RefPtr iconImageDataRef = adoptRef(WebKit::toImpl(WKDataCreate(static_cast<const unsigned char*>([png bytes]), [png length])));
 
     _listener->chooseFiles(filenames, displayString, iconImageDataRef.get());
     [self _dispatchDidDismiss];


### PR DESCRIPTION
#### de71d4602041131133097d9fe6dcf91c55a3a298
<pre>
Remove unnecessary uses of reinterpret_cast
<a href="https://bugs.webkit.org/show_bug.cgi?id=280155">https://bugs.webkit.org/show_bug.cgi?id=280155</a>
<a href="https://rdar.apple.com/136457809">rdar://136457809</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCopyCFString): Removed unneeded cast.

* Source/JavaScriptCore/assembler/ProbeStack.h:
(JSC::Probe::Page::get): Use static_cast.
(JSC::Probe::Page::set): Ditto.
(JSC::Probe::Page::physicalAddressFor): Ditto.
(JSC::Probe::Stack::get): Ditto.
(JSC::Probe::Stack::set): Ditto.

* Source/JavaScriptCore/assembler/RISCV64Assembler.h:
(JSC::RISCV64Assembler::repatchPointer): Use static_cast.
(JSC::RISCV64Assembler::relinkJump): Ditto.
(JSC::RISCV64Assembler::relinkCall): Ditto.
(JSC::RISCV64Assembler::replaceWithVMHalt): Ditto.
(JSC::RISCV64Assembler::replaceWithJump): Ditto.
(JSC::RISCV64Assembler::revertJumpReplacementToPatch): Ditto.
(JSC::RISCV64Assembler::readCallTarget): Ditto.
(JSC::RISCV64Assembler::cacheFlush): Ditto.
(JSC::RISCV64Assembler::fillNops): Ditto.

* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::isInt3): Use static_cast.
(JSC::X86Assembler::linkJump): Ditto.
(JSC::X86Assembler::linkCall): Ditto.
(JSC::X86Assembler::linkPointer): Ditto.
(JSC::X86Assembler::revertJumpTo_movq_i64r): Ditto.
(JSC::X86Assembler::revertJumpTo_movl_i32r): Ditto.
(JSC::X86Assembler::revertJumpTo_cmpl_ir_force32): Ditto.
(JSC::X86Assembler::revertJumpTo_cmpl_im_force32): Ditto.
(JSC::X86Assembler::fillNops): Ditto.

* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testProbeModifiesStackPointerToInsideProbeStateOnStack): Use static_cast.
(JSC::testProbeModifiesStackValues): Ditto.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::dumpSource): Use static_cast.

* Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp:
(JSC::tryToDisassemble): Removed unneeded cast.

* Source/JavaScriptCore/disassembler/X86Disassembler.cpp:
(JSC::tryToDisassemble): Removed unneeded cast.

* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::StackVisitor): Use static_cast.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation): Use static_cast.

* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::performJITMemcpy): Use static_cast.

* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate): Use static_cast.

* Source/WTF/wtf/DateMath.cpp:
(WTF::parseInt): Use byteCast.
(WTF::parseLong): Ditto.

* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::SizePolicy&gt;::deallocateTable): Removed unneeded cast.
(WTF::SizePolicy&gt;::rehash): Ditto.

* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::isUserVisibleURL): Removed unneeded cast.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource): Removed unneeded cast.

* Source/WebCore/platform/FileHandle.cpp:
(WebCore::FileHandle::printf): Use byteCast.

* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage): Removed uneeded casts.

* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::appendOpenTypeFeature): Use byteCast.

* Source/WebCore/platform/network/create-http-header-name-table:
(WebCore::findHTTPHeaderName): Use byteCast.

* Source/WebCore/platform/text/mac/TextBoundaries.mm:
(WebCore::tokenizerForString): Use byteCast.

* Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection): Use static_cast.

* Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm:
(WebKit::CoreIPCCFURL::createWithBaseURLAndBytes): Removed uneeded cast.
Also use bridge_cast.

* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel _chooseFiles:displayString:iconImage:]): Use static_cast.

Canonical link: <a href="https://commits.webkit.org/284050@main">https://commits.webkit.org/284050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79b93d5cf86fce635537c4c170a7e58b4e9a106e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19290 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17831 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61447 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74088 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67577 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3572 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43522 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15805 "Found 6 new JSC stress test failures: stress/string-value-of-error.js.bytecode-cache, wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-to-wasm-i64-stack.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->