### PR TITLE
[ Gardening ][ macOS ] 6x TestWebKitAPI.AudioRoutingArbitration* (api-tests) are flaky timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AudioRoutingArbitration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AudioRoutingArbitration.mm
@@ -76,12 +76,22 @@ public:
     }
 };
 
+// Disabling AudioRoutingArbitration tests until rdar://136533250 is resolved
+#if PLATFORM(MAC)
+TEST_F(AudioRoutingArbitration, DISABLED_Basic)
+#else
 TEST_F(AudioRoutingArbitration, Basic)
+#endif
 {
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Basic");
 }
 
+// Disabling AudioRoutingArbitration tests until rdar://136533250 is resolved
+#if PLATFORM(MAC)
+TEST_F(AudioRoutingArbitration, DISABLED_Mute)
+#else
 TEST_F(AudioRoutingArbitration, Mute)
+#endif
 {
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Mute 1");
 
@@ -94,7 +104,12 @@ TEST_F(AudioRoutingArbitration, Mute)
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Mute 3");
 }
 
+// Disabling AudioRoutingArbitration tests until rdar://136533250 is resolved
+#if PLATFORM(MAC)
+TEST_F(AudioRoutingArbitration, DISABLED_Navigation)
+#else
 TEST_F(AudioRoutingArbitration, Navigation)
+#endif
 {
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Navigation 1");
 
@@ -103,7 +118,12 @@ TEST_F(AudioRoutingArbitration, Navigation)
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusNone, "Navigation 2");
 }
 
+// Disabling AudioRoutingArbitration tests until rdar://136533250 is resolved
+#if PLATFORM(MAC)
+TEST_F(AudioRoutingArbitration, DISABLED_Deletion)
+#else
 TEST_F(AudioRoutingArbitration, Deletion)
+#endif
 {
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Deletion 1");
 
@@ -112,7 +132,12 @@ TEST_F(AudioRoutingArbitration, Deletion)
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusNone, "Deletion 2", true);
 }
 
+// Disabling AudioRoutingArbitration tests until rdar://136533250 is resolved
+#if PLATFORM(MAC)
+TEST_F(AudioRoutingArbitration, DISABLED_Close)
+#else
 TEST_F(AudioRoutingArbitration, Close)
+#endif
 {
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Close 1");
 
@@ -121,7 +146,12 @@ TEST_F(AudioRoutingArbitration, Close)
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusNone, "Close 2");
 }
 
+// Disabling AudioRoutingArbitration tests until rdar://136533250 is resolved
+#if PLATFORM(MAC)
+TEST_F(AudioRoutingArbitration, DISABLED_Updating)
+#else
 TEST_F(AudioRoutingArbitration, Updating)
+#endif
 {
     statusShouldBecomeEqualTo(WKWebViewAudioRoutingArbitrationStatusActive, "Updating 1");
 


### PR DESCRIPTION
#### 630b036e13b05248e96094023c28a5175005ecce
<pre>
[ Gardening ][ macOS ] 6x TestWebKitAPI.AudioRoutingArbitration* (api-tests) are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=280217">https://bugs.webkit.org/show_bug.cgi?id=280217</a>
<a href="https://rdar.apple.com/136533250">rdar://136533250</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AudioRoutingArbitration.mm:
(TEST_F(AudioRoutingArbitration, Basic)):
(TEST_F(AudioRoutingArbitration, Mute)):
(TEST_F(AudioRoutingArbitration, Navigation)):
(TEST_F(AudioRoutingArbitration, Deletion)):
(TEST_F(AudioRoutingArbitration, Close)):
(TEST_F(AudioRoutingArbitration, Updating)):

Canonical link: <a href="https://commits.webkit.org/284110@main">https://commits.webkit.org/284110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d9d32d9fa2a52d6dc118a12c65ed0831a03f283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21160 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/19646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19462 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/19646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12472 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/74264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/12511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10421 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/43694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/45962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->