### PR TITLE
BBQPlan should not be an EntryPlan

### DIFF
--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -775,6 +775,9 @@ void Options::notifyOptionsChanged()
     if (!Options::useWasm())
         disableAllWasmOptions();
 
+    if (!Options::useWasmLLInt() && !Options::useWasmIPInt())
+        Options::thresholdForBBQOptimizeAfterWarmUp() = 0; // Trigger immediate BBQ tier up.
+
     // At initialization time, we may decide that useJIT should be false for any
     // number of reasons (including failing to allocate JIT memory), and therefore,
     // will / should not be able to enable any JIT related services.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,17 +50,15 @@ namespace WasmBBQPlanInternal {
 static constexpr bool verbose = false;
 }
 
-BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation> moduleInformation, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, CalleeGroup* calleeGroup, CompletionTask&& completionTask)
-    : EntryPlan(vm, WTFMove(moduleInformation), CompilerMode::FullCompile, WTFMove(completionTask))
-    , m_calleeGroup(calleeGroup)
+BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation>&& moduleInformation, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
+    : Plan(vm, WTFMove(moduleInformation), WTFMove(completionTask))
+    , m_calleeGroup(WTFMove(calleeGroup))
     , m_functionIndex(functionIndex)
     , m_hasExceptionHandlers(hasExceptionHandlers)
 {
     ASSERT(Options::useBBQJIT());
     setMode(m_calleeGroup->mode());
     dataLogLnIf(WasmBBQPlanInternal::verbose, "Starting BBQ plan for ", functionIndex);
-    m_areWasmToJSStubsCompiled = true;
-    m_areWasmToWasmStubsCompiled = true;
 }
 
 FunctionAllowlist& BBQPlan::ensureGlobalBBQAllowlist()
@@ -72,26 +70,6 @@ FunctionAllowlist& BBQPlan::ensureGlobalBBQAllowlist()
         bbqAllowlist.construct(functionAllowlistFile);
     });
     return bbqAllowlist;
-}
-
-bool BBQPlan::prepareImpl()
-{
-    const auto& functions = m_moduleInformation->functions;
-    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), " WebAssembly functions"_s)
-        || !tryReserveCapacity(m_wasmInternalFunctionLinkBuffers, functions.size(), " compilation contexts"_s)
-        || !tryReserveCapacity(m_compilationContexts, functions.size(), " compilation contexts"_s)
-        || !tryReserveCapacity(m_callees, functions.size(), " BBQ callees"_s)
-        || !tryReserveCapacity(m_allLoopEntrypoints, functions.size(), " loop entrypoints"_s))
-        return false;
-
-    m_wasmInternalFunctions.resize(functions.size());
-    m_wasmInternalFunctionLinkBuffers.resize(functions.size());
-    m_exceptionHandlerLocations.resize(functions.size());
-    m_compilationContexts.resize(functions.size());
-    m_callees.resize(functions.size());
-    m_allLoopEntrypoints.resize(functions.size());
-
-    return true;
 }
 
 bool BBQPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffer, unsigned functionIndex, const TypeDefinition& signature, unsigned functionIndexSpace)
@@ -106,31 +84,9 @@ bool BBQPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffe
     return false;
 }
 
-void BBQPlan::work(CompilationEffort effort)
+void BBQPlan::work(CompilationEffort)
 {
-    if (!m_calleeGroup) {
-        switch (m_state) {
-        case State::Initial:
-            parseAndValidateModule();
-            if (!hasWork()) {
-                ASSERT(m_state == State::Validated);
-                Locker locker { m_lock };
-                complete();
-                break;
-            }
-            FALLTHROUGH;
-        case State::Validated:
-            prepare();
-            break;
-        case State::Prepared:
-            compileFunctions(effort);
-            break;
-        default:
-            break;
-        }
-        return;
-    }
-
+    ASSERT(m_calleeGroup->runnable());
     CompilationContext context;
     Vector<UnlinkedWasmToWasmCall> unlinkedWasmToWasmCalls;
     size_t functionIndexSpace = m_functionIndex + m_moduleInformation->importFunctionCount();
@@ -194,8 +150,8 @@ void BBQPlan::work(CompilationEffort effort)
             MacroAssembler::repatchPointer(call.calleeLocation, CalleeBits::boxNativeCalleeIfExists(calleeCallee));
         }
 
