### PR TITLE
RemoteDOMWindow::focus() and RemoteDOMWindow::blur() should have more security checks

### DIFF
--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -193,6 +193,7 @@ public:
     String origin() const;
     SecurityOrigin* securityOrigin() const;
 
+
     // DOM Level 2 AbstractView Interface
 
     WEBCORE_EXPORT Document* document() const;
@@ -257,6 +258,8 @@ public:
     bool isSecureContext() const;
 
     bool crossOriginIsolated() const;
+
+    bool isSameSecurityOriginAsMainFrame() const;
 
     // Events
     // EventTarget API
@@ -383,7 +386,7 @@ private:
     void failedToRegisterDeviceMotionEventListener();
 #endif
 
-    bool isSameSecurityOriginAsMainFrame() const;
+
 
 #if ENABLE(GAMEPAD)
     void incrementGamepadEventListenerCount();

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -66,22 +66,25 @@ void RemoteDOMWindow::closePage()
     m_frame->client().closePage();
 }
 
+
+
 void RemoteDOMWindow::frameDetached()
 {
     m_frame = nullptr;
 }
 
-void RemoteDOMWindow::focus(LocalDOMWindow&)
+void RemoteDOMWindow::focus(LocalDOMWindow& incumbentWindow)
 {
-    // FIXME(264713): Add security checks here equivalent to LocalDOMWindow::focus().
-    if (m_frame && m_frame->isMainFrame())
+    if (!incumbentWindow.isSameSecurityOriginAsMainFrame())
+        return;
+
+    if (m_frame && m_frame->isMainFrame() && !m_frame->settings().windowFocusRestricted())
         m_frame->client().focus();
 }
 
 void RemoteDOMWindow::blur()
 {
-    // FIXME(268121): Add security checks here equivalent to LocalDOMWindow::blur().
-    if (m_frame && m_frame->isMainFrame())
+    if (m_frame && m_frame->isMainFrame() && !m_frame->settings().windowFocusRestricted())
         m_frame->client().unfocus();
 }
 


### PR DESCRIPTION
#### 09d0d84edb0a738308253c5994d819e044eacefd
<pre>
RemoteDOMWindow::focus() and RemoteDOMWindow::blur() needs same security checks as LocalDOMWindow::focus() and LocalDOMWindow::blur()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264713">https://bugs.webkit.org/show_bug.cgi?id=264713</a>

Reviewed by NOBODY (OOPS!).

RemoteDOMWindow::focus() and RemoteDOMWindow::blur()
needs same security checks as LocalDOMWindow::focus() and LocalDOMWindow::blur()

* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::focus):
(WebCore::RemoteDOMWindow::blur):
* Source/WebCore/page/LocalDOMWindow.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09d0d84edb0a738308253c5994d819e044eacefd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54593 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12999 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43676 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59047 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.OpenedWindowFocusDelegates, TestWebKitAPI.SiteIsolation.FocusOpenedWindow (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17878 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62301 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.FocusOpenedWindow (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74135 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62063 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3604 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->