### PR TITLE
[ARMv7] Return exceptions from operations using long long

### DIFF
--- a/Source/JavaScriptCore/jit/OperationResult.h
+++ b/Source/JavaScriptCore/jit/OperationResult.h
@@ -34,21 +34,30 @@
 
 namespace JSC {
 
+// This is wrapped in a lambda since it's used by static_asserts thus needs to be an expression.
+// Additionally, it should not participate in SFINAE: substitution failure IS an error when used in
+// a type name below.
+template<typename T>
+constexpr bool assertNotOperationSignature = ([] { 
+    static_assert(!std::is_function_v<typename std::remove_pointer_t<T>>, "This should take a return type, not an operator signature."); 
+    return true; 
+})();
+
 template<typename T>
 concept canMakeExceptionOperationResult =
     std::is_standard_layout_v<T>
     && std::is_trivial_v<T>
-#if CPU(ARM64)
+#if CPU(ARM64) || CPU(ARM_THUMB2)
     && !std::is_floating_point_v<T> // The ARM64 ABI says that this should be returned in x0 instead of d0. Seems unlikely it's worth it to do the extra fmov.
 #endif
-#if !(CPU(ARM64) || CPU(X86_64))
-    && false // We don't have enough return registers on 32-bit (ARM64_32 seems to work) (didn't test RISCV64)
-#endif
     && sizeof(T) <= sizeof(CPURegister);
+
+#if USE(JSVALUE64)
 
 template<typename T>
 struct ExceptionOperationResult {
     using ResultType = T;
+    static_assert(assertNotOperationSignature<T>);
     T value;
     Exception* exception;
 };
@@ -137,6 +146,117 @@ ALWAYS_INLINE T makeOperationResult(Scope& scope, T result)
 {
     RELEASE_AND_RETURN(scope, result);
 }
+
+#else // USE(JSVALUE64)
+
+enum class ExceptionOperationResultTag : uint64_t { };
+
+struct ExceptionOperationResultVoid {
+    Exception* exception;
+};
+
+template<typename T>
+using ExceptionOperationResult = std::conditional_t<(std::is_same_v<T, void>), ExceptionOperationResultVoid, ExceptionOperationResultTag>;
+
+template<typename OperationType>
+concept OperationHasResult = FunctionTraits<OperationType>::hasResult && !std::is_same_v<typename FunctionTraits<OperationType>::ResultType, ExceptionOperationResult<void>>;
+
+// Note we need this because e.g. `requires (!OperationHasResult<int>)` will pass the requirement as the SFINAE in `OperationHasResult<int>`
+// means the concept returns false and the `!` makes it true.
+template<typename OperationType>
+concept OperationIsVoid = !FunctionTraits<OperationType>::hasResult || std::is_same_v<typename FunctionTraits<OperationType>::ResultType, ExceptionOperationResult<void>>;
+
+template<typename T>
+struct IsExceptionOperationResult : std::false_type { };
+
+template<>
+struct IsExceptionOperationResult<ExceptionOperationResultTag> : std::true_type { };
+
+template<>
+struct IsExceptionOperationResult<ExceptionOperationResultVoid> : std::true_type { };
+
+template<typename T>
+concept isExceptionOperationResult = IsExceptionOperationResult<T>::value;
+
+// Note: We always return an exception in a register if the operation's return type is void on all platforms (assuming it throws).
+template<typename T>
+using OperationReturnType = std::conditional_t<(assertNotOperationSignature<T> && (std::is_same_v<T, void> || canMakeExceptionOperationResult<T>)), ExceptionOperationResult<T>, T>;
+
+static ALWAYS_INLINE ExceptionOperationResultTag asExceptionResultBase(uint32_t value, Exception* exception)
+{
+    uint32_t v = bitwise_cast<uint32_t>(value);
+    return bitwise_cast<ExceptionOperationResultTag>(
+        static_cast<long long>(v)
+        | (static_cast<long long>(reinterpret_cast<uint32_t>(exception)) << 32));
+}
+
+template<typename T>
+requires (sizeof(T) == sizeof(uint32_t))
+static ALWAYS_INLINE ExceptionOperationResultTag asExceptionResult(T value, Exception* exception)
+{
+    uint32_t v = bitwise_cast<uint32_t>(value);
+    return asExceptionResultBase(v, exception);
+}
+
+template<typename T>
+requires (sizeof(T) < sizeof(uint32_t))
+static ALWAYS_INLINE ExceptionOperationResultTag asExceptionResult(T value, Exception* exception)
+{
+    uint32_t v = static_cast<uint32_t>(value);
+    return asExceptionResultBase(v, exception);
+}
+
+template<typename From>
+struct ExceptionOperationImplicitResult {
+
+    ALWAYS_INLINE operator ExceptionOperationResultTag()
+    {
+        return asExceptionResult(value, exception);
+    }
+
+    template<typename To>
+    ALWAYS_INLINE operator To()
+    {
+        return static_cast<To>(value);
+    }
+
+    From value;
+    Exception* exception;
+};
+
+template<>
+struct ExceptionOperationImplicitResult<void> {
+    ALWAYS_INLINE operator ExceptionOperationResultVoid()
+    {
+        return { exception };
+    }
+
+    Exception* exception;
+};
+
+template<typename Scope, typename T>
+requires canMakeExceptionOperationResult<T>
+ALWAYS_INLINE ExceptionOperationImplicitResult<T> makeOperationResult(Scope& scope, T result)
+{
+    static_assert(assertNotOperationSignature<T>);
+    return { result, scope.exception() };
+}
+
+template<typename Scope>
+ALWAYS_INLINE ExceptionOperationImplicitResult<void> makeOperationResult(Scope& scope)
+{
+    return { scope.exception() };
+}
+
+template<typename Scope, typename T>
+requires (!canMakeExceptionOperationResult<T>)
+ALWAYS_INLINE T makeOperationResult(Scope& scope, T result)
+{
+    static_assert(assertNotOperationSignature<T>);
+    RELEASE_AND_RETURN(scope, result);
+}
+
+#endif // USE(JSVALUE64)
 
 #define OPERATION_RETURN(scope__, ...) return makeOperationResult(scope__, ## __VA_ARGS__);
 #define OPERATION_RETURN_IF_EXCEPTION(scope__, ...) RETURN_IF_EXCEPTION(scope__, makeOperationResult(scope__, ## __VA_ARGS__))

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -547,6 +547,13 @@ end
     break
 end
 
+macro branchIfWasmException(exceptionTarget)
+    loadp JSWebAssemblyInstance::m_vm[cfr], t3
+    btpz VM::m_exception[t3], .noException
+    jmp exceptionTarget
+.noException:
+end
+
 macro zeroExtend32ToWord(r)
     if JSVALUE64
         andq 0xffffffff, r
@@ -713,6 +720,7 @@ end
     cCall3(_operationJSToWasmEntryWrapperBuildFrame)
 
 if ARMv7
+    # CodeBlock slot is not an instance yet, so use JS version.
     branchIfException(_wasm_throw_from_slow_path_trampoline)
 else
     btpnz r1, _wasm_throw_from_slow_path_trampoline
@@ -860,7 +868,7 @@ end
     cCall2(_operationJSToWasmEntryWrapperBuildReturnFrame)
 
 if ARMv7
-    branchIfException(_wasm_throw_from_slow_path_trampoline)
+    branchIfWasmException(_wasm_throw_from_slow_path_trampoline)
 else
     btpnz r1, _wasm_throw_from_slow_path_trampoline
 end

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -143,7 +143,9 @@ public:
     CodePtr<WasmEntryPtrTag> entrypointImpl() const;
     static JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
+#if ASSERT_ENABLED
     static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_ident); }
