### PR TITLE
REGRESSION(284065@main): [GStreamer][MediaStream] Assertion failure ASSERTION FAILED: canSafelyBeUsed()

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -141,7 +141,7 @@ class InternalSource final : public MediaStreamTrackPrivateObserver,
 public:
     InternalSource(GstElement* parent, MediaStreamTrackPrivate& track, const String& padName, bool consumerIsVideoPlayer)
         : m_parent(parent)
-        , m_track(track)
+        , m_track(&track)
         , m_padName(padName)
         , m_consumerIsVideoPlayer(consumerIsVideoPlayer)
     {
@@ -194,11 +194,8 @@ public:
 
     void replaceTrack(RefPtr<MediaStreamTrackPrivate>&& newTrack)
     {
-#ifndef NDEBUG
-        RefPtr currentTrack = m_track.get();
-        ASSERT(currentTrack);
-        ASSERT(currentTrack->type() == newTrack->type());
-#endif
+        ASSERT(m_track);
+        ASSERT(m_track->type() == newTrack->type());
         stopObserving();
         m_track = WTFMove(newTrack);
         startObserving();
@@ -207,10 +204,9 @@ public:
     void connectIncomingTrack()
     {
 #if USE(GSTREAMER_WEBRTC)
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
-        auto& trackSource = track->source();
+        auto& trackSource = m_track->source();
         int clientId;
         auto client = GRefPtr<GstElement>(m_src);
         if (trackSource.isIncomingAudioSource()) {
@@ -285,10 +281,9 @@ public:
         if (!m_webrtcSourceClientId)
             return;
 
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
-        auto& trackSource = track->source();
+        auto& trackSource = m_track->source();
         if (trackSource.isIncomingAudioSource()) {
             auto& source = static_cast<RealtimeIncomingAudioSourceGStreamer&>(trackSource);
             source.unregisterClient(*m_webrtcSourceClientId);
@@ -299,7 +294,7 @@ public:
 #endif
     }
 
-    WARN_UNUSED_RETURN RefPtr<MediaStreamTrackPrivate> track() const { return m_track.get(); }
+    WARN_UNUSED_RETURN RefPtr<MediaStreamTrackPrivate> track() const { return m_track; }
     const String& padName() const { return m_padName; }
     GstElement* get() const { return m_src.get(); }
 
@@ -308,16 +303,15 @@ public:
         if (m_isObserving)
             return;
 
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
 
-        GST_DEBUG_OBJECT(m_src.get(), "Starting observation of track %s", track->id().ascii().data());
-        track->addObserver(*this);
-        if (track->isAudio())
-            track->source().addAudioSampleObserver(*this);
-        else if (track->isVideo())
-            track->source().addVideoFrameObserver(*this);
+        GST_DEBUG_OBJECT(m_src.get(), "Starting observation of track %s", m_track->id().ascii().data());
+        m_track->addObserver(*this);
+        if (m_track->isAudio())
+            m_track->source().addAudioSampleObserver(*this);
+        else if (m_track->isVideo())
+            m_track->source().addVideoFrameObserver(*this);
         m_isObserving = true;
     }
 
@@ -326,26 +320,24 @@ public:
         if (!m_isObserving)
             return;
 
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
 
-        GST_DEBUG_OBJECT(m_src.get(), "Stopping observation of track %s", track->id().ascii().data());
+        GST_DEBUG_OBJECT(m_src.get(), "Stopping observation of track %s", m_track->id().ascii().data());
         m_isObserving = false;
 
-        if (track->isAudio())
-            track->source().removeAudioSampleObserver(*this);
-        else if (track->isVideo())
-            track->source().removeVideoFrameObserver(*this);
-        track->removeObserver(*this);
+        if (m_track->isAudio())
+            m_track->source().removeAudioSampleObserver(*this);
+        else if (m_track->isVideo())
+            m_track->source().removeVideoFrameObserver(*this);
+        m_track->removeObserver(*this);
     }
 
     void configureAudioTrack(float volume, bool isMuted, bool isPlaying)
     {
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
-        ASSERT(track->isAudio());
+        ASSERT(m_track->isAudio());
         m_audioTrack->setVolume(volume);
         m_audioTrack->setMuted(isMuted);
         m_audioTrack->setEnabled(m_audioTrack->streamTrack().enabled());
@@ -360,10 +352,10 @@ public:
         callOnMainThreadAndWait([&] {
             stopObserving();
         });
-        RefPtr track = m_track.get();
-        if (!track)
+
+        if (!m_track)
             return;
-        trackEnded(*track);
+        trackEnded(*m_track);
     }
 
     void pushSample(GRefPtr<GstSample>&& sample, [[maybe_unused]] const ASCIILiteral logMessage)
@@ -470,11 +462,10 @@ public:
             sample = gstVideoFrame->resizedSample(captureSize);
         }
 
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
 
-        auto settings = track->settings();
+        auto settings = m_track->settings();
         m_configuredSize.setWidth(settings.width());
         m_configuredSize.setHeight(settings.height());
 
@@ -500,7 +491,7 @@ public:
             m_lastKnownSize = m_configuredSize;
         }
 
