### PR TITLE
Implement full Wasm calling convention in IPInt

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-call-many-f32.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-call-many-f32.js
@@ -1,0 +1,19 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test_f32_10") (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32) (result f32)
+        (local.get 8)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test_f32_10 } = instance.exports
+    assert.eq(test_f32_10(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 9)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-multiret32.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-multiret32.js
@@ -1,0 +1,62 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test")
+        (result i32) (result i32) (result i32) (result i32)
+        (result i32) (result i32) (result i32) (result i32)
+        (result i32) (result i32) (result i32) (result i32)
+        (result i32) (result i32) (result i32) (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.const 4)
+        (i32.const 5)
+        (i32.const 6)
+        (i32.const 7)
+        (i32.const 8)
+        (i32.const 9)
+        (i32.const 10)
+        (i32.const 11)
+        (i32.const 12)
+        (i32.const 13)
+        (i32.const 14)
+        (i32.const 15)
+        (i32.const 16)
+        (return)
+    )
+    (func (export "test_fp")
+        (result f32) (result f32) (result f32) (result f32)
+        (result f32) (result f32) (result f32) (result f32)
+        (result f32) (result f32) (result f32) (result f32)
+        (result f32) (result f32) (result f32) (result f32)
+        (f32.const 1)
+        (f32.const 2)
+        (f32.const 3)
+        (f32.const 4)
+        (f32.const 5)
+        (f32.const 6)
+        (f32.const 7)
+        (f32.const 8)
+        (f32.const 9)
+        (f32.const 10)
+        (f32.const 11)
+        (f32.const 12)
+        (f32.const 13)
+        (f32.const 14)
+        (f32.const 15)
+        (f32.const 16)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test, test_fp } = instance.exports
+    assert.eq(test(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    assert.eq(test_fp(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -573,15 +573,6 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     nextIPIntInstruction()
 
 .ipint_exit:
-    # Clean up locals
-    # Don't overwrite the return registers
-    # Will use PM as a temp because we don't want to use the actual temps.
-    # move PL, sp
-    # loadi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], PM
-    # mulq LocalSize, PM
-    # addq PM, sp
-    ipintReloadMemory()
-
     restoreIPIntRegisters()
     restoreCallerPCAndCFR()
     ret

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -667,8 +667,12 @@ extern "C" void ipint_catch_all_entry();
     m(0x09, argumINT_fa1) \
     m(0x0a, argumINT_fa2) \
     m(0x0b, argumINT_fa3) \
-    m(0x0c, argumINT_stack) \
-    m(0x0d, argumINT_end) \
+    m(0x0c, argumINT_fa4) \
+    m(0x0d, argumINT_fa5) \
+    m(0x0e, argumINT_fa6) \
+    m(0x0f, argumINT_fa7) \
+    m(0x10, argumINT_stack) \
+    m(0x11, argumINT_end) \
 
 #define FOR_EACH_IPINT_SLOW_PATH(m) \
     m(0x00, local_get_slow_path) \
@@ -712,9 +716,22 @@ extern "C" void ipint_catch_all_entry();
 #define FOR_EACH_IPINT_UINT_OPCODE(m) \
     m(0x00, uint_r0) \
     m(0x01, uint_r1) \
-    m(0x02, uint_fr0) \
-    m(0x03, uint_stack) \
-    m(0x04, uint_ret) \
+    m(0x02, uint_r2) \
+    m(0x03, uint_r3) \
+    m(0x04, uint_r4) \
+    m(0x05, uint_r5) \
+    m(0x06, uint_r6) \
+    m(0x07, uint_r7) \
+    m(0x08, uint_fr0) \
+    m(0x09, uint_fr1) \
+    m(0x0a, uint_fr2) \
+    m(0x0b, uint_fr3) \
+    m(0x0c, uint_fr4) \
+    m(0x0d, uint_fr5) \
+    m(0x0e, uint_fr6) \
+    m(0x0f, uint_fr7) \
+    m(0x10, uint_stack) \
+    m(0x11, uint_ret) \
 
 #if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS))) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -1055,7 +1055,46 @@ _uint_begin:
 uintAlign(_r1)
     break
 
+uintAlign(_r2)
+    break
+
+uintAlign(_r3)
+    break
+
+uintAlign(_r4)
+    break
+
+uintAlign(_r5)
+    break
+
+uintAlign(_r6)
+    break
+
+uintAlign(_r7)
+    break
+
 uintAlign(_fr0)
+    break
+
+uintAlign(_fr1)
+    break
+
+uintAlign(_fr2)
+    break
+
+uintAlign(_fr3)
+    break
+
+uintAlign(_fr4)
+    break
+
+uintAlign(_fr5)
+    break
+
+uintAlign(_fr6)
+    break
+
+uintAlign(_fr7)
     break
 
 uintAlign(_stack)
@@ -1109,6 +1148,18 @@ argumINTAlign(_fa2)
     break
 
 argumINTAlign(_fa3)
+    break
+
+argumINTAlign(_fa4)
+    break
+
+argumINTAlign(_fa5)
+    break
+
+argumINTAlign(_fa6)
+    break
+
+argumINTAlign(_fa7)
     break
 
 argumINTAlign(_stack)

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -221,6 +221,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index
     , m_argumINTBytecodePointer(m_argumINTBytecode.data())
     , m_uINTBytecode(WTFMove(generator.m_uINTBytecode))
     , m_uINTBytecodePointer(m_uINTBytecode.data())
+    , m_highestReturnStackOffset(generator.m_highestReturnStackOffset)
     , m_localSizeToAlloc(roundUpToMultipleOf<2>(generator.m_numLocals))
     , m_numRethrowSlotsToAlloc(generator.m_numAlignedRethrowSlots)
     , m_numLocals(generator.m_numLocals)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -440,8 +440,12 @@ public:
 
     uint32_t functionIndex() const { return m_functionIndex; }
     void setEntrypoint(CodePtr<WasmEntryPtrTag>);
-    const uint8_t* getBytecode() const { return m_bytecode; }
-    const uint8_t* getMetadata() const { return m_metadata; }
+    const uint8_t* bytecode() const { return m_bytecode; }
+    const uint8_t* metadata() const { return m_metadata; }
+
+    unsigned numLocals() const { return m_numLocals; }
+    unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
+    unsigned rethrowSlots() const { return m_numRethrowSlotsToAlloc; }
 
     const TypeDefinition& signature(unsigned index) const
     {
@@ -480,9 +484,7 @@ private:
 #endif
     CodePtr<WasmEntryPtrTag> m_entrypoint;
     FixedVector<const TypeDefinition*> m_signatures;
-public:
-    // I couldn't figure out how to stop LLIntOffsetsExtractor.cpp from yelling at me.
-    // So just making these public.
+
     const uint8_t* m_bytecode;
     const uint8_t* m_bytecodeEnd;
     Vector<uint8_t> m_metadataVector;
@@ -491,6 +493,8 @@ public:
     const uint8_t* m_argumINTBytecodePointer;
     Vector<uint8_t> m_uINTBytecode;
     const uint8_t* m_uINTBytecodePointer;
+
+    unsigned m_highestReturnStackOffset;
 
     unsigned m_localSizeToAlloc;
     unsigned m_numRethrowSlotsToAlloc;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -102,7 +102,7 @@ private:
     void addLEB128ConstantInt32AndLength(uint32_t value, size_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, size_t length);
     void addLEB128V128Constant(v128_t value, size_t length);
-    void addReturnData(const Vector<Type, 16>& types);
+    void addReturnData(const FunctionSignature&);
 
     uint32_t m_functionIndex;
     bool m_tailCallClobbersInstance { false };
@@ -111,6 +111,7 @@ private:
     std::span<const uint8_t> m_bytecode;
     Vector<uint8_t> m_metadata { };
     Vector<uint8_t, 8> m_uINTBytecode { };
+    unsigned m_highestReturnStackOffset;
 
     uint32_t m_bytecodeOffset { 0 };
     unsigned m_maxFrameSizeInV128 { 0 };


### PR DESCRIPTION
#### fb3a2765f7892b78721a609c4d653bcf54d0d2a8
<pre>
Implement full Wasm calling convention in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=280230">https://bugs.webkit.org/show_bug.cgi?id=280230</a>
<a href="https://rdar.apple.com/problem/136536169">rdar://problem/136536169</a>

Reviewed by Yusuke Suzuki.

Previously, IPInt did not support a significant range of return signatures, due to
no stack returns being supported. This patch updates IPInt to support returning on
the stack. Additionally, the argument and return value bytecodes are generated
from `wasmCallingConvention()`, ensuring that it is consistent with the rest of
JSC&apos;s Wasm implementations.

* JSTests/wasm/ipint-tests/ipint-test-call-many-f32.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.f32.f32.f32.f32.f32.f32.f32.f32.f32.f32.result.f32.local.8.return.async test):
* JSTests/wasm/ipint-tests/ipint-test-multiret32.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.result.i32.i32.const.1.i32.const.2.i32.const.3.i32.const.4.i32.const.5.i32.const.6.i32.const.7.i32.const.8.i32.const.9.i32.const.10.i32.const.11.i32.const.12.i32.const.13.i32.const.14.i32.const.15.i32.const.16.return.func.export.string_appeared_here.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.result.f32.f32.const.1.f32.const.2.f32.const.3.f32.const.4.f32.const.5.f32.const.6.f32.const.7.f32.const.8.f32.const.9.f32.const.10.f32.const.11.f32.const.12.f32.const.13.f32.const.14.f32.const.15.f32.const.16.return.async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addArguments):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):

Canonical link: <a href="https://commits.webkit.org/284188@main">https://commits.webkit.org/284188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a5180dbbce8afc71eba4a957252a34d2983c384

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19813 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18170 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61786 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74431 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67916 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62252 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3825 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89695 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43861 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15887 "Found 5 new JSC stress test failures: wasm.yaml/wasm/stress/cc-infinite-int-glitch.js.wasm-collect-continuously, wasm.yaml/wasm/stress/f32-tuple-jsapi.js.wasm-eager, wasm.yaml/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-bbq, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44935 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->