### PR TITLE
Use span for MappedFileData and DataSegment

### DIFF
--- a/Source/JavaScriptCore/runtime/CachePayload.cpp
+++ b/Source/JavaScriptCore/runtime/CachePayload.cpp
@@ -56,24 +56,13 @@ CachePayload::CachePayload(std::variant<FileSystem::MappedFileData, std::pair<Ma
 
 CachePayload::~CachePayload() = default;
 
-const uint8_t* CachePayload::data() const
+std::span<const uint8_t> CachePayload::span() const
 {
     return WTF::switchOn(m_data,
         [](const FileSystem::MappedFileData& data) {
-            return data.span().data();
-        }, [](const std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>& data) -> const uint8_t* {
-            return data.first.get();
-        }
-    );
-}
-
-size_t CachePayload::size() const
-{
-    return WTF::switchOn(m_data,
-        [](const FileSystem::MappedFileData& data) -> size_t {
-            return data.size();
-        }, [](const std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>& data) -> size_t {
-            return data.second;
+            return data.span();
+        }, [](const std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>& data) {
+            return std::span<const uint8_t> { data.first.get(), data.second };
         }
     );
 }

--- a/Source/JavaScriptCore/runtime/CachePayload.h
+++ b/Source/JavaScriptCore/runtime/CachePayload.h
@@ -41,13 +41,11 @@ public:
     JS_EXPORT_PRIVATE CachePayload(CachePayload&&);
     JS_EXPORT_PRIVATE ~CachePayload();
 
-    JS_EXPORT_PRIVATE size_t size() const;
-    std::span<const uint8_t> span() const { return { data(), size() }; }
+    size_t size() const { return span().size(); }
+    JS_EXPORT_PRIVATE std::span<const uint8_t> span() const;
 
 private:
     CachePayload(std::variant<FileSystem::MappedFileData, std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>>&&);
-
-    JS_EXPORT_PRIVATE const uint8_t* data() const;
 
     std::variant<FileSystem::MappedFileData, std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>> m_data;
 };

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -310,7 +310,6 @@ void setMetadataURL(const String&, const String&, const String&)
 MappedFileData::MappedFileData(const String& filePath, MappedFileMode mapMode, bool& success)
 {
     auto fd = openFile(filePath, FileSystem::FileOpenMode::Read);
-
     success = mapFileHandle(fd, FileSystem::FileOpenMode::Read, mapMode);
     closeFile(fd);
 }
@@ -319,10 +318,10 @@ MappedFileData::MappedFileData(const String& filePath, MappedFileMode mapMode, b
 
 MappedFileData::~MappedFileData()
 {
-    if (!m_fileData)
+    if (!m_fileData.data())
         return;
 
-    munmap(m_fileData, m_fileSize);
+    munmap(m_fileData.data(), m_fileData.size());
 }
 
 bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openMode, MappedFileMode mapMode)
@@ -333,14 +332,12 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
     int fd = posixFileDescriptor(handle);
 
     struct stat fileStat;
-    if (fstat(fd, &fileStat)) {
+    if (fstat(fd, &fileStat))
         return false;
-    }
 
-    unsigned size;
-    if (!WTF::convertSafely(fileStat.st_size, size)) {
+    size_t size;
+    if (!WTF::convertSafely(fileStat.st_size, size))
         return false;
-    }
 
     if (!size)
         return true;
@@ -362,14 +359,11 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
 #endif
     }
 
-    void* data = mmap(0, size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), fd, 0);
-
-    if (data == MAP_FAILED) {
+    auto* data = mmap(0, size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), fd, 0);
+    if (data == MAP_FAILED)
         return false;
-    }
 
-    m_fileData = data;
-    m_fileSize = size;
+    m_fileData = { static_cast<uint8_t*>(data), size };
     return true;
 }
 #endif

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -346,8 +346,8 @@ std::optional<uint32_t> volumeFileBlockSize(const String& path)
 
 MappedFileData::~MappedFileData()
 {
-    if (m_fileData)
-        UnmapViewOfFile(m_fileData);
+    if (m_fileData.data())
+        UnmapViewOfFile(m_fileData.data());
 }
 
 bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openMode, MappedFileMode)
