### PR TITLE
Reduce use of LegacyNullableAtomicObjectIdentifier

### DIFF
--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -34,7 +34,7 @@ class CallFrame;
 class JSGlobalObject;
 
 enum class MicrotaskIdentifierType { };
-using MicrotaskIdentifier = LegacyNullableAtomicObjectIdentifier<MicrotaskIdentifierType>;
+using MicrotaskIdentifier = AtomicObjectIdentifier<MicrotaskIdentifierType>;
 
 class Microtask : public RefCounted<Microtask> {
 public:

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandleCloseScope.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandleCloseScope.h
@@ -41,15 +41,15 @@ public:
     {
         ASSERT(RunLoop::isMain());
 
-        if (m_identifier.isValid())
-            m_connection->closeHandle(m_identifier);
+        if (m_identifier)
+            m_connection->closeHandle(*m_identifier);
     }
 
     std::pair<FileSystemHandleIdentifier, bool> release()
     {
         Locker locker { m_lock };
-        ASSERT_WITH_MESSAGE(m_identifier.isValid(), "FileSystemHandleCloseScope should not be released more than once");
-        return { std::exchange(m_identifier, { }), m_isDirectory };
+        ASSERT_WITH_MESSAGE(!!m_identifier, "FileSystemHandleCloseScope should not be released more than once");
+        return { *std::exchange(m_identifier, std::nullopt), m_isDirectory };
     }
 
 private:
@@ -62,7 +62,7 @@ private:
     }
 
     Lock m_lock;
-    FileSystemHandleIdentifier m_identifier WTF_GUARDED_BY_LOCK(m_lock);
+    Markable<FileSystemHandleIdentifier> m_identifier WTF_GUARDED_BY_LOCK(m_lock);
     bool m_isDirectory;
     Ref<FileSystemStorageConnection> m_connection;
 };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class FileSystemHandleIdentifierType { };
-using FileSystemHandleIdentifier = LegacyNullableAtomicObjectIdentifier<FileSystemHandleIdentifierType>;
+using FileSystemHandleIdentifier = AtomicObjectIdentifier<FileSystemHandleIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class  MainThreadPermissionObserverIdentifierType { };
-using MainThreadPermissionObserverIdentifier = LegacyNullableAtomicObjectIdentifier<MainThreadPermissionObserverIdentifierType>;
+using MainThreadPermissionObserverIdentifier = AtomicObjectIdentifier<MainThreadPermissionObserverIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
@@ -53,7 +53,7 @@ class WebSocketChannel;
 class WebSocketChannelInspector;
 class WebSocketChannelClient;
 
