### PR TITLE
[scroll-animations] update `Animation` to use `CSSNumberish`

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -75,7 +75,7 @@ EffectTiming AnimationEffect::getBindingsTiming() const
     return timing;
 }
 
-std::optional<Seconds> AnimationEffect::localTime(std::optional<Seconds> startTime) const
+std::optional<CSSNumberishTime> AnimationEffect::localTime(std::optional<CSSNumberishTime> startTime) const
 {
     // 4.5.4. Local time
     // https://drafts.csswg.org/web-animations-1/#local-time-section
@@ -93,7 +93,7 @@ double AnimationEffect::playbackRate() const
     return m_animation ? m_animation->playbackRate() : 1;
 }
 
-BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<Seconds> startTime) const
+BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<CSSNumberishTime> startTime) const
 {
     return m_timing.getBasicTiming(localTime(startTime), playbackRate());
 }
@@ -105,7 +105,7 @@ ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
     return getComputedTiming();
 }
 
-ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<Seconds> startTime) const
+ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<CSSNumberishTime> startTime) const
 {
     auto localTime = this->localTime(startTime);
     auto resolvedTiming = m_timing.resolve(localTime, playbackRate());

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -56,9 +56,9 @@ public:
     virtual bool isKeyframeEffect() const { return false; }
 
     EffectTiming getBindingsTiming() const;
-    BasicEffectTiming getBasicTiming(std::optional<Seconds> = std::nullopt) const;
+    BasicEffectTiming getBasicTiming(std::optional<CSSNumberishTime> = std::nullopt) const;
     ComputedEffectTiming getBindingsComputedTiming() const;
-    ComputedEffectTiming getComputedTiming(std::optional<Seconds> = std::nullopt) const;
+    ComputedEffectTiming getComputedTiming(std::optional<CSSNumberishTime> = std::nullopt) const;
     ExceptionOr<void> bindingsUpdateTiming(Document&, std::optional<OptionalEffectTiming>);
     ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
 
@@ -114,7 +114,7 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    std::optional<Seconds> localTime(std::optional<Seconds>) const;
+    std::optional<CSSNumberishTime> localTime(std::optional<CSSNumberishTime>) const;
     double playbackRate() const;
 
     AnimationEffectTiming m_timing;

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -178,7 +178,7 @@ void CSSAnimation::setBindingsEffect(RefPtr<AnimationEffect>&& newEffect)
     }
 }
 
-ExceptionOr<void> CSSAnimation::setBindingsStartTime(const std::optional<CSSNumberish>& startTime)
+ExceptionOr<void> CSSAnimation::setBindingsStartTime(const std::optional<CSSNumberishTime>& startTime)
 {
     // https://drafts.csswg.org/css-animations-2/#animations
 

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -59,7 +59,7 @@ private:
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;
     void setBindingsEffect(RefPtr<AnimationEffect>&&) final;
-    ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberish>&) final;
+    ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberishTime>&) final;
     ExceptionOr<void> bindingsReverse() final;
 
     enum class Property : uint16_t {

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -35,6 +35,7 @@ public:
     CSSNumberishTime() = default;
 
     CSSNumberishTime(double);
+    CSSNumberishTime(Seconds);
     CSSNumberishTime(CSSNumberish);
 
     std::optional<Seconds> time() const;
@@ -49,7 +50,22 @@ public:
     bool operator>(CSSNumberishTime) const;
     bool operator>=(CSSNumberishTime) const;
 
+    CSSNumberishTime operator+(Seconds) const;
+    CSSNumberishTime operator-(Seconds) const;
+    bool operator<(Seconds) const;
+    bool operator<=(Seconds) const;
+    bool operator>(Seconds) const;
+    bool operator>=(Seconds) const;
+    bool operator==(Seconds) const;
+
+    CSSNumberishTime operator*(double) const;
+    CSSNumberishTime operator/(double) const;
+
+    operator double() const;
+    operator Seconds() const;
     operator CSSNumberish() const;
+
+    void dump(TextStream&) const;
 
 private:
     enum class Type : uint8_t { Unknown, Time, Percentage };
@@ -61,5 +77,7 @@ private:
     Source m_source { Source::Literal };
     double m_value { 0 };
 };
+
+TextStream& operator<<(TextStream&, CSSNumberishTime);
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2029,7 +2029,9 @@ void KeyframeEffect::applyPendingAcceleratedActions()
     m_pendingAcceleratedActions.clear();
 
     // To simplify the code we use a default of 0s for an unresolved current time since for a Stop action that is acceptable.
