### PR TITLE
[iOS] Tests under http/tests/css/css-masking/ fail consistently on iOS 18.0

### DIFF
--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
 <style>
     .container {
         display: inline-block;


### PR DESCRIPTION
#### a0f73d93cd1d6d2f9eecb161dd9f033ee89888ec
<pre>
[iOS] Tests under http/tests/css/css-masking/ fail consistently on iOS 18.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=280241">https://bugs.webkit.org/show_bug.cgi?id=280241</a>
<a href="https://rdar.apple.com/127327715">rdar://127327715</a>

Unreviewed test gardening. Adjust the pixel tolerance for these tests.

* LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html:
* LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html:
* LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html:

Canonical link: <a href="https://commits.webkit.org/284142@main">https://commits.webkit.org/284142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa20364d1a3cdb06a481017565df2d7d3a4c820e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19704 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19520 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13103 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62441 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74322 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16221 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62178 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15197 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10118 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3736 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->