### PR TITLE
[scroll-animations] update `AnimationTimeline.currentTime` to use `CSSNumberish`

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -75,14 +75,6 @@ void AnimationTimeline::removeAnimation(WebAnimation& animation)
     }
 }
 
-std::optional<double> AnimationTimeline::bindingsCurrentTime()
-{
-    auto time = currentTime();
-    if (!time)
-        return std::nullopt;
-    return secondsToWebAnimationsAPITime(*time);
-}
-
 void AnimationTimeline::detachFromDocument()
 {
     if (CheckedPtr controller = this->controller())

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -29,7 +29,6 @@
 #include "WebAnimationTypes.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
-#include <wtf/Seconds.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -50,8 +49,7 @@ public:
     virtual void animationTimingDidChange(WebAnimation&);
     virtual void removeAnimation(WebAnimation&);
 
-    std::optional<double> bindingsCurrentTime();
-    virtual std::optional<Seconds> currentTime() { return m_currentTime; }
+    virtual std::optional<CSSNumberishTime> currentTime() { return m_currentTime; }
 
     virtual void detachFromDocument();
 
@@ -72,7 +70,7 @@ protected:
 private:
     void updateGlobalPosition(WebAnimation&);
 
-    Markable<Seconds, Seconds::MarkableTraits> m_currentTime;
+    std::optional<CSSNumberishTime> m_currentTime;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.idl
+++ b/Source/WebCore/animation/AnimationTimeline.idl
@@ -23,10 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (double or CSSNumericValue) CSSNumberish;
+
 [
     ExportMacro=WEBCORE_EXPORT,
     CustomToJSObject,
     Exposed=Window
 ] interface AnimationTimeline {
-    [ImplementedAs=bindingsCurrentTime] readonly attribute double? currentTime;
+    readonly attribute CSSNumberish? currentTime;
 };

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -119,6 +119,20 @@ CSSNumberishTime CSSNumberishTime::operator-(CSSNumberishTime other) const
     return { m_type, m_source, m_value - other.m_value };
 }
 
+CSSNumberishTime& CSSNumberishTime::operator+=(const CSSNumberishTime& other)
+{
+    ASSERT(m_type == other.m_type);
+    m_value += other.m_value;
+    return *this;
+}
+
+CSSNumberishTime& CSSNumberishTime::operator-=(const CSSNumberishTime& other)
+{
+    ASSERT(m_type == other.m_type);
+    m_value -= other.m_value;
+    return *this;
+}
+
 bool CSSNumberishTime::operator<(CSSNumberishTime other) const
 {
     ASSERT(m_type == other.m_type);
@@ -141,6 +155,11 @@ bool CSSNumberishTime::operator>=(CSSNumberishTime other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value >= other.m_value;
+}
+
+bool CSSNumberishTime::operator==(CSSNumberishTime other) const
+{
+    return m_type == other.m_type && m_value == other.m_value;
 }
 
 CSSNumberishTime CSSNumberishTime::operator+(Seconds other) const

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -45,10 +45,13 @@ public:
 
     CSSNumberishTime operator+(CSSNumberishTime) const;
     CSSNumberishTime operator-(CSSNumberishTime) const;
+    CSSNumberishTime& operator+=(const CSSNumberishTime&);
+    CSSNumberishTime& operator-=(const CSSNumberishTime&);
     bool operator<(CSSNumberishTime) const;
     bool operator<=(CSSNumberishTime) const;
     bool operator>(CSSNumberishTime) const;
     bool operator>=(CSSNumberishTime) const;
+    bool operator==(CSSNumberishTime) const;
 
     CSSNumberishTime operator+(Seconds) const;
     CSSNumberishTime operator-(Seconds) const;

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -58,7 +58,7 @@ public:
 
     Document* document() const { return m_document.get(); }
 
-    std::optional<Seconds> currentTime() override;
+    std::optional<CSSNumberishTime> currentTime() override;
     ExceptionOr<Ref<WebAnimation>> animate(Ref<CustomEffectCallback>&&, std::optional<std::variant<double, CustomAnimationOptions>>&&);
 
     void animationTimingDidChange(WebAnimation&) override;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -588,7 +588,8 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
                         continue;
                     auto* effectAnimation = effect->animation();
                     auto* cssTransition = dynamicDowncast<CSSTransition>(effectAnimation);
-                    bool shouldUseTimelineTimeAtCreation = cssTransition && (!effectAnimation->startTime() || *effectAnimation->startTime() == document.timeline().currentTime());
+                    ASSERT(document.timeline().currentTime());
+                    bool shouldUseTimelineTimeAtCreation = cssTransition && (!effectAnimation->startTime() || effectAnimation->startTime() == document.timeline().currentTime());
                     effectAnimation->resolve(style, { nullptr }, shouldUseTimelineTimeAtCreation ? cssTransition->timelineTimeAtCreation() : std::nullopt);
                 }
             }


### PR DESCRIPTION
#### 69ae8979bdae428fcc054bdfad5f193be97db508
<pre>
[scroll-animations] update `AnimationTimeline.currentTime` to use `CSSNumberish`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279730">https://bugs.webkit.org/show_bug.cgi?id=279730</a>
<a href="https://rdar.apple.com/136031154">rdar://136031154</a>

Reviewed by Tim Nguyen.

The `AnimationTimeline.currentTime` property is changing to use `CSSNumberish` in order
to represent percentage values for `ScrollTimeline` and `ViewTimeline`. Before we do the
work to actually report a percentage `currentTime` on those timeline types, we modify
the existing API to use `CSSNumberishTime` to wrap the value through the API.

Some small refactoring was required as a result but also implementing some new `CSSNumberishTime`
operators.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::bindingsCurrentTime): Deleted.
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::currentTime):
* Source/WebCore/animation/AnimationTimeline.idl:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::operator+=):
(WebCore::CSSNumberishTime::operator-=):
(WebCore::CSSNumberishTime::operator== const):
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::currentTime):
(WebCore::DocumentTimeline::removeReplacedAnimations):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::updateCSSTransitionsForStyleableAndProperty):

Canonical link: <a href="https://commits.webkit.org/284168@main">https://commits.webkit.org/284168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/641f1bc776c230ab32a7b4ab9e51c44dfcc2dfad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13156 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16682 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16281 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62236 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3793 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10456 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->