### PR TITLE
Refactor MathML padding/border handling

### DIFF
--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -262,6 +262,27 @@ void RenderMathMLBlock::layoutFloatingChildren()
     }
 }
 
+void RenderMathMLBlock::shiftInFlowChildren(LayoutUnit left, LayoutUnit top)
+{
+    LayoutPoint shift(left, top);
+    for (auto* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox())
+        child->setLocation(child->location() + shift);
+}
+
+void RenderMathMLBlock::adjustPreferredLogicalWidthsForBorderAndPadding()
+{
+    ASSERT(preferredLogicalWidthsDirty());
+    m_minPreferredLogicalWidth += borderAndPaddingLogicalWidth();
+    m_maxPreferredLogicalWidth += borderAndPaddingLogicalWidth();
+}
+
+void RenderMathMLBlock::adjustLayoutForBorderAndPadding()
+{
+    setLogicalWidth(logicalWidth() + borderAndPaddingLogicalWidth());
+    setLogicalHeight(logicalHeight() + borderAndPaddingLogicalHeight());
+    shiftInFlowChildren(style().isLeftToRightDirection() ? borderAndPaddingStart() : borderAndPaddingEnd(), borderAndPaddingBefore());
+}
+
 }
 
 #endif

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
@@ -77,6 +77,10 @@ protected:
     void insertPositionedChildrenIntoContainingBlock();
     void layoutFloatingChildren();
 
+    void shiftInFlowChildren(LayoutUnit left, LayoutUnit top);
+    void adjustPreferredLogicalWidthsForBorderAndPadding();
+    void adjustLayoutForBorderAndPadding();
+
 private:
     bool isRenderMathMLBlock() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderMathMLBlock"_s; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
@@ -99,7 +99,7 @@ void RenderMathMLMath::layoutBlock(bool relayoutChildren, LayoutUnit pageLogical
         centerChildren(width);
     else
         setLogicalWidth(width);
-    shiftRowItems(0_lu, borderAndPaddingBefore());
+    shiftInFlowChildren(0_lu, borderAndPaddingBefore());
 
     setLogicalHeight(ascent + descent + borderAndPaddingLogicalHeight() + horizontalScrollbarHeight());
     updateLogicalHeight();

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
@@ -164,8 +164,10 @@ void RenderMathMLMenclose::computePreferredLogicalWidths()
 
     LayoutUnit preferredWidth = preferredLogicalWidthOfRowItems();
     SpaceAroundContent space = spaceAroundContent(preferredWidth, 0);
-    preferredWidth += space.left + space.right + borderAndPaddingLogicalWidth();
+    preferredWidth += space.left + space.right;
     m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth = preferredWidth;
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
 
     setPreferredLogicalWidthsDirty(false);
 }
@@ -190,15 +192,14 @@ void RenderMathMLMenclose::layoutBlock(bool relayoutChildren, LayoutUnit)
     layoutRowItems(contentWidth, contentAscent);
 
     SpaceAroundContent space = spaceAroundContent(contentWidth, contentAscent + contentDescent);
-    space.left += borderLeft() + paddingLeft();
-    space.right += borderRight() + paddingRight();
-    space.top += borderAndPaddingBefore();
-    space.bottom += borderAndPaddingAfter();
     setLogicalWidth(space.left + contentWidth + space.right);
     setLogicalHeight(space.top + contentAscent + contentDescent + space.bottom);
-    shiftRowItems(space.left, space.top);
+    shiftInFlowChildren(space.left, space.top);
 
     m_contentRect = LayoutRect(space.left, space.top, contentWidth, contentAscent + contentDescent);
+
+    adjustLayoutForBorderAndPadding();
+    m_contentRect.moveBy(LayoutPoint(borderLeft() + paddingLeft(), borderAndPaddingBefore()));
 
     layoutPositionedObjects(relayoutChildren);
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -249,9 +249,7 @@ void RenderMathMLOperator::layoutBlock(bool relayoutChildren, LayoutUnit pageLog
         setLogicalWidth(width);
 
         // We then move the children to take spacing into account.
-        LayoutPoint horizontalShift(style().direction() == TextDirection::LTR ? leadingSpaceValue : -leadingSpaceValue, 0_lu);
-        for (auto* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox())
-            child->setLocation(child->location() + horizontalShift);
+        shiftInFlowChildren(style().direction() == TextDirection::LTR ? leadingSpaceValue : -leadingSpaceValue, 0_lu);
     }
 
     updateScrollInfoAfterLayout();

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
@@ -78,8 +78,10 @@ void RenderMathMLPadded::computePreferredLogicalWidths()
     // Only the width attribute should modify the width.
     // We parse it using the preferred width of the content as its default value.
     LayoutUnit preferredWidth = preferredLogicalWidthOfRowItems();
