### PR TITLE
Add Key Generation/import/export support for CryptoKeyOKP(x25519/ed25519) using CryptoKit

### DIFF
--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -275,6 +275,15 @@ extension Curve25519.KeyAgreement.PrivateKey {
     }
 }
 
+extension Curve25519.KeyAgreement.PublicKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+
 extension CryptoKit.HMAC {
     static func authenticationCode(
         data: SpanConstUInt8,

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -41,7 +41,8 @@ static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, const
         return Exception { ExceptionCode::OperationError };
     ccec25519pubkey pk;
     const struct ccdigest_info* di = ccsha512_di();
-    cced25519_make_pub(di, pk, sk.data());
+    if (cced25519_make_pub(di, pk, sk.data()))
+        return Exception { ExceptionCode::OperationError };
     ccec25519signature newSignature;
 
 #if HAVE(CORE_CRYPTO_SIGNATURES_INT_RETURN_VALUE)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -31,6 +31,9 @@
 #include "Logging.h"
 #include <wtf/text/Base64.h>
 
+#if HAVE(SWIFT_CPP_INTEROP)
+#include <pal/PALSwift.h>
+#endif
 #include <pal/spi/cocoa/CoreCryptoSPI.h>
 
 namespace WebCore {
@@ -44,7 +47,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
 {
     if (!isPlatformSupportedCurve(namedCurve))
         return { };
-
+#if !HAVE(SWIFT_CPP_INTEROP)
     ccec25519pubkey ccPublicKey;
     ccec25519secretkey ccPrivateKey;
     switch (identifier) {
@@ -88,6 +91,40 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
     auto privateKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Private, Vector<uint8_t>(std::span { ccPrivateKey }), extractable, usages);
     ASSERT(privateKey);
     return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
+#else
+    switch (identifier) {
+    case CryptoAlgorithmIdentifier::Ed25519: {
+        auto privateKeyPlatform = PAL::EdKey::generatePrivateKey(PAL::EdSigningAlgorithm::ed25519());
+        RELEASE_ASSERT(privateKeyPlatform.size() == 32);
+        auto publicKeyPlatformRv = PAL::EdKey::privateToPublic(PAL::EdSigningAlgorithm::ed25519(), privateKeyPlatform.span());
+        if (publicKeyPlatformRv.errorCode != Cpp::ErrorCodes::Success)
+            return std::nullopt;
+        bool isPublicKeyExtractable = true;
+        auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, WTFMove(publicKeyPlatformRv.result), isPublicKeyExtractable, usages);
+        RELEASE_ASSERT(publicKey);
+        auto privateKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Private, WTFMove(privateKeyPlatform), extractable, usages);
+        RELEASE_ASSERT(privateKey);
+        return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
+    }
+    case CryptoAlgorithmIdentifier::X25519: {
+        auto privateKeyPlatform = PAL::EdKey::generatePrivateKeyKeyAgreement(PAL::EdKeyAgreementAlgorithm::x25519());
+        RELEASE_ASSERT(privateKeyPlatform.size() == 32);
+        auto publicKeyPlatformRv = PAL::EdKey::privateToPublicKeyAgreement(PAL::EdKeyAgreementAlgorithm::x25519(), privateKeyPlatform.span());
+        if (publicKeyPlatformRv.errorCode != Cpp::ErrorCodes::Success)
+            return std::nullopt;
+        bool isPublicKeyExtractable = true;
+        auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, WTFMove(publicKeyPlatformRv.result), isPublicKeyExtractable, usages);
+        RELEASE_ASSERT(publicKey);
+        auto privateKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Private, WTFMove(privateKeyPlatform), extractable, usages);
+        RELEASE_ASSERT(privateKey);
+        return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
+    }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+#endif
 }
 
 bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
@@ -97,31 +134,42 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier,
 
     if (privateKey.size() != 32 || publicKey.size() != 32)
         return false;
