### PR TITLE
[ iOS ] css3/filters/backdrop-filter-page-scale.html is a flaky image failure.

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7451,9 +7451,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-ze
 # webkit.org/b/278233 imported/w3c/web-platform-tests/websockets/basic-auth.any.sharedworker.html?wss is flakey failure on iOS Sim
 imported/w3c/web-platform-tests/websockets/basic-auth.any.sharedworker.html?wss [ Pass Failure ]
 
-# webkit.org/b/278323 REGRESSION(282170@main): [ iOS ] css3/filters/backdrop-filter-page-scale.html is a flaky image failure
-css3/filters/backdrop-filter-page-scale.html [ Pass ImageOnlyFailure ]
-
 # webkit.org/b/277841 REGRESSION (281870@main): [ macOS iOS wk2 ] imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html is a flaky failure
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1006,13 +1006,15 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << layerTreeTransaction.pageScaleFactor());
 
         // When web-process-originated scale changes occur, pin the
-        // vertical scroll position to the top edge of the content,
+        // scroll position to the top edge of the content,
         // instead of the center (which UIScrollView does by default).
-        CGFloat contentOffsetY = [_scrollView contentOffset].y * layerTreeTransaction.pageScaleFactor() / [_scrollView zoomScale];
+        CGFloat scaleRatio = layerTreeTransaction.pageScaleFactor() / [_scrollView zoomScale];
+        CGFloat contentOffsetY = [_scrollView contentOffset].y * scaleRatio;
+        CGFloat contentOffsetX = [_scrollView contentOffset].x * scaleRatio;
 
         [_scrollView setZoomScale:layerTreeTransaction.pageScaleFactor()];
 
-        changeContentOffsetBoundedInValidRange(_scrollView.get(), CGPointMake([_scrollView contentOffset].x, contentOffsetY));
+        changeContentOffsetBoundedInValidRange(_scrollView.get(), CGPointMake(contentOffsetX, contentOffsetY));
     }
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -212,10 +212,10 @@ Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
 
 void WebPageProxyTesting::setPageScaleFactor(float scaleFactor, IntPoint point, CompletionHandler<void()>&& completionHandler)
 {
-    Ref callback = CallbackAggregator::create(WTFMove(completionHandler));
     protectedPage()->forEachWebContentProcess([&](auto& process, auto pageID) {
-        process.sendWithAsyncReply(Messages::WebPageTesting::SetPageScaleFactor(scaleFactor, point), [callback] { }, pageID);
+        process.send(Messages::WebPageTesting::SetPageScaleFactor(scaleFactor, point), pageID);
     });
+    protectedPage()->callAfterNextPresentationUpdate(WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -117,13 +117,11 @@ void WebPageTesting::setTopContentInset(float contentInset, CompletionHandler<vo
     completionHandler();
 }
 
-void WebPageTesting::setPageScaleFactor(double scale, IntPoint origin, CompletionHandler<void()>&& completionHandler)
+void WebPageTesting::setPageScaleFactor(double scale, IntPoint origin)
 {
     RefPtr page = m_page->corePage();
-    if (!page)
-        return completionHandler();
-    page->setPageScaleFactor(scale, origin);
-    completionHandler();
+    if (page)
+        page->setPageScaleFactor(scale, origin);
 }
 
 Ref<WebPage> WebPageTesting::protectedPage() const

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -64,7 +64,7 @@ private:
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
 
-    void setPageScaleFactor(double scale, WebCore::IntPoint origin, CompletionHandler<void()>&&);
+    void setPageScaleFactor(double scale, WebCore::IntPoint origin);
 
     void clearWheelEventTestMonitor();
     Ref<WebPage> protectedPage() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -33,5 +33,5 @@ messages -> WebPageTesting NotRefCounted {
     ClearWheelEventTestMonitor()
 
     SetTopContentInset(float contentInset) -> ()
-    SetPageScaleFactor(double scale, WebCore::IntPoint origin) -> ()
+    SetPageScaleFactor(double scale, WebCore::IntPoint origin)
 }


### PR DESCRIPTION
#### b7e4c4a702a5b14d31790daf0a89850516b5ddf2
<pre>
[ iOS ] css3/filters/backdrop-filter-page-scale.html is a flaky image failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280260">https://bugs.webkit.org/show_bug.cgi?id=280260</a>
&lt;<a href="https://rdar.apple.com/134269886">rdar://134269886</a>&gt;

Reviewed by Wenson Hsieh.

The main change here is extending the fix in 258521@main to apply to the X axis
as well.

This test applies a page scale (with no offset) in the WebProcess (via a
WebPageProxy).  When this reaches WkWebViewIOS in the following
RemoteLayerTreeTransaction, it applies the same zoomScale, and zooms towards the
middle in the X axis. This leaves the left 200px offscreen (which includes all
the test content).  updateVisibleContentRects is then sent back to the
WebProcess with the new scroll offset, which calls setPageScaleFactor a second
time, with the scroll offset.

This test regressed by making it more async, which gives time for this multiple
transaction scrolling to take place, and then the test content is sometimes
offscreen.

This also fixes the TestRunner setPageScaleFactor setter to wait until a
rendering update has been done with the new page scale, before allowing tests to
complete.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::setPageScaleFactor):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::setPageScaleFactor):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:

Canonical link: <a href="https://commits.webkit.org/284197@main">https://commits.webkit.org/284197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1003b5305a69075e601b35b05ee066f64dc6157

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19850 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13193 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35226 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74468 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16338 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62243 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-translate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62271 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15253 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3848 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43898 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44972 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->