### PR TITLE
Clean up SVGSMILElement::findInstanceTime

### DIFF
--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -796,33 +796,21 @@ SMILTime SVGSMILElement::findInstanceTime(BeginOrEnd beginOrEnd, SMILTime minimu
     if (list.empty())
         return beginOrEnd == Begin ? SMILTime::unresolved() : SMILTime::indefinite();
 
-    auto result = std::lower_bound(list.begin(), list.end(), minimumTime, [](const SMILTimeWithOrigin& item, SMILTime time) {
-        return item.time() < time;
-    });
+    // If an equal value is not accepted, return the next bigger item in the list, if any.
+    auto predicate = [equalsMinimumOK](const SMILTimeWithOrigin& instanceTime, const SMILTime& time) {
+        return equalsMinimumOK ? instanceTime.time() < time : instanceTime.time() <= time;
+    };
 
-    if (result == list.end())
+    auto item = std::lower_bound(list.begin(), list.end(), minimumTime, predicate);
+
+    if (item == list.end())
         return SMILTime::unresolved();
-
-    const SMILTime& currentTime = result->time();
 
     // The special value "indefinite" does not yield an instance time in the begin list.
-    if (currentTime.isIndefinite() && beginOrEnd == Begin)
+    if (item->time().isIndefinite() && beginOrEnd == Begin)
         return SMILTime::unresolved();
 
-    if (currentTime > minimumTime)
-        return currentTime;
-
-    ASSERT(currentTime == minimumTime);
-    if (equalsMinimumOK)
-        return currentTime;
-
-    // If the equals is not accepted, return the next bigger item in the list.
-    for (auto it = result + 1; it != list.end(); ++it) {
-        if (it->time() > minimumTime)
-            return it->time();
-    }
-
-    return beginOrEnd == Begin ? SMILTime::unresolved() : SMILTime::indefinite();
+    return item->time();
 }
 
 SMILTime SVGSMILElement::repeatingDuration() const


### PR DESCRIPTION
#### ef70c59a7640833f5321a850fb89cf296721e06c
<pre>
Clean up SVGSMILElement::findInstanceTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=275725">https://bugs.webkit.org/show_bug.cgi?id=275725</a>
<a href="https://rdar.apple.com/130730896">rdar://130730896</a>

Reviewed by Rob Buis.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1400822">https://chromium-review.googlesource.com/c/chromium/src/+/1400822</a>

Use lambdas and iterators, handling the case where an instance time
equal to the request time is not a valid result in the predicate passed
to std::lower_bound().

There&apos;s theoretically a change in behavior where (for &apos;begin&apos; times), we
could previously have returned the magic &apos;indefinite&apos; value after
looking for the next larger instance time.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::findInstanceTime const):
(WebCore::extractTimeFromVector): Deleted.

Canonical link: <a href="https://commits.webkit.org/315341@main">https://commits.webkit.org/315341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae91efbe267f4789fe5783f2c6d12181c3b27b6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126342 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fc19ced-69f2-43a3-8e85-166f679f5e2a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fa51259-07f6-4243-8f88-8f19684f9341) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61fd8d01-de06-4b73-9ab1-279fd1bf185b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26662 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180569 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33289 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35595 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139726 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42206 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37609 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42894 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106597 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34864 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114654 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41398 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6013 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40795 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40940 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->