-    auto timeOffset = animation()->currentTime().value_or(0_s).seconds() - delay().seconds();
+    auto cssNumberishTimeOffset = animation()->currentTime().value_or(0_s) - delay();
+    ASSERT(cssNumberishTimeOffset.time());
+    auto timeOffset = cssNumberishTimeOffset.time()->seconds();
 
     auto startAnimation = [&]() -> RunningAccelerated {
         if (isRunningAccelerated())

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -131,13 +131,13 @@ void StyleOriginatedAnimation::syncPropertiesWithBackingAnimation()
 {
 }
 
-std::optional<double> StyleOriginatedAnimation::bindingsStartTime() const
+std::optional<CSSNumberishTime> StyleOriginatedAnimation::bindingsStartTime() const
 {
     flushPendingStyleChanges();
     return WebAnimation::bindingsStartTime();
 }
 
-std::optional<double> StyleOriginatedAnimation::bindingsCurrentTime() const
+std::optional<CSSNumberishTime> StyleOriginatedAnimation::bindingsCurrentTime() const
 {
     flushPendingStyleChanges();
     return WebAnimation::bindingsCurrentTime();

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -52,8 +52,8 @@ public:
     void setBackingAnimation(const Animation&);
     void cancelFromStyle(WebAnimation::Silently = WebAnimation::Silently::No);
 
-    std::optional<double> bindingsStartTime() const final;
-    std::optional<double> bindingsCurrentTime() const final;
+    std::optional<CSSNumberishTime> bindingsStartTime() const final;
+    std::optional<CSSNumberishTime> bindingsCurrentTime() const final;
     WebAnimation::PlayState bindingsPlayState() const final;
     WebAnimation::ReplaceState bindingsReplaceState() const final;
     bool bindingsPending() const final;

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -83,8 +83,8 @@ public:
     AnimationTimeline* timeline() const { return m_timeline.get(); }
     virtual void setTimeline(RefPtr<AnimationTimeline>&&);
 
-    std::optional<Seconds> currentTime(std::optional<Seconds> = std::nullopt) const;
-    ExceptionOr<void> setCurrentTime(std::optional<Seconds>);
+    std::optional<CSSNumberishTime> currentTime(std::optional<CSSNumberishTime> = std::nullopt) const;
+    ExceptionOr<void> setCurrentTime(std::optional<CSSNumberishTime>);
 
     double playbackRate() const { return m_playbackRate + 0; }
     void setPlaybackRate(double);
@@ -115,12 +115,12 @@ public:
     void persist();
     ExceptionOr<void> commitStyles();
 
-    virtual std::optional<double> bindingsStartTime() const;
-    virtual ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberish>&);
-    std::optional<Seconds> startTime() const { return m_startTime; }
-    void setStartTime(std::optional<Seconds>);
-    virtual std::optional<double> bindingsCurrentTime() const;
-    virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<CSSNumberish>&);
+    virtual std::optional<CSSNumberishTime> bindingsStartTime() const;
+    virtual ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberishTime>&);
+    std::optional<CSSNumberishTime> startTime() const { return m_startTime; }
+    void setStartTime(std::optional<CSSNumberishTime>);
+    virtual std::optional<CSSNumberishTime> bindingsCurrentTime() const;
+    virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<CSSNumberishTime>&);
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }
     virtual bool bindingsPending() const { return pending(); }
@@ -128,7 +128,7 @@ public:
     virtual FinishedPromise& bindingsFinished() { return finished(); }
     virtual ExceptionOr<void> bindingsPlay() { return play(); }
     virtual ExceptionOr<void> bindingsPause() { return pause(); }
-    std::optional<Seconds> holdTime() const { return m_holdTime; }
+    std::optional<CSSNumberishTime> holdTime() const { return m_holdTime; }
 
     virtual std::variant<FramesPerSecond, AnimationFrameRatePreset> bindingsFrameRate() const { return m_bindingsFrameRate; }
     virtual void setBindingsFrameRate(std::variant<FramesPerSecond, AnimationFrameRatePreset>&&);
@@ -179,14 +179,13 @@ private:
     enum class AutoRewind : bool { No, Yes };
     enum class TimeToRunPendingTask : uint8_t { NotScheduled, ASAP, WhenReady };
 
-    ExceptionOr<std::optional<Seconds>> validateCSSNumberishValue(const std::optional<CSSNumberish>&) const;
     void timingDidChange(DidSeek, SynchronouslyNotify, Silently = Silently::No);
     void updateFinishedState(DidSeek, SynchronouslyNotify);
     Seconds effectEndTime() const;
     WebAnimation& readyPromiseResolve();
     WebAnimation& finishedPromiseResolve();
-    std::optional<Seconds> currentTime(RespectHoldTime, std::optional<Seconds> = std::nullopt) const;
-    ExceptionOr<void> silentlySetCurrentTime(std::optional<Seconds>);
+    std::optional<CSSNumberishTime> currentTime(RespectHoldTime, std::optional<CSSNumberishTime> = std::nullopt) const;
+    ExceptionOr<void> silentlySetCurrentTime(std::optional<CSSNumberishTime>);
     void finishNotificationSteps();
     bool hasPendingPauseTask() const { return m_timeToRunPendingPauseTask != TimeToRunPendingTask::NotScheduled; }
     bool hasPendingPlayTask() const { return m_timeToRunPendingPlayTask != TimeToRunPendingTask::NotScheduled; }
@@ -217,9 +216,9 @@ private:
     RefPtr<AnimationTimeline> m_timeline;
     UniqueRef<ReadyPromise> m_readyPromise;
     UniqueRef<FinishedPromise> m_finishedPromise;