-using WebSocketChannelIdentifier = LegacyNullableAtomicObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 
 class ThreadableWebSocketChannel : public Identified<WebSocketIdentifier> {
     WTF_MAKE_NONCOPYABLE(ThreadableWebSocketChannel);

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
@@ -44,7 +44,7 @@ WebSocketChannelInspector::~WebSocketChannelInspector() = default;
 
 void WebSocketChannelInspector::didCreateWebSocket(const URL& url) const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::didCreateWebSocket(m_document.get(), m_progressIdentifier, url);
@@ -52,7 +52,7 @@ void WebSocketChannelInspector::didCreateWebSocket(const URL& url) const
 
 void WebSocketChannelInspector::willSendWebSocketHandshakeRequest(const ResourceRequest& request) const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::willSendWebSocketHandshakeRequest(m_document.get(), m_progressIdentifier, request);
@@ -60,7 +60,7 @@ void WebSocketChannelInspector::willSendWebSocketHandshakeRequest(const Resource
 
 void WebSocketChannelInspector::didReceiveWebSocketHandshakeResponse(const ResourceResponse& response) const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::didReceiveWebSocketHandshakeResponse(m_document.get(), m_progressIdentifier, response);
@@ -68,7 +68,7 @@ void WebSocketChannelInspector::didReceiveWebSocketHandshakeResponse(const Resou
 
 void WebSocketChannelInspector::didCloseWebSocket() const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::didCloseWebSocket(m_document.get(), m_progressIdentifier);
@@ -76,7 +76,7 @@ void WebSocketChannelInspector::didCloseWebSocket() const
 
 void WebSocketChannelInspector::didReceiveWebSocketFrame(const WebSocketFrame& frame) const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::didReceiveWebSocketFrame(m_document.get(), m_progressIdentifier, frame);
@@ -84,7 +84,7 @@ void WebSocketChannelInspector::didReceiveWebSocketFrame(const WebSocketFrame& f
 
 void WebSocketChannelInspector::didSendWebSocketFrame(const WebSocketFrame& frame) const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::didSendWebSocketFrame(m_document.get(), m_progressIdentifier, frame);
@@ -92,15 +92,10 @@ void WebSocketChannelInspector::didSendWebSocketFrame(const WebSocketFrame& fram
 
 void WebSocketChannelInspector::didReceiveWebSocketFrameError(const String& errorMessage) const
 {
-    if (!m_progressIdentifier || !m_document)
+    if (!m_document)
         return;
 
     InspectorInstrumentation::didReceiveWebSocketFrameError(m_document.get(), m_progressIdentifier, errorMessage);
-}
-
-WebSocketChannelIdentifier WebSocketChannelInspector::progressIdentifier() const
-{
-    return m_progressIdentifier;
 }
 
 WebSocketFrame WebSocketChannelInspector::createFrame(std::span<const uint8_t> data, WebSocketFrame::OpCode opCode)

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
@@ -39,7 +39,7 @@ class ResourceResponse;
 class WebSocketChannel;
 class WebSocketChannelInspector;
 
-using WebSocketChannelIdentifier = LegacyNullableAtomicObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 
 class WEBCORE_EXPORT WebSocketChannelInspector {
 public:
@@ -54,7 +54,7 @@ public:
     void didSendWebSocketFrame(const WebSocketFrame&) const;
     void didReceiveWebSocketFrameError(const String& errorMessage) const;
     
-    WebSocketChannelIdentifier progressIdentifier() const;
+    WebSocketChannelIdentifier progressIdentifier() const { return m_progressIdentifier; }
 
     static WebSocketFrame createFrame(std::span<const uint8_t> data, WebSocketFrame::OpCode);
 

--- a/Source/WebCore/Modules/websockets/WebSocketIdentifier.h
+++ b/Source/WebCore/Modules/websockets/WebSocketIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class WebSocketIdentifierType { };
-using WebSocketIdentifier = LegacyNullableAtomicObjectIdentifier<WebSocketIdentifierType>;
+using WebSocketIdentifier = AtomicObjectIdentifier<WebSocketIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MessagePortIdentifier.h
+++ b/Source/WebCore/dom/MessagePortIdentifier.h
@@ -68,7 +68,7 @@ struct MessagePortIdentifierHash {
 };
 
 template<> struct HashTraits<WebCore::MessagePortIdentifier> : GenericHashTraits<WebCore::MessagePortIdentifier> {
-    static WebCore::MessagePortIdentifier emptyValue() { return { }; }
+    static WebCore::MessagePortIdentifier emptyValue() { return { HashTraits<WebCore::ProcessIdentifier>::emptyValue(), HashTraits<WebCore::PortIdentifier>::emptyValue() }; }
     static bool isEmptyValue(const WebCore::MessagePortIdentifier& value) { return value.portIdentifier.isHashTableEmptyValue(); }
 
     static void constructDeletedValue(WebCore::MessagePortIdentifier& slot) { new (NotNull, &slot.processIdentifier) WebCore::ProcessIdentifier(WTF::HashTableDeletedValue); }

--- a/Source/WebCore/dom/PortIdentifier.h
+++ b/Source/WebCore/dom/PortIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class PortIdentifierType { };
-using PortIdentifier = LegacyNullableAtomicObjectIdentifier<PortIdentifierType>;
+using PortIdentifier = AtomicObjectIdentifier<PortIdentifierType>;
 
 }

--- a/Source/WebCore/dom/messageports/MessagePortChannel.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.cpp
@@ -39,16 +39,15 @@ Ref<MessagePortChannel> MessagePortChannel::create(MessagePortChannelRegistry& r
 }
 
 MessagePortChannel::MessagePortChannel(MessagePortChannelRegistry& registry, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2)
-    : m_registry(registry)
+    : m_ports { port1, port2 }
+    , m_registry(registry)
 {
     ASSERT(isMainThread());
 
     relaxAdoptionRequirement();
 
-    m_ports[0] = port1;
     m_processes[0] = port1.processIdentifier;
     m_entangledToProcessProtectors[0] = this;
-    m_ports[1] = port2;
     m_processes[1] = port2.processIdentifier;
     m_entangledToProcessProtectors[1] = this;
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -107,7 +107,7 @@ struct Styleable;
 class WebGLProgram;
 #endif
 
-using WebSocketChannelIdentifier = LegacyNullableAtomicObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 enum class StorageType : uint8_t;
 
 struct ComputedEffectTiming;

--- a/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h
+++ b/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h
@@ -34,7 +34,7 @@ class ResourceRequest;
 class ResourceResponse;
 class WebSocketChannel;
 struct WebSocketFrame;
-using WebSocketChannelIdentifier = LegacyNullableAtomicObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 
 class WEBCORE_EXPORT LegacyWebSocketInspectorInstrumentation {
 public:

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -37,7 +37,7 @@ class LocalFrame;
 class SecurityOrigin;
 
 enum class OpaqueOriginIdentifierType { };
-using OpaqueOriginIdentifier = LegacyNullableAtomicObjectIdentifier<OpaqueOriginIdentifierType>;
+using OpaqueOriginIdentifier = AtomicObjectIdentifier<OpaqueOriginIdentifierType>;
 
 class SecurityOriginData {
 public:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3098,7 +3098,7 @@ uint64_t Internals::messagePortIdentifier(const MessagePort& port) const
 
 bool Internals::isMessagePortAlive(uint64_t messagePortIdentifier) const
 {
-    MessagePortIdentifier portIdentifier { Process::identifier(), LegacyNullableAtomicObjectIdentifier<PortIdentifierType>(messagePortIdentifier) };
+    MessagePortIdentifier portIdentifier { Process::identifier(), AtomicObjectIdentifier<PortIdentifierType>(messagePortIdentifier) };
     return MessagePort::isMessagePortAliveForTesting(portIdentifier);
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -257,14 +257,15 @@ bool NetworkConnectionToWebProcess::dispatchMessage(IPC::Connection& connection,
     }
 
     if (decoder.messageReceiverName() == Messages::NetworkResourceLoader::messageReceiverName()) {
-        MESSAGE_CHECK_WITH_RETURN_VALUE(decoder.destinationID(), false);
+        MESSAGE_CHECK_WITH_RETURN_VALUE(AtomicObjectIdentifier<WebCore::ResourceLoader>::isValidIdentifier(decoder.destinationID()), false);
         if (RefPtr loader = m_networkResourceLoaders.get(AtomicObjectIdentifier<WebCore::ResourceLoader>(decoder.destinationID())))
             loader->didReceiveMessage(connection, decoder);
         return true;
     }
 
     if (decoder.messageReceiverName() == Messages::NetworkSocketChannel::messageReceiverName()) {
-        if (auto* channel = m_networkSocketChannels.get(LegacyNullableAtomicObjectIdentifier<WebSocketIdentifierType>(decoder.destinationID())))
+        MESSAGE_CHECK_WITH_RETURN_VALUE(AtomicObjectIdentifier<WebSocketIdentifierType>::isValidIdentifier(decoder.destinationID()), false);
+        if (auto* channel = m_networkSocketChannels.get(AtomicObjectIdentifier<WebSocketIdentifierType>(decoder.destinationID())))
             channel->didReceiveMessage(connection, decoder);
         return true;
     }

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -163,7 +163,7 @@ void WebSharedWorker::resumeIfNeeded()
 void WebSharedWorker::forEachSharedWorkerObject(const Function<void(WebCore::SharedWorkerObjectIdentifier, const WebCore::TransferredMessagePort&)>& apply) const
 {
     for (auto& object : m_sharedWorkerObjects)
-        apply(object.identifier, object.state.port);
+        apply(object.identifier, *object.state.port);
 }
 
 std::optional<WebCore::ProcessIdentifier> WebSharedWorker::firstSharedWorkerObjectProcess() const

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -95,7 +95,7 @@ public:
 
     struct SharedWorkerObjectState {
         bool isSuspended { false };
-        WebCore::TransferredMessagePort port;
+        std::optional<WebCore::TransferredMessagePort> port;
     };
 
     struct Object {

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -167,7 +167,7 @@ private:
     void persisted(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
     void persist(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
     void estimate(const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::StorageEstimate>)>&&);
-    void fileSystemGetDirectory(IPC::Connection&, WebCore::ClientOrigin&&, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
+    void fileSystemGetDirectory(IPC::Connection&, WebCore::ClientOrigin&&, CompletionHandler<void(Expected<std::optional<WebCore::FileSystemHandleIdentifier>, FileSystemStorageError>)>&&);
     void closeHandle(WebCore::FileSystemHandleIdentifier);
     void isSameEntry(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(bool)>&&);
     void move(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, const String& newName, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
@@ -180,7 +180,7 @@ private:
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);
     void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&&);
     void getHandleNames(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
-    void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, FileSystemStorageError>)>&&);
+    void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, FileSystemStorageError>)>&&);
     
     // Message handlers for WebStorage.
     void connectToStorageArea(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<StorageAreaIdentifier>, HashMap<String, String>, uint64_t)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -27,7 +27,7 @@
     Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Estimate(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::StorageEstimate> result);
-    FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
+    FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<std::optional<WebCore::FileSystemHandleIdentifier>, WebKit::FileSystemStorageError> result)
     CloseHandle(WebCore::FileSystemHandleIdentifier identifier)
     IsSameEntry(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (bool result)
     GetFileHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
@@ -40,7 +40,7 @@
     CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier) -> ()
     RequestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity) -> (std::optional<uint64_t> result)
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
-    GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, WebKit::FileSystemStorageError> result)
+    GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, WebKit::FileSystemStorageError> result)
 
     ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier)
     ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
@@ -65,7 +65,7 @@ uint64_t OriginQuotaManager::usage()
 
 void OriginQuotaManager::requestSpace(uint64_t spaceRequested, RequestCallback&& callback)
 {
-    m_requests.append(OriginQuotaManager::Request { spaceRequested, WTFMove(callback), QuotaIncreaseRequestIdentifier { } });
+    m_requests.append(OriginQuotaManager::Request { spaceRequested, WTFMove(callback), std::nullopt });
     handleRequests();
 }
 
@@ -91,7 +91,7 @@ void OriginQuotaManager::handleRequests()
         }
     
         m_currentRequest->identifier = QuotaIncreaseRequestIdentifier::generate();
-        m_increaseQuotaFunction(m_currentRequest->identifier, m_quota, *m_usage, m_currentRequest->spaceRequested);
+        m_increaseQuotaFunction(*m_currentRequest->identifier, m_quota, *m_usage, m_currentRequest->spaceRequested);
     }
 }
 

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -67,7 +67,7 @@ private:
     struct Request {
         uint64_t spaceRequested;
         RequestCallback callback;
-        QuotaIncreaseRequestIdentifier identifier;
+        Markable<QuotaIncreaseRequestIdentifier> identifier;
     };
     Deque<Request> m_requests;
     std::optional<Request> m_currentRequest;

--- a/Source/WebKit/Shared/ProcessQualified.serialization.in
+++ b/Source/WebKit/Shared/ProcessQualified.serialization.in
@@ -24,7 +24,7 @@
 additional_forward_declaration: namespace WebCore { using BackForwardItemIdentifierID = LegacyNullableObjectIdentifier<BackForwardItemIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using DOMCacheIdentifierID = LegacyNullableAtomicObjectIdentifier<DOMCacheIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using FrameIdentifierID = ObjectIdentifier<FrameIdentifierType>; }
-additional_forward_declaration: namespace WebCore { using OpaqueOriginIdentifier = LegacyNullableAtomicObjectIdentifier<OpaqueOriginIdentifierType>; }
+additional_forward_declaration: namespace WebCore { using OpaqueOriginIdentifier = AtomicObjectIdentifier<OpaqueOriginIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using PlatformLayerIdentifierID = ObjectIdentifier<PlatformLayerIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using ScrollingNodeIdentifier = LegacyNullableObjectIdentifier<ScrollingNodeIDType>; }
 additional_forward_declaration: namespace WebCore { using SharedWorkerObjectIdentifierID = LegacyNullableObjectIdentifier<SharedWorkerObjectIdentifierType>; }

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -166,28 +166,17 @@ template: struct WebKit::WebExtensionWindowIdentifierType
 }
 
 header: <wtf/ObjectIdentifier.h>
