### PR TITLE
Fix PlayStation build following 284151@main

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -31,7 +31,6 @@
 
 #include "WebPage.h"
 #include "WebPageInlines.h"
-#include <WebCore/CoordinatedImageBackingStore.h>
 #include <WebCore/DOMWindow.h>
 #include <WebCore/Document.h>
 #include <WebCore/GraphicsContext.h>

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -30,6 +30,7 @@
 
 #include "WebPage.h"
 #include <WebCore/CoordinatedGraphicsLayer.h>
+#include <WebCore/CoordinatedImageBackingStore.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/GraphicsLayerClient.h>
 #include <WebCore/GraphicsLayerFactory.h>
@@ -47,7 +48,6 @@ class SceneIntegration;
 
 namespace WebCore {
 class BitmapTexturePool;
-class CoordinatedImageBackingStore;
 class GraphicsContext;
 class GraphicsLayer;
 class Image;
@@ -137,7 +137,7 @@ private:
     std::unique_ptr<WebCore::BitmapTexturePool> m_skiaAcceleratedBitmapTexturePool;
     RefPtr<WorkerPool> m_skiaUnacceleratedThreadedRenderingPool;
 #endif
-    HashMap<uint64_t, Ref<CoordinatedImageBackingStore>> m_imageBackingStores;
+    HashMap<uint64_t, Ref<WebCore::CoordinatedImageBackingStore>> m_imageBackingStores;
 
     // We don't send the messages related to releasing resources to renderer during purging, because renderer already had removed all resources.
     bool m_isPurging { false };


### PR DESCRIPTION
#### 263ed2f06f03c621c791a0fe993f2b7ad6a56826
<pre>
Fix PlayStation build following 284151@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=280268">https://bugs.webkit.org/show_bug.cgi?id=280268</a>

Unreviewed build fix.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:
Add missing WebCore:: prefix, ensure that T is included in the header when we have a HashMap&lt;..., Ref&lt;T&gt;&gt; member.

Canonical link: <a href="https://commits.webkit.org/284193@main">https://commits.webkit.org/284193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31d9760cbc6eeebd8f30901967817b49dae0024d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19761 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54725 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71683 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43875 "13 new passes 4 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40542 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16671 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74379 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62199 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62226 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10169 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10471 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43809 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->