### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make WebProcess DrawingArea objects RefCounted

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -41,10 +41,16 @@ struct UpdateInfo;
 
 class DrawingAreaCoordinatedGraphics final : public DrawingArea {
 public:
-    DrawingAreaCoordinatedGraphics(WebPage&, const WebPageCreationParameters&);
+    static Ref<DrawingAreaCoordinatedGraphics> create(WebPage& webPage, const WebPageCreationParameters& parameters)
+    {
+        return adoptRef(*new DrawingAreaCoordinatedGraphics(webPage, parameters));
+    }
+
     virtual ~DrawingAreaCoordinatedGraphics();
 
 private:
+    DrawingAreaCoordinatedGraphics(WebPage&, const WebPageCreationParameters&);
+
     // DrawingArea
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const WebCore::IntRect&) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -55,7 +55,7 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DrawingArea);
 
-std::unique_ptr<DrawingArea> DrawingArea::create(WebPage& webPage, const WebPageCreationParameters& parameters)
+RefPtr<DrawingArea> DrawingArea::create(WebPage& webPage, const WebPageCreationParameters& parameters)
 {
 #if PLATFORM(MAC)
     SandboxExtension::consumePermanently(parameters.renderServerMachExtensionHandle);
@@ -65,21 +65,21 @@ std::unique_ptr<DrawingArea> DrawingArea::create(WebPage& webPage, const WebPage
 #if PLATFORM(COCOA)
 #if !PLATFORM(IOS_FAMILY)
     case DrawingAreaType::TiledCoreAnimation:
-        return makeUnique<TiledCoreAnimationDrawingArea>(webPage, parameters);
+        return TiledCoreAnimationDrawingArea::create(webPage, parameters);
 #endif
     case DrawingAreaType::RemoteLayerTree:
 #if PLATFORM(MAC)
-        return makeUnique<RemoteLayerTreeDrawingAreaMac>(webPage, parameters);
+        return RemoteLayerTreeDrawingAreaMac::create(webPage, parameters);
 #else
-        return makeUnique<RemoteLayerTreeDrawingArea>(webPage, parameters);
+        return RemoteLayerTreeDrawingArea::create(webPage, parameters);
 #endif
 #elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     case DrawingAreaType::CoordinatedGraphics:
-        return makeUnique<DrawingAreaCoordinatedGraphics>(webPage, parameters);
+        return DrawingAreaCoordinatedGraphics::create(webPage, parameters);
 #endif
 #if USE(GRAPHICS_LAYER_WC)
     case DrawingAreaType::WC:
-        return makeUnique<DrawingAreaWC>(webPage, parameters);
+        return DrawingAreaWC::create(webPage, parameters);
 #endif
     }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -71,12 +71,12 @@ class LayerTreeHost;
 struct WebPageCreationParameters;
 struct WebPreferencesStore;
 
-class DrawingArea : public IPC::MessageReceiver, public WebCore::DisplayRefreshMonitorFactory {
+class DrawingArea : public RefCounted<DrawingArea>, public IPC::MessageReceiver, public WebCore::DisplayRefreshMonitorFactory {
     WTF_MAKE_TZONE_ALLOCATED(DrawingArea);
     WTF_MAKE_NONCOPYABLE(DrawingArea);
 
 public:
-    static std::unique_ptr<DrawingArea> create(WebPage&, const WebPageCreationParameters&);
+    static RefPtr<DrawingArea> create(WebPage&, const WebPageCreationParameters&);
     virtual ~DrawingArea();
     
     DrawingAreaType type() const { return m_type; }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -38,15 +38,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class RemoteLayerTreeDrawingArea;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLayerTreeDrawingArea> : std::true_type { };
-}
-
 namespace WebCore {
 class PlatformCALayer;
 class ThreadSafeImageBufferFlusher;
@@ -60,7 +51,11 @@ class RemoteLayerTreeContext;
 class RemoteLayerTreeDrawingArea : public DrawingArea, public WebCore::GraphicsLayerClient {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingArea);
 public:
-    RemoteLayerTreeDrawingArea(WebPage&, const WebPageCreationParameters&);
+    static RefPtr<RemoteLayerTreeDrawingArea> create(WebPage& webPage, const WebPageCreationParameters& parameters)
+    {
+        return adoptRef(*new RemoteLayerTreeDrawingArea(webPage, parameters));
+    }
+
     virtual ~RemoteLayerTreeDrawingArea();
 
     TransactionID nextTransactionID() const { return m_currentTransactionID.next(); }
@@ -71,6 +66,8 @@ public:
     void gpuProcessConnectionWasDestroyed();
 
 protected:
+    RemoteLayerTreeDrawingArea(WebPage&, const WebPageCreationParameters&);
+
     void updateRendering();
 
 private:

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -475,6 +475,7 @@ public:
     inline WebCore::IntRect bounds() const;
 
     DrawingArea* drawingArea() const { return m_drawingArea.get(); }
+    RefPtr<DrawingArea> protectedDrawingArea() const;
 
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
@@ -2361,7 +2362,7 @@ private:
 
     WebCore::IntSize m_viewSize;
     LayerHostingMode m_layerHostingMode;
-    std::unique_ptr<DrawingArea> m_drawingArea;
+    RefPtr<DrawingArea> m_drawingArea;
 
     std::unique_ptr<WebPageTesting> m_webPageTesting;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -39,10 +39,16 @@ namespace WebKit {
 class RemoteLayerTreeDrawingAreaMac final : public RemoteLayerTreeDrawingArea {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaMac);
 public:
-    RemoteLayerTreeDrawingAreaMac(WebPage&, const WebPageCreationParameters&);
+    static Ref<RemoteLayerTreeDrawingAreaMac> create(WebPage& webPage, const WebPageCreationParameters& parameters)
+    {
+        return adoptRef(*new RemoteLayerTreeDrawingAreaMac(webPage, parameters));
+    }
+
     virtual ~RemoteLayerTreeDrawingAreaMac();
 
 private:
+    RemoteLayerTreeDrawingAreaMac(WebPage&, const WebPageCreationParameters&);
+
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const final;
 
     void setColorSpace(std::optional<WebCore::DestinationColorSpace>) final;

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -39,15 +39,6 @@
 
 OBJC_CLASS CALayer;
 
-namespace WebKit {
-class TiledCoreAnimationDrawingArea;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::TiledCoreAnimationDrawingArea> : std::true_type { };
-}
-
 namespace WebCore {
 class LocalFrameView;
 class PlatformCALayer;
@@ -62,10 +53,16 @@ class LayerHostingContext;
 class TiledCoreAnimationDrawingArea final : public DrawingArea {
     WTF_MAKE_TZONE_ALLOCATED(TiledCoreAnimationDrawingArea);
 public:
-    TiledCoreAnimationDrawingArea(WebPage&, const WebPageCreationParameters&);
+    static Ref<TiledCoreAnimationDrawingArea> create(WebPage& webPage, const WebPageCreationParameters& parameters)
+    {
+        return adoptRef(*new TiledCoreAnimationDrawingArea(webPage, parameters));
+    }
+
     virtual ~TiledCoreAnimationDrawingArea();
 
 private:
+    TiledCoreAnimationDrawingArea(WebPage&, const WebPageCreationParameters&);
+
     // DrawingArea
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const WebCore::IntRect&) override;

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -35,24 +35,21 @@
 #include <WebCore/Timer.h>
 
 namespace WebKit {
-class DrawingAreaWC;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::DrawingAreaWC> : std::true_type { };
-}
-
-namespace WebKit {
 
 class DrawingAreaWC final
     : public DrawingArea
     , public GraphicsLayerWC::Observer {
 public:
-    DrawingAreaWC(WebPage&, const WebPageCreationParameters&);
+    static Ref<DrawingAreaWC> create(WebPage& webPage, const WebPageCreationParameters& parameters)
+    {
+        return adoptRef(*new DrawingAreaWC(webPage, parameters));
+    }
+
     ~DrawingAreaWC() override;
 
 private:
+    DrawingAreaWC(WebPage&, const WebPageCreationParameters&);
+
     // DrawingArea
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
     void setNeedsDisplay() override;


### PR DESCRIPTION
#### eb7e6e832deb5c0511825feefcfae917e2035236
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make WebProcess DrawingArea objects RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280281">https://bugs.webkit.org/show_bug.cgi?id=280281</a>
<a href="https://rdar.apple.com/136602976">rdar://136602976</a>

Reviewed by Geoffrey Garen.

The same will need to be done for the associated Proxy objects, but
that will be done in a later patch.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::create):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::create):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::updateAfterDrawingAreaCreation):
(WebKit::WebPage::gpuProcessConnectionWasDestroyed):
(WebKit::WebPage::reinitializeWebPage):
(WebKit::WebPage::enterAcceleratedCompositingMode):
(WebKit::WebPage::exitAcceleratedCompositingMode):
(WebKit::WebPage::close):
(WebKit::WebPage::setSize):
(WebKit::WebPage::sendViewportAttributesChanged):
(WebKit::WebPage::didScalePage):
(WebKit::WebPage::setDeviceScaleFactor):
(WebKit::WebPage::viewportPropertiesDidChange):
(WebKit::WebPage::updateDrawingAreaLayerTreeFreezeState):
(WebKit::WebPage::updateFrameSize):
(WebKit::WebPage::tryMarkLayersVolatile):
(WebKit::WebPage::mouseEvent):
(WebKit::WebPage::setBackgroundColor):
(WebKit::WebPage::setTopContentInsetFenced):
(WebKit::WebPage::setActivityState):
(WebKit::WebPage::setLayerHostingMode):
(WebKit::WebPage::updateRenderingWithForcedRepaintWithoutCallback):
(WebKit::WebPage::updateRenderingWithForcedRepaint):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::willDestroyDecodedDataForAllImages):
(WebKit::WebPage::setMainFrameIsScrollable):
(WebKit::WebPage::willReplaceMultipartContent):
(WebKit::WebPage::didReplaceMultipartContent):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::setShouldScaleViewToFitDocument):
(WebKit::WebPage::dispatchDidReachLayoutMilestone):
(WebKit::WebPage::protectedDrawingArea const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:

Canonical link: <a href="https://commits.webkit.org/284292@main">https://commits.webkit.org/284292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aceaa4987ae2969350232f68407f9f202003698d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20048 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54886 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13341 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40771 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18404 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62523 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4003 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->