### PR TITLE
Repeating background-image sized to the content-box fails to fill the viewport in an iframe

### DIFF
--- a/LayoutTests/fast/backgrounds/background-clip-on-root-expected.html
+++ b/LayoutTests/fast/backgrounds/background-clip-on-root-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            width: 700px;
+            height: 500px;
+            padding: 100px;
+            box-sizing: border-box;
+            background-image: url('../images/resources/red-green-blue-900-300.png');
+            background-size: contain;
+            background-origin: content-box;
+        }
+    </style>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/background-clip-on-root.html
+++ b/LayoutTests/fast/backgrounds/background-clip-on-root.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            border: none;
+            width: 700px;
+            height: 500px;
+            background-color: white;
+        }
+    </style>
+</head>
+<body>
+    <iframe srcdoc="
+    <style>
+        html {
+            height: 100%;
+            padding: 100px;
+            background-image: url('../images/resources/red-green-blue-900-300.png');
+            background-size: contain;
+            background-clip: content-box;
+            background-origin: content-box;
+            box-sizing: border-box;
+        }
+    </style>
+    "></iframe>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -442,7 +442,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         // Multiline inline boxes paint like the image was one long strip spanning lines. The backgroundImageStrip is this fictional rectangle.
         auto imageRect = backgroundImageStrip.isEmpty() ? scrolledPaintRect : backgroundImageStrip;
         auto paintOffset = backgroundImageStrip.isEmpty() ? rect.location() : backgroundImageStrip.location();
-        auto geometry = calculateBackgroundImageGeometry(m_renderer, m_paintInfo.paintContainer, bgLayer, paintOffset, imageRect, m_overrideClip);
+        auto geometry = calculateBackgroundImageGeometry(m_renderer, m_paintInfo.paintContainer, bgLayer, paintOffset, imageRect, m_overrideOrigin);
 
         auto& clientForBackgroundImage = backgroundObject ? *backgroundObject : m_renderer;
         bgImage->setContainerContextForRenderer(clientForBackgroundImage, geometry.tileSizeWithoutPixelSnapping, m_renderer.style().usedZoom());

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -60,6 +60,7 @@ public:
     BackgroundPainter(RenderBoxModelObject&, const PaintInfo&);
 
     void setOverrideClip(FillBox overrideClip) { m_overrideClip = overrideClip; }
+    void setOverrideOrigin(FillBox overrideOrigin) { m_overrideOrigin = overrideOrigin; }
 
     void paintBackground(const LayoutRect&, BackgroundBleedAvoidance) const;
 
@@ -84,6 +85,7 @@ private:
     RenderBoxModelObject& m_renderer;
     const PaintInfo& m_paintInfo;
     std::optional<FillBox> m_overrideClip;
+    std::optional<FillBox> m_overrideOrigin;
 };
 
 }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1429,8 +1429,10 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
         fillRect = LayoutRect { adjustedPaintOffset, size() };
     auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     BackgroundPainter painter { *this, paintInfo };
-    if (backgroundObject != this)
+    if (backgroundObject != this) {
         painter.setOverrideClip(FillBox::BorderBox);
+        painter.setOverrideOrigin(FillBox::BorderBox);
+    }
     painter.paintFillLayers(color, bgLayer, fillRect, BackgroundBleedNone, compositeOp, backgroundObject);
 }
 


### PR DESCRIPTION
#### 8dc84bd0499b8b77ad84e8c41d606b148a717c83
<pre>
Repeating background-image sized to the content-box fails to fill the viewport in an iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=278166">https://bugs.webkit.org/show_bug.cgi?id=278166</a>
<a href="https://rdar.apple.com/133952319">rdar://133952319</a>

Reviewed by Alan Baradlay.

283482@main fixed background-clip to not apply to the root. This should have fixed the behavior
seen in <a href="https://codepen.io/thebabydino/pen/GRbOXZp">https://codepen.io/thebabydino/pen/GRbOXZp</a> where WebKit failed to tile the gradient image,
however 282712@main introduced a regression; it conflated `background-clip` and `background-origin`
when passing the the `m_overrideClip` value to `calculateBackgroundImageGeometry()`, which caused
us to use the border-box as the background-origin at the root.

Fix by separating m_overrideClip from m_overrideOrigin in BackgroundPainter; the table code has
to set both.

* LayoutTests/fast/backgrounds/background-clip-on-root-expected.html: Added.
* LayoutTests/fast/backgrounds/background-clip-on-root.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
* Source/WebCore/rendering/BackgroundPainter.h:
(WebCore::BackgroundPainter::setOverrideOrigin):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):

Canonical link: <a href="https://commits.webkit.org/284165@main">https://commits.webkit.org/284165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ac70d5cfc857785db3650699d20542eac9b0ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54693 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13114 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74335 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62161 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3748 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43765 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->