### PR TITLE
[UnifiedPDF] [iOS] Keyboard presented on password form does not have a "Go" return key

### DIFF
--- a/Source/WebCore/html/EnterKeyHint.h
+++ b/Source/WebCore/html/EnterKeyHint.h
@@ -41,6 +41,6 @@ enum class EnterKeyHint : uint8_t {
 };
 
 EnterKeyHint enterKeyHintForAttributeValue(StringView);
-String attributeValueForEnterKeyHint(EnterKeyHint);
+WEBCORE_EXPORT String attributeValueForEnterKeyHint(EnterKeyHint);
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -31,6 +31,7 @@
 #import "PDFLayerControllerSPI.h"
 #import "PDFPlugin.h"
 #import <WebCore/AddEventListenerOptions.h>
+#import <WebCore/EnterKeyHint.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
 #import <WebCore/HTMLElement.h>
@@ -54,6 +55,7 @@ Ref<Element> PDFPluginPasswordField::createAnnotationElement()
 {
     auto element = PDFPluginTextAnnotation::createAnnotationElement();
     element->setAttribute(typeAttr, "password"_s);
+    element->setAttribute(enterkeyhintAttr, AtomString { attributeValueForEnterKeyHint(EnterKeyHint::Go) });
     element->addEventListener(eventNames().keyupEvent, *eventListener(), false);
     return element;
 }


### PR DESCRIPTION
#### 4f5964be3536e376c201166b35115f6298a68dcf
<pre>
[UnifiedPDF] [iOS] Keyboard presented on password form does not have a &quot;Go&quot; return key
<a href="https://bugs.webkit.org/show_bug.cgi?id=280221">https://bugs.webkit.org/show_bug.cgi?id=280221</a>
<a href="https://rdar.apple.com/136209243">rdar://136209243</a>

Reviewed by Aditya Keerthi.

This patch sets the right enterkeyhint attribute in the password field
so that the presented keyboard has the appropriately labeled return key.

* Source/WebCore/html/EnterKeyHint.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm:
(WebKit::PDFPluginPasswordField::createAnnotationElement):

Canonical link: <a href="https://commits.webkit.org/284122@main">https://commits.webkit.org/284122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c5aa8c33f2b814da527647a98333b4a985eb587

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21167 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19653 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/13085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59159 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16580 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16191 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62153 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10095 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10433 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43701 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->