@@ -356,13 +356,11 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
         return false;
 
     auto size = fileSize(handle);
-    if (!size || *size > std::numeric_limits<size_t>::max() || *size > std::numeric_limits<decltype(m_fileSize)>::max()) {
+    if (!size || *size > std::numeric_limits<size_t>::max())
         return false;
-    }
 
-    if (!*size) {
+    if (!*size)
         return true;
-    }
 
     DWORD pageProtection = PAGE_READONLY;
     DWORD desiredAccess = FILE_MAP_READ;
@@ -385,10 +383,11 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
     if (!m_fileMapping)
         return false;
 
-    m_fileData = MapViewOfFile(m_fileMapping.get(), desiredAccess, 0, 0, *size);
-    if (!m_fileData)
+    auto* data = MapViewOfFile(m_fileMapping.get(), desiredAccess, 0, 0, *size);
+    if (!data)
         return false;
-    m_fileSize = *size;
+
+    m_fileData = { static_cast<uint8_t*>(data), static_cast<size_t>(*size) };
     return true;
 }
 

--- a/Source/WebCore/platform/ShareableResource.cpp
+++ b/Source/WebCore/platform/ShareableResource.cpp
@@ -43,8 +43,7 @@ ShareableResourceHandle::ShareableResourceHandle(SharedMemory::Handle&& handle, 
 RefPtr<SharedBuffer> ShareableResource::wrapInSharedBuffer()
 {
     return SharedBuffer::create(DataSegment::Provider {
-        [self = Ref { *this }]() { return self->span().data(); },
-        [self = Ref { *this }]() { return self->size(); }
+        [self = Ref { *this }]() { return self->span(); }
     });
 }
 
@@ -102,7 +101,7 @@ auto ShareableResource::createHandle() -> std::optional<Handle>
 
 std::span<const uint8_t> ShareableResource::span() const
 {
-    return m_sharedMemory->span().subspan(m_offset);
+    return m_sharedMemory->span().subspan(m_offset, m_size);
 }
 
 unsigned ShareableResource::size() const

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -37,6 +37,10 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/UTF8Conversion.h>
 
+#if USE(CF)
+#include <wtf/cf/VectorCF.h>
+#endif
+
 static constexpr size_t minimumPageSize = 4096;
 #if USE(UNIX_DOMAIN_SOCKETS)
 static constexpr bool useUnixDomainSockets = true;
@@ -119,7 +123,7 @@ FragmentedSharedBuffer::FragmentedSharedBuffer(FileSystem::MappedFileData&& file
 }
 
 FragmentedSharedBuffer::FragmentedSharedBuffer(DataSegment::Provider&& provider)
-    : m_size(provider.size())
+    : m_size(provider.span().size())
 {
     m_segments.append({ 0, DataSegment::create(WTFMove(provider)) });
 }
@@ -250,23 +254,17 @@ String FragmentedSharedBuffer::toHexString() const
 
 RefPtr<ArrayBuffer> FragmentedSharedBuffer::tryCreateArrayBuffer() const
 {
+    // FIXME: This check is no longer needed to avoid integer truncation. Consider removing it.
     if (size() > std::numeric_limits<unsigned>::max()) {
         WTFLogAlways("SharedBuffer::tryCreateArrayBuffer Unable to create buffer. Requested size is too large (%zu)\n", size());
         return nullptr;
     }
-    auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(static_cast<unsigned>(size()), 1);
+    auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(size(), 1);
     if (!arrayBuffer) {
         WTFLogAlways("SharedBuffer::tryCreateArrayBuffer Unable to create buffer. Requested size was %zu\n", size());
         return nullptr;
     }
-
-    size_t position = 0;
-    for (const auto& segment : m_segments) {
-        memcpy(static_cast<uint8_t*>(arrayBuffer->data()) + position, segment.segment->data(), segment.segment->size());
-        position += segment.segment->size();
-    }
-
-    ASSERT(position == m_size);
+    copyTo(arrayBuffer->mutableSpan());
     ASSERT(internallyConsistent());
     return arrayBuffer;
 }
@@ -333,7 +331,7 @@ void DataSegment::iterate(const Function<void(std::span<const uint8_t>)>& apply)
     if (auto* data = std::get_if<RetainPtr<CFDataRef>>(&m_immutableData))
         return iterate(data->get(), apply);
 #endif
-    apply({ data(), size() });
+    apply(span());
 }
 
 void FragmentedSharedBuffer::forEachSegmentAsSharedBuffer(const Function<void(Ref<SharedBuffer>&&)>& apply) const