-template: class WebCore::WebSocketChannel
-template: class WebCore::WebSocketChannelClient
-template: class WebCore::WebSocketChannelInspector
 template: enum class IPC::ConnectionSyncRequestIDType
-template: enum class JSC::MicrotaskIdentifierType
 template: enum class WebCore::DOMCacheIdentifierType
-template: enum class WebCore::DisplayConfigurationClientIdentifierType
-template: enum class WebCore::FileSystemHandleIdentifierType
 template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
 template: enum class WebCore::LibWebRTCSocketIdentifierType
-template: enum class WebCore::MainThreadPermissionObserverIdentifierType
-template: enum class WebCore::OpaqueOriginIdentifierType
-template: enum class WebCore::PortIdentifierType
 template: enum class WebCore::RTCDataChannelLocalIdentifierType
 template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
 template: enum class WebCore::RenderingResourceIdentifierType
 template: enum class WebCore::ServiceWorkerIdentifierType
 template: enum class WebCore::IDBDatabaseConnectionIdentifierType
-template: enum class WebCore::WebSocketIdentifierType
 template: enum class WebCore::WorkerFileSystemStorageConnectionCallbackIdentifierType
 template: enum class WebKit::GraphicsContextGLIdentifierType
-template: enum class WebKit::QuotaIncreaseRequestIdentifierType
 template: enum class WebKit::RemoteVideoFrameIdentifierType
 template: enum class WebKit::RenderingBackendIdentifierType
 template: enum class WebKit::VideoDecoderIdentifierType
