### PR TITLE
Remove IsDeprecatedWeakRefSmartPointerException from webpushd files

### DIFF
--- a/Source/WebKit/webpushd/ApplePushServiceConnection.h
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.h
@@ -32,19 +32,14 @@
 #include <wtf/HashMap.h>
 
 namespace WebPushD {
-class ApplePushServiceConnection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebPushD::ApplePushServiceConnection> : std::true_type { };
-}
-
-namespace WebPushD {
 
 class ApplePushServiceConnection final : public PushServiceConnection {
 public:
-    ApplePushServiceConnection(const String& incomingPushServiceName);
+    static Ref<ApplePushServiceConnection> create(const String& incomingPushServiceName)
+    {
+        return adoptRef(*new ApplePushServiceConnection(incomingPushServiceName));
+    }
+
     ~ApplePushServiceConnection();
 
     void subscribe(const String& topic, const Vector<uint8_t>& vapidPublicKey, SubscribeHandler&&) final;
@@ -63,6 +58,8 @@ public:
     void setTopicLists(TopicLists&&) override;
 
 private:
+    ApplePushServiceConnection(const String& incomingPushServiceName);
+
     RetainPtr<APSConnection> m_connection;
     RetainPtr<id<APSConnectionDelegate>> m_delegate;
     unsigned m_handlerIdentifier { 0 };

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -29,6 +29,7 @@
 #if HAVE(APPLE_PUSH_SERVICE_URL_TOKEN_SUPPORT)
 
 #import <wtf/BlockPtr.h>
+#import <wtf/WeakPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 @interface _WKAPSConnectionDelegate : NSObject<APSConnectionDelegate> {

--- a/Source/WebKit/webpushd/MockPushServiceConnection.h
+++ b/Source/WebKit/webpushd/MockPushServiceConnection.h
@@ -31,7 +31,11 @@ namespace WebPushD {
 
 class MockPushServiceConnection final : public PushServiceConnection {
 public:
-    MockPushServiceConnection();
+    static Ref<MockPushServiceConnection> create()
+    {
+        return adoptRef(*new MockPushServiceConnection());
+    }
+
     ~MockPushServiceConnection();
 
     WebCore::PushCrypto::ClientKeys generateClientKeys() final;
@@ -54,6 +58,8 @@ public:
     void setPublicTokenForTesting(Vector<uint8_t>&&) override;
 
 private:
+    MockPushServiceConnection();
+
     Vector<String> m_enabledTopics;
     Vector<String> m_ignoredTopics;
     Vector<String> m_opportunisticTopics;

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -90,7 +90,7 @@ public:
 #endif
 
 private:
-    PushService(UniqueRef<PushServiceConnection>&&, UniqueRef<WebCore::PushDatabase>&&, IncomingPushMessageHandler&&);
+    PushService(Ref<PushServiceConnection>&&, UniqueRef<WebCore::PushDatabase>&&, IncomingPushMessageHandler&&);
 
     using PushServiceRequestMap = HashMap<String, Deque<std::unique_ptr<PushServiceRequest>>>;
     void enqueuePushServiceRequest(PushServiceRequestMap&, std::unique_ptr<PushServiceRequest>&&);
@@ -100,7 +100,7 @@ private:
 
     void updateTopicLists(CompletionHandler<void()>&&);
 
-    UniqueRef<PushServiceConnection> m_connection;
+    Ref<PushServiceConnection> m_connection;
     UniqueRef<WebCore::PushDatabase> m_database;
 
     IncomingPushMessageHandler m_incomingPushMessageHandler;

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -130,7 +130,7 @@ void PushService::create(const String& incomingPushServiceName, const String& da
     auto transaction = adoptOSObject(os_transaction_create("com.apple.webkit.webpushd.push-service-init"));
 
     // Create the connection ASAP so that we bootstrap_check_in to the service in a timely manner.
-    auto connection = makeUniqueRef<ApplePushServiceConnection>(incomingPushServiceName);
+    auto connection = ApplePushServiceConnection::create(incomingPushServiceName);
 
     performAfterFirstUnlock([databasePath, transaction = WTFMove(transaction), connection = WTFMove(connection), messageHandler = WTFMove(messageHandler), creationHandler = WTFMove(creationHandler)]() mutable {
         PushDatabase::create(databasePath, [transaction, connection = WTFMove(connection), messageHandler = WTFMove(messageHandler), creationHandler = WTFMove(creationHandler)](auto&& databaseResult) mutable {
@@ -172,13 +172,13 @@ void PushService::createMockService(IncomingPushMessageHandler&& messageHandler,
             return;
         }
 
-        auto connection = makeUniqueRef<MockPushServiceConnection>();
+        auto connection = MockPushServiceConnection::create();
         auto database = makeUniqueRefFromNonNullUniquePtr(WTFMove(databaseResult));
         creationHandler(std::unique_ptr<PushService>(new PushService(WTFMove(connection), WTFMove(database), WTFMove(messageHandler))));
     });
 }
 
-PushService::PushService(UniqueRef<PushServiceConnection>&& pushServiceConnection, UniqueRef<PushDatabase>&& pushDatabase, IncomingPushMessageHandler&& incomingPushMessageHandler)
+PushService::PushService(Ref<PushServiceConnection>&& pushServiceConnection, UniqueRef<PushDatabase>&& pushDatabase, IncomingPushMessageHandler&& incomingPushMessageHandler)
     : m_connection(WTFMove(pushServiceConnection))
     , m_database(WTFMove(pushDatabase))
     , m_incomingPushMessageHandler(WTFMove(incomingPushMessageHandler))

--- a/Source/WebKit/webpushd/PushServiceConnection.h
+++ b/Source/WebKit/webpushd/PushServiceConnection.h
@@ -29,33 +29,23 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS NSError;
 OBJC_CLASS NSString;
 OBJC_CLASS NSDictionary;
 
-namespace WebKit {
-class PushServiceConnection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PushServiceConnection> : std::true_type { };
-}
-
 namespace WebPushD {
 
-class PushServiceConnection : public CanMakeWeakPtr<PushServiceConnection> {
+class PushServiceConnection : public RefCountedAndCanMakeWeakPtr<PushServiceConnection> {
     WTF_MAKE_TZONE_ALLOCATED(PushServiceConnection);
 public:
     using IncomingPushMessageHandler = Function<void(NSString *, NSDictionary *)>;
 
-    PushServiceConnection() = default;
     virtual ~PushServiceConnection() = default;
 
     virtual WebCore::PushCrypto::ClientKeys generateClientKeys();
@@ -90,6 +80,9 @@ public:
 
     void startListeningForPushMessages(IncomingPushMessageHandler&&);
     void didReceivePushMessage(NSString *topic, NSDictionary *userInfo);
+
+protected:
+    PushServiceConnection() = default;
 
 private:
     Function<void(Vector<uint8_t>&&)> m_publicTokenChangeHandler;

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -30,22 +30,13 @@
 #include <WebCore/PushPermissionState.h>
 #include <memory>
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 using WebKit::WebPushD::PushMessageForTesting;
-
-namespace WebPushTool {
-class Connection;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebPushTool::Connection> : std::true_type { };
-}
 
 namespace WebPushTool {
 
@@ -59,10 +50,10 @@ enum class WaitForServiceToExist : bool {
     Yes,
 };
 
-class Connection final : public CanMakeWeakPtr<Connection>, public IPC::MessageSender {
+class Connection final : public RefCountedAndCanMakeWeakPtr<Connection>, public IPC::MessageSender {
     WTF_MAKE_TZONE_ALLOCATED(Connection);
 public:
-    static std::unique_ptr<Connection> create(PreferTestService, String bundleIdentifier, String pushPartition);
+    static Ref<Connection> create(PreferTestService, String bundleIdentifier, String pushPartition);
     Connection(PreferTestService, String bundleIdentifier, String pushPartition);
     ~Connection() final { }
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -45,9 +45,9 @@ namespace WebPushTool {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Connection);
 
-std::unique_ptr<Connection> Connection::create(PreferTestService preferTestService, String bundleIdentifier, String pushPartition)
+Ref<Connection> Connection::create(PreferTestService preferTestService, String bundleIdentifier, String pushPartition)
 {
-    return makeUnique<Connection>(preferTestService, bundleIdentifier, pushPartition);
+    return adoptRef(*new Connection(preferTestService, bundleIdentifier, pushPartition));
 }
 
 static mach_port_t maybeConnectToService(const char* serviceName)

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -288,7 +288,7 @@ int WebPushToolMain(int, char **)
 
     auto connection = WebPushTool::Connection::create(preferTestService, bundleIdentifier.get(), pushPartition.get());
     connection->connectToService(host ? WebPushTool::WaitForServiceToExist::No : WebPushTool::WaitForServiceToExist::Yes);
-    verb->run(*connection);
+    verb->run(connection.get());
 
     CFRunLoopRun();
     return 0;


### PR DESCRIPTION
#### 095c5547863ec1ab1318873faebf412eb435d6ef
<pre>
Remove IsDeprecatedWeakRefSmartPointerException from webpushd files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280204">https://bugs.webkit.org/show_bug.cgi?id=280204</a>
<a href="https://rdar.apple.com/136527276">rdar://136527276</a>

Reviewed by Geoffrey Garen.

Removing IsDeprecatedWeakRefSmartPointerException.

* Source/WebKit/webpushd/ApplePushServiceConnection.h:
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
* Source/WebKit/webpushd/MockPushServiceConnection.h:
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::create):
(WebPushD::PushService::createMockService):
(WebPushD::PushService::PushService):
* Source/WebKit/webpushd/PushServiceConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::create):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(WebKit::WebPushToolMain):

Canonical link: <a href="https://commits.webkit.org/284136@main">https://commits.webkit.org/284136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57fecc7c186a95a1f802b5594c8761cb53aac9d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19632 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54665 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13074 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40434 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62149 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3692 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43680 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->