-    preferredWidth = mpaddedWidth(preferredWidth) + borderAndPaddingLogicalWidth();
+    preferredWidth = mpaddedWidth(preferredWidth);
     m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth = preferredWidth;
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
 
     setPreferredLogicalWidthsDirty(false);
 }
@@ -105,16 +107,18 @@ void RenderMathMLPadded::layoutBlock(bool relayoutChildren, LayoutUnit)
     layoutRowItems(contentWidth, contentAscent);
 
     // We parse the mpadded attributes using the content metrics as the default value.
-    LayoutUnit width = mpaddedWidth(contentWidth) + borderAndPaddingLogicalWidth();
-    LayoutUnit ascent = mpaddedHeight(contentAscent) + borderAndPaddingBefore();
-    LayoutUnit descent = mpaddedDepth(contentDescent) + borderAndPaddingAfter();
+    LayoutUnit width = mpaddedWidth(contentWidth);
+    LayoutUnit ascent = mpaddedHeight(contentAscent);
+    LayoutUnit descent = mpaddedDepth(contentDescent);
 
     // Align children on the new baseline and shift them by (lspace, -voffset)
-    shiftRowItems(borderLeft() + paddingLeft() + lspace(), ascent - contentAscent - voffset());
+    shiftInFlowChildren(lspace(), ascent - contentAscent - voffset());
 
     // Set the final metrics.
     setLogicalWidth(width);
     setLogicalHeight(ascent + descent);
+
+    adjustLayoutForBorderAndPadding();
 
     layoutPositionedObjects(relayoutChildren);
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -179,9 +179,10 @@ void RenderMathMLRoot::computePreferredLogicalWidths()
         preferredWidth += m_radicalOperator.maxPreferredWidth();
         preferredWidth += getBase().maxPreferredLogicalWidth() + marginIntrinsicLogicalWidthForChild(getBase());
     }
-    preferredWidth += borderAndPaddingLogicalWidth();
-
     m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = preferredWidth;
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
+
     setPreferredLogicalWidthsDirty(false);
 }
 
@@ -236,12 +237,12 @@ void RenderMathMLRoot::layoutBlock(bool relayoutChildren, LayoutUnit)
 
     // We set the logical width.
     if (rootType() == RootType::SquareRoot)
-        setLogicalWidth(m_radicalOperator.width() + m_baseWidth + borderAndPaddingLogicalWidth());
+        setLogicalWidth(m_radicalOperator.width() + m_baseWidth);
     else {
         ASSERT(rootType() == RootType::RootWithIndex);
         LayoutUnit indexWidth = getIndex().logicalWidth() + getIndex().marginLogicalWidth();
         horizontal = horizontalParameters(indexWidth);
-        setLogicalWidth(horizontal.kernBeforeDegree + indexWidth + horizontal.kernAfterDegree + m_radicalOperator.width() + m_baseWidth + borderAndPaddingLogicalWidth());
+        setLogicalWidth(horizontal.kernBeforeDegree + indexWidth + horizontal.kernAfterDegree + m_radicalOperator.width() + m_baseWidth);
     }
 
     // For <mroot>, we update the metrics to take into account the index.
@@ -251,12 +252,10 @@ void RenderMathMLRoot::layoutBlock(bool relayoutChildren, LayoutUnit)
         indexDescent = getIndex().logicalHeight() + getIndex().marginLogicalHeight() - indexAscent;
         ascent = std::max<LayoutUnit>(radicalAscent, indexBottomRaise + indexDescent + indexAscent - descent);
     }
-    ascent += borderAndPaddingBefore();
-    descent += borderAndPaddingAfter();
 
     // We set the final position of children.
     m_radicalOperatorTop = ascent - radicalAscent + vertical.extraAscender;
