### PR TITLE
Annotate RemoteAudioSessionProxy message endpoints with feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4616,6 +4616,8 @@ MediaDevicesEnabled:
 MediaEnabled:
   type: bool
   status: embedder
+  humanReadableName: "HTML Media Elements"
+  humanReadableDescription: "Enable HTML media elements <audio>, <video> and <track>"
   condition: ENABLE(VIDEO)
   defaultValue:
     WebKitLegacy:
@@ -4624,6 +4626,20 @@ MediaEnabled:
       default: true
     WebCore:
       default: true
+
+MediaPlaybackEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "Media Playback Functionalities"
+  humanReadableDescription: "Enable media playback functionalities"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+  sharedPreferenceForWebProcess: true
 
 MediaPreferredFullscreenWidth:
   type: double

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -269,6 +269,11 @@ void AudioSession::setIsPlayingToBluetoothOverride(std::optional<bool>)
     notImplemented();
 }
 
+void AudioSession::setEnabled(bool)
+{
+    notImplemented();
+}
+
 Logger& AudioSession::logger()
 {
     if (!m_logger)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -175,6 +175,7 @@ public:
     using SoundStageSize = AudioSessionSoundStageSize;
     virtual void setSoundStageSize(SoundStageSize) { }
     virtual SoundStageSize soundStageSize() const { return SoundStageSize::Automatic; }
+    virtual void setEnabled(bool);
 
 protected:
     friend class NeverDestroyed<AudioSession>;

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -34,7 +34,7 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     void ClearNowPlayingInfo()
     void SetNowPlayingInfo(struct WebCore::NowPlayingInfo nowPlayingInfo)
 #if USE(AUDIO_SESSION)
-    EnsureAudioSession() -> (struct WebKit::RemoteAudioSessionConfiguration configuration) Synchronous
+    [EnabledBy=MediaPlaybackEnabled] EnsureAudioSession() -> (struct WebKit::RemoteAudioSessionConfiguration configuration) Synchronous
 #endif
 #if PLATFORM(IOS_FAMILY)
     EnsureMediaSessionHelper()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -196,6 +196,12 @@ void RemoteAudioSessionProxy::triggerEndInterruptionForTesting()
     AudioSession::sharedSession().endInterruptionForTesting();
 }
 
