### PR TITLE
Remove obsolete SPI usage related to downloads

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -115,7 +115,6 @@ void Download::platformDestroyDownload()
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     m_bookmarkURL = nil;
     [m_progress cancel];
-    [m_progress unpublish];
 #else
     if (m_progress)
 #if HAVE(NSPROGRESS_PUBLISHING_SPI)
@@ -155,8 +154,6 @@ void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmark
         // This is to make sure the placeholder has not been moved to the final download URL before the client received the placeholder URL.
         if (!isUsingPlaceholder)
             startUpdatingProgress();
-
-        [m_progress publish];
     } else {
         m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url sandboxExtension:nullptr]);
 #if HAVE(NSPROGRESS_PUBLISHING_SPI)


### PR DESCRIPTION
#### 170660c9bb51446f5930a3f69eea19daeb8f0798
<pre>
Remove obsolete SPI usage related to downloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=280283">https://bugs.webkit.org/show_bug.cgi?id=280283</a>
<a href="https://rdar.apple.com/136604458">rdar://136604458</a>

Reviewed by Sihui Liu.

Remove obsolete SPI usage of -[NSProgress publish] and -[NSProgress unpublish] when we have MODERN_DOWNLOADPROGRESS.

* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::platformDestroyDownload):
(WebKit::Download::publishProgress):

Canonical link: <a href="https://commits.webkit.org/284275@main">https://commits.webkit.org/284275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d5017bdd875e605aed7e95fe80a2f0bf6a5484e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54753 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13170 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40582 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18169 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62223 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62249 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3818 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10522 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43860 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44934 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->