### PR TITLE
[css-anchor-position-1] Parse anchor() as a calc() function

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt
@@ -19,8 +19,8 @@ PASS Invalid anchor function,  cross-axis query (horizontal)
 PASS Invalid anchor function, anchor-size() in inset
 PASS Invalid anchor function, anchor() in sizing property
 PASS Invalid anchor function, nested left
-PASS Invalid anchor function, nested right
-PASS Invalid anchor function, nested bottom
+FAIL Invalid anchor function, nested right assert_equals: left expected "0px" but got "188.4375px"
+FAIL Invalid anchor function, nested bottom assert_equals: top expected "0px" but got "182px"
 PASS Invalid anchor function, nested top
 PASS Invalid anchor function, nested min-width
 PASS Invalid anchor function, nested min-height

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt
@@ -2015,7 +2015,7 @@ PASS e.style['inset-inline-end'] = "anchor(--foo 50%, anchor(--bar left))" shoul
 PASS e.style['inset-inline-end'] = "anchor(50% --foo, anchor(--bar left))" should set the property value
 PASS e.style['inset-inline-end'] = "anchor(--foo 50%, anchor(--bar left, anchor(--baz right)))" should set the property value
 PASS e.style['inset-inline-end'] = "anchor(50% --foo, anchor(--bar left, anchor(--baz right)))" should set the property value
-FAIL e.style['top'] = "calc((anchor(--foo top) + anchor(--bar bottom)) / 2)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['top'] = "anchor(--foo top, calc(anchor(--bar bottom) * 0.5))" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['top'] = "min(100px, 10%, anchor(--foo top), anchor(--bar bottom))" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['top'] = "calc((anchor(--foo top) + anchor(--bar bottom)) / 2)" should set the property value assert_equals: serialization should be canonical expected "calc((anchor(--foo top) + anchor(--bar bottom)) / 2)" but got "calc(0.5 * (anchor(--foo top) + anchor(--bar bottom)))"
+FAIL e.style['top'] = "anchor(--foo top, calc(anchor(--bar bottom) * 0.5))" should set the property value assert_equals: serialization should be canonical expected "anchor(--foo top, calc(anchor(--bar bottom) * 0.5))" but got "anchor(--foo top, calc(0.5 * anchor(--bar bottom)))"
+PASS e.style['top'] = "min(100px, 10%, anchor(--foo top), anchor(--bar bottom))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-custom-property-registration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-custom-property-registration-expected.txt
@@ -1,5 +1,10 @@
 
-PASS anchor() cannot be used as <length> initial value
+FAIL anchor() cannot be used as <length> initial value assert_throws_dom: function "() => CSS.registerProperty({
+    name: '--x',
+    syntax: '<length>',
+    inherits: false,
+    initialValue: 'anchor(--foo top)',
+  })" did not throw
 PASS anchor-size() cannot be used as <length> initial value
 PASS anchor() cannot be used as <length-percentage> initial value
 PASS anchor-size() cannot be used as <length-percentage> initial value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-typed-om-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-typed-om-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL anchor() computes to pixels assert_true: expected true got false
+FAIL anchor() computes to pixels assert_equals: expected 35 but got 0
 FAIL anchor-size() computes to pixels assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL ::before uses originating element's implicit anchor assert_equals: expected "50px" but got "0px"
 FAIL ::after uses originating element's implicit anchor assert_equals: expected "250px" but got "0px"
-FAIL ::backdrop uses originating element's implicit anchor assert_equals: expected "140px" but got "0px"
+FAIL ::backdrop uses originating element's implicit anchor assert_equals: expected "140px" but got "-10px"
 

