### PR TITLE
REGRESSION (280914@main): [macOS wk2] media/now-playing-status-for-video-conference-web-page.html is a flaky failure

### DIFF
--- a/LayoutTests/media/now-playing-status-for-video-conference-web-page.html
+++ b/LayoutTests/media/now-playing-status-for-video-conference-web-page.html
@@ -35,13 +35,13 @@ promise_test(async (t) => {
         return;
 
     await new Promise(resolve => setTimeout(resolve, 500));
-    assert_false(internals.nowPlayingState.haveEverRegisteredAsNowPlayingApplication);
+    assert_false(internals.elementIsActiveNowPlayingSession(localVideo), 'internals.elementIsActiveNowPlayingSession(localVideo) is false before muting');
 
     internals.setMediaStreamTrackMuted(localStream.getAudioTracks()[0], false); 
     internals.setMediaStreamTrackMuted(localStream.getVideoTracks()[0], false); 
 
     await new Promise(resolve => setTimeout(resolve, 500));
-    assert_false(internals.nowPlayingState.haveEverRegisteredAsNowPlayingApplication);
+    assert_false(internals.elementIsActiveNowPlayingSession(localVideo), 'internals.elementIsActiveNowPlayingSession(localVideo) is false after muting');
 }, "Check NowPlaying status on a VC page");
         </script>
     </body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1786,8 +1786,6 @@ webkit.org/b/275873 storage/indexeddb/database-transaction-cycle.html [ Pass Fai
 
 webkit.org/b/276389 media/video-transformed.html [ Pass Failure ] 
 
-webkit.org/b/277024 media/now-playing-status-for-video-conference-web-page.html [ Pass Failure ]
-
 # webkit.org/b/277841 [ macOS wk2 ] imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html is a flaky failure
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9734,6 +9734,11 @@ String HTMLMediaElement::localizedSourceType() const
     return { };
 }
 
+bool HTMLMediaElement::isActiveNowPlayingSession() const
+{
+    return m_mediaSession && m_mediaSession->isActiveNowPlayingSession();
+}
+
 void HTMLMediaElement::isActiveNowPlayingSessionChanged()
 {
     if (RefPtr page = protectedDocument()->protectedPage())

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -243,6 +243,7 @@ public:
 
     MediaSessionGroupIdentifier mediaSessionGroupIdentifier() const final;
 
+    WEBCORE_EXPORT bool isActiveNowPlayingSession() const;
     void isActiveNowPlayingSessionChanged() final;
 
 // DOM API

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5217,6 +5217,11 @@ ExceptionOr<RefPtr<VTTCue>> Internals::mediaElementCurrentlySpokenCue(HTMLMediaE
 }
 #endif
 
+bool Internals::elementIsActiveNowPlayingSession(HTMLMediaElement& element) const
+{
+    return element.isActiveNowPlayingSession();
+}
+
 #endif // ENABLE(VIDEO)
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1214,6 +1214,8 @@ public:
     ExceptionOr<RefPtr<VTTCue>> mediaElementCurrentlySpokenCue(HTMLMediaElement&);
 #endif
 
+    bool elementIsActiveNowPlayingSession(HTMLMediaElement&) const;
+
 #endif // ENABLE(VIDEO)
 
     void setCaptureExtraNetworkLoadMetricsEnabled(bool);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1239,6 +1239,7 @@ enum RenderingMode {
 
     [Conditional=VIDEO] readonly attribute NowPlayingMetadata? nowPlayingMetadata;
     [Conditional=VIDEO] readonly attribute NowPlayingState nowPlayingState;
+    [Conditional=VIDEO] boolean elementIsActiveNowPlayingSession(HTMLMediaElement element);
 
     [Conditional=VIDEO] HTMLMediaElement bestMediaElementForRemoteControls(PlaybackControlsPurpose purpose);
     [Conditional=VIDEO] MediaSessionState mediaSessionState(HTMLMediaElement element);


### PR DESCRIPTION
#### 02cd89be8171c01f3c62bd167b4f030728e5c70a
<pre>
REGRESSION (280914@main): [macOS wk2] media/now-playing-status-for-video-conference-web-page.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=277024">https://bugs.webkit.org/show_bug.cgi?id=277024</a>
<a href="https://rdar.apple.com/132426511">rdar://132426511</a>

Reviewed by Youenn Fablet.

NowPlayingState.haveEverRegisteredAsNowPlayingApplication is not consistently reset between tests, so do not rely
upon its value for testing purposes. Instead, add an Internals method that returns whether a specific media element
currently represents the &quot;now playing session&quot;.

* LayoutTests/media/now-playing-status-for-video-conference-web-page.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isActiveNowPlayingSession const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::elementIsActiveNowPlayingSession const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/284177@main">https://commits.webkit.org/284177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6839fc2c8f3a773beb3be61ca71b11425b23534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54668 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13070 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16556 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17982 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74243 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62117 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62141 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15242 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3687 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43673 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->