-        m_calleeGroup->callsiteCollection().addCallsites(locker, *m_calleeGroup, callee->wasmToWasmCallsites());
-        m_calleeGroup->callsiteCollection().updateCallsitesToCallUs(locker, *m_calleeGroup, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex, functionIndexSpace);
+        m_calleeGroup->callsiteCollection().addCallsites(locker, m_calleeGroup.get(), callee->wasmToWasmCallsites());
+        m_calleeGroup->callsiteCollection().updateCallsitesToCallUs(locker, m_calleeGroup.get(), CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex, functionIndexSpace);
 
         {
             if (Options::useWasmIPInt()) {
@@ -215,35 +171,7 @@ void BBQPlan::work(CompilationEffort effort)
     dataLogLnIf(WasmBBQPlanInternal::verbose, "Finished BBQ ", m_functionIndex);
 
     Locker locker { m_lock };
-    moveToState(State::Completed);
-    runCompletionTasks();
-}
-
-void BBQPlan::compileFunction(uint32_t functionIndex)
-{
-    m_unlinkedWasmToWasmCalls[functionIndex] = Vector<UnlinkedWasmToWasmCall>();
-
-    unsigned functionIndexSpace = m_moduleInformation->importFunctionCount() + functionIndex;
-    bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
-    SavedFPWidth savedFPWidth = usesSIMD ? SavedFPWidth::SaveVectors : SavedFPWidth::DontSaveVectors;
-    auto& context = m_compilationContexts[functionIndex];
-    Ref<BBQCallee> bbqCallee = BBQCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), savedFPWidth);
-    auto* calleePtr = bbqCallee.ptr();
-    m_wasmInternalFunctions[functionIndex] = compileFunction(functionIndex, bbqCallee.get(), context, m_unlinkedWasmToWasmCalls[functionIndex]);
-    {
-        auto linkBuffer = makeUnique<LinkBuffer>(*context.wasmEntrypointJIT, calleePtr, LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);
-        if (linkBuffer->isValid())
-            m_wasmInternalFunctionLinkBuffers[functionIndex] = WTFMove(linkBuffer);
-    }
-    m_callees[functionIndex] = WTFMove(bbqCallee);
-
-    if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
-        auto callee = JSEntrypointCallee::create(m_moduleInformation->internalFunctionTypeIndices[functionIndex], m_moduleInformation->usesSIMD(functionIndex));
-
-        Locker locker { m_lock };
-        auto result = m_jsToWasmInternalFunctions.add(functionIndex, WTFMove(callee));
-        ASSERT_UNUSED(result, result.isNewEntry);
-    }
+    complete();
 }
 
 std::unique_ptr<InternalFunction> BBQPlan::compileFunction(uint32_t functionIndex, BBQCallee& callee, CompilationContext& context, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls)
@@ -267,85 +195,10 @@ std::unique_ptr<InternalFunction> BBQPlan::compileFunction(uint32_t functionInde
             // Multiple compiles could fail simultaneously. We arbitrarily choose the first.
             fail(makeString(parseAndCompileResult.error(), ", in function at index "_s, functionIndex)); // FIXME make this an Expected.
         }
-        m_currentIndex = m_moduleInformation->functions.size();
         return nullptr;
     }
 
     return WTFMove(*parseAndCompileResult);
