### PR TITLE
Use UnixFileDescriptor in IPC and ProcessLauncher

### DIFF
--- a/Source/WebKit/Platform/IPC/IPCUtilities.h
+++ b/Source/WebKit/Platform/IPC/IPCUtilities.h
@@ -31,6 +31,10 @@
 #include <windows.h>
 #endif
 
+#if USE(UNIX_DOMAIN_SOCKETS)
+#include <wtf/unix/UnixFileDescriptor.h>
+#endif
+
 namespace IPC {
 
 // Function to check when asserting IPC-related failures, so that IPC testing skips the assertions
@@ -49,8 +53,8 @@ inline bool isTestingIPC()
 
 #if USE(UNIX_DOMAIN_SOCKETS)
 struct SocketPair {
-    int client;
-    int server;
+    UnixFileDescriptor client;
+    UnixFileDescriptor server;
 };
 
 enum PlatformConnectionOptions {

--- a/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
+++ b/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
@@ -66,11 +66,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return false;
 
     if (auto connectionIdentifier = parseInteger<int>(span(argv[argIndex++])))
-        m_parameters.connectionIdentifier = IPC::Connection::Identifier { *connectionIdentifier };
+        m_parameters.connectionIdentifier = IPC::Connection::Identifier { { *connectionIdentifier, UnixFileDescriptor::Adopt } };
     else
         return false;
 
-    if (!m_parameters.processIdentifier->toRawValue() || m_parameters.connectionIdentifier.handle <= 0)
+    if (!m_parameters.processIdentifier->toRawValue() || m_parameters.connectionIdentifier.handle.value() <= 0)
         return false;
 
 #if USE(GLIB) && OS(LINUX)

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
@@ -53,7 +53,7 @@ ProcessLauncher::~ProcessLauncher()
         tracePoint(ProcessLaunchEnd, m_launchOptions.processIdentifier.toUInt64(), static_cast<uint64_t>(m_launchOptions.processType));
 }
 
-#if !PLATFORM(COCOA) && !USE(GLIB)
+#if !PLATFORM(COCOA)
 void ProcessLauncher::platformDestroy()
 {
 }

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -204,7 +204,6 @@ private:
 
 #if USE(GLIB) && OS(LINUX)
     GSocketMonitor m_socketMonitor;
-    int m_pidServerSocket { -1 };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -55,16 +55,6 @@
 
 namespace WebKit {
 
-void ProcessLauncher::platformDestroy()
-{
-#if OS(LINUX)
-    if (m_pidServerSocket != -1) {
-        close(m_pidServerSocket);
-        m_pidServerSocket = -1;
-    }
-#endif
-}
-
 #if OS(LINUX)
 static bool isFlatpakSpawnUsable()
 {
@@ -111,7 +101,7 @@ void ProcessLauncher::launchProcess()
     GUniquePtr<gchar> processIdentifier(g_strdup_printf("%" PRIu64, m_launchOptions.processIdentifier.toUInt64()));
 
     IPC::SocketPair webkitSocketPair = IPC::createPlatformConnection(connectionOptions());
-    GUniquePtr<gchar> webkitSocket(g_strdup_printf("%d", webkitSocketPair.client));
+    GUniquePtr<gchar> webkitSocket(g_strdup_printf("%d", webkitSocketPair.client.value()));
 
 #if USE(LIBWPE) && !ENABLE(BUBBLEWRAP_SANDBOX)
     if (ProcessProviderLibWPE::singleton().isEnabled()) {
@@ -124,13 +114,13 @@ void ProcessLauncher::launchProcess()
         argv[i++] = nullptr;
         WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-        m_processID = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv, webkitSocketPair.client);
+        m_processID = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv, WTFMove(webkitSocketPair.client));
         if (m_processID <= -1)
             g_error("Unable to spawn a new child process");
 
         // We've finished launching the process, message back to the main run loop.
-        RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = webkitSocketPair.server] {
-            didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { serverSocket });
+        RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = WTFMove(webkitSocketPair.server)] {
+            didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
         });
 
         return;
@@ -139,7 +129,7 @@ void ProcessLauncher::launchProcess()
 
 #if OS(LINUX)
     IPC::SocketPair pidSocketPair = IPC::createPlatformConnection(IPC::PlatformConnectionOptions::SetCloexecOnClient | IPC::PlatformConnectionOptions::SetCloexecOnServer | IPC::PlatformConnectionOptions::SetPasscredOnServer);
