### PR TITLE
Use SharedPreferencesForWebProcess in Model process and filter IPC messages by model element feature flag

### DIFF
--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -71,6 +71,7 @@ ModelConnectionToWebProcess::ModelConnectionToWebProcess(ModelProcess& modelProc
 #if HAVE(AUDIT_TOKEN)
     , m_presentingApplicationAuditToken(parameters.presentingApplicationAuditToken ? std::optional(parameters.presentingApplicationAuditToken->auditToken()) : std::nullopt)
 #endif
+    , m_sharedPreferencesForWebProcess(WTFMove(parameters.sharedPreferencesForWebProcess))
 {
     RELEASE_ASSERT(RunLoop::isMain());
 

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -32,6 +32,7 @@
 #include "MessageReceiverMap.h"
 #include "ModelConnectionToWebProcessMessages.h"
 #include "ScopedActiveMessageReceiveQueue.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
@@ -74,6 +75,9 @@ public:
     virtual ~ModelConnectionToWebProcess();
 
     USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<ModelConnectionToWebProcess>);
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
+    void updateSharedPreferencesForWebProcess(const SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess); }
 
     IPC::Connection& connection() { return m_connection.get(); }
     Ref<IPC::Connection> protectedConnection() { return m_connection; }
@@ -137,6 +141,8 @@ private:
 #if ENABLE(IPC_TESTING_API)
     IPCTester m_ipcTester;
 #endif
+
+    SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.messages.in
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.messages.in
@@ -22,6 +22,7 @@
 
 #if ENABLE(MODEL_PROCESS)
 
+[EnabledBy=ModelElementEnabled]
 messages -> ModelConnectionToWebProcess WantsDispatchMessage {
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     CreateVisibilityPropagationContextForPage(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, bool canShowWhileLocked)

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -92,6 +92,13 @@ void ModelProcess::createModelConnectionToWebProcess(WebCore::ProcessIdentifier 
     m_webProcessConnections.add(identifier, WTFMove(newConnection));
 }
 
+void ModelProcess::sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier identifier, SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess, CompletionHandler<void()>&& completionHandler)
+{
+    if (RefPtr connection = m_webProcessConnections.get(identifier))
+        connection->updateSharedPreferencesForWebProcess(WTFMove(sharedPreferencesForWebProcess));
+    completionHandler();
+}
+
 void ModelProcess::removeModelConnectionToWebProcess(ModelConnectionToWebProcess& connection)
 {
     RELEASE_LOG(Process, "%p - ModelProcess::removeModelConnectionToWebProcess: processIdentifier=%" PRIu64, this, connection.webProcessIdentifier().toUInt64());

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -29,6 +29,7 @@
 
 #include "AuxiliaryProcess.h"
 #include "SandboxExtension.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
@@ -87,6 +88,7 @@ private:
     // Message Handlers
     void initializeModelProcess(ModelProcessCreationParameters&&, CompletionHandler<void()>&&);
     void createModelConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, ModelProcessConnectionParameters&&, CompletionHandler<void()>&&);
+    void sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier, SharedPreferencesForWebProcess&&, CompletionHandler<void()>&&);
     void addSession(PAL::SessionID);
     void removeSession(PAL::SessionID);
 

--- a/Source/WebKit/ModelProcess/ModelProcess.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcess.messages.in
@@ -26,6 +26,7 @@ messages -> ModelProcess : AuxiliaryProcess {
     InitializeModelProcess(struct WebKit::ModelProcessCreationParameters processCreationParameters) -> ()
 
     CreateModelConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::ConnectionHandle connectionHandle, struct WebKit::ModelProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
+    SharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier processIdentifier, struct WebKit::SharedPreferencesForWebProcess sharedPreferencesForWebProcess) -> ()
 
     PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> ()
     ProcessDidResume()

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -47,6 +47,12 @@ ModelProcessModelPlayerManagerProxy::~ModelProcessModelPlayerManagerProxy()
     clear();
 }
 