-}
-
-void BBQPlan::didCompleteCompilation()
-{
-    generateStubsIfNecessary();
-
-    for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
-        CompilationContext& context = m_compilationContexts[functionIndex];
-        TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-        const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
-        ASSERT(functionIndexSpace < m_moduleInformation->functionIndexSpaceSize());
-        InternalFunction* function = m_wasmInternalFunctions[functionIndex].get();
-        if (!m_wasmInternalFunctionLinkBuffers[functionIndex]) {
-            Base::fail(makeString("Out of executable memory in function at index "_s, functionIndex));
-            return;
-        }
-
-        auto& linkBuffer = *m_wasmInternalFunctionLinkBuffers[functionIndex];
-
-        computeExceptionHandlerAndLoopEntrypointLocations(m_exceptionHandlerLocations[functionIndex], m_allLoopEntrypoints[functionIndex], function, context, linkBuffer);
-
-        computePCToCodeOriginMap(context, linkBuffer);
-
-        bool alreadyDumped = dumpDisassembly(context, linkBuffer, functionIndex, signature, functionIndexSpace);
-        function->entrypoint.compilation = makeUnique<Compilation>(
-            FINALIZE_CODE_IF((!alreadyDumped && shouldDumpDisassemblyFor(CompilationMode::BBQMode)), linkBuffer, JITCompilationPtrTag, nullptr, "WebAssembly BBQ function[%i] %s name %s", functionIndex, signature.toString().ascii().data(), makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data()),
-            WTFMove(context.wasmEntrypointByproducts));
-        auto iter = m_jsToWasmInternalFunctions.find(functionIndex);
-        if (iter != m_jsToWasmInternalFunctions.end())
-            iter->value->setReplacementTarget(function->entrypoint.compilation->code().retagged<WasmEntryPtrTag>());
-    }
-
-    for (auto& unlinked : m_unlinkedWasmToWasmCalls) {
-        for (auto& call : unlinked) {
-            CodePtr<WasmEntryPtrTag> executableAddress;
-            if (m_moduleInformation->isImportedFunctionFromFunctionIndexSpace(call.functionIndexSpace)) {
-                // FIXME imports could have been linked in B3, instead of generating a patchpoint. This condition should be replaced by a RELEASE_ASSERT. https://bugs.webkit.org/show_bug.cgi?id=166462
-                executableAddress = m_wasmToWasmExitStubs.at(call.functionIndexSpace).code();
-            } else
-                executableAddress = m_wasmInternalFunctions.at(call.functionIndexSpace - m_moduleInformation->importFunctionCount())->entrypoint.compilation->code().retagged<WasmEntryPtrTag>();
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(executableAddress));
-            if (call.calleeLocation)
-                MacroAssembler::repatchPointer(call.calleeLocation, 0);
-        }
-    }
-}
-
-void BBQPlan::initializeCallees(const CalleeInitializer& callback)
-{
-    ASSERT(!failed());
-    for (unsigned internalFunctionIndex = 0; internalFunctionIndex < m_wasmInternalFunctions.size(); ++internalFunctionIndex) {
-        RefPtr<JSEntrypointCallee> jsEntrypointCallee;
-        RefPtr<BBQCallee> wasmEntrypointCallee = m_callees[internalFunctionIndex];
-        {
-            assertIsHeld(m_lock);
-            auto iter = m_jsToWasmInternalFunctions.find(internalFunctionIndex);
-            if (iter != m_jsToWasmInternalFunctions.end())
-                jsEntrypointCallee = iter->value;
-        }
-
-        InternalFunction* function = m_wasmInternalFunctions[internalFunctionIndex].get();
-        wasmEntrypointCallee->setEntrypoint(WTFMove(function->entrypoint), WTFMove(m_unlinkedWasmToWasmCalls[internalFunctionIndex]), WTFMove(function->stackmaps), WTFMove(function->exceptionHandlers), WTFMove(m_exceptionHandlerLocations[internalFunctionIndex]), WTFMove(m_allLoopEntrypoints[internalFunctionIndex]), { }, function->osrEntryScratchBufferSize);
-
-        if (m_compilationContexts[internalFunctionIndex].pcToCodeOriginMap)
-            NativeCalleeRegistry::singleton().addPCToCodeOriginMap(wasmEntrypointCallee.get(), WTFMove(m_compilationContexts[internalFunctionIndex].pcToCodeOriginMap));
-
-        callback(internalFunctionIndex, WTFMove(jsEntrypointCallee), wasmEntrypointCallee.releaseNonNull());
-    }
-}
-
-bool BBQPlan::didReceiveFunctionData(unsigned, const FunctionData&)
-{
-    return true;
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,53 +48,38 @@ class BBQCallee;
 class CalleeGroup;
 class JSEntrypointCallee;
 
-class BBQPlan final : public EntryPlan {
+class BBQPlan final : public Plan {
 public:
-    using Base = EntryPlan;
+    using Base = Plan;
 
-    using Base::Base;
-
-    BBQPlan(VM&, Ref<ModuleInformation>, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, CalleeGroup*, CompletionTask&&);
-
-    bool hasWork() const final
+    static Ref<BBQPlan> create(VM& vm, Ref<ModuleInformation>&& info, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
     {
-        if (m_compilerMode == CompilerMode::Validation)
-            return m_state < State::Validated;
-        return m_state < State::Compiled;
+        return adoptRef(*new BBQPlan(vm, WTFMove(info), functionIndex, hasExceptionHandlers, WTFMove(calleeGroup), WTFMove(completionTask)));
     }
 
+    bool hasWork() const final { return !m_completed; }
     void work(CompilationEffort) final;
-
-    using CalleeInitializer = Function<void(uint32_t, RefPtr<JSEntrypointCallee>&&, Ref<BBQCallee>&&)>;
-    void initializeCallees(const CalleeInitializer&);
-
-    bool didReceiveFunctionData(unsigned, const FunctionData&) final;
-
-    bool parseAndValidateModule()
-    {
-        return Base::parseAndValidateModule(m_source.span());
-    }
+    bool multiThreaded() const final { return false; }
 
     static FunctionAllowlist& ensureGlobalBBQAllowlist();
 
+
 private:
-    bool prepareImpl() final;
+    BBQPlan(VM&, Ref<ModuleInformation>&&, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, Ref<CalleeGroup>&&, CompletionTask&&);
+
     bool dumpDisassembly(CompilationContext&, LinkBuffer&, unsigned functionIndex, const TypeDefinition&, unsigned functionIndexSpace);
-    void compileFunction(uint32_t functionIndex) final;
-    void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) final;
 
     std::unique_ptr<InternalFunction> compileFunction(uint32_t functionIndex, BBQCallee&, CompilationContext&, Vector<UnlinkedWasmToWasmCall>&);
+    bool isComplete() const final { return m_completed; }
+    void complete() WTF_REQUIRES_LOCK(m_lock) final
+    {
+        m_completed = true;
+        runCompletionTasks();
+    }
 
-    Vector<std::unique_ptr<InternalFunction>> m_wasmInternalFunctions;
-    Vector<std::unique_ptr<LinkBuffer>> m_wasmInternalFunctionLinkBuffers;
-    Vector<Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>> m_exceptionHandlerLocations;
-    HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions WTF_GUARDED_BY_LOCK(m_lock);
-    Vector<CompilationContext> m_compilationContexts;
-    Vector<RefPtr<BBQCallee>> m_callees;
-    Vector<Vector<CodeLocationLabel<WasmEntryPtrTag>>> m_allLoopEntrypoints;
-
-    RefPtr<CalleeGroup> m_calleeGroup { nullptr };
+    Ref<CalleeGroup> m_calleeGroup;
     uint32_t m_functionIndex;
+    bool m_completed { false };
     std::optional<bool> m_hasExceptionHandlers;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -76,68 +76,35 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callsiteCollection(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    if (Options::useWasmLLInt()) {
-        m_plan = adoptRef(*new LLIntPlan(vm, moduleInformation, m_llintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
-            if (!m_plan) {
-                m_errorMessage = makeString("Out of memory while creating LLInt CalleeGroup"_s);
-                setCompilationFinished();
-                return;
-            }
-            Locker locker { m_lock };
-            if (m_plan->failed()) {
-                m_errorMessage = m_plan->errorMessage();
-                setCompilationFinished();
-                return;
-            }
-
-            m_wasmIndirectCallEntryPoints = FixedVector<CodePtr<WasmEntryPtrTag>>(m_calleeCount);
-            m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
-
-            for (unsigned i = 0; i < m_calleeCount; ++i) {
-                m_wasmIndirectCallEntryPoints[i] = m_llintCallees->at(i)->entrypoint();
-                m_wasmIndirectCallWasmCallees[i] = m_llintCallees->at(i).ptr();
-            }
-
-            m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
-            m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
-            m_jsEntrypointCallees = static_cast<LLIntPlan*>(m_plan.get())->takeJSCallees();
-
+    m_plan = adoptRef(*new LLIntPlan(vm, moduleInformation, m_llintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
+        if (!m_plan) {
+            m_errorMessage = makeString("Out of memory while creating LLInt CalleeGroup"_s);
             setCompilationFinished();
-        })));
-    }
-#if ENABLE(WEBASSEMBLY_BBQJIT)
-    else {
-        m_plan = adoptRef(*new BBQPlan(vm, moduleInformation, CompilerMode::FullCompile, createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
-            Locker locker { m_lock };
-            if (m_plan->failed()) {
-                m_errorMessage = m_plan->errorMessage();
-                setCompilationFinished();
-                return;
-            }
-
-            m_wasmIndirectCallEntryPoints = FixedVector<CodePtr<WasmEntryPtrTag>>(m_calleeCount);
-            m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
-
-            BBQPlan* bbqPlan = static_cast<BBQPlan*>(m_plan.get());
-            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JSEntrypointCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
-                if (jsEntrypointCallee) {
-                    auto result = m_jsEntrypointCallees.set(calleeIndex, WTFMove(jsEntrypointCallee));
-                    ASSERT_UNUSED(result, result.isNewEntry);
-                }
-                m_wasmIndirectCallEntryPoints[calleeIndex] = wasmEntrypoint->entrypoint();
-                m_wasmIndirectCallWasmCallees[calleeIndex] = nullptr;
-                setBBQCallee(locker, calleeIndex, adoptRef(*static_cast<BBQCallee*>(wasmEntrypoint.leakRef())));
-            });
-
-            m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
-            m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
-
+            return;
+        }
+        Locker locker { m_lock };
+        if (m_plan->failed()) {
+            m_errorMessage = m_plan->errorMessage();
             setCompilationFinished();
-        })));
-    }
-#endif
+            return;
+        }
+
+        m_wasmIndirectCallEntryPoints = FixedVector<CodePtr<WasmEntryPtrTag>>(m_calleeCount);
+        m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
+
+        for (unsigned i = 0; i < m_calleeCount; ++i) {
+            m_wasmIndirectCallEntryPoints[i] = m_llintCallees->at(i)->entrypoint();
+            m_wasmIndirectCallWasmCallees[i] = m_llintCallees->at(i).ptr();
+        }
+
+        m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
+        m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
+        m_jsEntrypointCallees = static_cast<LLIntPlan*>(m_plan.get())->takeJSCallees();
+
+        setCompilationFinished();
+    })));
     m_plan->setMode(mode);