-    LayoutUnit horizontalOffset = borderAndPaddingStart() + m_radicalOperator.width();
+    LayoutUnit horizontalOffset = m_radicalOperator.width();
     if (rootType() == RootType::RootWithIndex)
         horizontalOffset += horizontal.kernBeforeDegree + getIndex().logicalWidth() + getIndex().marginLogicalWidth() + horizontal.kernAfterDegree;
     if (rootType() == RootType::SquareRoot) {
@@ -267,11 +266,13 @@ void RenderMathMLRoot::layoutBlock(bool relayoutChildren, LayoutUnit)
         ASSERT(rootType() == RootType::RootWithIndex);
         LayoutPoint baseLocation(mirrorIfNeeded(horizontalOffset + getBase().marginStart(), getBase()), ascent - baseAscent + getBase().marginBefore());
         getBase().setLocation(baseLocation);
-        LayoutPoint indexLocation(mirrorIfNeeded(borderAndPaddingStart() + horizontal.kernBeforeDegree + getIndex().marginStart(), getIndex()), ascent + descent - indexBottomRaise - indexDescent - indexAscent + getIndex().marginBefore());
+        LayoutPoint indexLocation(mirrorIfNeeded(horizontal.kernBeforeDegree + getIndex().marginStart(), getIndex()), ascent + descent - indexBottomRaise - indexDescent - indexAscent + getIndex().marginBefore());
         getIndex().setLocation(indexLocation);
     }
 
     setLogicalHeight(ascent + descent);
+
+    adjustLayoutForBorderAndPadding();
 
     layoutPositionedObjects(relayoutChildren);
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -132,7 +132,9 @@ void RenderMathMLRow::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());
 
-    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = preferredLogicalWidthOfRowItems() + borderAndPaddingLogicalWidth();
+    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = preferredLogicalWidthOfRowItems();
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
 
     setPreferredLogicalWidthsDirty(false);
 }
@@ -155,13 +157,6 @@ void RenderMathMLRow::layoutRowItems(LayoutUnit width, LayoutUnit ascent)
     }
 }
 
-void RenderMathMLRow::shiftRowItems(LayoutUnit left, LayoutUnit top)
-{
-    LayoutPoint shift(left, top);
-    for (auto* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox())
-        child->setLocation(child->location() + shift);
-}
-
 void RenderMathMLRow::layoutBlock(bool relayoutChildren, LayoutUnit)
 {
     ASSERT(needsLayout());
@@ -182,9 +177,11 @@ void RenderMathMLRow::layoutBlock(bool relayoutChildren, LayoutUnit)
     stretchVerticalOperatorsAndLayoutChildren();
     getContentBoundingBox(width, ascent, descent);
     layoutRowItems(width, ascent);
-    setLogicalWidth(width + borderAndPaddingLogicalWidth());
-    setLogicalHeight(ascent + descent + borderAndPaddingLogicalHeight() + scrollbarLogicalHeight());
-    shiftRowItems(borderLeft() + paddingLeft(), borderAndPaddingBefore());
+    setLogicalWidth(width);
+    setLogicalHeight(ascent + descent);
+
+    adjustLayoutForBorderAndPadding();
+
     updateLogicalHeight();
 
     layoutPositionedObjects(relayoutChildren);

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.h
@@ -49,7 +49,6 @@ protected:
     void stretchVerticalOperatorsAndLayoutChildren();
     void getContentBoundingBox(LayoutUnit& width, LayoutUnit& ascent, LayoutUnit& descent) const;
     void layoutRowItems(LayoutUnit width, LayoutUnit ascent);
-    void shiftRowItems(LayoutUnit left, LayoutUnit top);
     LayoutUnit preferredLogicalWidthOfRowItems();
     void computePreferredLogicalWidths() override;
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -231,8 +231,9 @@ void RenderMathMLScripts::computePreferredLogicalWidths()
     }
     }
 
-    m_maxPreferredLogicalWidth += borderAndPaddingLogicalWidth();
     m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth;
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
 
     setPreferredLogicalWidthsDirty(false);
 }
