### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make ExtensionCapabilityGranter CanMakeWeakPtr classes RefCounted or CheckedPtr

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
@@ -36,20 +36,10 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
-class ExtensionCapabilityGranter;
-struct ExtensionCapabilityGranterClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ExtensionCapabilityGranter> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ExtensionCapabilityGranterClient> : std::true_type { };
-}
-
-namespace WebKit {
 
 class ExtensionCapability;
 class ExtensionCapabilityGrant;
+class ExtensionCapabilityGranter;
 class GPUProcessProxy;
 class MediaCapability;
 class WebPageProxy;
@@ -57,16 +47,17 @@ class WebProcessProxy;
 
 struct ExtensionCapabilityGranterClient : public CanMakeWeakPtr<ExtensionCapabilityGranterClient> {
     virtual ~ExtensionCapabilityGranterClient() = default;
+    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) = 0;
     virtual RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) = 0;
 };
 
-class ExtensionCapabilityGranter : public CanMakeWeakPtr<ExtensionCapabilityGranter> {
+class ExtensionCapabilityGranter : public CanMakeWeakPtr<ExtensionCapabilityGranter>, public RefCounted<ExtensionCapabilityGranter> {
     WTF_MAKE_TZONE_ALLOCATED(ExtensionCapabilityGranter);
     WTF_MAKE_NONCOPYABLE(ExtensionCapabilityGranter);
 public:
-    static UniqueRef<ExtensionCapabilityGranter> create(ExtensionCapabilityGranterClient&);
+    static RefPtr<ExtensionCapabilityGranter> create(ExtensionCapabilityGranterClient&);
 
     void grant(const ExtensionCapability&);
     void revoke(const ExtensionCapability&);
@@ -75,7 +66,6 @@ public:
     void invalidateGrants(Vector<ExtensionCapabilityGrant>&&);
 
 private:
-    friend UniqueRef<ExtensionCapabilityGranter> WTF::makeUniqueRefWithoutFastMallocCheck(ExtensionCapabilityGranterClient&);
     explicit ExtensionCapabilityGranter(ExtensionCapabilityGranterClient&);
 
     WeakRef<ExtensionCapabilityGranterClient> m_client;

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -145,9 +145,9 @@ static bool finalizeGrant(ExtensionCapabilityGranter& granter, const String& env
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ExtensionCapabilityGranter);
 
-UniqueRef<ExtensionCapabilityGranter> ExtensionCapabilityGranter::create(ExtensionCapabilityGranterClient& client)
+RefPtr<ExtensionCapabilityGranter> ExtensionCapabilityGranter::create(ExtensionCapabilityGranterClient& client)
 {
-    return makeUniqueRef<ExtensionCapabilityGranter>(client);
+    return adoptRef(new ExtensionCapabilityGranter(client));
 }
 
 ExtensionCapabilityGranter::ExtensionCapabilityGranter(ExtensionCapabilityGranterClient& client)
@@ -189,7 +189,9 @@ void ExtensionCapabilityGranter::grant(const ExtensionCapability& capability)
             gpuProcessGrant.setPlatformGrant(WTFMove(result->gpuProcessGrant));
             webProcessGrant.setPlatformGrant(WTFMove(result->webProcessGrant));
         }
-        if (!weakThis) {
+        RefPtr protectedThis = weakThis.get();
+        RefPtr client = protectedThis ? m_client.ptr() : nullptr;
+        if (!client) {
             invalidateGrants(Vector<ExtensionCapabilityGrant>::from(WTFMove(gpuProcessGrant), WTFMove(webProcessGrant)));
             return;
         }
@@ -228,11 +230,13 @@ void ExtensionCapabilityGranter::revoke(const ExtensionCapability& capability)
 
     String environmentIdentifier = capability.environmentIdentifier();
 
-    if (RefPtr gpuProcess = m_client->gpuProcessForCapabilityGranter(*this))
-        grants.append(gpuProcess->extensionCapabilityGrants().take(environmentIdentifier));
+    if (RefPtr client = m_client.ptr()) {
+        if (RefPtr gpuProcess = m_client->gpuProcessForCapabilityGranter(*this))
+            grants.append(gpuProcess->extensionCapabilityGrants().take(environmentIdentifier));
 
-    if (RefPtr webProcess = m_client->webProcessForCapabilityGranter(*this, environmentIdentifier))
-        grants.append(webProcess->extensionCapabilityGrants().take(environmentIdentifier));
+        if (RefPtr webProcess = m_client->webProcessForCapabilityGranter(*this, environmentIdentifier))
+            grants.append(webProcess->extensionCapabilityGrants().take(environmentIdentifier));
+    }
 
     invalidateGrants(WTFMove(grants));
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1291,7 +1291,7 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
 ExtensionCapabilityGranter& WebProcessPool::extensionCapabilityGranter()
 {
     if (!m_extensionCapabilityGranter)
-        m_extensionCapabilityGranter = ExtensionCapabilityGranter::create(*this).moveToUniquePtr();
+        m_extensionCapabilityGranter = ExtensionCapabilityGranter::create(*this);
     return *m_extensionCapabilityGranter;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -583,6 +583,9 @@ public:
     ExtensionCapabilityGranter& extensionCapabilityGranter();
     RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) final;
     RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) final;
+
+    void ref() const final { API::ObjectImpl<API::Object::Type::ProcessPool>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::ProcessPool>::deref(); }
 #endif
 
     bool usesSingleWebProcess() const { return m_configuration->usesSingleWebProcess(); }
@@ -909,7 +912,7 @@ private:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    std::unique_ptr<ExtensionCapabilityGranter> m_extensionCapabilityGranter;
+    RefPtr<ExtensionCapabilityGranter> m_extensionCapabilityGranter;
 #endif
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 77e0b41b2660a4fbb6266599bb5928d64de2ab5c
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make ExtensionCapabilityGranter CanMakeWeakPtr classes RefCounted or CheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=280197">https://bugs.webkit.org/show_bug.cgi?id=280197</a>

Reviewed by Ryosuke Niwa.

To remove IsDeprecatedWeakRefSmartPointerException, adopt RefCounted or CheckedPtr to the related classes.

* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::ExtensionCapabilityGranter::create):
(WebKit::ExtensionCapabilityGranter::grant):
(WebKit::ExtensionCapabilityGranter::revoke):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::extensionCapabilityGranter):
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/284129@main">https://commits.webkit.org/284129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78d7f32c657e090265de2d4746a8545c4beb6703

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21180 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19666 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43798 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40465 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18023 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12492 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12532 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15191 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10091 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43714 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44788 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->