+SharedPreferencesForWebProcess RemoteAudioSessionProxy::sharedPreferencesForWebProcess() const
+{
+    RefPtr gpuConnectionToWebProcess = m_gpuConnection.get();
+    return gpuConnectionToWebProcess->sharedPreferencesForWebProcess();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -44,6 +44,7 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 class RemoteAudioSessionProxyManager;
+struct SharedPreferencesForWebProcess;
 
 class RemoteAudioSessionProxy
     : public RefCounted<RemoteAudioSessionProxy>, public IPC::MessageReceiver {
@@ -81,6 +82,7 @@ public:
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
+    SharedPreferencesForWebProcess sharedPreferencesForWebProcess() const;
 
 private:
     explicit RemoteAudioSessionProxy(GPUConnectionToWebProcess&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -25,6 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
 
+[EnabledBy=MediaPlaybackEnabled]
 messages -> RemoteAudioSessionProxy NotRefCounted {
     SetCategory(enum:uint8_t WebCore::AudioSessionCategory type, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     SetPreferredBufferSize(uint64_t preferredBufferSize)

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPageUpdatePreferences.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPageUpdatePreferences.cpp.erb
@@ -31,6 +31,7 @@
 #include "WebPreferencesDefinitions.h"
 #include "WebPreferencesKeys.h"
 #include "WebPreferencesStore.h"
+#include <WebCore/AudioSession.h>
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Page.h>
 #include <WebCore/Settings.h>
@@ -69,6 +70,11 @@ void WebPage::updatePreferencesGenerated(const WebPreferencesStore& store)
 #endif
 <%- end -%>
 <%- end -%>
+
+#if USE(AUDIO_SESSION)
+    if (store.getBoolValueForKey(WebPreferencesKey::mediaPlaybackEnabledKey()))
+        WebCore::AudioSession::sharedSession().setEnabled(true);
+#endif
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1316,7 +1316,7 @@ def generate_enabled_by_for_receiver(receiver, messages, ignore_invalid_message_
     enabled_by = receiver.receiver_enabled_by
     enabled_by_conjunction = receiver.receiver_enabled_by_conjunction
     shared_preferences_retrieval = [
-        '    auto& sharedPreferences = sharedPreferencesForWebProcess(%s);\n' % ('connection' if receiver.shared_preferences_needs_connection else ''),
+        '    auto sharedPreferences = sharedPreferencesForWebProcess(%s);\n' % ('connection' if receiver.shared_preferences_needs_connection else ''),
         '    UNUSED_VARIABLE(sharedPreferences);\n'
     ]
     if not enabled_by:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
@@ -40,7 +40,7 @@ namespace WebKit {
 
 void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto& sharedPreferences = sharedPreferencesForWebProcess();
+    auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!(sharedPreferences.someFeature && sharedPreferences.otherFeature)) {
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp
@@ -40,7 +40,7 @@ namespace WebKit {
 
 void TestWithEnabledBy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto& sharedPreferences = sharedPreferencesForWebProcess(connection);
+    auto sharedPreferences = sharedPreferencesForWebProcess(connection);
     UNUSED_VARIABLE(sharedPreferences);
     Ref protectedThis { *this };
     if (decoder.messageName() == Messages::TestWithEnabledBy::AlwaysEnabled::name())

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
@@ -40,7 +40,7 @@ namespace WebKit {
 
 void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto& sharedPreferences = sharedPreferencesForWebProcess();
+    auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!(sharedPreferences.someFeature || sharedPreferences.otherFeature)) {
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
@@ -40,7 +40,7 @@ namespace WebKit {
 
 void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto& sharedPreferences = sharedPreferencesForWebProcess();
+    auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!sharedPreferences.someFeature) {
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -69,6 +69,8 @@ void RemoteAudioSession::gpuProcessConnectionDidClose(GPUProcessConnection& conn
 
 IPC::Connection& RemoteAudioSession::ensureConnection()
 {
+    RELEASE_ASSERT(m_enabled);
+
     auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!gpuProcessConnection) {
         gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
@@ -91,13 +93,20 @@ const RemoteAudioSessionConfiguration& RemoteAudioSession::configuration() const
 
 RemoteAudioSessionConfiguration& RemoteAudioSession::configuration()
 {
-    if (!m_configuration)
-        ensureConnection();
+    if (!m_configuration) {
+        if (m_enabled)
+            ensureConnection();
+        else
+            m_configuration = RemoteAudioSessionConfiguration { };
+    }
     return *m_configuration;
 }
 
 void RemoteAudioSession::setCategory(CategoryType type, Mode mode, RouteSharingPolicy policy)
 {
+    if (!m_enabled)
+        return;
+
 #if PLATFORM(COCOA)
     if (type == m_category && mode == m_mode && policy == m_routeSharingPolicy && !m_isPlayingToBluetoothOverrideChanged)
         return;
@@ -116,6 +125,9 @@ void RemoteAudioSession::setCategory(CategoryType type, Mode mode, RouteSharingP
 
 void RemoteAudioSession::setPreferredBufferSize(size_t size)
 {
+    if (!m_enabled)
+        return;
+
     configuration().preferredBufferSize = size;
     ensureConnection().send(Messages::RemoteAudioSessionProxy::SetPreferredBufferSize(size), { });
 }
@@ -144,6 +156,9 @@ void RemoteAudioSession::removeConfigurationChangeObserver(AudioSessionConfigura
 
 void RemoteAudioSession::setIsPlayingToBluetoothOverride(std::optional<bool> value)
 {
+    if (!m_enabled)
+        return;
+
     m_isPlayingToBluetoothOverrideChanged = true;
     ensureConnection().send(Messages::RemoteAudioSessionProxy::SetIsPlayingToBluetoothOverride(value), { });
 }
@@ -197,22 +212,34 @@ void RemoteAudioSession::endInterruptionRemote(MayResume mayResume)
 
 void RemoteAudioSession::beginAudioSessionInterruption()
 {
+    if (!m_enabled)
+        return;
+
     ensureConnection().send(Messages::RemoteAudioSessionProxy::BeginInterruptionRemote(), { });
 }
 
 void RemoteAudioSession::endAudioSessionInterruption(MayResume mayResume)
 {
+    if (!m_enabled)
+        return;
+
     ensureConnection().send(Messages::RemoteAudioSessionProxy::EndInterruptionRemote(mayResume), { });
 }
 
 void RemoteAudioSession::beginInterruptionForTesting()
 {
+    if (!m_enabled)
+        return;
+
     m_isInterruptedForTesting = true;
     ensureConnection().send(Messages::RemoteAudioSessionProxy::TriggerBeginInterruptionForTesting(), { });
 }
 
 void RemoteAudioSession::endInterruptionForTesting()
 {
+    if (!m_enabled)
+        return;
+
     if (!m_isInterruptedForTesting)
         return;
 
@@ -222,14 +249,32 @@ void RemoteAudioSession::endInterruptionForTesting()
 
 void RemoteAudioSession::setSceneIdentifier(const String& sceneIdentifier)
 {
+    if (!m_enabled)
+        return;
+
     configuration().sceneIdentifier = sceneIdentifier;
     ensureConnection().send(Messages::RemoteAudioSessionProxy::SetSceneIdentifier(sceneIdentifier), { });
 }
 
 void RemoteAudioSession::setSoundStageSize(AudioSession::SoundStageSize size)
 {
+    if (!m_enabled)
+        return;
+
     configuration().soundStageSize = size;
     ensureConnection().send(Messages::RemoteAudioSessionProxy::SetSoundStageSize(size), { });
+}
+
+void RemoteAudioSession::setEnabled(bool enabled)
+{
+    if (m_enabled == enabled)
+        return;
+
+    m_enabled = enabled;
+
+    // Sync configuration when session is enabled.
+    if (m_enabled && m_configuration)
+        m_configuration = std::nullopt;
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -107,6 +107,7 @@ private:
 
     void setSoundStageSize(SoundStageSize) final;
     SoundStageSize soundStageSize() const final { return configuration().soundStageSize; }
+    void setEnabled(bool);
 
     const RemoteAudioSessionConfiguration& configuration() const;
     RemoteAudioSessionConfiguration& configuration();
@@ -127,6 +128,7 @@ private:
     std::optional<RemoteAudioSessionConfiguration> m_configuration;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     bool m_isInterruptedForTesting { false };
+    bool m_enabled { false };
 };
 
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4801,6 +4801,11 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(store.getBoolValueForKey(WebPreferencesKey::sWVPDecodersAlwaysEnabledKey()));
 #endif
 
+#if USE(AUDIO_SESSION)
+    if (store.getBoolValueForKey(WebPreferencesKey::mediaPlaybackEnabledKey()))
+        AudioSession::sharedSession().setEnabled(true);
+#endif
+
     // FIXME: This should be automated by adding a new field in WebPreferences*.yaml
     // that indicates override state for Lockdown mode. https://webkit.org/b/233100.
     if (WebProcess::singleton().isLockdownModeEnabled())


### PR DESCRIPTION
#### 76bbaa0950c935aea5d06b58f5e6500051ddbb22
<pre>
Annotate RemoteAudioSessionProxy message endpoints with feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=280238">https://bugs.webkit.org/show_bug.cgi?id=280238</a>
<a href="https://rdar.apple.com/136540877">rdar://136540877</a>

Reviewed by Eric Carlson.

Add a feature flag for guarding media playback functionalities and annotate RemoteAudioSessionProxy messages with it.
This means when media playback is disabled, web process should not be sending RemoteAudioSessionProxy messages to GPU
process.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::setEnabled):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/Scripts/PreferencesTemplates/WebPageUpdatePreferences.cpp.erb:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_enabled_by_for_receiver):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByAndConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp:
(WebKit::TestWithEnabledBy::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByOrConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::ensureConnection):
(WebKit::RemoteAudioSession::configuration):
(WebKit::RemoteAudioSession::setCategory):
(WebKit::RemoteAudioSession::setPreferredBufferSize):
(WebKit::RemoteAudioSession::setIsPlayingToBluetoothOverride):
(WebKit::RemoteAudioSession::beginAudioSessionInterruption):
(WebKit::RemoteAudioSession::endAudioSessionInterruption):
(WebKit::RemoteAudioSession::beginInterruptionForTesting):
(WebKit::RemoteAudioSession::endInterruptionForTesting):
(WebKit::RemoteAudioSession::setSceneIdentifier):
(WebKit::RemoteAudioSession::setSoundStageSize):
(WebKit::RemoteAudioSession::setEnabled):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):

Canonical link: <a href="https://commits.webkit.org/284331@main">https://commits.webkit.org/284331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30eb0657ff140c8c693702a81e50f061013d0c6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13428 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35463 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/68577 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17061 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18600 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74860 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68314 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15326 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4135 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44272 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15975 "Found 38 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck.js.default, ChakraCore.yaml/ChakraCore/test/typedarray/bug2230916.js.default, stress/arguments-non-configurable.js.bytecode-cache, stress/async-await-basic.js.dfg-eager, stress/async-iteration-for-await-of.js.dfg-eager, stress/big-int-bitwise-or-type-error.js.dfg-eager, stress/big-int-bitwise-or-type-error.js.mini-mode, stress/big-int-exp-negative-exponent.js.bytecode-cache, stress/big-int-exp-negative-exponent.js.dfg-eager ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46541 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45087 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->