### PR TITLE
Short Description: Crash while running reduced-72.html

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -299,16 +299,24 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
         layer.setShowRepaintCounter(showRepaintCounters);
     };
 
-    propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
-    propagateSettingsToLayer(*m_contentsLayer);
+    if (m_pageBackgroundsContainerLayer) {
+        propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
+    }
+    if (m_contentsLayer) {
+        propagateSettingsToLayer(*m_contentsLayer);
+    }
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
-    propagateSettingsToLayer(*m_selectionLayer);
-#endif
 
-    for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {
-        propagateSettingsToLayer(pageLayer);
-        if (pageLayer->children().size())
-            propagateSettingsToLayer(pageLayer->children()[0]);
+    if (m_selectionLayer) {
+        propagateSettingsToLayer(*m_selectionLayer);
+    }
+#endif
+    if (m_pageBackgroundsContainerLayer) {
+        for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {
+            propagateSettingsToLayer(pageLayer);
+            if (pageLayer->children().size())
+                propagateSettingsToLayer(pageLayer->children()[0]);
+        }
     }
 
     if (RefPtr asyncRenderer = asyncRendererIfExists())

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -301,7 +301,7 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
 
     if (m_pageBackgroundsContainerLayer)
         propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
-    
+
     if (m_contentsLayer)
         propagateSettingsToLayer(*m_contentsLayer);
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -299,17 +299,15 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
         layer.setShowRepaintCounter(showRepaintCounters);
     };
 
-    if (m_pageBackgroundsContainerLayer) {
+    if (m_pageBackgroundsContainerLayer)
         propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
-    }
-    if (m_contentsLayer) {
+    
+    if (m_contentsLayer)
         propagateSettingsToLayer(*m_contentsLayer);
-    }
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
 
-    if (m_selectionLayer) {
+    if (m_selectionLayer)
         propagateSettingsToLayer(*m_selectionLayer);
-    }
 #endif
     if (m_pageBackgroundsContainerLayer) {
         for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -610,17 +610,14 @@ void UnifiedPDFPlugin::didChangeSettings()
         layer.setShowDebugBorder(showDebugBorders);
         layer.setShowRepaintCounter(showRepaintCounter);
     };
-    if (m_rootLayer) {
+    if (m_rootLayer)
         propagateSettingsToLayer(*m_rootLayer);
-    }
 
-    if (m_scrollContainerLayer) {
+    if (m_scrollContainerLayer)
         propagateSettingsToLayer(*m_scrollContainerLayer);
-    }
     
-    if (m_scrolledContentsLayer) {
+    if (m_scrolledContentsLayer)
         propagateSettingsToLayer(*m_scrolledContentsLayer);
-    }
     
     if (m_layerForHorizontalScrollbar)
         propagateSettingsToLayer(*m_layerForHorizontalScrollbar);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -610,10 +610,18 @@ void UnifiedPDFPlugin::didChangeSettings()
         layer.setShowDebugBorder(showDebugBorders);
         layer.setShowRepaintCounter(showRepaintCounter);
     };
-    propagateSettingsToLayer(*m_rootLayer);
-    propagateSettingsToLayer(*m_scrollContainerLayer);
-    propagateSettingsToLayer(*m_scrolledContentsLayer);
+    if (m_rootLayer) {
+        propagateSettingsToLayer(*m_rootLayer);
+    }
 
+    if (m_scrollContainerLayer) {
+        propagateSettingsToLayer(*m_scrollContainerLayer);
+    }
+    
+    if (m_scrolledContentsLayer) {
+        propagateSettingsToLayer(*m_scrolledContentsLayer);
+    }
+    
     if (m_layerForHorizontalScrollbar)
         propagateSettingsToLayer(*m_layerForHorizontalScrollbar);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -615,10 +615,10 @@ void UnifiedPDFPlugin::didChangeSettings()
 
     if (m_scrollContainerLayer)
         propagateSettingsToLayer(*m_scrollContainerLayer);
-    
+
     if (m_scrolledContentsLayer)
         propagateSettingsToLayer(*m_scrolledContentsLayer);
-    
+
     if (m_layerForHorizontalScrollbar)
         propagateSettingsToLayer(*m_layerForHorizontalScrollbar);
 


### PR DESCRIPTION
#### 0156f07bf62b5eb79cc966ab1474ae3a90ac06ed
<pre>
Short Description: Crash while running reduced-72.html
Bug URL:<a href="https://rdar.apple.com/135586580">rdar://135586580</a>
Radar link:<a href="https://rdar.apple.com/135586580">rdar://135586580</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

The bug was caused by referencing NULL pointers. The fix makes sure that the pointers are not NULL before trying to access the same

 On branch fix_reduced-72
 Changes to be committed:
        modified:   Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
        modified:   Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
</pre>
----------------------------------------------------------------------
#### 4612686b96b7aa26d851f42e5e098460a5758adf
<pre>
Description: Crash in didChangeSettings caused by NULL pointer access
The html file causing issue: &lt;embed hidden=&quot;hidden&quot; type=&quot;application/pdf&quot; results=&quot;2&quot;&gt;

Radar link:<a href="https://rdar.apple.com/135586580">rdar://135586580</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateDebugBorders):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::didChangeSettings):

On branch fix_reduced-72
Changes to be committed:
        modified:   Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
        modified:   Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm

Changes: Added check to NULL pointer before accessing files
</pre>
----------------------------------------------------------------------
#### db8e28cac09b4b95bd51f6fd12d3f9446348374c
<pre>
Fix for crash due to reduced-72.html
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0156f07bf62b5eb79cc966ab1474ae3a90ac06ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19589 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54646 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13053 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40404 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74207 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62100 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62121 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3660 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->