@@ -355,7 +353,7 @@ bool FragmentedSharedBuffer::startsWith(std::span<const uint8_t> prefix) const
     size_t remaining = prefix.size();
     for (auto& segment : m_segments) {
         size_t amountToCompareThisTime = std::min(remaining, segment.segment->size());
-        if (memcmp(prefixPtr, segment.segment->data(), amountToCompareThisTime))
+        if (memcmp(prefixPtr, segment.segment->span().data(), amountToCompareThisTime))
             return false;
         remaining -= amountToCompareThisTime;
         if (!remaining)
@@ -413,24 +411,23 @@ void FragmentedSharedBuffer::copyTo(std::span<uint8_t> destination, size_t offse
         segment = std::upper_bound(segment, end(), offset, comparator);
         segment--; // std::upper_bound gives a pointer to the segment that is greater than offset. We want the segment just before that.
     }
-    auto destinationPtr = destination.data();
 
     size_t positionInSegment = offset - segment->beginPosition;
     size_t amountToCopyThisTime = std::min(remaining, segment->segment->size() - positionInSegment);
-    memcpy(destinationPtr, segment->segment->data() + positionInSegment, amountToCopyThisTime);
+    memcpySpan(destination, segment->segment->span().subspan(positionInSegment, amountToCopyThisTime));
     remaining -= amountToCopyThisTime;
     if (!remaining)
         return;
-    destinationPtr += amountToCopyThisTime;
+    destination = destination.subspan(amountToCopyThisTime);
 
     // If we reach here, there must be at least another segment available as we have content left to be fetched.
     for (++segment; segment != end(); ++segment) {
         size_t amountToCopyThisTime = std::min(remaining, segment->segment->size());
-        memcpy(destinationPtr, segment->segment->data(), amountToCopyThisTime);
+        memcpySpan(destination, segment->segment->span().first(amountToCopyThisTime));
         remaining -= amountToCopyThisTime;
         if (!remaining)
             return;
-        destinationPtr += amountToCopyThisTime;
+        destination = destination.subspan(amountToCopyThisTime);
     }
 }
 
@@ -483,7 +480,7 @@ bool FragmentedSharedBuffer::operator==(const FragmentedSharedBuffer& other) con
         size_t otherRemaining = otherSegment.size() - otherOffset;
         size_t remaining = std::min(thisRemaining, otherRemaining);
 
-        if (memcmp(thisSegment.data() + thisOffset, otherSegment.data() + otherOffset, remaining))
+        if (!equalSpans(thisSegment.span().subspan(thisOffset, remaining), otherSegment.span().subspan(otherOffset, remaining)))
             return false;
 
         thisOffset += remaining;
@@ -545,22 +542,22 @@ RefPtr<SharedBuffer> SharedBuffer::createWithContentsOfFile(const String& filePa
     return SharedBuffer::create(WTFMove(*buffer));
 }
 
-const uint8_t* SharedBuffer::data() const
+std::span<const uint8_t> SharedBuffer::span() const
 {
     if (m_segments.isEmpty())
-        return nullptr;
-    return m_segments[0].segment->data();
+        return { };
+    return m_segments[0].segment->span();
 }
 
 const uint8_t& SharedBuffer::operator[](size_t i) const
 {
     RELEASE_ASSERT(i < size() && !m_segments.isEmpty());
-    return m_segments[0].segment->data()[i];
+    return m_segments[0].segment->span()[i];
 }
 
 WTF::Persistence::Decoder SharedBuffer::decoder() const
 {
-    return { { data(), size() } };
+    return { span() };
 }
 
 Ref<DataSegment> DataSegment::create(Vector<uint8_t>&& data)