-    GUniquePtr<gchar> pidSocketString(g_strdup_printf("%d", pidSocketPair.client));
+    GUniquePtr<gchar> pidSocketString(g_strdup_printf("%d", pidSocketPair.client.value()));
 #endif
 
     String executablePath;
@@ -210,9 +200,11 @@ void ProcessLauncher::launchProcess()
     //
     // Please keep this comment in sync with the duplicate comment in XDGDBusProxy::launch.
     GRefPtr<GSubprocessLauncher> launcher = adoptGRef(g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_INHERIT_FDS));
-    g_subprocess_launcher_take_fd(launcher.get(), webkitSocketPair.client, webkitSocketPair.client);
+    int webkitClientSocketValue = webkitSocketPair.client.release();
+    g_subprocess_launcher_take_fd(launcher.get(), webkitClientSocketValue, webkitClientSocketValue);
 #if OS(LINUX)
-    g_subprocess_launcher_take_fd(launcher.get(), pidSocketPair.client, pidSocketPair.client);
+    int pidClientSocketValue = pidSocketPair.client.release();
+    g_subprocess_launcher_take_fd(launcher.get(), pidClientSocketValue, pidClientSocketValue);
 #endif
 
 #if USE(SYSPROF_CAPTURE)
@@ -236,7 +228,7 @@ void ProcessLauncher::launchProcess()
     bool sandboxEnabled = m_launchOptions.extraInitializationData.get<HashTranslatorASCIILiteral>("enable-sandbox"_s) == "true"_s;
 
     if (sandboxEnabled && isInsideFlatpak() && isFlatpakSpawnUsable())
-        process = flatpakSpawn(launcher.get(), m_launchOptions, argv, webkitSocketPair.client, pidSocketPair.client, &error.outPtr());
+        process = flatpakSpawn(launcher.get(), m_launchOptions, argv, webkitClientSocketValue, pidClientSocketValue, &error.outPtr());
 #if ENABLE(BUBBLEWRAP_SANDBOX)
     // You cannot use bubblewrap within Flatpak or some containers so lets ensure it never happens.
     // Snap can allow it but has its own limitations that require workarounds.
@@ -251,15 +243,16 @@ void ProcessLauncher::launchProcess()
         g_error("Unable to spawn a new child process: %s", error->message);
 
 #if OS(LINUX)
-    GRefPtr<GSocket> pidSocket = adoptGRef(g_socket_new_from_fd(pidSocketPair.server, &error.outPtr()));
+    GRefPtr<GSocket> pidSocket = adoptGRef(g_socket_new_from_fd(pidSocketPair.server.release(), &error.outPtr()));
     if (!pidSocket)
+        // Note: g_socket_new_from_fd() takes ownership of the fd only on success, so if this error
+        // were not fatal, we would need to close it here.
         g_error("Failed to create pid socket wrapper: %s", error->message);
 
     // We need to get the pid of the actual WebKit auxiliary process, not the bwrap or flatpak-spawn
     // intermediate process. And do it without blocking, because process launching is slow.
     g_socket_set_blocking(pidSocket.get(), FALSE);
-    m_pidServerSocket = webkitSocketPair.server;
-    m_socketMonitor.start(pidSocket.get(), G_IO_IN, RunLoop::main(), [protectedThis = Ref { *this }, this, pidSocket](GIOCondition condition) -> gboolean {
+    m_socketMonitor.start(pidSocket.get(), G_IO_IN, RunLoop::main(), [protectedThis = Ref { *this }, this, pidSocket, serverSocket = WTFMove(webkitSocketPair.server)](GIOCondition condition) mutable -> gboolean {
         if (!(condition & G_IO_IN))
             g_error("Failed to read pid from child process");
 
@@ -268,9 +261,7 @@ void ProcessLauncher::launchProcess()
 
         m_socketMonitor.stop();
 
-        didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { m_pidServerSocket });
-        m_pidServerSocket = -1;
-
+        didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
         return G_SOURCE_REMOVE;
     });
 #else
@@ -281,8 +272,8 @@ void ProcessLauncher::launchProcess()
     m_processID = g_ascii_strtoll(processIdStr, nullptr, 0);
     RELEASE_ASSERT(m_processID);
 
-    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = webkitSocketPair.server] {
-        didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { serverSocket });
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = WTFMove(webkitSocketPair.server)] {
+        didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
     });
 #endif
 }