-    Markable<Seconds, Seconds::MarkableTraits> m_previousCurrentTime;
-    Markable<Seconds, Seconds::MarkableTraits> m_startTime;
-    Markable<Seconds, Seconds::MarkableTraits> m_holdTime;
+    std::optional<CSSNumberishTime> m_previousCurrentTime;
+    std::optional<CSSNumberishTime> m_startTime;
+    std::optional<CSSNumberishTime> m_holdTime;
     MarkableDouble m_pendingPlaybackRate;
     double m_playbackRate { 1 };
     std::variant<FramesPerSecond, AnimationFrameRatePreset> m_bindingsFrameRate { AnimationFrameRatePreset::Auto };

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -213,8 +213,8 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const IntRect
         m_paused = animation->playState() == WebAnimation::PlayState::Paused;
         m_playbackRate = animation->playbackRate();
         ASSERT(animation->holdTime() || animation->startTime());
-        m_holdTime = animation->holdTime();
-        m_startTime = animation->startTime();
+        m_holdTime = animation->holdTime() ? animation->holdTime()->time() : std::nullopt;
+        m_startTime = animation->startTime() ? animation->startTime()->time() : std::nullopt;
         if (auto* styleAnimation = dynamicDowncast<StyleOriginatedAnimation>(*animation)) {
             if (auto* defaultKeyframeTimingFunction = styleAnimation->backingAnimation().timingFunction())
                 m_defaultKeyframeTimingFunction = defaultKeyframeTimingFunction;


### PR DESCRIPTION
#### 5a5dc44dab988042b54b60d53a007d67a355912b
<pre>
[scroll-animations] update `Animation` to use `CSSNumberish`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279729">https://bugs.webkit.org/show_bug.cgi?id=279729</a>
<a href="https://rdar.apple.com/136031116">rdar://136031116</a>

Reviewed by Tim Nguyen.

The `Animation` interface uses `CSSNumberish?` for the `startTime` and `currentTime` properties.
Up to now, we would validate the values provided through the bindings and store time values as
`std::optional&lt;Seconds&gt;`.

In order to support Scroll-driven Animations, we now store such values as `std::optional&lt;CSSNumberishTime&gt;`
so that we can represent both time values, but also percentages. This requires refactoring a number
of methods throughout the animation code to no longer use `Seconds`, but also adding functionality
to `CSSNumberishTime` such that it can:

- automatically convert to and from `Seconds`,
- perform simple arithmetic operations and comparisons with `Seconds`,
- automatically convert to and from `double` (with values being milliseconds, as in the Web Animations API).

Since our animation code still relies on time-based values through and through, `CSSNumberishTime::isValid()`
still requires time values, but as we implement more of the Scroll-driven Animations functionality, we will
add the relevant specific code to determine whether times are valid based on the associated timeline type.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::localTime const):
(WebCore::AnimationEffect::getBasicTiming const):
(WebCore::AnimationEffect::getComputedTiming const):
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::setBindingsStartTime):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::CSSNumberishTime):
(WebCore::CSSNumberishTime::isValid const):
(WebCore::CSSNumberishTime::operator+ const):
(WebCore::CSSNumberishTime::operator- const):
(WebCore::CSSNumberishTime::operator&lt; const):
(WebCore::CSSNumberishTime::operator&lt;= const):
(WebCore::CSSNumberishTime::operator&gt; const):
(WebCore::CSSNumberishTime::operator&gt;= const):
(WebCore::CSSNumberishTime::operator== const):
(WebCore::CSSNumberishTime::operator* const):
(WebCore::CSSNumberishTime::operator/ const):
(WebCore::CSSNumberishTime::operator double const):
(WebCore::CSSNumberishTime::operator Seconds const):
(WebCore::CSSNumberishTime::dump const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::bindingsStartTime const):
(WebCore::StyleOriginatedAnimation::bindingsCurrentTime const):
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::bindingsStartTime const):
(WebCore::WebAnimation::setBindingsStartTime):
(WebCore::WebAnimation::setStartTime):
(WebCore::WebAnimation::bindingsCurrentTime const):
(WebCore::WebAnimation::setBindingsCurrentTime):
(WebCore::WebAnimation::currentTime const):
(WebCore::WebAnimation::silentlySetCurrentTime):
(WebCore::WebAnimation::setCurrentTime):
(WebCore::WebAnimation::updateFinishedState):
(WebCore::WebAnimation::play):
(WebCore::WebAnimation::validateCSSNumberishValue const): Deleted.
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::startTime const):
(WebCore::WebAnimation::holdTime const):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):

Canonical link: <a href="https://commits.webkit.org/284160@main">https://commits.webkit.org/284160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/612feacb8faee04bfe12be57e2afccdc687b0406

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47992 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21259 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54710 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71667 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43859 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 13 new passes 3 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35173 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40526 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 4 new passes 3 flakes 1 failures; Uploaded test results; 4 new passes 6 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18102 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74363 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67848 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16255 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62186 "Found 1 new test failure: compositing/repaint/copy-forward-dirty-region-purged.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3769 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10450 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43793 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->