### PR TITLE
[ Gardening ][ macOS ] 4x TestWebKitAPI.InWindowFullscreen* (api-tests) are flaky timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm
@@ -51,7 +51,12 @@ TEST(InWindowFullscreen, EmptyDocument)
     [webView _close];
 }
 
+// rdar://136551692
+#if PLATFORM(MAC)
+TEST(InWindowFullscreen, DISABLED_CanToggleAfterPlaybackStarts)
+#else
 TEST(InWindowFullscreen, CanToggleAfterPlaybackStarts)
+#endif
 {
     auto webView = createInWindowFullscreenWebView();
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
@@ -71,7 +76,12 @@ TEST(InWindowFullscreen, CanToggleAfterPlaybackStarts)
     [webView _close];
 }
 
+// rdar://136551692
+#if PLATFORM(MAC)
+TEST(InWindowFullscreen, DISABLED_ToggleChangesIsActive)
+#else
 TEST(InWindowFullscreen, ToggleChangesIsActive)
+#endif
 {
     auto webView = createInWindowFullscreenWebView();
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
@@ -102,7 +112,12 @@ TEST(InWindowFullscreen, ToggleChangesIsActive)
     [webView _close];
 }
 
+// rdar://136551692
+#if PLATFORM(MAC)
+TEST(InWindowFullscreen, DISABLED_EnterAndExitChangeIsActive)
+#else
 TEST(InWindowFullscreen, EnterAndExitChangeIsActive)
+#endif
 {
     auto webView = createInWindowFullscreenWebView();
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
@@ -133,7 +148,12 @@ TEST(InWindowFullscreen, EnterAndExitChangeIsActive)
     [webView _close];
 }
 
+// rdar://136551692
+#if PLATFORM(MAC)
+TEST(InWindowFullscreen, DISABLED_EnterChangesIsActiveWithoutUserGesture)
+#else
 TEST(InWindowFullscreen, EnterChangesIsActiveWithoutUserGesture)
+#endif
 {
     auto webView = createInWindowFullscreenWebView();
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];


### PR DESCRIPTION
#### dd2f7300b2fa6d90313353ad19ad95d6ed9fb05f
<pre>
[ Gardening ][ macOS ] 4x TestWebKitAPI.InWindowFullscreen* (api-tests) are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=280245">https://bugs.webkit.org/show_bug.cgi?id=280245</a>
<a href="https://rdar.apple.com/136551692">rdar://136551692</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm:
(TestWebKitAPI::TEST(InWindowFullscreen, CanToggleAfterPlaybackStarts)):
(TestWebKitAPI::TEST(InWindowFullscreen, ToggleChangesIsActive)):
(TestWebKitAPI::TEST(InWindowFullscreen, EnterAndExitChangeIsActive)):
(TestWebKitAPI::TEST(InWindowFullscreen, EnterChangesIsActiveWithoutUserGesture)):

Canonical link: <a href="https://commits.webkit.org/284134@main">https://commits.webkit.org/284134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a352192f9e9556fa14e938baafdd2490e0adce51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21227 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/19713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19529 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/19713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/16972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12539 "Failed to checkout and rebase branch from PR 34141") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/74331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/12579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43761 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->