### PR TITLE
mod_pywebsocket: module 'ssl' has no attribute 'wrap_socket' with Python 3.12

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/servers/websocket_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/websocket_server.py
@@ -125,7 +125,7 @@ class PyWebSocket(http_server_base.HttpServerBase):
         wpt_tools_base = self._filesystem.join(self._layout_tests, "imported", "w3c", "web-platform-tests", "tools")
         pywebsocket_base = self._filesystem.join(wpt_tools_base, "third_party", "pywebsocket3")
         pywebsocket_deps = [self._filesystem.join(wpt_tools_base, "third_party", "six")]
-        pywebsocket_script = self._filesystem.join(pywebsocket_base, 'mod_pywebsocket', 'standalone.py')
+        pywebsocket_script = self._filesystem.join(pywebsocket_base, 'pywebsocket3', 'standalone.py')
         start_cmd = [
             python_interp, '-u', pywebsocket_script,
             '--server-host', '0.0.0.0' if self._port_obj.get_option("http_all_interfaces") else 'localhost',


### PR DESCRIPTION
#### 447fa314e666e8b9bb28f296852afa28b1d966e6
<pre>
mod_pywebsocket: module &apos;ssl&apos; has no attribute &apos;wrap_socket&apos; with Python 3.12
<a href="https://bugs.webkit.org/show_bug.cgi?id=280224">https://bugs.webkit.org/show_bug.cgi?id=280224</a>

Reviewed by NOBODY (OOPS!).

run-webkit-tests was failing to start the WebSocket server with Python
3.12 due to an error in pywebsocket3/mod_pywebsocket/websocket_server.py.
&gt; AttributeError: module &apos;ssl&apos; has no attribute &apos;wrap_socket&apos;

&lt;<a href="https://github.com/web-platform-tests/wpt/commit/a7a594d8c03a850fd99bab1fd85bb6fe310081a2">https://github.com/web-platform-tests/wpt/commit/a7a594d8c03a850fd99bab1fd85bb6fe310081a2</a>&gt;
moved mod_pywebsocket/standalone.py to pywebsocket3/standalone.py.
&gt; rename tools/third_party/pywebsocket3/{mod_pywebsocket =&gt; pywebsocket3}/standalone.py (96%)
Then, &lt;<a href="https://github.com/web-platform-tests/wpt/commit/efa4a99b8dde1d9ab572efb9e1757e6900289bed">https://github.com/web-platform-tests/wpt/commit/efa4a99b8dde1d9ab572efb9e1757e6900289bed</a>&gt;
fixed the problem for the new one.

Switched run-webkit-tests to execute the new one.

I&apos;ll rerun import-w3c-tests with --clean-dest-dir switch to remove the
old mod_pywebsocket directory in a follow-up patch.

With the above change,
http/tests/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1.html
failed with an error message &quot;Compressed bit must be 0 if no
negotiated deflate-frame extension&quot;. Send a close frame as well as
&lt;<a href="https://github.com/web-platform-tests/wpt/blob/master/websockets/handlers/simple_handshake_wsh.py">https://github.com/web-platform-tests/wpt/blob/master/websockets/handlers/simple_handshake_wsh.py</a>&gt;.

* LayoutTests/http/tests/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1_wsh.py:
(web_socket_do_extra_handshake):
* Tools/Scripts/webkitpy/layout_tests/servers/websocket_server.py:
(PyWebSocket._prepare_config):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/447fa314e666e8b9bb28f296852afa28b1d966e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19711 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54792 "Found 6 new test failures: http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-comp-bit-onoff.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-parameter.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-set-bfinal.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-split-frames.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-unsolicited-negotiation-response.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-window-bits.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13227 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35257 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/68261 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16786 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16379 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62280 "Found 7 new test failures: http/tests/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-comp-bit-onoff.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-parameter.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-set-bfinal.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-split-frames.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-unsolicited-negotiation-response.html http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-window-bits.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62315 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3886 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43943 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->