### PR TITLE
[JSC] Add fast path for `Array.prototype.with`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-with-fast-path.js
+++ b/JSTests/microbenchmarks/array-prototype-with-fast-path.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1, index, value) {
+    return array1.with(index, value);
+}
+
+noInline(test);
+
+const array = new Array(1024);
+array.fill(99);
+
+const index = 512;
+const newValue = 300;
+
+for (let i = 0; i < 1e2; i++) {
+    const result = test(array, index, newValue);
+    shouldBe(result[index], newValue);
+    shouldBe(result.length, array.length);
+}

--- a/JSTests/stress/array-prototype-with-effect.js
+++ b/JSTests/stress/array-prototype-with-effect.js
@@ -1,0 +1,21 @@
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const arr = [0, 1, 2];
+
+let get0Count = 0;
+Object.defineProperty(arr, "0", {
+    get() {
+        get0Count++;
+        return 0;
+    }
+});
+
+arr.with(1, 2);
+sameValue(get0Count, 1);
+arr.with(2, 2);
+sameValue(get0Count, 2);
+arr.with(0, 2);
+sameValue(get0Count, 2);

--- a/JSTests/stress/array-prototype-with-empty.js
+++ b/JSTests/stress/array-prototype-with-empty.js
@@ -1,0 +1,98 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let source = new Array(0);
+    let result = source.concat();
+    shouldBe(result.length, 0);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42;
+    source[1] = 43;
+    let result = source.with(0, 44);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 44);
+    shouldBe(result[1], 43);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42.195;
+    source[1] = 43.195;
+    let result = source.with(0, 44.195);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 44.195);
+    shouldBe(result[1], 43.195);
+}
+
+{
+    let source = new Array(6);
+    let result = source.with(3, undefined);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42;
+    let result = source.with(0, 43);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], 43);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42.195;
+    let result = source.with(0, 43.195);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], 43.195);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    let result = source.with(0, "stringstring");
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "stringstring");
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    $vm.ensureArrayStorage(source);
+    source[1000] = "Hello";
+    let result = source.with(0, "stringstring").with(1000, "HelloHello");
+    shouldBe(result.length, 1001);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "stringstring");
+        else if (i === 1000)
+            shouldBe(result[i], "HelloHello");
+    }
+}

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -704,6 +704,11 @@ function with(index, value)
         @throwRangeError("Array index out of Range");
 
     // Step 7.
+    var fastResult = @arrayFromFastFillWithUndefined(@Array, array);
+    if (fastResult) {
+        @putByValDirect(fastResult, actualIndex, value);
+        return fastResult;
+    }
     var result = @newArrayWithSize(length);
 
     // Step 8-9


### PR DESCRIPTION
#### d9f92208c3d08a39be8c82d142e6f34280839f41
<pre>
[JSC] Add fast path for `Array.prototype.with`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280182">https://bugs.webkit.org/show_bug.cgi?id=280182</a>

Reviewed by Yusuke Suzuki.

This patch adds a fast path for `Array.prototype.with` using `@arrayFromFastFillWithUndefined`.

According to the microbenth, it is 1.8x faster.

                                        TipOfTree                  Patched

array-prototype-with-fast-path        0.5715+-0.0107     ^      0.3120+-0.0122        ^ definitely 1.8316x faster

&lt;geometric&gt;                           0.5715+-0.0107     ^      0.3120+-0.0122        ^ definitely 1.8316x faster

* JSTests/microbenchmarks/array-prototype-with-fast-path.js: Added.
(shouldBe):
(test):
* JSTests/stress/array-prototype-with-empty.js: Added.
(shouldBe):
(throw.new.Error):
(else.shouldBe):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(with):
* JSTests/stress/array-prototype-with-effect.js: Added.
(sameValue):

Canonical link: <a href="https://commits.webkit.org/284332@main">https://commits.webkit.org/284332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/204c2294b028c874ef9f86fdd95a52114938d439

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19578 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54638 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13045 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17935 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61551 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74193 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67681 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62134 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3650 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89460 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43626 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15835 "Found 9 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison, wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-collect-continuously, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call-double.js.wasm-eager-jettison, wasm.yaml/wasm/stress/tail-call.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->