@@ -607,24 +604,24 @@ Ref<DataSegment> DataSegment::create(Provider&& provider)
     return adoptRef(*new DataSegment(WTFMove(provider)));
 }
 
-const uint8_t* DataSegment::data() const
+std::span<const uint8_t> DataSegment::span() const
 {
     auto visitor = WTF::makeVisitor(
-        [](const Vector<uint8_t>& data) -> const uint8_t* { return data.data(); },
+        [](const Vector<uint8_t>& data) { return data.span(); },
 #if USE(CF)
-        [](const RetainPtr<CFDataRef>& data) -> const uint8_t* { return CFDataGetBytePtr(data.get()); },
+        [](const RetainPtr<CFDataRef>& data) { return WTF::span(data.get()); },
 #endif
 #if USE(GLIB)
-        [](const GRefPtr<GBytes>& data) -> const uint8_t* { return static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)); },
+        [](const GRefPtr<GBytes>& data) -> std::span<const uint8_t> { return { static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get()) }; },
 #endif
 #if USE(GSTREAMER)
-        [](const RefPtr<GstMappedOwnedBuffer>& data) -> const uint8_t* { return data->data(); },
+        [](const RefPtr<GstMappedOwnedBuffer>& data) -> std::span<const uint8_t> { return { data->data(), data->size() }; },
 #endif
 #if USE(SKIA)
-        [](const sk_sp<SkData>& data) -> const uint8_t* { return data->bytes(); },
+        [](const sk_sp<SkData>& data) -> std::span<const uint8_t> { return { data->bytes(), data->size() }; },
 #endif
-        [](const FileSystem::MappedFileData& data) -> const uint8_t* { return data.span().data(); },
-        [](const Provider& provider) -> const uint8_t* { return provider.data(); }
+        [](const FileSystem::MappedFileData& data) { return data.span(); },
+        [](const Provider& provider) { return provider.span(); }
     );
     return std::visit(visitor, m_immutableData);
 }
@@ -632,28 +629,6 @@ const uint8_t* DataSegment::data() const
 bool DataSegment::containsMappedFileData() const
 {
     return std::holds_alternative<FileSystem::MappedFileData>(m_immutableData);
-}
-
-size_t DataSegment::size() const
-{
-    auto visitor = WTF::makeVisitor(
-        [](const Vector<uint8_t>& data) -> size_t { return data.size(); },
-#if USE(CF)
-        [](const RetainPtr<CFDataRef>& data) -> size_t { return CFDataGetLength(data.get()); },
-#endif
-#if USE(GLIB)
-        [](const GRefPtr<GBytes>& data) -> size_t { return g_bytes_get_size(data.get()); },
-#endif
-#if USE(GSTREAMER)
-        [](const RefPtr<GstMappedOwnedBuffer>& data) -> size_t { return data->size(); },
-#endif
-#if USE(SKIA)
-        [](const sk_sp<SkData>& data) -> size_t { return data->size(); },
-#endif
-        [](const FileSystem::MappedFileData& data) -> size_t { return data.size(); },
-        [](const Provider& provider) -> size_t { return provider.size(); }
-    );
-    return std::visit(visitor, m_immutableData);
 }
 
 SharedBufferBuilder::SharedBufferBuilder(RefPtr<FragmentedSharedBuffer>&& buffer)
