### PR TITLE
REGRESSION(283414@main): [WPE][GTK] File descriptor leak if process launch is canceled immediately

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
@@ -53,7 +53,7 @@ ProcessLauncher::~ProcessLauncher()
         tracePoint(ProcessLaunchEnd, m_launchOptions.processIdentifier.toUInt64(), static_cast<uint64_t>(m_launchOptions.processType));
 }
 
-#if !PLATFORM(COCOA)
+#if !PLATFORM(COCOA) && !USE(GLIB)
 void ProcessLauncher::platformDestroy()
 {
 }

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -186,6 +186,7 @@ private:
 
 #if USE(GLIB) && OS(LINUX)
     GSocketMonitor m_socketMonitor;
+    int m_pidServerSocket { -1 };
 #endif
 };
 


### PR DESCRIPTION
#### 7dd6aeafdd8e4bf1e88de4f72bd39ad4d25ca5e6
<pre>
REGRESSION(283414@main): [WPE][GTK] File descriptor leak if process launch is canceled immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=280073">https://bugs.webkit.org/show_bug.cgi?id=280073</a>

Reviewed by Carlos Garcia Campos.

If the socket monitor callback is not called, the server socket is
leaked. Oops.

I am separately working on converting ProcessLauncher and
IPC::Connection to use UnixFileDescriptor, which will make errors like
this less likely. But that&apos;s a large change, and we should fix this
with a small change.

* Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::platformDestroy):
(WebKit::ProcessLauncher::launchProcess):

Canonical link: <a href="https://commits.webkit.org/284159@main">https://commits.webkit.org/284159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a180d8cedb0a3925c5ded9858863f738db3f533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19583 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54642 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35104 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40393 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10040 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3654 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43631 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44705 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45899 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->