@@ -201,14 +190,22 @@ template: enum class TestWebKitAPI::TestedObjectIdentifierType
 
 header: <wtf/ObjectIdentifier.h>
 template: class WebCore::ResourceLoader
+template: class WebCore::WebSocketChannel
+template: enum class JSC::MicrotaskIdentifierType
+template: enum class WebCore::WebSocketIdentifierType
 template: enum class WebCore::BroadcastChannelIdentifierType
+template: enum class WebCore::FileSystemHandleIdentifierType
 template: enum class WebCore::IDBObjectStoreIdentifierType
+template: enum class WebCore::MainThreadPermissionObserverIdentifierType
+template: enum class WebCore::OpaqueOriginIdentifierType
+template: enum class WebCore::PortIdentifierType
 template: enum class WebCore::ServiceWorkerJobIdentifierType
 template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
 template: enum class WebCore::WebLockIdentifierType
 template: enum class WebKit::GPUProcessConnectionIdentifierType
 template: enum class WebKit::LegacyCustomProtocolIDType
 template: enum class WebKit::LibWebRTCResolverIdentifierType
+template: enum class WebKit::QuotaIncreaseRequestIdentifierType
 template: struct IPC::AsyncReplyIDType
 template: struct WebKit::StorageAreaIdentifierType
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::AtomicObjectIdentifier {

--- a/Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h
+++ b/Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class QuotaIncreaseRequestIdentifierType { };
-using QuotaIncreaseRequestIdentifier = LegacyNullableAtomicObjectIdentifier<QuotaIncreaseRequestIdentifierType>;
+using QuotaIncreaseRequestIdentifier = AtomicObjectIdentifier<QuotaIncreaseRequestIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
@@ -46,7 +46,7 @@ void WebSocketChannelManager::networkProcessCrashed()
 
 void WebSocketChannelManager::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto iterator = m_channels.find(LegacyNullableAtomicObjectIdentifier<WebCore::WebSocketIdentifierType>(decoder.destinationID()));
+    auto iterator = m_channels.find(AtomicObjectIdentifier<WebCore::WebSocketIdentifierType>(decoder.destinationID()));
     if (iterator != m_channels.end())
         iterator->value->didReceiveMessage(connection, decoder);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -83,9 +83,7 @@ void WebFileSystemStorageConnection::getFileHandle(WebCore::FileSystemHandleIden
         if (!result)
             return completionHandler(convertToException(result.error()));
 
-        auto identifier = result.value();
-        ASSERT(identifier.isValid());
-        completionHandler(WebCore::FileSystemHandleCloseScope::create(identifier, false, *this));
+        completionHandler(WebCore::FileSystemHandleCloseScope::create(result.value(), false, *this));
     });
 }
 
