### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make WebProcess/XR and WebProcess/WebStorage files ref counted

### DIFF
--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -71,10 +71,11 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     if (!isImmersive(sessionMode))
         return;
 
-    if (!m_xrSystem)
+    RefPtr xrSystem = m_xrSystem.get();
+    if (!xrSystem)
         return;
 
-    m_xrSystem->initializeTrackingAndRendering();
+    xrSystem->initializeTrackingAndRendering();
 
     // This is called from the constructor of WebXRSession. Since sessionDidInitializeInputSources()
     // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we
@@ -91,14 +92,14 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
 
 void XRDeviceProxy::shutDownTrackingAndRendering()
 {
-    if (m_xrSystem)
-        m_xrSystem->shutDownTrackingAndRendering();
+    if (RefPtr xrSystem = m_xrSystem.get())
+        xrSystem->shutDownTrackingAndRendering();
 }
 
 void XRDeviceProxy::didCompleteShutdownTriggeredBySystem()
 {
-    if (m_xrSystem)
-        m_xrSystem->didCompleteShutdownTriggeredBySystem();
+    if (RefPtr xrSystem = m_xrSystem.get())
+        xrSystem->didCompleteShutdownTriggeredBySystem();
 }
 
 Vector<PlatformXR::Device::ViewData> XRDeviceProxy::views(SessionMode mode) const
