### PR TITLE
[WGSL] Helper functions should be static

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -237,7 +237,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     if (m_shaderModule.usesPackArray()) {
         m_shaderModule.clearUsesPackArray();
         m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s,
-            m_indent, "array<typename T::PackedType, N> __pack(array<T, N> unpacked)\n"_s,
+            m_indent, "static array<typename T::PackedType, N> __pack(array<T, N> unpacked)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -253,7 +253,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
         if (m_shaderModule.usesPackedVec3()) {
             m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s,
-                m_indent, "array<PackedVec3<T>, N> __pack(array<vec<T, 3>, N> unpacked)\n"_s,
+                m_indent, "static array<PackedVec3<T>, N> __pack(array<vec<T, 3>, N> unpacked)\n"_s,
                 m_indent, "{\n"_s);
             {
                 IndentationScope scope(m_indent);
@@ -272,7 +272,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     if (m_shaderModule.usesUnpackArray()) {
         m_shaderModule.clearUsesUnpackArray();
         m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s,
-            m_indent, "array<typename T::UnpackedType, N> __unpack(array<T, N> packed)\n"_s,
+            m_indent, "static array<typename T::UnpackedType, N> __unpack(array<T, N> packed)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -288,7 +288,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
         if (m_shaderModule.usesPackedVec3()) {
             m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s,
-                m_indent, "array<vec<T, 3>, N> __unpack(array<PackedVec3<T>, N> packed)\n"_s,
+                m_indent, "static array<vec<T, 3>, N> __unpack(array<PackedVec3<T>, N> packed)\n"_s,
                 m_indent, "{\n"_s);
             {
                 IndentationScope scope(m_indent);
@@ -307,23 +307,23 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     if (m_shaderModule.usesPackVector()) {
         m_shaderModule.clearUsesPackVector();
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "packed_vec<T, 3> __pack(vec<T, 3> unpacked) { return unpacked; }\n\n"_s);
+            m_indent, "static packed_vec<T, 3> __pack(vec<T, 3> unpacked) { return unpacked; }\n\n"_s);
     }
 
     if (m_shaderModule.usesUnpackVector()) {
         m_shaderModule.clearUsesUnpackVector();
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "vec<T, 3> __unpack(packed_vec<T, 3> packed) { return packed; }\n\n"_s);
+            m_indent, "static vec<T, 3> __unpack(packed_vec<T, 3> packed) { return packed; }\n\n"_s);
 
         if (m_shaderModule.usesPackedVec3()) {
             m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-                m_indent, "vec<T, 3> __unpack(PackedVec3<T> packed) { return packed; }\n\n"_s);
+                m_indent, "static vec<T, 3> __unpack(PackedVec3<T> packed) { return packed; }\n\n"_s);
         }
     }
 
     if (m_shaderModule.usesWorkgroupUniformLoad()) {
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "T __workgroup_uniform_load(threadgroup T* const ptr)\n"_s,
+            m_indent, "static T __workgroup_uniform_load(threadgroup T* const ptr)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -337,7 +337,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesDivision()) {
         m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s,
-            m_indent, "V __wgslDiv(T lhs, U rhs)\n"_s,
+            m_indent, "static V __wgslDiv(T lhs, U rhs)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -354,7 +354,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesModulo()) {
         m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s,
-            m_indent, "V __wgslMod(T lhs, U rhs)\n"_s,
+            m_indent, "static V __wgslMod(T lhs, U rhs)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -380,7 +380,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         }
         m_stringBuilder.append(m_indent, "};\n\n"_s,
             m_indent, "template<typename T, typename U = conditional_t<is_vector_v<T>, vec<int, vec_elements<T>::value ?: 2>, int>>\n"_s,
-            m_indent, "__frexp_result<T, U> __wgslFrexp(T value)\n"_s,
+            m_indent, "static __frexp_result<T, U> __wgslFrexp(T value)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -401,7 +401,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         }
         m_stringBuilder.append(m_indent, "};\n\n"_s,
             m_indent, "template<typename T>\n"_s,
-            m_indent, "__modf_result<T, T> __wgslModf(T value)\n"_s,
+            m_indent, "static __modf_result<T, T> __wgslModf(T value)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -433,7 +433,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesDot()) {
         m_stringBuilder.append(m_indent, "template<typename T, unsigned N>\n"_s,
-            m_indent, "T __wgslDot(vec<T, N> lhs, vec<T, N> rhs)\n"_s,
+            m_indent, "static T __wgslDot(vec<T, N> lhs, vec<T, N> rhs)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -446,7 +446,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesDot4I8Packed()) {
-        m_stringBuilder.append(m_indent, "int __wgslDot4I8Packed(uint lhs, uint rhs)\n"_s,
+        m_stringBuilder.append(m_indent, "static int __wgslDot4I8Packed(uint lhs, uint rhs)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -458,7 +458,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesDot4U8Packed()) {
-        m_stringBuilder.append(m_indent, "uint __wgslDot4U8Packed(uint lhs, uint rhs)\n"_s,
+        m_stringBuilder.append(m_indent, "static uint __wgslDot4U8Packed(uint lhs, uint rhs)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -471,7 +471,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesFirstLeadingBit()) {
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "T __wgslFirstLeadingBit(T e)\n"_s,
+            m_indent, "static T __wgslFirstLeadingBit(T e)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -485,7 +485,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesFirstTrailingBit()) {
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "T __wgslFirstTrailingBit(T e)\n"_s,
+            m_indent, "static T __wgslFirstTrailingBit(T e)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -496,7 +496,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesSign()) {
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "T __wgslSign(T e)\n"_s,
+            m_indent, "static T __wgslSign(T e)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -507,7 +507,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesExtractBits()) {
         m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "T __wgslExtractBits(T e, uint offset, uint count)\n"_s,
+            m_indent, "static T __wgslExtractBits(T e, uint offset, uint count)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
@@ -666,7 +666,7 @@ void FunctionDefinitionWriter::generatePackingHelpers(AST::Structure& structure)
     const String& packedName = structure.name();
     auto unpackedName = structure.original()->name();
 
-    m_stringBuilder.append(m_indent, packedName, " __pack("_s, unpackedName, " unpacked)\n"_s,
+    m_stringBuilder.append(m_indent, "static "_s, packedName, " __pack("_s, unpackedName, " unpacked)\n"_s,
         m_indent, "{\n"_s);
     {
         IndentationScope scope(m_indent);
@@ -681,7 +681,7 @@ void FunctionDefinitionWriter::generatePackingHelpers(AST::Structure& structure)
         m_stringBuilder.append(m_indent, "return packed;\n"_s);
     }
     m_stringBuilder.append(m_indent, "}\n\n"_s,
-        m_indent, unpackedName, " __unpack("_s, packedName, " packed)\n"_s,
+        m_indent, "static "_s, unpackedName, " __unpack("_s, packedName, " packed)\n"_s,
         m_indent, "{\n"_s);
     {
         IndentationScope scope(m_indent);

--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -23,6 +23,7 @@ config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
 # FIXME: fix these so this list is empty
 ignored_warnings = [
     '-Wno-unused-variable',
+    '-Wno-unused-function',
     '-Wno-missing-braces',
     '-Wno-c++17-extensions',
     '-Wno-parentheses-equality'

--- a/Source/WebGPU/WGSL/tests/valid/fuzz-128785160.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fuzz-128785160.wgsl
@@ -1,0 +1,13 @@
+// RUN: %metal-compile main
+
+struct S {
+  @size(1<<30) f0: u32,
+}
+
+@group(0) @binding(0)
+var<storage, read_write> k: S;
+
+@compute @workgroup_size(1)
+fn main() {
+  k.f0 = 0;
+}

--- a/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
@@ -4,7 +4,7 @@ const b = vec2f(a);
 @compute @workgroup_size(1)
 fn main() {
   // CHECK: vec.* local\d+ = vec<float, 4>\(0., 0., 0., 0.\)
-  // CHECK: \(void\)\(local\d+\[min\(unsigned\(0\), \(4u - 1u\)\)\]\)
+  // CHECK: \(void\)\(local\d+\[__wgslMin\(unsigned\(0\), \(4u - 1u\)\)\]\)
   let x = vec4f(b, 0, 0);
   _ = x[0];
 }

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -188,10 +188,10 @@ fn testFieldAccess() -> i32
 fn testIndexAccess() -> i32
 {
     // CHECK: local\d+ = __unpack\(global\d+\);
-    // CHECK-NEXT: local\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\] = __unpack\(global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\]\);
-    // CHECK-NEXT: global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\] = global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\];
-    // CHECK-NEXT: global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\] = __pack\(local\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\]\);
-    // CHECK-NEXT: global\d+\[min\(unsigned\(global\d+\), \(2u - 1u\)\)\] = __pack\(local\d+\[min\(unsigned\(global\d+\), \(2u - 1u\)\)\]\);
+    // CHECK-NEXT: local\d+\[__wgslMin\(unsigned\(0\), \(2u - 1u\)\)\] = __unpack\(global\d+\[__wgslMin\(unsigned\(0\), \(2u - 1u\)\)\]\);
+    // CHECK-NEXT: global\d+\[__wgslMin\(unsigned\(0\), \(2u - 1u\)\)\] = global\d+\[__wgslMin\(unsigned\(0\), \(2u - 1u\)\)\];
+    // CHECK-NEXT: global\d+\[__wgslMin\(unsigned\(0\), \(2u - 1u\)\)\] = __pack\(local\d+\[__wgslMin\(unsigned\(0\), \(2u - 1u\)\)\]\);
+    // CHECK-NEXT: global\d+\[__wgslMin\(unsigned\(global\d+\), \(2u - 1u\)\)\] = __pack\(local\d+\[__wgslMin\(unsigned\(global\d+\), \(2u - 1u\)\)\]\);
     var at = at1;
     at[0] = at1[0];
     at1[0] = at2[0];


### PR DESCRIPTION
#### c7e03e6c664c7160842d008ab49e74f317fb37fe
<pre>
[WGSL] Helper functions should be static
<a href="https://bugs.webkit.org/show_bug.cgi?id=280168">https://bugs.webkit.org/show_bug.cgi?id=280168</a>
<a href="https://rdar.apple.com/128785160">rdar://128785160</a>

Reviewed by Mike Wyrzykowski.

We hit some pathological slow compilations in Metal when generating
packing helpers for large structs, but making the function static
helps avoid the issue, so long as the helpers are not used.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::generatePackingHelpers):
* Source/WebGPU/WGSL/tests/lit.cfg:
* Source/WebGPU/WGSL/tests/valid/fuzz-128785160.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl:
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/284219@main">https://commits.webkit.org/284219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3882803d4ce8e27181db6440cd8eeb1e3cb0a211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19529 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19345 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54599 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 17 flakes 104 failures; Uploaded test results; Running layout-tests-repeat-failures; Compiled WebKit (warnings); 10 flakes 74 failures; Passed layout tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13004 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40352 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74143 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62050 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62071 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9995 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3611 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43577 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->