-        if (track->enabled()) {
+        if (m_track->enabled()) {
             pushSample(WTFMove(sample), "Pushing video frame from enabled track"_s);
             return;
         }
@@ -513,12 +504,11 @@ public:
         if (!m_parent || !m_isObserving)
             return;
 
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
 
         const auto& data = static_cast<const GStreamerAudioData&>(audioData);
-        if (track->enabled()) {
+        if (m_track->enabled()) {
             GRefPtr<GstSample> sample = data.getSample();
             pushSample(WTFMove(sample), "Pushing audio sample from enabled track"_s);
             return;
@@ -574,12 +564,11 @@ private:
         auto width = m_lastKnownSize.width() ? m_lastKnownSize.width() : 320;
         auto height = m_lastKnownSize.height() ? m_lastKnownSize.height() : 240;
 
-        RefPtr track = m_track.get();
-        if (!track)
+        if (!m_track)
             return;
 
         int frameRateNumerator, frameRateDenominator;
-        gst_util_double_to_fraction(track->settings().frameRate(), &frameRateNumerator, &frameRateDenominator);
+        gst_util_double_to_fraction(m_track->settings().frameRate(), &frameRateNumerator, &frameRateDenominator);
 
         if (!m_blackFrameCaps)
             m_blackFrameCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "I420", "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
@@ -637,7 +626,7 @@ private:
     }
 
     GstElement* m_parent { nullptr };
-    WeakPtr<MediaStreamTrackPrivate> m_track;
+    RefPtr<MediaStreamTrackPrivate> m_track;
     GRefPtr<GstElement> m_src;
     GstClockTime m_firstBufferPts { GST_CLOCK_TIME_NONE };
     bool m_enoughData { false };


### PR DESCRIPTION
#### 678c69226d9c26d3645fb7967cac3a1a0b6119f8
<pre>
REGRESSION(284065@main): [GStreamer][MediaStream] Assertion failure ASSERTION FAILED: canSafelyBeUsed()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280269">https://bugs.webkit.org/show_bug.cgi?id=280269</a>

Reviewed by Xabier Rodriguez-Calvar.

Using WeakPtr for keeping track of the MediaStreamTrackPrivate in the mediastreamsrc element was a
mistake because the video frame dispatching can be triggered from a different thread.
ThreadSafeWeakPtr can&apos;t be used either, and actually there&apos;s no risk of reference cycles here, so
use RefPtr.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:

Canonical link: <a href="https://commits.webkit.org/284211@main">https://commits.webkit.org/284211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d11f5069774a436a068399d3354e2178a5b9aad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54726 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13149 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18119 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74380 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12588 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16272 "Found 1 new test failure: media/track/track-text-track-destructor-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62201 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62228 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3784 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43810 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->