@@ -731,8 +706,7 @@ SharedBufferDataView::SharedBufferDataView(const SharedBufferDataView& other, si
 Ref<SharedBuffer> SharedBufferDataView::createSharedBuffer() const
 {
     return SharedBuffer::create(DataSegment::Provider {
-        [segment = m_segment, data = span().data()]() { return data; },
-        [size = size()]() { return size; }
+        [segment = m_segment, data = span()]() { return data; }
     });
 }
 

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -78,8 +78,8 @@ class SharedMemoryHandle;
 // To modify or combine the data, allocate a new DataSegment.
 class DataSegment : public ThreadSafeRefCounted<DataSegment> {
 public:
-    WEBCORE_EXPORT size_t size() const;
-    std::span<const uint8_t> span() const { return std::span { data(), size() }; }
+    size_t size() const { return span().size(); }
+    WEBCORE_EXPORT std::span<const uint8_t> span() const;
 
     WEBCORE_EXPORT static Ref<DataSegment> create(Vector<uint8_t>&&);
 
@@ -98,10 +98,8 @@ public:
     WEBCORE_EXPORT static Ref<DataSegment> create(FileSystem::MappedFileData&&);
 
     struct Provider {
-        Function<const uint8_t*()> data;
-        Function<size_t()> size;
+        Function<std::span<const uint8_t>()> span;
     };
-
     WEBCORE_EXPORT static Ref<DataSegment> create(Provider&&);
 
 #if USE(FOUNDATION)
@@ -115,8 +113,6 @@ private:
 #if USE(FOUNDATION)
     void iterate(CFDataRef, const Function<void(std::span<const uint8_t>)>& apply) const;
 #endif
-
-    WEBCORE_EXPORT const uint8_t* data() const;
 
     explicit DataSegment(Vector<uint8_t>&& data)
         : m_immutableData(WTFMove(data)) { }
@@ -156,6 +152,7 @@ private:
 #endif
         FileSystem::MappedFileData,
         Provider> m_immutableData;
+
     friend class FragmentedSharedBuffer;
     friend class SharedBuffer; // For createCFData
 };
@@ -309,7 +306,7 @@ public:
     WEBCORE_EXPORT static Ref<SharedBuffer> create(Ref<FragmentedSharedBuffer>&&);
 
     WEBCORE_EXPORT const uint8_t& operator[](size_t) const;
-    std::span<const uint8_t> span() const { return std::span(data(), size()); }
+    WEBCORE_EXPORT std::span<const uint8_t> span() const;
     WTF::Persistence::Decoder decoder() const;
 
     enum class MayUseFileMapping : bool { No, Yes };
@@ -339,7 +336,6 @@ private:
     WEBCORE_EXPORT explicit SharedBuffer(Ref<FragmentedSharedBuffer>&&);
 
     WEBCORE_EXPORT static RefPtr<SharedBuffer> createFromReadingFile(const String& filePath);
-    WEBCORE_EXPORT const uint8_t* data() const;
 };
 
 class SharedBufferBuilder {

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -84,11 +84,8 @@ Ref<SharedBuffer> SharedMemory::createSharedBuffer(size_t dataSize) const
 {
     ASSERT(dataSize <= size());
     return SharedBuffer::create(DataSegment::Provider {
-        [protectedThis = Ref { *this }] () -> const uint8_t* {
-            return protectedThis->span().data();
-        },
-        [dataSize] () -> size_t {
-            return dataSize;
+        [protectedThis = Ref { *this }, dataSize]() {
+            return protectedThis->span().first(dataSize);
         }
     });
 }

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -120,7 +120,7 @@ RetainPtr<CMBlockBufferRef> FragmentedSharedBuffer::createCMBlockBuffer() const
         allocator.refCon = const_cast<DataSegment*>(&segment);
         segment.ref();
         CMBlockBufferRef partialBuffer = nullptr;
-        if (PAL::CMBlockBufferCreateWithMemoryBlock(nullptr, static_cast<void*>(const_cast<uint8_t*>(segment.data())), segment.size(), nullptr, &allocator, 0, segment.size(), 0, &partialBuffer) != kCMBlockBufferNoErr)
+        if (PAL::CMBlockBufferCreateWithMemoryBlock(nullptr, const_cast<uint8_t*>(segment.span().data()), segment.size(), nullptr, &allocator, 0, segment.size(), 0, &partialBuffer) != kCMBlockBufferNoErr)
             return nullptr;
         return adoptCF(partialBuffer);
     };

--- a/Source/WebCore/platform/glib/SharedBufferGlib.cpp
+++ b/Source/WebCore/platform/glib/SharedBufferGlib.cpp
@@ -41,7 +41,7 @@ Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(GBytes* bytes)
 GRefPtr<GBytes> SharedBuffer::createGBytes() const
 {
     ref();
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data(), size(), [](gpointer data) {
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(span().data(), size(), [](gpointer data) {
         static_cast<SharedBuffer*>(data)->deref();
     }, const_cast<SharedBuffer*>(this)));
     return bytes;

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
@@ -62,23 +62,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScalableImageDecoder);
 
 namespace {
 
-static unsigned copyFromSharedBuffer(char* buffer, unsigned bufferLength, const FragmentedSharedBuffer& sharedBuffer)
-{
-    unsigned bytesExtracted = 0;
-    for (const auto& element : sharedBuffer) {
-        if (bytesExtracted + element.segment->size() <= bufferLength) {
-            memcpy(buffer + bytesExtracted, element.segment->span().data(), element.segment->size());
-            bytesExtracted += element.segment->size();
-        } else {
-            ASSERT(bufferLength - bytesExtracted < element.segment->size());
-            memcpy(buffer + bytesExtracted, element.segment->span().data(), bufferLength - bytesExtracted);
-            bytesExtracted = bufferLength;
-            break;
-        }
-    }
-    return bytesExtracted;
-}
-
 #if !PLATFORM(COCOA)
 static bool matchesGIFSignature(char* contents)
 {
@@ -149,11 +132,12 @@ static bool matchesJPEGXLSignature(const uint8_t* contents, size_t length)
 
 RefPtr<ScalableImageDecoder> ScalableImageDecoder::create(FragmentedSharedBuffer& data, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {
-    static const unsigned lengthOfLongestSignature = 14; // To wit: "RIFF????WEBPVP"
-    char contents[lengthOfLongestSignature];
-    unsigned length = copyFromSharedBuffer(contents, lengthOfLongestSignature, data);
-    if (length < lengthOfLongestSignature)
+    constexpr size_t lengthOfLongestSignature = 14; // To wit: "RIFF????WEBPVP"
+    if (data.size() < lengthOfLongestSignature)
         return nullptr;
+
+    char contents[lengthOfLongestSignature];
+    data.copyTo(byteCast<uint8_t>(std::span { contents }));
 
 #if !PLATFORM(COCOA)
     if (matchesGIFSignature(contents))
@@ -184,7 +168,7 @@ RefPtr<ScalableImageDecoder> ScalableImageDecoder::create(FragmentedSharedBuffer
 #endif
 
 #if USE(JPEGXL)
-    if (matchesJPEGXLSignature(reinterpret_cast<const uint8_t*>(contents), length))
+    if (matchesJPEGXLSignature(reinterpret_cast<const uint8_t*>(contents), lengthOfLongestSignature))
         return JPEGXLImageDecoder::create(alphaOption, gammaAndColorProfileOption);
 #endif
 

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -372,7 +372,7 @@ static bool writeFilePathsOrDataBuffersToFile(const Vector<std::pair<String, Ref
 
     for (auto& part : filePathsOrDataBuffers) {
         if (part.second) {
-            int length = part.second->size();
+            int64_t length = part.second->size();
             if (FileSystem::writeToFile(file, part.second->span()) != length) {
                 LOG_ERROR("Failed writing a Blob to temporary file");
                 return false;

--- a/Source/WebCore/platform/skia/SharedBufferSkia.cpp
+++ b/Source/WebCore/platform/skia/SharedBufferSkia.cpp
@@ -43,7 +43,7 @@ Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(sk_sp<SkData>&& data)
 sk_sp<SkData> SharedBuffer::createSkData() const
 {
     ref();
-    return SkData::MakeWithProc(data(), size(), [](const void*, void* context) {
+    return SkData::MakeWithProc(span().data(), size(), [](const void*, void* context) {
         static_cast<SharedBuffer*>(context)->deref();
     }, const_cast<SharedBuffer*>(this));
 }

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -73,7 +73,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
             return completionHandler(nullptr);
 
         size_t dataSize { 0 };
-        const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebPushD::protocolEncodedMessageKey, &dataSize));
+        auto* data = static_cast<const uint8_t*>(xpc_dictionary_get_data(reply, WebPushD::protocolEncodedMessageKey, &dataSize));
         auto decoder = IPC::Decoder::create({ data, dataSize }, { });
 
         completionHandler(decoder.get());

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -275,7 +275,9 @@ static std::span<const uint8_t> dataFrom(const String& string)
 
 static Ref<WebCore::DataSegment> dataReferenceFrom(const String& string)
 {
-    return WebCore::DataSegment::create(dataFrom(string));
+    return WebCore::DataSegment::create(WebCore::DataSegment::Provider { [span = dataFrom(string)]() {
+        return span;
+    } });
 }
 
 static void loadString(WKPageRef pageRef, WKStringRef stringRef, const String& mimeType, const String& baseURL, WKTypeRef userDataRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -173,8 +173,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
 {
-    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
-    _page->loadAlternateHTML(WebCore::DataSegment::create((__bridge CFDataRef)data), "UTF-8"_s, baseURL, unreachableURL);
+    RetainPtr data = bridge_cast([string dataUsingEncoding:NSUTF8StringEncoding]);
+    _page->loadAlternateHTML(WebCore::DataSegment::create(WTFMove(data)), "UTF-8"_s, baseURL, unreachableURL);
 }
 
 - (void)loadData:(NSData *)data MIMEType:(NSString *)MIMEType textEncodingName:(NSString *)encodingName baseURL:(NSURL *)baseURL

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -175,6 +175,7 @@
 #import <wtf/UUID.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/darwin/dyldSPI.h>
 #import <wtf/text/MakeString.h>
@@ -3184,8 +3185,8 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
 {
     THROW_IF_SUSPENDED;
-    auto *data = [string dataUsingEncoding:NSUTF8StringEncoding] ?: NSData.data;
-    _page->loadAlternateHTML(WebCore::DataSegment::create((__bridge CFDataRef)data), "UTF-8"_s, baseURL, unreachableURL);
+    RetainPtr data = bridge_cast([string dataUsingEncoding:NSUTF8StringEncoding] ?: NSData.data);
+    _page->loadAlternateHTML(WebCore::DataSegment::create(WTFMove(data)), "UTF-8"_s, baseURL, unreachableURL);
 }
 
 - (WKNavigation *)_loadData:(NSData *)data MIMEType:(NSString *)MIMEType characterEncodingName:(NSString *)characterEncodingName baseURL:(NSURL *)baseURL userData:(id)userData

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -300,7 +300,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
     }
 
     size_t dataSize { 0 };
-    auto data = static_cast<const uint8_t*>(xpc_dictionary_get_data(request, protocolEncodedMessageKey, &dataSize));
+    auto* data = static_cast<const uint8_t*>(xpc_dictionary_get_data(request, protocolEncodedMessageKey, &dataSize));
     if (!data) {
         RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - No encoded message data in xpc message");
         tryCloseRequestConnection(request);


### PR DESCRIPTION
#### 6646f0585b449208fb9eabe1b43a3dd5ae153e6f
<pre>
Use span for MappedFileData and DataSegment
<a href="https://bugs.webkit.org/show_bug.cgi?id=274756">https://bugs.webkit.org/show_bug.cgi?id=274756</a>
<a href="https://rdar.apple.com/128807880">rdar://128807880</a>

Reviewed by Chris Dumez.

Changed JSC::CachePayload, WTF::MappedFileData, and
WebCore::DataSegment::Provider to use spans instead of pointer/size pairs.

* Source/JavaScriptCore/runtime/CachePayload.cpp:
(JSC::CachePayload::span const): Added.
(JSC::CachePayload::data const): Deleted.
(JSC::CachePayload::size const): Deleted.
* Source/JavaScriptCore/runtime/CachePayload.h: Updated for the above.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Decoder::offsetOf): Tweaked coding style a bit
(JSC::decodeCodeBlockImpl): Ditto.
(JSC::isCachedBytecodeStillValid): Removed use of CachePayload::size
in function that already calls CachePayload::span.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::MappedFileData::~MappedFileData): Updated since
m_fileData is now a span.
(WTF::FileSystemImpl::MappedFileData::mapFileHandle): Use span for
m_fileData.

* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::MappedFileData::~MappedFileData): Updated since
m_fileData is now a span.
(WTF::FileSystemImpl::MappedFileData::mapFileHandle): Use span for
m_fileData.

* Source/WTF/wtf/FileSystem.h: Use span for m_fileData. Return a span
from leakHandle.

* Source/WebCore/platform/ShareableResource.cpp:
(WebCore::ShareableResource::wrapInSharedBuffer): Updated since
DataSegment::Provider now takes a Function that returns a span.
(WebCore::ShareableResource::span const): Fixed bug where the span
returned here was bigger than it should be: not past the end of the
shared memory, but possibly past the end of the resource.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::FragmentedSharedBuffer): Updated
since DataSegment::Provider now takes a Function that returns a span.
(WebCore::FragmentedSharedBuffer::tryCreateArrayBuffer const):
Removed unneeded cast to unsigned. Use copyTo instead of a hand-written
loop to copy the data from m_segments into the ArrayBuffer.
(WebCore::DataSegment::iterate const): Use span.
(WebCore::FragmentedSharedBuffer::startsWith const): Ditto.
(WebCore::FragmentedSharedBuffer::copyTo const): Use span, memcpySpan,
and subspan instead of pointers.
(WebCore::FragmentedSharedBuffer::operator== const): Use equalSpans.
(WebCore::SharedBuffer::span const): Added.
(WebCore::SharedBuffer::data const): Deleted.
(WebCore::SharedBuffer::operator[] const): Updated since
DataSegment::Provider now takes a Function that returns a span.
(WebCore::SharedBuffer::decoder const): Use span.
(WebCore::DataSegment::span const): Added.
(WebCore::DataSegment::data const): Deleted.
(WebCore::DataSegment::size const): Deleted.
(WebCore::SharedBufferDataView::createSharedBuffer const): Updated
since DataSegment::Provider now takes a Function that returns a span.

* Source/WebCore/platform/SharedBuffer.h: Changed
DataSegment::Provider to a single Function that returns a span instead
of one that returns a data pointer and another that returns a size.

* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::createSharedBuffer const): Updated
since DataSegment::Provider now takes a Function that returns a span.

* Source/WebCore/platform/cocoa/SharedBufferCocoa.mm:
(WebCore::FragmentedSharedBuffer::createCMBlockBuffer const):
Removed unneeded cast.

* Source/WebCore/platform/glib/SharedBufferGlib.cpp:
(WebCore::SharedBuffer::createGBytes const): Use span.

* Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp:
(copyFromSharedBuffer): Deleted.
(WebCore::ScalableImageDecoder::create): Use FragmentedSharedBuffer::copyTo
instead of a local copyFromSharedBuffer function here that does the same thing.

* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::writeFilePathsOrDataBuffersToFile): Use the correct int64_t type here,
which matches the return type of FileSystem::writeToFile.

* Source/WebCore/platform/skia/SharedBufferSkia.cpp:
(WebCore::SharedBuffer::createSkData const): Use span.

* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
Tweak coding style.

* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::adoptMap): Updated since MappedFileData::leakHandle now
returns a span.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(dataReferenceFrom): Updated since DataSegment::Provider now takes a Function that
returns a span. This new version now holds a reference to the string instead of
making a copy of the bytes, which seems what was intended from the start.

* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController loadAlternateHTMLString:baseURL:forUnreachableURL:]):
Updated for changes to DataSegment. This now makes the object lifetime clearer
using an explicit RetainPtr.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _loadAlternateHTMLString:baseURL:forUnreachableURL:]): Ditto.

* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler): Use auto* for style consistency.

Canonical link: <a href="https://commits.webkit.org/284419@main">https://commits.webkit.org/284419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/505ed264e2ad6393b300f6be3a5dc9882352230f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20321 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17274 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18848 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62429 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75107 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68559 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16842 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62701 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15386 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4328 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90341 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44517 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16019 "Found 29 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-both-proven-final-object.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-proven-final-object.js.layout, stress/block-scope-redeclarations.js.dfg-eager, stress/do-eval-virtual-call-correctly.js.bytecode-cache, stress/get-private-name-with-primitive.js.dfg-eager, stress/hashbang.js.bytecode-cache, stress/intl-locale-exceptions.js.dfg-eager, stress/iterator-prototype-find.js.dfg-eager, stress/iterator-prototype-reduce.js.dfg-eager, stress/private-accesor-duplicate-name-early-errors.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->