@@ -388,10 +389,10 @@ void RenderMathMLScripts::layoutBlock(bool relayoutChildren, LayoutUnit)
     LayoutUnit baseAscent = ascentForChild(*reference.base) + reference.base->marginBefore();
     LayoutUnit baseDescent = reference.base->logicalHeight() + reference.base->marginLogicalHeight() - baseAscent;
     LayoutUnit baseItalicCorrection = std::min(reference.base->logicalWidth() + reference.base->marginLogicalWidth(), italicCorrection(reference));
-    LayoutUnit horizontalOffset = borderAndPaddingStart();
+    LayoutUnit horizontalOffset = 0;
 
-    LayoutUnit ascent = std::max(baseAscent, metrics.ascent + metrics.supShift) + borderAndPaddingBefore();
-    LayoutUnit descent = std::max(baseDescent, metrics.descent + metrics.subShift) + borderAndPaddingAfter();
+    LayoutUnit ascent = std::max(baseAscent, metrics.ascent + metrics.supShift);
+    LayoutUnit descent = std::max(baseDescent, metrics.descent + metrics.subShift);
     setLogicalHeight(ascent + descent);
 
     switch (scriptType()) {
@@ -399,7 +400,7 @@ void RenderMathMLScripts::layoutBlock(bool relayoutChildren, LayoutUnit)
     case MathMLScriptsElement::ScriptType::Under: {
         LayoutUnit baseWidth = reference.base->logicalWidth() + reference.base->marginLogicalWidth();
         LayoutUnit contentWidth = baseWidth + std::max(0_lu, reference.firstPostScript->logicalWidth() + reference.firstPostScript->marginLogicalWidth() - baseItalicCorrection + space);
-        setLogicalWidth(contentWidth + borderAndPaddingLogicalWidth());
+        setLogicalWidth(contentWidth);
         LayoutPoint baseLocation(mirrorIfNeeded(horizontalOffset + reference.base->marginStart(), *reference.base), ascent - baseAscent + reference.base->marginBefore());
         reference.base->setLocation(baseLocation);
         horizontalOffset += baseWidth;
@@ -412,7 +413,7 @@ void RenderMathMLScripts::layoutBlock(bool relayoutChildren, LayoutUnit)
     case MathMLScriptsElement::ScriptType::Over: {
         LayoutUnit baseWidth = reference.base->logicalWidth() + reference.base->marginLogicalWidth();
         LayoutUnit contentWidth = baseWidth + std::max(0_lu, reference.firstPostScript->logicalWidth() + reference.firstPostScript->marginLogicalWidth() + space);
-        setLogicalWidth(contentWidth + borderAndPaddingLogicalWidth());
+        setLogicalWidth(contentWidth);
         LayoutPoint baseLocation(mirrorIfNeeded(horizontalOffset + reference.base->marginStart(), *reference.base), ascent - baseAscent + reference.base->marginBefore());
         reference.base->setLocation(baseLocation);
         horizontalOffset += baseWidth;
@@ -425,7 +426,7 @@ void RenderMathMLScripts::layoutBlock(bool relayoutChildren, LayoutUnit)
     case MathMLScriptsElement::ScriptType::UnderOver:
     case MathMLScriptsElement::ScriptType::Multiscripts: {
         // Calculate the logical width.
-        LayoutUnit logicalWidth = borderAndPaddingLogicalWidth();
+        LayoutUnit logicalWidth = 0;
         auto subScript = reference.firstPreScript;
         while (subScript) {
             auto supScript = subScript->nextInFlowSiblingBox();
@@ -479,6 +480,8 @@ void RenderMathMLScripts::layoutBlock(bool relayoutChildren, LayoutUnit)
         }
     }
     }
+
+    adjustLayoutForBorderAndPadding();
 
     layoutPositionedObjects(relayoutChildren);
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -49,7 +49,9 @@ void RenderMathMLSpace::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());
 
-    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = spaceWidth() + borderAndPaddingLogicalWidth();
+    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = spaceWidth();
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
 
     setPreferredLogicalWidthsDirty(false);
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -511,7 +511,8 @@ void RenderMathMLToken::computePreferredLogicalWidths()
     if (m_mathVariantCodePoint) {
         auto mathVariantGlyph = style().fontCascade().glyphDataForCharacter(m_mathVariantCodePoint.value(), m_mathVariantIsMirrored);
         if (mathVariantGlyph.font) {
-            m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth = mathVariantGlyph.font->widthForGlyph(mathVariantGlyph.glyph) + borderAndPaddingLogicalWidth();
+            m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth = mathVariantGlyph.font->widthForGlyph(mathVariantGlyph.glyph);
+            adjustPreferredLogicalWidthsForBorderAndPadding();
             setPreferredLogicalWidthsDirty(false);
             return;
         }
@@ -592,8 +593,10 @@ void RenderMathMLToken::layoutBlock(bool relayoutChildren, LayoutUnit pageLogica
     recomputeLogicalWidth();
     for (auto* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox())
         child->layoutIfNeeded();
-    setLogicalWidth(LayoutUnit(mathVariantGlyph.font->widthForGlyph(mathVariantGlyph.glyph)) + borderAndPaddingLogicalWidth());
-    setLogicalHeight(LayoutUnit(mathVariantGlyph.font->boundsForGlyph(mathVariantGlyph.glyph).height()) + borderAndPaddingLogicalHeight());
+    setLogicalWidth(LayoutUnit(mathVariantGlyph.font->widthForGlyph(mathVariantGlyph.glyph)));
+    setLogicalHeight(LayoutUnit(mathVariantGlyph.font->boundsForGlyph(mathVariantGlyph.glyph).height()));
+
+    adjustLayoutForBorderAndPadding();
 
     layoutPositionedObjects(relayoutChildren);
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -204,16 +204,18 @@ void RenderMathMLUnderOver::computePreferredLogicalWidths()
     if (scriptType() == MathMLScriptsElement::ScriptType::Over || scriptType() == MathMLScriptsElement::ScriptType::UnderOver)
         preferredWidth = std::max(preferredWidth, over().maxPreferredLogicalWidth() + marginIntrinsicLogicalWidthForChild(over()));
 
-    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = preferredWidth + borderAndPaddingLogicalWidth();
+    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = preferredWidth;
+
+    adjustPreferredLogicalWidthsForBorderAndPadding();
 
     setPreferredLogicalWidthsDirty(false);
 }
 
 LayoutUnit RenderMathMLUnderOver::horizontalOffset(const RenderBox& child) const
 {
-    LayoutUnit contentBoxInlineSize = logicalWidth() - borderAndPaddingLogicalWidth();
+    LayoutUnit contentBoxInlineSize = logicalWidth();
     LayoutUnit childMarginBoxInlineSize = child.logicalWidth() + child.marginLogicalWidth();
-    return borderLeft() + paddingLeft() + (contentBoxInlineSize - childMarginBoxInlineSize) / 2 + child.marginLeft();
+    return (contentBoxInlineSize - childMarginBoxInlineSize) / 2 + child.marginLeft();
 }
 
 bool RenderMathMLUnderOver::hasAccent(bool accentUnder) const
@@ -327,10 +329,10 @@ void RenderMathMLUnderOver::layoutBlock(bool relayoutChildren, LayoutUnit pageLo
         logicalWidth = std::max(logicalWidth, under().logicalWidth() + under().marginLogicalWidth());
     if (scriptType() == MathMLScriptsElement::ScriptType::Over || scriptType() == MathMLScriptsElement::ScriptType::UnderOver)
         logicalWidth = std::max(logicalWidth, over().logicalWidth() + over().marginLogicalWidth());
-    setLogicalWidth(logicalWidth + borderAndPaddingLogicalWidth());
+    setLogicalWidth(logicalWidth);
 
     VerticalParameters parameters = verticalParameters();
-    LayoutUnit verticalOffset = borderAndPaddingBefore();
+    LayoutUnit verticalOffset = 0;
     if (scriptType() == MathMLScriptsElement::ScriptType::Over || scriptType() == MathMLScriptsElement::ScriptType::UnderOver) {
         verticalOffset += parameters.overExtraAscender;
         verticalOffset += over().marginBefore();
@@ -367,9 +369,10 @@ void RenderMathMLUnderOver::layoutBlock(bool relayoutChildren, LayoutUnit pageLo
         verticalOffset += under().marginAfter();
         verticalOffset += parameters.underExtraDescender;
     }
-    verticalOffset += borderAndPaddingAfter();
 
     setLogicalHeight(verticalOffset);
+
+    adjustLayoutForBorderAndPadding();
 
     layoutPositionedObjects(relayoutChildren);
 


### PR DESCRIPTION
#### 97d4de776b5b9d02ab766ef3df769127c4b1c810
<pre>
Refactor MathML padding/border handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=280261">https://bugs.webkit.org/show_bug.cgi?id=280261</a>

Reviewed by Rob Buis.

MathML width/height is applied after the math layout to obtain the
content box and before the inclusion of border/padding. In order to
facilitate the implementation of width/height on MathML elements, this
patch moves the incluson of padding/border at the end of math layout.
In addition, the helper function RenderMathMLRow::shiftRowItems() is
moved to the parent class RenderMathMLBlock and renamed
shiftInFlowChildren() so that it can be used in various places,
including for taking into account padding/border. There should be no
behavior changes.

    * Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
    (WebCore::RenderMathMLBlock::shiftInFlowChildren): Renamed from RenderMathMLRow::shiftRowItems().
    (WebCore::RenderMathMLBlock::adjustPreferredLogicalWidthsForBorderAndPadding): New method to add border/padding to preferred widths.
    (WebCore::RenderMathMLBlock::adjustLayoutForBorderAndPadding): Ditto for layout.
    * Source/WebCore/rendering/mathml/RenderMathMLBlock.h: Declare new methods.
    * Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
    (WebCore::RenderMathMLFraction::computePreferredLogicalWidths): Only consider border/padding at the end.
    (WebCore::RenderMathMLFraction::horizontalOffset const): Don&apos;t consider border/padding in this method.
    (WebCore::RenderMathMLFraction::fractionAscent const): Ditto.
    (WebCore::RenderMathMLFraction::layoutBlock): Only consider border/padding at the end.
    (WebCore::RenderMathMLFraction::paint): Add border/padding removed from fractionAscent().
    (WebCore::RenderMathMLFraction::firstLineBaseline const):
    * Source/WebCore/rendering/mathml/RenderMathMLMath.cpp:
    (WebCore::RenderMathMLMath::layoutBlock): s/shiftRowItems/shiftInFlowChildren/
    * Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp:
    (WebCore::RenderMathMLMenclose::computePreferredLogicalWidths): Only consider border/padding at the end.
    (WebCore::RenderMathMLMenclose::layoutBlock): Ditto and also s/shiftRowItems/shiftInFlowChildren/
    * Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
    (WebCore::RenderMathMLOperator::layoutBlock): Directly new shiftInFlowChildren method.
    * Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp:
    (WebCore::RenderMathMLPadded::computePreferredLogicalWidths): Only consider border/padding at the end.
    (WebCore::RenderMathMLPadded::layoutBlock): Ditto and also s/shiftRowItems/shiftInFlowChildren/
    * Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
    (WebCore::RenderMathMLRoot::computePreferredLogicalWidths): Only consider border/padding at the end.
    (WebCore::RenderMathMLRoot::layoutBlock): Ditto.
    * Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
    (WebCore::RenderMathMLRow::computePreferredLogicalWidths): Ditto.
    (WebCore::RenderMathMLRow::layoutBlock): Ditto and also s/shiftRowItems/shiftInFlowChildren/
    (WebCore::RenderMathMLRow::shiftRowItems): Deleted.
    * Source/WebCore/rendering/mathml/RenderMathMLRow.h: Remove declaration.
    * Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
    (WebCore::RenderMathMLScripts::computePreferredLogicalWidths): Only consider border/padding at the end.
    (WebCore::RenderMathMLScripts::layoutBlock): Ditto.
    * Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
    (WebCore::RenderMathMLSpace::computePreferredLogicalWidths): Ditto.
    * Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
    (WebCore::RenderMathMLToken::computePreferredLogicalWidths): Ditto.
    (WebCore::RenderMathMLToken::layoutBlock): Ditto.
    * Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
    (WebCore::RenderMathMLUnderOver::computePreferredLogicalWidths): Ditto.
    (WebCore::RenderMathMLUnderOver::horizontalOffset const): Don&apos;t consider border/padding in this method.
    (WebCore::RenderMathMLUnderOver::layoutBlock): Only consider border/padding at the end.

Canonical link: <a href="https://commits.webkit.org/284819@main">https://commits.webkit.org/284819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71b3a0d44b60b7f42e94ea70a18bc4503b57183f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55838 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14308 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15638 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11533 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5169 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->