-
+#if !HAVE(SWIFT_CPP_INTEROP)
     ccec25519pubkey ccPublicKey;
     static_assert(sizeof(ccPublicKey) == 32);
 
     switch (identifier) {
     case CryptoAlgorithmIdentifier::Ed25519: {
         auto* di = ccsha512_di();
-
-#if HAVE(CORE_CRYPTO_SIGNATURES_INT_RETURN_VALUE)
         if (cced25519_make_pub(di, ccPublicKey, privateKey.data()))
             return false;
+        break;
+    }
+    case CryptoAlgorithmIdentifier::X25519: {
+#if HAVE(CORE_CRYPTO_SIGNATURES_INT_RETURN_VALUE)
+        if (cccurve25519_make_pub(ccPublicKey, privateKey.data()))
+            return false;
 #else
-        cced25519_make_pub(di, ccPublicKey, privateKey.data());
+        cccurve25519_make_pub(ccPublicKey, privateKey.data());
 #endif
         break;
     }
-    case CryptoAlgorithmIdentifier::X25519:
-        cccurve25519_make_pub(ccPublicKey, privateKey.data());
-        break;
     default:
         ASSERT_NOT_REACHED();
         return false;
     }
-
     return !std::memcmp(ccPublicKey, publicKey.data(), sizeof(ccPublicKey));
+#else // HAVE(SWIFT_CPP_INTEROP)
+    switch (identifier) {
+    case CryptoAlgorithmIdentifier::Ed25519:
+        return PAL::EdKey::validateKeyPair(PAL::EdSigningAlgorithm::ed25519(), privateKey.span(), publicKey.span());
+    case CryptoAlgorithmIdentifier::X25519:
+        return PAL::EdKey::validateKeyPairKeyAgreement(PAL::EdKeyAgreementAlgorithm::x25519(), privateKey.span(), publicKey.span());
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return false;
+    }
+#endif
 }
 
 // Per https://www.ietf.org/rfc/rfc5280.txt
@@ -379,6 +427,7 @@ String CryptoKeyOKP::generateJwkX() const
         return base64URLEncodeToString(m_data);
 
     ASSERT(type() == CryptoKeyType::Private);
+#if !HAVE(SWIFT_CPP_INTEROP)
     ccec25519pubkey publicKey;
     switch (namedCurve()) {
     case NamedCurve::Ed25519: {
@@ -399,6 +448,23 @@ String CryptoKeyOKP::generateJwkX() const
         return String(""_s);
     }
     return base64URLEncodeToString(std::span { publicKey, sizeof(publicKey) });
+#else
+    switch (namedCurve()) {
+    case NamedCurve::Ed25519: {
+        auto publicKeyPlatformRv = PAL::EdKey::privateToPublic(PAL::EdSigningAlgorithm::ed25519(), platformKey().span());
+        RELEASE_ASSERT(publicKeyPlatformRv.errorCode == Cpp::ErrorCodes::Success);
+        return base64URLEncodeToString(publicKeyPlatformRv.result.span());
+    }
+    case NamedCurve::X25519: {
+        auto publicKeyPlatformRv = PAL::EdKey::privateToPublicKeyAgreement(PAL::EdKeyAgreementAlgorithm::x25519(), platformKey().span());
+        RELEASE_ASSERT(publicKeyPlatformRv.errorCode == Cpp::ErrorCodes::Success);
+        return base64URLEncodeToString(publicKeyPlatformRv.result.span());
+    }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return String(""_s);
+    }
+#endif
 }
 
 Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const


### PR DESCRIPTION
#### 070a4485adadd784fdfc346dcbedf7d9b539cf6e
<pre>
Add Key Generation/import/export support for CryptoKeyOKP(x25519/ed25519) using CryptoKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=280195">https://bugs.webkit.org/show_bug.cgi?id=280195</a>
<a href="https://rdar.apple.com/136368298">rdar://136368298</a>

Reviewed by David Kilzer.

Adding CryptoKit implementation of CryptoKeyOKP.
Serialization and Deserialization of SPKI/PKCS8 formats is not available
in CryptoKit so the the WebKit implementation is still used.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt:
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(EdKey.generatePrivateKey(_:)):
(EdKey.generatePrivateKeyKeyAgreement(_:)):
(EdKey.privateToPublic(_:priv:)):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::generateJwkX const):

Canonical link: <a href="https://commits.webkit.org/284473@main">https://commits.webkit.org/284473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7851eb3aac545004f3bf6dfb9f8c6561f185a069

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55266 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13727 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62935 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62845 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10866 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4493 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44711 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46980 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->