### PR TITLE
[ Gardening ][ macOS ] 5x TestWebKitAPI.MediaSessionCoordinatorTest* (api-tests) are flaky failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
@@ -374,7 +374,12 @@ private:
     RetainPtr<NSMutableArray> _messageHandlers;
 };
 
+// rdar://136550811
+#if PLATFORM(MAC)
+TEST_F(MediaSessionCoordinatorTest, DISABLED_JoinAndLeave)
+#else
 TEST_F(MediaSessionCoordinatorTest, JoinAndLeave)
+#endif
 {
     loadPageAndBecomeReady("media-remote"_s);
     listenForPromiseMessages({ "join"_s });
@@ -421,7 +426,12 @@ TEST_F(MediaSessionCoordinatorTest, JoinAndLeave)
     EXPECT_STREQ("", coordinator().lastMethodCalled.UTF8String);
 }
 
+// rdar://136550811
+#if PLATFORM(MAC)
+TEST_F(MediaSessionCoordinatorTest, DISABLED_StateChanges)
+#else
 TEST_F(MediaSessionCoordinatorTest, StateChanges)
+#endif
 {
     loadPageAndBecomeReady("media-remote"_s);
 
@@ -477,7 +487,12 @@ TEST_F(MediaSessionCoordinatorTest, StateChanges)
     EXPECT_STREQ("closed", [state UTF8String]);
 }
 
+// rdar://136550811
+#if PLATFORM(MAC)
+TEST_F(MediaSessionCoordinatorTest, DISABLED_CoordinatorMethodCallbacks)
+#else
 TEST_F(MediaSessionCoordinatorTest, CoordinatorMethodCallbacks)
+#endif
 {
     loadPageAndBecomeReady("media-remote"_s);
 
@@ -508,7 +523,12 @@ TEST_F(MediaSessionCoordinatorTest, CoordinatorMethodCallbacks)
     }
 }
 
+// rdar://136550811
+#if PLATFORM(MAC)
+TEST_F(MediaSessionCoordinatorTest, DISABLED_CallSessionMethods)
+#else
 TEST_F(MediaSessionCoordinatorTest, CallSessionMethods)
+#endif
 {
     loadPageAndBecomeReady("media-remote"_s);
     listenForSessionHandlerMessages({ "play"_s, "pause"_s, "seekto"_s, "nexttrack"_s });
@@ -552,7 +572,12 @@ TEST_F(MediaSessionCoordinatorTest, CallSessionMethods)
     EXPECT_STREQ("setSessionTrack", lastMethodCalled.utf8().data());
 }
 
+// rdar://136550811
+#if PLATFORM(MAC)
+TEST_F(MediaSessionCoordinatorTest, DISABLED_JoinAndPrivateLeave)
+#else
 TEST_F(MediaSessionCoordinatorTest, JoinAndPrivateLeave)
+#endif
 {
     loadPageAndBecomeReady("media-remote"_s);
     listenForPromiseMessages({ "join"_s });


### PR DESCRIPTION
#### 2e90509e2a4db6dfb28c272112153d1607cedbd7
<pre>
[ Gardening ][ macOS ] 5x TestWebKitAPI.MediaSessionCoordinatorTest* (api-tests) are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=280244">https://bugs.webkit.org/show_bug.cgi?id=280244</a>
<a href="https://rdar.apple.com/136550811">rdar://136550811</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm:
(TestWebKitAPI::TEST_F(MediaSessionCoordinatorTest, JoinAndLeave)):
(TestWebKitAPI::TEST_F(MediaSessionCoordinatorTest, StateChanges)):
(TestWebKitAPI::TEST_F(MediaSessionCoordinatorTest, CoordinatorMethodCallbacks)):
(TestWebKitAPI::TEST_F(MediaSessionCoordinatorTest, CallSessionMethods)):
(TestWebKitAPI::TEST_F(MediaSessionCoordinatorTest, JoinAndPrivateLeave)):

Canonical link: <a href="https://commits.webkit.org/284132@main">https://commits.webkit.org/284132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d74ef5578938c5ae9dab1c2dc43ae88974ed795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21226 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/19712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/19712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71634 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/12538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/74330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/12578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10438 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/43760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/44576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->