-    if (Options::useWasmLLInt()) {
+    {
         Ref plan { *m_plan };
         if (plan->completeSyncIfPossible())
             return;
@@ -155,63 +122,30 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callsiteCollection(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    if (Options::useWasmIPInt()) {
-        m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
-            Locker locker { m_lock };
-            if (m_plan->failed()) {
-                m_errorMessage = m_plan->errorMessage();
-                setCompilationFinished();
-                return;
-            }
-
-            m_wasmIndirectCallEntryPoints = FixedVector<CodePtr<WasmEntryPtrTag>>(m_calleeCount);
-            m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
-
-            for (unsigned i = 0; i < m_calleeCount; ++i) {
-                m_wasmIndirectCallEntryPoints[i] = m_ipintCallees->at(i)->entrypoint();
-                m_wasmIndirectCallWasmCallees[i] = m_ipintCallees->at(i).ptr();
-            }
-
-            m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
-            m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
-            m_jsEntrypointCallees = static_cast<IPIntPlan*>(m_plan.get())->takeJSCallees();
-
+    m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
+        Locker locker { m_lock };
+        if (m_plan->failed()) {
+            m_errorMessage = m_plan->errorMessage();
             setCompilationFinished();
-        })));
-    }
-#if ENABLE(WEBASSEMBLY_BBQJIT)
-    else {
-        m_plan = adoptRef(*new BBQPlan(vm, moduleInformation, CompilerMode::FullCompile, createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
-            Locker locker { m_lock };
-            if (m_plan->failed()) {
-                m_errorMessage = m_plan->errorMessage();
-                setCompilationFinished();
-                return;
-            }
+            return;
+        }
 
-            m_wasmIndirectCallEntryPoints = FixedVector<CodePtr<WasmEntryPtrTag>>(m_calleeCount);
-            m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
+        m_wasmIndirectCallEntryPoints = FixedVector<CodePtr<WasmEntryPtrTag>>(m_calleeCount);
+        m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
 
-            BBQPlan* bbqPlan = static_cast<BBQPlan*>(m_plan.get());
-            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JSEntrypointCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
-                if (jsEntrypointCallee) {
-                    auto result = m_jsEntrypointCallees.set(calleeIndex, WTFMove(jsEntrypointCallee));
-                    ASSERT_UNUSED(result, result.isNewEntry);
-                }
-                m_wasmIndirectCallEntryPoints[calleeIndex] = wasmEntrypoint->entrypoint();
-                m_wasmIndirectCallWasmCallees[calleeIndex] = nullptr;
-                setBBQCallee(locker, calleeIndex, adoptRef(*static_cast<BBQCallee*>(wasmEntrypoint.leakRef())));
-            });
+        for (unsigned i = 0; i < m_calleeCount; ++i) {
+            m_wasmIndirectCallEntryPoints[i] = m_ipintCallees->at(i)->entrypoint();
+            m_wasmIndirectCallWasmCallees[i] = m_ipintCallees->at(i).ptr();
+        }
 