+#endif
     static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_wasmCallee); }
     static constexpr ptrdiff_t offsetOfWasmFunctionPrologue() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_wasmFunctionPrologue); }
     static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_frameSize); }
@@ -154,7 +156,9 @@ public:
     static constexpr unsigned RegisterStackSpaceAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(
         FPRInfo::numberOfArgumentRegisters * bytesForWidth(Width::Width64) + GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister));
 
+#if ASSERT_ENABLED
     unsigned ident() const { return m_ident; }
+#endif
     unsigned frameSize() const { return m_frameSize; }
     EncodedJSValue wasmCallee() const { return m_wasmCallee; }
     TypeIndex typeIndex() const { return m_typeIndex; }
@@ -172,7 +176,9 @@ public:
 private:
     JSEntrypointCallee(TypeIndex, bool);
 
+#if ASSERT_ENABLED
     const unsigned m_ident { 0xBF };
+#endif
     unsigned m_frameSize { };
     // This must be initialized after the callee is created unfortunately.
     EncodedJSValue m_wasmCallee;

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -54,8 +54,8 @@ typedef int64_t EncodedWasmValue;
 JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSEntrypointCallee*, (void*, CallFrame*, WebAssemblyFunction*));
 JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJSValue, (void*, CallFrame*));
 JSC_DECLARE_JIT_OPERATION(operationGetWasmCalleeStackSize, EncodedJSValue, (JSWebAssemblyInstance*, Wasm::Callee*));
-JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, (void*, CallFrame*, void*, JSWebAssemblyInstance*));
-JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValue, (void* sp, CallFrame* cfr, JSWebAssemblyInstance*));
+JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void*, CallFrame*, void*, JSWebAssemblyInstance*));
+JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* sp, CallFrame* cfr, JSWebAssemblyInstance*));
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 void loadValuesIntoBuffer(Probe::Context&, const StackMap&, uint64_t* buffer, SavedFPWidth);


### PR DESCRIPTION
#### 3ebc10609bfec7c5b8e1da3236e141d2eb0ae13e
<pre>
[ARMv7] Return exceptions from operations using long long
<a href="https://bugs.webkit.org/show_bug.cgi?id=280196">https://bugs.webkit.org/show_bug.cgi?id=280196</a>

Reviewed by Keith Miller.

In JSToWasm, we now return exceptions via a register to make the ARMv7
port match the 64-bit ports. Returning an EncodedJSValue + an exception
is still not supported, so we modify the signatures of these JSToWasm
operations to return pointers or void instead.

We also fix a little issue with the templating logic, and add a static_assert
preventing it from happening again.

* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::operationExceptionRegister):
* Source/JavaScriptCore/jit/OperationResult.h:
(JSC::asExceptionResultBase):
(JSC::requires):
(JSC::ExceptionOperationImplicitResult::operator ExceptionOperationResultTag):
(JSC::ExceptionOperationImplicitResult::operator To):
(JSC::ExceptionOperationImplicitResult&lt;void&gt;::operator ExceptionOperationResultVoid):
(JSC::makeOperationResult):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
(JSC::Wasm::createJSToWasmJITShared):

Canonical link: <a href="https://commits.webkit.org/284329@main">https://commits.webkit.org/284329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a192a30ad3f90864ed7a9545a8a777d136f81246

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69050 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54975 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/13421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18582 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74840 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68296 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16634 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62525 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4118 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44254 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15970 "Found 109 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/sets.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck.js.default, ChakraCore.yaml/ChakraCore/test/strict/16.catch_sm.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-alias-one-block.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-alias.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-osr-exit-multiple-blocks.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-check-function-change-structure.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-object-then-exit-on-other.js.layout ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->