### PR TITLE
[Win] WebCore/platform/win/SystemInfo.cpp: error: 'GetVersionExW' is deprecated

### DIFF
--- a/Source/WebCore/platform/win/SystemInfo.cpp
+++ b/Source/WebCore/platform/win/SystemInfo.cpp
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+IGNORE_CLANG_WARNINGS_BEGIN("deprecated-declarations")
+
 WindowsVersion windowsVersion(int* major, int* minor)
 {
     static bool initialized = false;
@@ -76,6 +78,8 @@ WindowsVersion windowsVersion(int* major, int* minor)
         *minor = minorVersion;
     return version;
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 static String osVersionForUAString()
 {


### PR DESCRIPTION
#### f036a16b0d4e20409f928643119f3a0cce3a90d7
<pre>
[Win] WebCore/platform/win/SystemInfo.cpp: error: &apos;GetVersionExW&apos; is deprecated
<a href="https://bugs.webkit.org/show_bug.cgi?id=280254">https://bugs.webkit.org/show_bug.cgi?id=280254</a>

Reviewed by Ross Kirsling.

Without -Wno-deprecated-declarations, Windows port can&apos;t compile due
to the following warning:

&gt; Source\WebCore\platform\win\SystemInfo.cpp(46,9): error: &apos;GetVersionExW&apos; is deprecated [-Werror,-Wdeprecated-declarations]

Chromium ignores the warning for it.
&lt;<a href="https://github.com/chromium/chromium/blob/9611525cd73157bf693c0c6c1fbc669649d067d8/base/win/windows_version.cc#L86-L94">https://github.com/chromium/chromium/blob/9611525cd73157bf693c0c6c1fbc669649d067d8/base/win/windows_version.cc#L86-L94</a>&gt;

* Source/WebCore/platform/win/SystemInfo.cpp:
Ignore the warning for GetVersionEx.

Canonical link: <a href="https://commits.webkit.org/284183@main">https://commits.webkit.org/284183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9992bb76f56f660e8bd1c4a114a0a300efebb445

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71648 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43845 "Too many flaky failures: fast/events/ios/activating-button-should-not-scroll-page.html, fast/events/ios/activating-checkbox-should-not-scroll-page.html, fast/events/ios/activating-radio-button-should-not-scroll-page.html, fast/events/ios/activating-reset-button-should-not-scroll-page.html, fast/events/ios/activating-submit-button-should-not-scroll-page.html, fast/events/ios/keypress-keys-in-non-editable-element.html, fast/events/ios/tab-into-text-field-inside-iframe.html, fast/forms/ios/focus-input-via-button.html, fast/forms/ios/focus-reset-button.html, fast/forms/ios/focus-ring-size.html, fast/forms/ios/focus-search-field.html, fast/forms/ios/focus-submit-button.html, fast/forms/ios/focus-text-field.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59218 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35162 "Found 1 new API test failure: /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16641 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62197 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3756 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43774 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->