-            m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
-            m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
+        m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
+        m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
+        m_jsEntrypointCallees = static_cast<IPIntPlan*>(m_plan.get())->takeJSCallees();
 
-            setCompilationFinished();
-        })));
-    }
-#endif
+        setCompilationFinished();
+    })));
     m_plan->setMode(mode);
-    if (Options::useWasmIPInt()) {
+    {
         Ref plan { *m_plan };
         if (plan->completeSyncIfPossible())
             return;

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -114,9 +114,9 @@ static inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, JSWebAs
     if (compile) {
         uint32_t functionIndex = callee->functionIndex();
         if (Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex)) {
-            auto plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
+            auto plan = Wasm::BBQPlan::create(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), Ref(*instance->calleeGroup()), Wasm::Plan::dontFinalize());
             Wasm::ensureWorklist().enqueue(plan.get());
-            if (UNLIKELY(!Options::useConcurrentJIT()))
+            if (UNLIKELY(!Options::useConcurrentJIT() || !Options::useWasmIPInt()))
                 plan->waitForCompletion();
             else
                 tierUpCounter.optimizeAfterWarmUp();

--- a/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
@@ -64,6 +64,7 @@ public:
     void optimizeAfterWarmUp()
     {
         setNewThreshold(Options::thresholdForBBQOptimizeAfterWarmUp());
+        ASSERT(Options::useWasmIPInt() || checkIfOptimizationThresholdReached());
     }
 
     bool checkIfOptimizationThresholdReached()

--- a/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
@@ -62,6 +62,7 @@ public:
     void optimizeAfterWarmUp()
     {
         setNewThreshold(Options::thresholdForBBQOptimizeAfterWarmUp());
+        ASSERT(Options::useWasmLLInt() || checkIfOptimizationThresholdReached());
     }
 
     bool checkIfOptimizationThresholdReached()

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -123,10 +123,8 @@ Ref<CalleeGroup> Module::getOrCreateCalleeGroup(VM& vm, MemoryMode mode)
     if (!calleeGroup || (calleeGroup->compilationFinished() && !calleeGroup->runnable())) {
         if (Options::useWasmIPInt())
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromIPInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_ipintCallees.copyRef());
-        else if (Options::useWasmLLInt())
-            m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_llintCallees.copyRef());
         else
-            m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), nullptr);
+            m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_llintCallees.copyRef());
     }
     return calleeGroup.releaseNonNull();
 }