@@ -114,21 +115,22 @@ Vector<PlatformXR::Device::ViewData> XRDeviceProxy::views(SessionMode mode) cons
 
 void XRDeviceProxy::requestFrame(std::optional<PlatformXR::RequestData>&& requestData, PlatformXR::Device::RequestFrameCallback&& callback)
 {
-    if (m_xrSystem)
-        m_xrSystem->requestFrame(WTFMove(requestData), WTFMove(callback));
+    if (RefPtr xrSystem = m_xrSystem.get())
+        xrSystem->requestFrame(WTFMove(requestData), WTFMove(callback));
     else
         callback({ });
 }
 
 std::optional<PlatformXR::LayerHandle> XRDeviceProxy::createLayerProjection(uint32_t width, uint32_t height, bool alpha)
 {
-    return m_xrSystem ? m_xrSystem->createLayerProjection(width, height, alpha) : std::nullopt;
+    RefPtr xrSystem = m_xrSystem.get();
+    return xrSystem ? xrSystem->createLayerProjection(width, height, alpha) : std::nullopt;
 }
 
 void XRDeviceProxy::submitFrame(Vector<PlatformXR::Device::Layer>&&)
 {
-    if (m_xrSystem)
-        m_xrSystem->submitFrame();
+    if (RefPtr xrSystem = m_xrSystem.get())
+        xrSystem->submitFrame();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8915,7 +8915,7 @@ void WebPage::textAutosizingUsesIdempotentModeChanged()
 PlatformXRSystemProxy& WebPage::xrSystemProxy()
 {
     if (!m_xrSystemProxy)
-        m_xrSystemProxy = std::unique_ptr<PlatformXRSystemProxy>(new PlatformXRSystemProxy(*this));
+        m_xrSystemProxy = makeUniqueWithoutRefCountedCheck<PlatformXRSystemProxy>(*this);
     return *m_xrSystemProxy;
 }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1270,7 +1270,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     ASSERT_UNUSED(connection, m_networkProcessConnection == connection);
 
     for (auto key : copyToVector(m_storageAreaMaps.keys())) {
-        if (auto map = m_storageAreaMaps.get(key))
+        if (RefPtr map = m_storageAreaMaps.get(key).get())
             map->disconnect();
     }
 

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.cpp
@@ -50,57 +50,60 @@ StorageAreaImpl::StorageAreaImpl(StorageAreaMap& storageAreaMap)
 
 StorageAreaImpl::~StorageAreaImpl()
 {
-    if (m_storageAreaMap)
-        m_storageAreaMap->decrementUseCount();
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        storageAreaMap->decrementUseCount();
 }
 
 unsigned StorageAreaImpl::length()
 {
-    return m_storageAreaMap ? m_storageAreaMap->length() : 0;
+    RefPtr storageAreaMap = m_storageAreaMap.get();
+    return storageAreaMap ? storageAreaMap->length() : 0;
 }
 
 String StorageAreaImpl::key(unsigned index)
 {
-    return m_storageAreaMap ? m_storageAreaMap->key(index) : nullString();
+    RefPtr storageAreaMap = m_storageAreaMap.get();
+    return storageAreaMap ? storageAreaMap->key(index) : nullString();
 }
 
 String StorageAreaImpl::item(const String& key)
 {
-    return m_storageAreaMap ? m_storageAreaMap->item(key) : nullString();
+    RefPtr storageAreaMap = m_storageAreaMap.get();
+    return storageAreaMap ? storageAreaMap->item(key) : nullString();
 }
 
 void StorageAreaImpl::setItem(LocalFrame& sourceFrame, const String& key, const String& value, bool& quotaException)
 {
     ASSERT(!value.isNull());
 
-    if (m_storageAreaMap)
-        m_storageAreaMap->setItem(sourceFrame, this, key, value, quotaException);
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        storageAreaMap->setItem(sourceFrame, this, key, value, quotaException);
 }
 
 void StorageAreaImpl::removeItem(LocalFrame& sourceFrame, const String& key)
 {
-    if (m_storageAreaMap)
-        m_storageAreaMap->removeItem(sourceFrame, this, key);
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        storageAreaMap->removeItem(sourceFrame, this, key);
 }
 
 void StorageAreaImpl::clear(LocalFrame& sourceFrame)
 {
-    if (m_storageAreaMap)
-        m_storageAreaMap->clear(sourceFrame, this);
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        storageAreaMap->clear(sourceFrame, this);
 }
 
 bool StorageAreaImpl::contains(const String& key)
 {
-    if (m_storageAreaMap)
-        return m_storageAreaMap->contains(key);
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        return storageAreaMap->contains(key);
 
     return false;
 }
 
 StorageType StorageAreaImpl::storageType() const
 {
-    if (m_storageAreaMap)
-        return m_storageAreaMap->type();
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        return storageAreaMap->type();
 
     // We probably need an Invalid type.
     return StorageType::Local;
@@ -113,8 +116,8 @@ size_t StorageAreaImpl::memoryBytesUsedByCache()
 
 void StorageAreaImpl::prewarm()
 {
-    if (m_storageAreaMap)
-        m_storageAreaMap->connect();
+    if (RefPtr storageAreaMap = m_storageAreaMap.get())
+        storageAreaMap->connect();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
@@ -81,9 +81,9 @@ void StorageNamespaceImpl::destroyStorageAreaMap(StorageAreaMap& map)
 Ref<StorageArea> StorageNamespaceImpl::storageArea(const SecurityOrigin& securityOrigin)
 {
     auto& map = m_storageAreaMaps.ensure(securityOrigin.data(), [&] {
-        return makeUnique<StorageAreaMap>(*this, securityOrigin);
+        return StorageAreaMap::create(*this, securityOrigin);
     }).iterator->value;
-    return StorageAreaImpl::create(*map);
+    return StorageAreaImpl::create(map);
 }
 
 Ref<StorageNamespace> StorageNamespaceImpl::copy(Page& newPage)

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
@@ -79,7 +79,7 @@ private:
     const unsigned m_quotaInBytes;
     std::optional<Identifier> m_storageNamespaceID;
 
-    HashMap<WebCore::SecurityOriginData, std::unique_ptr<StorageAreaMap>> m_storageAreaMaps;
+    HashMap<WebCore::SecurityOriginData, Ref<StorageAreaMap>> m_storageAreaMaps;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -134,6 +134,16 @@ bool PlatformXRSystemProxy::webXREnabled() const
     return m_page.corePage() && m_page.corePage()->settings().webXREnabled();
 }
 
+void PlatformXRSystemProxy::ref() const
+{
+    m_page.ref();
+}
+
+void PlatformXRSystemProxy::deref() const
+{
+    m_page.deref();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WEBXR)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -31,15 +31,7 @@
 #include "XRDeviceIdentifier.h"
 #include "XRDeviceProxy.h"
 #include <WebCore/PlatformXR.h>
-
-namespace WebKit {
-class PlatformXRSystemProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PlatformXRSystemProxy> : std::true_type { };
-}
+#include <wtf/FastMalloc.h>
 
 namespace WebCore {
 class SecurityOriginData;
@@ -50,6 +42,7 @@ namespace WebKit {
 class WebPage;
 
 class PlatformXRSystemProxy : public IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     PlatformXRSystemProxy(WebPage&);
     virtual ~PlatformXRSystemProxy();
@@ -62,6 +55,9 @@ public:
     void requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&);
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool);
     void submitFrame();
+
+    void ref() const;
+    void deref() const;
 
 private:
     RefPtr<XRDeviceProxy> deviceByIdentifier(XRDeviceIdentifier);


### PR DESCRIPTION
#### 608e68962f08d8e1b0e05c26788b0b08e9552981
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make WebProcess/XR and WebProcess/WebStorage files ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280231">https://bugs.webkit.org/show_bug.cgi?id=280231</a>
<a href="https://rdar.apple.com/136536190">rdar://136536190</a>

Reviewed by Chris Dumez.

Remove IsDeprecatedWeakRefSmartPointerException. Since PlatformXRSystemProxy
has a single owner which does not re-assign it, we make PlatformXRSystemProxy
ref counted by adding ref() and deref() functions that forward the ref&apos;ing to
the owner rather than making PlatformXRSystemProxy a subclass of RefCounted&lt;&gt;.

That&apos;s not the case for StorageAreaMap, so we make it subclass RefCounted.

* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
(WebKit::XRDeviceProxy::shutDownTrackingAndRendering):
(WebKit::XRDeviceProxy::didCompleteShutdownTriggeredBySystem):
(WebKit::XRDeviceProxy::requestFrame):
(WebKit::XRDeviceProxy::createLayerProjection):
(WebKit::XRDeviceProxy::submitFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::xrSystemProxy):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::networkProcessConnectionClosed):
* Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.cpp:
(WebKit::StorageAreaImpl::~StorageAreaImpl):
(WebKit::StorageAreaImpl::length):
(WebKit::StorageAreaImpl::key):
(WebKit::StorageAreaImpl::item):
(WebKit::StorageAreaImpl::setItem):
(WebKit::StorageAreaImpl::removeItem):
(WebKit::StorageAreaImpl::clear):
(WebKit::StorageAreaImpl::contains):
(WebKit::StorageAreaImpl::storageType const):
(WebKit::StorageAreaImpl::prewarm):
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp:
(WebKit::StorageNamespaceImpl::storageArea):
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::ref const):
(WebKit::PlatformXRSystemProxy::deref const):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/284189@main">https://commits.webkit.org/284189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78a8f9de7e049b9686a81ac8aaa7fb0601c4d1db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19797 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54739 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40572 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62216 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3813 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43845 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->