--- a/Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
+++ b/Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
@@ -64,12 +64,12 @@ void ProcessLauncher::launchProcess()
     IPC::SocketPair socketPair = IPC::createPlatformConnection(IPC::PlatformConnectionOptions::SetCloexecOnServer);
 
     int sendBufSize = 32 * 1024;
-    setsockopt(socketPair.server, SOL_SOCKET, SO_SNDBUF, &sendBufSize, 4);
-    setsockopt(socketPair.client, SOL_SOCKET, SO_SNDBUF, &sendBufSize, 4);
+    setsockopt(socketPair.server.value(), SOL_SOCKET, SO_SNDBUF, &sendBufSize, 4);
+    setsockopt(socketPair.client.value(), SOL_SOCKET, SO_SNDBUF, &sendBufSize, 4);
 
     int recvBufSize = 32 * 1024;
-    setsockopt(socketPair.server, SOL_SOCKET, SO_RCVBUF, &recvBufSize, 4);
-    setsockopt(socketPair.client, SOL_SOCKET, SO_RCVBUF, &recvBufSize, 4);
+    setsockopt(socketPair.server.value(), SOL_SOCKET, SO_RCVBUF, &recvBufSize, 4);
+    setsockopt(socketPair.client.value(), SOL_SOCKET, SO_RCVBUF, &recvBufSize, 4);
 
     char coreProcessIdentifierString[16];
     snprintf(coreProcessIdentifierString, sizeof coreProcessIdentifierString, "%ld", m_launchOptions.processIdentifier.toUInt64());
@@ -82,7 +82,7 @@ void ProcessLauncher::launchProcess()
 #if USE(WPE_BACKEND_PLAYSTATION)
     auto appLocalPid = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv, socketPair.client);
 #else
-    PlayStation::LaunchParam param { socketPair.client, m_launchOptions.userId };
+    PlayStation::LaunchParam param { socketPair.client.value(), m_launchOptions.userId };
     int32_t appLocalPid = PlayStation::launchProcess(
         !m_launchOptions.processPath.isEmpty() ? m_launchOptions.processPath.utf8().data() : defaultProcessPath(m_launchOptions.processType),
         argv, param);
@@ -94,12 +94,12 @@ void ProcessLauncher::launchProcess()
 #endif
         return;
     }
-    close(socketPair.client);
 
     // We've finished launching the process, message back to the main run loop.
+    IPC::Connection::Identifier serverIdentifier { WTFMove(socketPair.server) };
     RefPtr<ProcessLauncher> protectedThis(this);
     RunLoop::main().dispatch([=] {
-        protectedThis->didFinishLaunchingProcess(appLocalPid, IPC::Connection::Identifier { socketPair.server });
+        protectedThis->didFinishLaunchingProcess(appLocalPid, WTFMove(serverIdentifier));
     });
 }
 


### PR DESCRIPTION
#### 0b420fd88a458a0ba19beeb53b6447b6bfdbbb1c
<pre>
Use UnixFileDescriptor in IPC and ProcessLauncher
<a href="https://bugs.webkit.org/show_bug.cgi?id=280237">https://bugs.webkit.org/show_bug.cgi?id=280237</a>

Reviewed by Carlos Garcia Campos.

Using UnixFileDescriptor wherever possible makes it harder to
accidentally leak file descriptors.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::Identifier::operator bool const):
* Source/WebKit/Platform/IPC/IPCUtilities.h:
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::socketDescriptor const):
(IPC::Connection::platformInitialize):
(IPC::Connection::platformInvalidate):
(IPC::createPlatformConnection):
(IPC::Connection::createConnectionIdentifierPair):
* Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
(WebKit::ProcessLauncher::platformDestroy): Deleted.
* Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp:
(WebKit::ProcessLauncher::launchProcess):

Canonical link: <a href="https://commits.webkit.org/288001@main">https://commits.webkit.org/288001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77f1a4fd6cd4853354c264b421ef95c2b279025c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63654 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74225 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43943 "Failed to checkout and rebase branch from PR 34133") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/688 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31016 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71979 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71212 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14192 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->