### PR DESCRIPTION
#### 754ed19097422f6e5912cb4cfb33afcf21245f16
<pre>
BBQPlan should not be an EntryPlan
<a href="https://bugs.webkit.org/show_bug.cgi?id=280274">https://bugs.webkit.org/show_bug.cgi?id=280274</a>
<a href="https://rdar.apple.com/136594153">rdar://136594153</a>

Reviewed by Yusuke Suzuki.

Right now BBQPlan is also an EntryPlan which means it needs to do all the
validation/module call graph steps required for entry. This was error prone
as e.g. BBQPlan with useWasmLLInt=0 would not report it&apos;s callsites to the
CalleeGroup thus would never would call OMG code.

This patch instead makes useWasmLLInt/useWasmIPInt=0 instantly trigger a
sync tier up to BBQ. This should simplify the code paths and make things
much simpler.

* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::BBQPlan):
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
(JSC::Wasm::BBQPlan::prepareImpl): Deleted.
(JSC::Wasm::BBQPlan::didCompleteCompilation): Deleted.
(JSC::Wasm::BBQPlan::initializeCallees): Deleted.
(JSC::Wasm::BBQPlan::didReceiveFunctionData): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
* Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h:
(JSC::Wasm::IPIntTierUpCounter::optimizeAfterWarmUp):
* Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h:
(JSC::Wasm::LLIntTierUpCounter::optimizeAfterWarmUp):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::getOrCreateCalleeGroup):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::jitCompileSIMDFunction):

Canonical link: <a href="https://commits.webkit.org/284175@main">https://commits.webkit.org/284175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e03e84bf58938505908dbdee0773c7de3b5f92e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19807 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19623 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13166 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71729 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35212 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16711 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18164 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61780 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74425 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67910 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12633 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62248 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/10209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89689 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10459 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43855 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15886 "Found 5 new JSC stress test failures: wasm.yaml/wasm/function-references/br_on_null.js.wasm-no-cjit, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-bbq, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call.js.wasm-eager, wasm.yaml/wasm/v8/many-parameters.js.wasm-eager-jettison (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->