### PR TITLE
[GTK][WPE]  check-for-invalid-symbols-in-version-script wrongly matches hidden symbols

### DIFF
--- a/Tools/Scripts/check-for-invalid-symbols-in-version-script
+++ b/Tools/Scripts/check-for-invalid-symbols-in-version-script
@@ -3,8 +3,8 @@
 import subprocess
 import sys
 
-def script_symbols(script):
-    symbols = []
+def linker_script_symbols(script):
+    symbols = set()
     in_symbols = False
     with open(script, 'r') as f:
         for line in f.readlines():
@@ -14,25 +14,24 @@ def script_symbols(script):
                 line = line.lstrip()
                 line = line.rstrip('\n')
                 line = line.rstrip(';')
-                symbols.append(line.strip('"'))
+                symbols.add(line.strip('"'))
             elif line.lstrip() == 'extern "C++" {\n':
                 in_symbols = True
     return symbols
+
+def elf_visible_symbols(path):
+    p = subprocess.Popen(['nm', '-jUCD', path], stdout=subprocess.PIPE, encoding='ascii')
+    data = p.communicate()
+    return frozenset(data[0].splitlines())
 
 if len(sys.argv) < 3:
     print("Usage: %s script lib" % sys.argv[0])
     sys.exit(1)
 
+script_symbols = linker_script_symbols(sys.argv[1])
+elf_symbols = elf_visible_symbols(sys.argv[2])
 
-symbols = script_symbols(sys.argv[1])
-p = subprocess.Popen(['objdump', '-t', '-C', sys.argv[2]], stdout=subprocess.PIPE, encoding="ascii")
-data = p.communicate()[0]
-
-symbols = []
-for symbol in script_symbols(sys.argv[1]):
-    if symbol not in data:
-        symbols.append(symbol)
-
+symbols = script_symbols - elf_symbols
 if symbols:
     print('The following symbols are in version script %s and not in library %s' % (sys.argv[1], sys.argv[2]))
     print('\n'.join(sorted(symbols)))


### PR DESCRIPTION
#### dda1d973f908e00100021dd7e37936efe9ed36a7
<pre>
[GTK][WPE]  check-for-invalid-symbols-in-version-script wrongly matches hidden symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=280170">https://bugs.webkit.org/show_bug.cgi?id=280170</a>

Reviewed by Carlos Garcia Campos.

Replace usage of &quot;objdump -t -C&quot;, which lists all kinds of symbols,
with &quot;nm -jUCD&quot;, which lists only visible symbols from the ELF dynamic
section. This way the tool checks exacrlt against that list, which
always was the intended behaviour.

* Tools/Scripts/check-for-invalid-symbols-in-version-script:
(linker_script_symbols): Renamed from script_symbols to avoid a name
clash, and make the function return a set of strings.
(elf_visible_symbols): Added, runs &quot;nm -jUCD&quot; on the binary and returns
a set of visible symbols exported by the ELF dynamic section.
(script_symbols): Deleted.

Canonical link: <a href="https://commits.webkit.org/284063@main">https://commits.webkit.org/284063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1748f7c88111aeddaa118eac0a3f7db3592886e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19356 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/13014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43694 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40362 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62319 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16095 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12405 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10004 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10394 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43588 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44662 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->