### PR TITLE
mix-blend-mode stop working on a fixed layer if resolution is too large

### DIFF
--- a/LayoutTests/compositing/blend-mode/tiled-to-non-tiled-with-blend-mode-expected.html
+++ b/LayoutTests/compositing/blend-mode/tiled-to-non-tiled-with-blend-mode-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            background-color: silver;
+        }
+
+        .blending {
+            margin: 50px;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+            background-color: green;
+            mix-blend-mode: screen;
+        }
+        
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <div class="composited blending"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/blend-mode/tiled-to-non-tiled-with-blend-mode.html
+++ b/LayoutTests/compositing/blend-mode/tiled-to-non-tiled-with-blend-mode.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            background-color: silver;
+        }
+
+        .blending {
+            margin: 50px;
+            width: 2097px;
+            height: 200px;
+            border: 1px solid black;
+            background-color: green;
+            mix-blend-mode: screen;
+        }
+        
+        body.changed .blending {
+            width: 200px;
+        }
+        
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            document.body.classList.add('changed');
+            await UIHelper.renderingUpdate();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="composited blending"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4612,6 +4612,7 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
         | FiltersChanged
         | BackdropFiltersChanged
         | BackdropRootChanged
+        | BlendModeChanged
         | MaskLayerChanged
         | OpacityChanged
         | EventRegionChanged


### PR DESCRIPTION
#### 08a3623d456b76c16483a4b13c4d18eb1227d69b
<pre>
mix-blend-mode stop working on a fixed layer if resolution is too large
<a href="https://bugs.webkit.org/show_bug.cgi?id=250828">https://bugs.webkit.org/show_bug.cgi?id=250828</a>
<a href="https://rdar.apple.com/104686540">rdar://104686540</a>

Reviewed by Matt Woodrow.

When a composited layer goes between tiled and non-tiled mode, it would lose its blend mode.

Fix by adding `BlendModeChanged` to the list of dirty bits for things we update when the tiling
mode changes.

* LayoutTests/compositing/blend-mode/tiled-to-non-tiled-with-blend-mode-expected.html: Added.
* LayoutTests/compositing/blend-mode/tiled-to-non-tiled-with-blend-mode.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::changeLayerTypeTo):

Canonical link: <a href="https://commits.webkit.org/284163@main">https://commits.webkit.org/284163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33f0e3c6886997cd9b227633fdc887da1d2db084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54677 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13096 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3730 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43740 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->