@@ -98,9 +96,7 @@ void WebFileSystemStorageConnection::getDirectoryHandle(WebCore::FileSystemHandl
         if (!result)
             return completionHandler(convertToException(result.error()));
 
-        auto identifier = result.value();
-        ASSERT(identifier.isValid());
-        completionHandler(WebCore::FileSystemHandleCloseScope::create(identifier, true, *this));
+        completionHandler(WebCore::FileSystemHandleCloseScope::create(result.value(), true, *this));
     });
 }
 
@@ -183,8 +179,7 @@ void WebFileSystemStorageConnection::getHandle(WebCore::FileSystemHandleIdentifi
         if (!result)
             return completionHandler(convertToException(result.error()));
         
-        auto [identifier, isDirectory] = result.value();
-        ASSERT(identifier.isValid());
+        auto [identifier, isDirectory] = *result.value();
         completionHandler(WebCore::FileSystemHandleCloseScope::create(identifier, isDirectory, *this));
     });
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
@@ -69,11 +69,11 @@ void WebStorageConnection::fileSystemGetDirectory(WebCore::ClientOrigin&& origin
             return completionHandler(convertToException(result.error()));
 
         auto identifier = result.value();
-        if (!identifier.isValid())
+        if (!identifier)
             return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
         auto connection = RefPtr<WebCore::FileSystemStorageConnection> { &WebProcess::singleton().fileSystemStorageConnection() };
-        return completionHandler(std::pair { identifier, WTFMove(connection) });
+        return completionHandler(std::pair { *identifier, WTFMove(connection) });
     });
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -60,7 +60,7 @@ class SocketStreamHandle;
 class SocketStreamError;
 class WebSocketChannelClient;
 class WebSocketChannel;