+const SharedPreferencesForWebProcess& ModelProcessModelPlayerManagerProxy::sharedPreferencesForWebProcess() const
+{
+    ASSERT(m_modelConnectionToWebProcess);
+    return m_modelConnectionToWebProcess->sharedPreferencesForWebProcess();
+}
+
 void ModelProcessModelPlayerManagerProxy::clear()
 {
     auto proxies = std::exchange(m_proxies, { });

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
@@ -30,6 +30,7 @@
 #include "Connection.h"
 #include "MessageReceiver.h"
 #include "ModelConnectionToWebProcess.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <WebCore/ModelPlayerIdentifier.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -49,6 +50,8 @@ public:
     }
 
     ~ModelProcessModelPlayerManagerProxy();
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     ModelConnectionToWebProcess* modelConnectionToWebProcess() { return m_modelConnectionToWebProcess.get(); }
     void clear();

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in
@@ -23,6 +23,7 @@
 
 #if ENABLE(MODEL_PROCESS)
 
+[EnabledBy=ModelElementEnabled]
 messages -> ModelProcessModelPlayerManagerProxy NotRefCounted {
     CreateModelPlayer(WebCore::ModelPlayerIdentifier identifier)
     DeleteModelPlayer(WebCore::ModelPlayerIdentifier identifier)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -30,6 +30,7 @@
 #include "Connection.h"
 #include "LayerHostingContext.h"
 #include "MessageReceiver.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <CoreRE/CoreRE.h>
 #include <WebCore/Color.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
@@ -65,6 +66,8 @@ class ModelProcessModelPlayerProxy final
 public:
     static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
     ~ModelProcessModelPlayerProxy();
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     static bool transformSupported(const simd_float4x4& transform);
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -23,6 +23,7 @@
 
 #if ENABLE(MODEL_PROCESS)
 
+[EnabledBy=ModelElementEnabled]
 messages -> ModelProcessModelPlayerProxy {
     CreateLayer()
     

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -80,6 +80,13 @@ ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy()
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy deallocated id=%" PRIu64, this, m_id.toUInt64());
 }
 
+const SharedPreferencesForWebProcess& ModelProcessModelPlayerProxy::sharedPreferencesForWebProcess() const
+{
+    RefPtr strongManager = m_manager.get();
+    RELEASE_ASSERT(strongManager);
+    return strongManager->sharedPreferencesForWebProcess();
+}
+
 bool ModelProcessModelPlayerProxy::transformSupported(const simd_float4x4& transform)
 {
     RESRT srt = REMakeSRTFromMatrix(transform);

--- a/Source/WebKit/Shared/ModelProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/ModelProcessConnectionParameters.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(MODEL_PROCESS)
 
+#include "SharedPreferencesForWebProcess.h"
 #include <WebCore/ProcessIdentity.h>
 #include <wtf/MachSendRight.h>
 
@@ -38,6 +39,7 @@ namespace WebKit {
 
 struct ModelProcessConnectionParameters {
     WebCore::ProcessIdentity webProcessIdentity;
+    SharedPreferencesForWebProcess sharedPreferencesForWebProcess;
 
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting { false };

--- a/Source/WebKit/Shared/ModelProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/ModelProcessConnectionParameters.serialization.in
@@ -24,6 +24,7 @@
 
 [RValue] struct WebKit::ModelProcessConnectionParameters {
     WebCore::ProcessIdentity webProcessIdentity;
+    WebKit::SharedPreferencesForWebProcess sharedPreferencesForWebProcess;
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting;
 #endif

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -132,6 +132,11 @@ void ModelProcessProxy::createModelProcessConnection(WebProcessProxy& webProcess
     }, 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 }
 
+void ModelProcessProxy::sharedPreferencesForWebProcessDidChange(WebProcessProxy& webProcessProxy, SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess, CompletionHandler<void()>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::ModelProcess::SharedPreferencesForWebProcessDidChange { webProcessProxy.coreProcessIdentifier(), WTFMove(sharedPreferencesForWebProcess) }, WTFMove(completionHandler));
+}
+
 void ModelProcessProxy::modelProcessExited(ProcessTerminationReason reason)
 {
     Ref protectedThis { *this };

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -47,6 +47,7 @@ class WebProcessProxy;
 class WebsiteDataStore;
 struct ModelProcessConnectionParameters;
 struct ModelProcessCreationParameters;
+struct SharedPreferencesForWebProcess;
 
 class ModelProcessProxy final : public AuxiliaryProcessProxy {
     WTF_MAKE_TZONE_ALLOCATED(ModelProcessProxy);
@@ -58,6 +59,7 @@ public:
     ~ModelProcessProxy();
 
     void createModelProcessConnection(WebProcessProxy&, IPC::Connection::Handle&& connectionIdentifier, ModelProcessConnectionParameters&&);
+    void sharedPreferencesForWebProcessDidChange(WebProcessProxy&, SharedPreferencesForWebProcess&&, CompletionHandler<void()>&&);
 
     void updateProcessAssertion();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6089,6 +6089,14 @@ void WebPageProxy::preferencesDidChange()
                 });
             }
 #endif
+#if ENABLE(MODEL_PROCESS)
+            if (RefPtr modelProcess = webProcess.processPool().modelProcess()) {
+                modelProcess->sharedPreferencesForWebProcessDidChange(webProcess, WTFMove(*sharedPreferences), [weakWebProcess = WeakPtr { webProcess }, syncedVersion = sharedPreferences->version]() {
+                    if (RefPtr webProcess = weakWebProcess.get())
+                        webProcess->didSyncSharedPreferencesForWebProcessWithModelProcess(syncedVersion);
+                });
+            }
+#endif
         }
 
         if (m_isPerformingDOMPrintOperation) {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1168,6 +1168,8 @@ void WebProcessProxy::createModelProcessConnection(IPC::Connection::Handle&& con
         anyPageHasModelProcessEnabled |= page->preferences().modelElementEnabled() && page->preferences().modelProcessEnabled();
     MESSAGE_CHECK(anyPageHasModelProcessEnabled);
 
+    parameters.sharedPreferencesForWebProcess = sharedPreferencesForWebProcess();
+
 #if ENABLE(IPC_TESTING_API)
     parameters.ignoreInvalidMessageForTesting = ignoreInvalidMessageForTesting();
 #endif
@@ -2265,6 +2267,9 @@ void WebProcessProxy::didSyncSharedPreferencesForWebProcessWithNetworkProcess(ui
 #if ENABLE(GPU_PROCESS)
         || m_sharedPreferencesVersionInGPUProcess < m_awaitedSharedPreferencesVersion
 #endif
+#if ENABLE(MODEL_PROCESS)
+        || m_sharedPreferencesVersionInModelProcess < m_awaitedSharedPreferencesVersion
+#endif
         )
         return;
     auto completionHandler = std::exchange(m_sharedPreferencesForWebProcessCompletionHandler, { });
@@ -2279,7 +2284,29 @@ void WebProcessProxy::didSyncSharedPreferencesForWebProcessWithGPUProcess(uint64
 {
     m_sharedPreferencesVersionInGPUProcess = syncedSharedPreferencesVersion;
     if (m_sharedPreferencesVersionInNetworkProcess < m_awaitedSharedPreferencesVersion
-        || m_sharedPreferencesVersionInGPUProcess < m_awaitedSharedPreferencesVersion)
+        || m_sharedPreferencesVersionInGPUProcess < m_awaitedSharedPreferencesVersion
+#if ENABLE(MODEL_PROCESS)
+        || m_sharedPreferencesVersionInModelProcess < m_awaitedSharedPreferencesVersion
+#endif
+        )
+        return;
+    auto completionHandler = std::exchange(m_sharedPreferencesForWebProcessCompletionHandler, { });
+    if (!completionHandler)
+        return;
+    completionHandler(true);
+    m_awaitedSharedPreferencesVersion = 0;
+}
+#endif
+
+#if ENABLE(MODEL_PROCESS)
+void WebProcessProxy::didSyncSharedPreferencesForWebProcessWithModelProcess(uint64_t syncedSharedPreferencesVersion)
+{
+    m_sharedPreferencesVersionInModelProcess = syncedSharedPreferencesVersion;
+    if (m_sharedPreferencesVersionInNetworkProcess < m_awaitedSharedPreferencesVersion
+#if ENABLE(GPU_PROCESS)
+        || m_sharedPreferencesVersionInGPUProcess < m_awaitedSharedPreferencesVersion
+#endif
+        || m_sharedPreferencesVersionInModelProcess < m_awaitedSharedPreferencesVersion)
         return;
     auto completionHandler = std::exchange(m_sharedPreferencesForWebProcessCompletionHandler, { });
     if (!completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -187,6 +187,9 @@ public:
 #if ENABLE(GPU_PROCESS)
     void didSyncSharedPreferencesForWebProcessWithGPUProcess(uint64_t syncedPreferencesVersion);
 #endif
+#if ENABLE(MODEL_PROCESS)
+    void didSyncSharedPreferencesForWebProcessWithModelProcess(uint64_t syncedPreferencesVersion);
+#endif
     void waitForSharedPreferencesForWebProcessToSync(uint64_t sharedPreferencesVersion, CompletionHandler<void(bool success)>&&);
 
     bool isMatchingRegistrableDomain(const WebCore::RegistrableDomain& domain) const { return m_registrableDomain ? *m_registrableDomain == domain : false; }
@@ -772,6 +775,9 @@ private:
     uint64_t m_sharedPreferencesVersionInNetworkProcess { 0 };
 #if ENABLE(GPU_PROCESS)
     uint64_t m_sharedPreferencesVersionInGPUProcess { 0 };
+#endif
+#if ENABLE(MODEL_PROCESS)
+    uint64_t m_sharedPreferencesVersionInModelProcess { 0 };
 #endif
     uint64_t m_awaitedSharedPreferencesVersion { 0 };
     CompletionHandler<void(bool success)> m_sharedPreferencesForWebProcessCompletionHandler;


### PR DESCRIPTION
#### a27c02d607ead123026e5b83e6aa07497c632d58
<pre>
Use SharedPreferencesForWebProcess in Model process and filter IPC messages by model element feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=280277">https://bugs.webkit.org/show_bug.cgi?id=280277</a>
<a href="https://rdar.apple.com/123263852">rdar://123263852</a>

Reviewed by Ryosuke Niwa and Mike Wyrzykowski.

Have ModelConnectionToWebProcess store a SharedPreferencesForWebProcess similar to how
it&apos;s done in GPUConnectionToWebProcess. Update WebPageProxy::preferencesDidChange to also
notify the model process of new shared preferences changes.

Use EnabledBy in model process message receivers to filter messages
based on the model element runtime feature flag.

* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::m_presentingApplicationAuditToken): Deleted.
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
(WebKit::ModelConnectionToWebProcess::sharedPreferencesForWebProcess const):
(WebKit::ModelConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.messages.in:
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::sharedPreferencesForWebProcessDidChange):
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/ModelProcess/ModelProcess.messages.in:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
(WebKit::ModelProcessModelPlayerManagerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/Shared/ModelProcessConnectionParameters.h:
* Source/WebKit/Shared/ModelProcessConnectionParameters.serialization.in:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::sharedPreferencesForWebProcessDidChange):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::preferencesDidChange):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createModelProcessConnection):
(WebKit::WebProcessProxy::didSyncSharedPreferencesForWebProcessWithNetworkProcess):
(WebKit::WebProcessProxy::didSyncSharedPreferencesForWebProcessWithGPUProcess):
(WebKit::WebProcessProxy::didSyncSharedPreferencesForWebProcessWithModelProcess):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/284246@main">https://commits.webkit.org/284246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d13178c581bd229036ed01925925e1d292c3038

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19803 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54743 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13164 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40580 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18160 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74421 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62243 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3817 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43851 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->