### PR TITLE
[IFC][Bidi] Empty inline box does not generate valid geometry

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7941,7 +7941,6 @@ imported/blink/fast/ruby/ruby-first-letter.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ruby/ruby-line-breaking-003.html [ ImageOnlyFailure ]
 webkit.org/b/276007 [ Debug ] fast/ruby/ruby-with-continuation-crash.html [ Skip ]
 
-webkit.org/b/266537 [ Debug ] imported/w3c/web-platform-tests/css/css-ruby/empty-ruby-text-container-float.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-ruby/break-within-bases/basic.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ruby/break-within-bases/no-break-opportunity-at-end.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ruby/break-within-bases/nowrap.html [ ImageOnlyFailure ]

--- a/LayoutTests/css3/unicode-bidi-float-crash.html
+++ b/LayoutTests/css3/unicode-bidi-float-crash.html
@@ -1,0 +1,14 @@
+<style>
+div {
+  float: left;
+}
+</style>
+<span style="unicode-bidi: isolate"><span style="unicode-bidi: isolate"><span id=inline_box><div></div></span></span></span>
+<pre id="renderTree"></pre>
+<script>
+  if (window.testRunner)
+      window.testRunner.dumpAsText();
+
+  var text = document.getElementById("renderTree");
+  text.innerHTML = window.internals.elementRenderTreeAsText(document.documentElement);
+</script>

--- a/LayoutTests/platform/glib/css3/unicode-bidi-float-crash-expected.txt
+++ b/LayoutTests/platform/glib/css3/unicode-bidi-float-crash-expected.txt
@@ -1,0 +1,11 @@
+ layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x579
+      RenderBlock (anonymous) at (0,0) size 784x0
+        RenderInline {SPAN} at (0,-14) size 0x17
+          RenderInline {SPAN} at (0,-14) size 0x17
+            RenderInline {SPAN} at (0,0) size 0x0
+              RenderBlock (floating) {DIV} at (0,0) size 0x0
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {PRE} at (0,13) size 784x0
+

--- a/LayoutTests/platform/ios/css3/unicode-bidi-float-crash-expected.txt
+++ b/LayoutTests/platform/ios/css3/unicode-bidi-float-crash-expected.txt
@@ -1,0 +1,11 @@
+ layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x579
+      RenderBlock (anonymous) at (0,0) size 784x0
+        RenderInline {SPAN} at (0,-15) size 0x19
+          RenderInline {SPAN} at (0,-15) size 0x19
+            RenderInline {SPAN} at (0,0) size 0x0
+              RenderBlock (floating) {DIV} at (0,0) size 0x0
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {PRE} at (0,13) size 784x0
+

--- a/LayoutTests/platform/mac/css3/unicode-bidi-float-crash-expected.txt
+++ b/LayoutTests/platform/mac/css3/unicode-bidi-float-crash-expected.txt
@@ -1,0 +1,11 @@
+ layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x579
+      RenderBlock (anonymous) at (0,0) size 784x0
+        RenderInline {SPAN} at (0,-14) size 0x18
+          RenderInline {SPAN} at (0,-14) size 0x18
+            RenderInline {SPAN} at (0,0) size 0x0
+              RenderBlock (floating) {DIV} at (0,0) size 0x0
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {PRE} at (0,13) size 784x0
+

--- a/LayoutTests/platform/win/css3/unicode-bidi-float-crash-expected.txt
+++ b/LayoutTests/platform/win/css3/unicode-bidi-float-crash-expected.txt
@@ -1,0 +1,11 @@
+ layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x579
+      RenderBlock (anonymous) at (0,0) size 784x0
+        RenderInline {SPAN} at (0,-14) size 0x17
+          RenderInline {SPAN} at (0,-14) size 0x17
+            RenderInline {SPAN} at (0,0) size 0x0
+              RenderBlock (floating) {DIV} at (0,0) size 0x0
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {PRE} at (0,13) size 784x0
+

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -711,10 +711,17 @@ void InlineItemsBuilder::breakAndComputeBidiLevels(InlineItemList& inlineItemLis
                 inlineItem.setBidiLevel(InlineItem::opaqueBidiLevel);
                 continue;
             }
-            // Mark the inline box stack with "content yes", when we come across a content type of inline item.
-            auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem);
-            if (!inlineTextItem || !inlineTextItem->isWhitespace() || TextUtil::shouldPreserveSpacesAndTabs(inlineTextItem->layoutBox()))
+
+            auto isContentfulInlineItem = [&] {
+                if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem))
+                    return !inlineTextItem->isWhitespace() || TextUtil::shouldPreserveSpacesAndTabs(inlineTextItem->layoutBox());
+                return inlineItem.isAtomicInlineBox() || inlineItem.isLineBreak() || (inlineItem.isOpaque() && inlineItem.layoutBox().isOutOfFlowPositioned());
+            };
+            if (isContentfulInlineItem()) {
+                // Mark the inline box stack with "content yes", when we come across a content type of inline item
+                // so that we can mark the inline box as opaque and let the content drive visual ordering.
                 inlineBoxContentFlagStack.fill(InlineBoxHasContent::Yes);
+            }
         }
     };
     setBidiLevelForOpaqueInlineItems();


### PR DESCRIPTION
#### 8581b67df6d8ab1326d7b351dd5ad5a731372951
<pre>
[IFC][Bidi] Empty inline box does not generate valid geometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=266537">https://bugs.webkit.org/show_bug.cgi?id=266537</a>

Reviewed by Alan Baradlay.

An inline box containing only a float should not be considered as contentful.

* LayoutTests/TestExpectations:
* LayoutTests/css3/unicode-bidi-float-crash.html: Added.
* LayoutTests/platform/glib/css3/unicode-bidi-float-crash-expected.txt: Added.
* LayoutTests/platform/ios/css3/unicode-bidi-float-crash-expected.txt: Added.
* LayoutTests/platform/mac/css3/unicode-bidi-float-crash-expected.txt: Added.
* LayoutTests/platform/win/css3/unicode-bidi-float-crash-expected.txt: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::breakAndComputeBidiLevels):

Canonical link: <a href="https://commits.webkit.org/284402@main">https://commits.webkit.org/284402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84880f0dfa8b1a693e0342aa4c9227cf2f55dc8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55063 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74988 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62625 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15377 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4239 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44400 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->