### PR TITLE
[WPE][cross-toolchain-helper] Default to not preferring system libsysprof-capture after 283841@main

### DIFF
--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -39,7 +39,7 @@ conf_local_path = rpi/local-rpi3-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi3-32bits-userland]
 repo_manifest_path = rpi/manifest.xml
@@ -49,7 +49,7 @@ image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
 # WTR and MiniBrowser require wpbackend-fdo, with wpbackend-rdk we can only build cog
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-32bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -58,7 +58,7 @@ conf_local_path = rpi/local-rpi4-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 # ARM 64-bits targets (AArch64)
 
@@ -69,7 +69,7 @@ conf_local_path = rpi/local-rpi3-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-64bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -78,7 +78,7 @@ conf_local_path = rpi/local-rpi4-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [qemu-riscv64]
 repo_manifest_path = riscv/manifest.xml
@@ -87,4 +87,4 @@ conf_local_path = riscv/local-qemu-riscv64.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"


### PR DESCRIPTION
#### 2c4e224a390e056be7d4f1876dd616bb019efca3
<pre>
[WPE][cross-toolchain-helper] Default to not preferring system libsysprof-capture after 283841@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=280184">https://bugs.webkit.org/show_bug.cgi?id=280184</a>

Reviewed by Nikolas Zimmermann.

After 283841@main the build defaults to use the system libsysprof-capture
but the version of that we still ship on the cross-toolchain-helper
environment (via Yocto) is not modern enough.
So, for now, default back this setting to off on this environment.

* Tools/yocto/targets.conf:

Canonical link: <a href="https://commits.webkit.org/284071@main">https://commits.webkit.org/284071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23d4cebe97b96fdccc162d55384d1b6f9d15f5bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/13035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43712 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40380 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62338 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74179 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12430 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/10024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10397 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43613 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->