### PR TITLE
MediaSession.setMicrophoneActive(true) is prompting repeatedly if microphone was muted by the UA once

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -662,6 +662,8 @@ void CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged()
         UInt32 muteUplinkOutput = !isProducingMicrophoneSamples();
         auto error = m_ioUnit->set(kAUVoiceIOProperty_MuteOutput, kAudioUnitScope_Global, outputBus, &muteUplinkOutput, sizeof(muteUplinkOutput));
         RELEASE_LOG_ERROR_IF(error, WebRTC, "CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged(%p) unable to set kAUVoiceIOProperty_MuteOutput, error %d (%.4s)", this, (int)error, (char*)&error);
+
+        setMutedState(muteUplinkOutput);
     }
     updateVoiceActiveDetection();
 
@@ -849,7 +851,7 @@ void CoreAudioSharedUnit::disableMutedSpeechActivityEventListener()
 
 void CoreAudioSharedUnit::handleMuteStatusChangedNotification(bool isMuting)
 {
-    if (m_muteStatusChangedCallback)
+    if (m_muteStatusChangedCallback && isMuting == isProducingMicrophoneSamples())
         m_muteStatusChangedCallback(isMuting);
 }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -175,6 +175,7 @@ private:
     void updateVoiceActiveDetection();
     bool shouldEnableVoiceActivityDetection() const;
     RetainPtr<WebCoreAudioInputMuteChangeListener> createAudioInputMuteChangeListener();
+    void setMutedState(bool isMuted);
 
     CreationCallback m_creationCallback;
     GetSampleRateCallback m_getSampleRateCallback;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -243,6 +243,21 @@ void CoreAudioSharedUnit::setMuteStatusChangedCallback(Function<void(bool)>&& ca
 #endif
 }
 
+void CoreAudioSharedUnit::setMutedState(bool isMuted)
+{
+#if HAVE(AVAUDIOAPPLICATION)
+    auto *audioApplication = getSharedAVAudioApplication();
+    if (!audioApplication)
+        return;
+
+    NSError *error = nil;
+    [audioApplication setInputMuted:isMuted error:&error];
+    RELEASE_LOG_ERROR_IF(error, WebRTC, "CoreAudioSharedUnit::setMutedState failed due to error: %@.", error.localizedDescription);
+#else
+    UNUSED_PARAM(isMuted);
+#endif
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11501,7 +11501,7 @@ void WebPageProxy::microphoneMuteStatusChanged(bool isMuting)
     else
         mutedState.remove(WebCore::MediaProducerMutedState::AudioCaptureIsMuted);
 
-    setMuted(mutedState);
+    setMuted(mutedState, FromApplication::Yes);
 }
 
 void WebPageProxy::requestUserMediaPermissionForFrame(IPC::Connection& connection, UserMediaRequestIdentifier userMediaID, FrameIdentifier frameID, const SecurityOriginData& userMediaDocumentOriginData, const SecurityOriginData& topLevelDocumentOriginData, MediaStreamRequest&& request)


### PR DESCRIPTION
#### 192b7af2b1385c1878d0f9d94f0aa3a7d43e2e72
<pre>
MediaSession.setMicrophoneActive(true) is prompting repeatedly if microphone was muted by the UA once
<a href="https://rdar.apple.com/135941062">rdar://135941062</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=279658">https://bugs.webkit.org/show_bug.cgi?id=279658</a>

Reviewed by Eric Carlson.

When web page is muting, it notified CoreAudioSharedUnit which can then send back an AirPod muted notification.
This triggers the fact that, even though web page decided to be muted, we know think that the user decided to mute.
When web page tries to unmute, user is then prompted.

We update CoreAudioSharedUnit to only send back muted notifications when isMuting is not aligned with isProducingMicrophoneSamples().

We will be able to test this with some refactoring in the way we mock audio capture.
A follow-up patch will do this testing refactoring and improvement.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged):
(WebCore::CoreAudioSharedUnit::handleMuteStatusChangedNotification):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(WebCore::CoreAudioSharedUnit::setMutedState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::microphoneMuteStatusChanged):

Canonical link: <a href="https://commits.webkit.org/284399@main">https://commits.webkit.org/284399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebca87affaf5b6bf38dd946a8c501e9ad1760f89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21924 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20258 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59786 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17216 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17561 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13233 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59869 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4281 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44455 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->