-using WebSocketChannelIdentifier = LegacyNullableAtomicObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 
 class WebSocketChannel final : public RefCounted<WebSocketChannel>, public SocketStreamHandleClient, public ThreadableWebSocketChannel, public FileReaderLoaderClient
 {


### PR DESCRIPTION
#### f40dca81c492428dec3f1c977b27ed2e906bbf30
<pre>
Reduce use of LegacyNullableAtomicObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=280236">https://bugs.webkit.org/show_bug.cgi?id=280236</a>

Reviewed by Ryosuke Niwa.

* Source/JavaScriptCore/runtime/Microtask.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemHandleCloseScope.h:
(WebCore::FileSystemHandleCloseScope::~FileSystemHandleCloseScope):
(WebCore::FileSystemHandleCloseScope::release):
* Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h:
* Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::PermissionStatus):
(WebCore::PermissionStatus::~PermissionStatus):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h:
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp:
(WebCore::WebSocketChannelInspector::didCreateWebSocket const):
(WebCore::WebSocketChannelInspector::willSendWebSocketHandshakeRequest const):
(WebCore::WebSocketChannelInspector::didReceiveWebSocketHandshakeResponse const):
(WebCore::WebSocketChannelInspector::didCloseWebSocket const):
(WebCore::WebSocketChannelInspector::didReceiveWebSocketFrame const):
(WebCore::WebSocketChannelInspector::didSendWebSocketFrame const):
(WebCore::WebSocketChannelInspector::didReceiveWebSocketFrameError const):
(WebCore::WebSocketChannelInspector::progressIdentifier const): Deleted.
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.h:
* Source/WebCore/Modules/websockets/WebSocketIdentifier.h:
* Source/WebCore/dom/MessagePortIdentifier.h:
(WTF::HashTraits&lt;WebCore::MessagePortIdentifier&gt;::emptyValue):
* Source/WebCore/dom/PortIdentifier.h:
* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::MessagePortChannel::MessagePortChannel):
(WebCore::m_registry):
* Source/WebCore/inspector/InspectorInstrumentation.h:
* Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h:
* Source/WebCore/page/SecurityOriginData.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isMessagePortAlive const):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::dispatchMessage):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::WebSharedWorker::forEachSharedWorkerObject const):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::fileSystemGetDirectory):
(WebKit::NetworkStorageManager::getHandle):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
(WebKit::OriginQuotaManager::requestSpace):
(WebKit::OriginQuotaManager::handleRequests):
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
* Source/WebKit/Shared/ProcessQualified.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h:
* Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp:
(WebKit::WebSocketChannelManager::didReceiveMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::getFileHandle):
(WebKit::WebFileSystemStorageConnection::getDirectoryHandle):
(WebKit::WebFileSystemStorageConnection::getHandle):
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp:
(WebKit::WebStorageConnection::fileSystemGetDirectory):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::connect):
(WebCore::WebSocketChannel::disconnect):
(WebCore::WebSocketChannel::didOpenSocketStream):
(WebCore::WebSocketChannel::didCloseSocketStream):
(WebCore::WebSocketChannel::processBuffer):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/284167@main">https://commits.webkit.org/284167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4af5ac16a5d644a5bde797540a5e42de146a9afd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68536 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54675 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13093 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18038 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61654 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74299 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67784 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62145 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62170 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3724 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89563 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10453 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43729 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15859 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->