--- a/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
@@ -75,6 +75,7 @@ static auto toCalculationValue(const CanonicalDimension&, const ToConversionOpti
 static auto toCalculationValue(const NonCanonicalDimension&, const ToConversionOptions&) -> Calculation::Child;
 static auto toCalculationValue(const Symbol&, const ToConversionOptions&) -> Calculation::Child;
 template<typename Op> auto toCalculationValue(const IndirectNode<Op>&, const ToConversionOptions&) -> Calculation::Child;
+static auto toCalculationValue(const IndirectNode<Anchor>&, const ToConversionOptions&) -> Calculation::Child;
 
 static CanonicalDimension::Dimension determineCanonicalDimension(Calculation::Category category)
 {
@@ -261,6 +262,12 @@ template<typename Op> Calculation::Child toCalculationValue(const IndirectNode<O
     using CalculationOp = typename Op::Base;
 
     return Calculation::makeChild(WTF::apply([&](const auto& ...x) { return CalculationOp { toCalculationValue(x, options)... }; } , *root));
+}
+
+Calculation::Child toCalculationValue(const IndirectNode<Anchor>&, const ToConversionOptions&)
+{
+    ASSERT_NOT_REACHED("Unevaluated anchor() functions are not supported in the Calculation::Tree");
+    return Calculation::number(0);
 }
 
 // MARK: - Exposed functions

--- a/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
@@ -154,6 +154,10 @@ static void collectComputedStyleDependencies(const Child& root, ComputedStyleDep
         [&](const Symbol& root) {
             collectComputedStyleDependencies(root.unit, dependencies);
         },
+        [&](const IndirectNode<Anchor>& anchor) {
+            if (anchor->fallback)
+                collectComputedStyleDependencies(*anchor->fallback, dependencies);
+        },
         [&](const auto& root) {
             forAllChildNodes(*root, [&](const auto& root) { collectComputedStyleDependencies(root, dependencies); });
         }

--- a/Source/WebCore/css/calc/CSSCalcTree+Copy.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Copy.cpp
@@ -37,6 +37,7 @@ static auto copy(const Children&) -> Children;
 static auto copy(const Child&) -> Child;
 template<Leaf Op> Child copy(const Op&);
 template<typename Op> static auto copy(const IndirectNode<Op>&) -> Child;
+static auto copy(const IndirectNode<Anchor>&) -> Child;
 
 // MARK: Copying
 
@@ -75,6 +76,11 @@ template<Leaf Op> Child copy(const Op& root)
 template<typename Op> Child copy(const IndirectNode<Op>& root)
 {
     return makeChild(WTF::apply([](const auto& ...x) { return Op { copy(x)... }; } , *root), root.type);
+}
+
+Child copy(const IndirectNode<Anchor>& anchor)
+{
+    return makeChild(Anchor { .elementName = anchor->elementName, .side = anchor->side, .fallback = copy(anchor->fallback) }, anchor.type);
 }
 
 // MARK: Exposed functions

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -47,6 +47,7 @@ static auto evaluate(const IndirectNode<Product>&, const EvaluationOptions&) -> 
 static auto evaluate(const IndirectNode<Min>&, const EvaluationOptions&) -> std::optional<double>;
 static auto evaluate(const IndirectNode<Max>&, const EvaluationOptions&) -> std::optional<double>;
 static auto evaluate(const IndirectNode<Hypot>&, const EvaluationOptions&) -> std::optional<double>;
+static auto evaluate(const IndirectNode<Anchor>&, const EvaluationOptions&) -> std::optional<double>;
 template<typename Op>
 static auto evaluate(const IndirectNode<Op>&, const EvaluationOptions&) -> std::optional<double>;
 
@@ -163,6 +164,19 @@ std::optional<double> evaluate(const IndirectNode<Max>& root, const EvaluationOp
 std::optional<double> evaluate(const IndirectNode<Hypot>& root, const EvaluationOptions& options)
 {
     return executeVariadicMathOperationAfterUnwrapping(root, options);
+}
+
+std::optional<double> evaluate(const IndirectNode<Anchor>& anchor, const EvaluationOptions& options)
+{
+    if (!options.conversionData || !options.conversionData->style())
+        return { };
+
+    // FIXME: Evaluate the anchor.
+    bool isValid = !anchor->elementName.isNull() || !options.conversionData->style()->positionAnchor().isNull();
+    if (!isValid && anchor->fallback)
+        return evaluate(*anchor->fallback, options);
+
+    return { };
 }
 
 template<typename Op> std::optional<double> evaluate(const IndirectNode<Op>& root, const EvaluationOptions& options)

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -97,6 +97,7 @@ std::optional<Child> simplify(Log&, const SimplificationOptions&);
 std::optional<Child> simplify(Exp&, const SimplificationOptions&);
 std::optional<Child> simplify(Abs&, const SimplificationOptions&);
 std::optional<Child> simplify(Sign&, const SimplificationOptions&);
+std::optional<Child> simplify(Anchor&, const SimplificationOptions&);
 
 // MARK: Unit Canonicalization
 

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -33,6 +33,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -70,6 +71,7 @@ struct Log;
 struct Exp;
 struct Abs;
 struct Sign;
+struct Anchor;
 
 template<typename Op>
 concept Leaf = requires(Op) {
@@ -186,7 +188,8 @@ using Node = std::variant<
     IndirectNode<Log>,
     IndirectNode<Exp>,
     IndirectNode<Abs>,
-    IndirectNode<Sign>
+    IndirectNode<Sign>,
+    IndirectNode<Anchor>
 >;
 
 using Child = Node;
@@ -704,6 +707,23 @@ public:
     bool operator==(const Sign&) const = default;
 };
 
+
+struct Anchor {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Anchor);
+public:
+    static constexpr auto id = CSSValueAnchor;
+
+    // <anchor()> = anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )
+
+    using Side = std::variant<CSSValueID, double>;
+
+    AtomString elementName;
+    Side side;
+    std::optional<Child> fallback;
+
+    bool operator==(const Anchor&) const = default;
+};
+
 // MARK: Size assertions
 
 static_assert(sizeof(Child) == 24);
@@ -1148,6 +1168,7 @@ OP_TUPLE_LIKE_CONFORMANCE(Log, 2);
 OP_TUPLE_LIKE_CONFORMANCE(Exp, 1);
 OP_TUPLE_LIKE_CONFORMANCE(Abs, 1);
 OP_TUPLE_LIKE_CONFORMANCE(Sign, 1);
+OP_TUPLE_LIKE_CONFORMANCE(Anchor, 0);
 
 #undef OP_TUPLE_LIKE_CONFORMANCE
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
@@ -83,14 +83,23 @@ RefPtr<CSSPrimitiveValue> consumeCustomIdent(CSSParserTokenRange& range, bool sh
 // MARK: <dashed-ident>
 // https://drafts.csswg.org/css-values/#dashed-idents
 
-RefPtr<CSSPrimitiveValue> consumeDashedIdent(CSSParserTokenRange& range, bool shouldLowercase)
+String consumeDashedIdentRaw(CSSParserTokenRange& range, bool shouldLowercase)
 {
     auto rangeCopy = range;
-    auto result = consumeCustomIdent(range, shouldLowercase);
-    if (result && result->stringValue().startsWith("--"_s))
-        return result;
-    range = rangeCopy;
-    return nullptr;
+    auto identifier = consumeCustomIdentRaw(range, shouldLowercase);
+    if (!identifier.startsWith("--"_s)) {
+        range = rangeCopy;
+        return { };
+    }
+    return identifier;
+}
+
+RefPtr<CSSPrimitiveValue> consumeDashedIdent(CSSParserTokenRange& range, bool shouldLowercase)
+{
+    auto identifier = consumeDashedIdentRaw(range, shouldLowercase);
+    if (identifier.isNull())
+        return nullptr;
+    return CSSPrimitiveValue::createCustomIdent(WTFMove(identifier));
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h
@@ -109,6 +109,7 @@ RefPtr<CSSPrimitiveValue> consumeCustomIdent(CSSParserTokenRange&, bool shouldLo
 // MARK: <dashed-ident>
 // https://drafts.csswg.org/css-values/#dashed-idents
 
+String consumeDashedIdentRaw(CSSParserTokenRange&, bool shouldLowercase = false);
 RefPtr<CSSPrimitiveValue> consumeDashedIdent(CSSParserTokenRange&, bool shouldLowercase = false);
 
 } // namespace CSSPropertyParserHelpers


### PR DESCRIPTION
#### 9e5342da427ea97dfa23896043fa0bd0b20bb36b
<pre>
[css-anchor-position-1] Parse anchor() as a calc() function
<a href="https://bugs.webkit.org/show_bug.cgi?id=280191">https://bugs.webkit.org/show_bug.cgi?id=280191</a>
<a href="https://rdar.apple.com/136514213">rdar://136514213</a>

Reviewed by Darin Adler and Sam Weinig.

Add calc tree node and parsing and serialization support for anchor().
The new code is only used in the calc(anchor(foo)) case for now, not with a top level anchor().

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-custom-property-registration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-typed-om-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt:

New FAILs are in previously unimplemented feature.

* Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp:
(WebCore::CSSCalc::toCalculationValue):
* Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp:
(WebCore::CSSCalc::collectComputedStyleDependencies):
* Source/WebCore/css/calc/CSSCalcTree+Copy.cpp:
(WebCore::CSSCalc::copy):
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::isCalcFunction):
(WebCore::CSSCalc::consumeAnchor):
(WebCore::CSSCalc::parseCalcFunction):
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::serializeMathFunctionArguments):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):
(WebCore::CSSCalc::copyAndSimplifyChildren):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp:
(WebCore::CSSPropertyParserHelpers::consumeDashedIdentRaw):
(WebCore::CSSPropertyParserHelpers::consumeDashedIdent):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.h:

Canonical link: <a href="https://commits.webkit.org/284215@main">https://commits.webkit.org/284215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91b04585d634162426a3bdf2b35f9371d536ecf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19910 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70882 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59374 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16800 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74529 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16392 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59456 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3900 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43958 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45032 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->