### PR TITLE
Add assertion in PageLoadTimingFrameLoadStateObserver::didFinishLoad for main frames

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -175,11 +175,12 @@ private:
         m_loadingFrameCount--;
     }
 
-    void didFinishLoad(IsMainFrame, const URL& url) final
+    void didFinishLoad(IsMainFrame isMainFrame, const URL& url) final
     {
         ASSERT(m_loadingFrameCount);
         m_loadingFrameCount--;
-        // FIXME: Assert that m_loadingFrameCount is zero if this is a main frame.
+        if (isMainFrame == IsMainFrame::Yes)
+            ASSERT(!m_loadingFrameCount);
     }
 
     size_t m_loadingFrameCount { 0 };


### PR DESCRIPTION
#### 5cc8bfb6ad9dfc79611a42dd0968395dc722325d
<pre>
Add assertion in PageLoadTimingFrameLoadStateObserver::didFinishLoad for main frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=280222">https://bugs.webkit.org/show_bug.cgi?id=280222</a>
<a href="https://rdar.apple.com/136534330">rdar://136534330</a>

Reviewed by NOBODY (OOPS!).

I didn&apos;t add it last week because I was trying to reduce assertions quickly.
Now we can carefully add it.

* Source/WebKit/UIProcess/WebPageProxyInternals.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc8bfb6ad9dfc79611a42dd0968395dc722325d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72576 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13080 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40452 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12478 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16187 "Found 60 new test failures: dom/xhtml/level2/html/HTMLIFrameElement11.xhtml editing/execCommand/apply-style-command-crash.html editing/inserting/insert-list-then-edit-command-crash.html editing/style/apply-style-crash.html fast/dom/createAttribute-exception.html fast/dom/onload-open.html fast/events/mouse-moved-remove-frame-crash.html fast/forms/form-submission-crash-successful-submit-button.html fast/forms/password-scrolled-after-caps-lock-toggled.html fast/frames/frame-append-body-child-crash.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62127 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62152 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3706 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43700 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->