### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make PageLoadState and related classes RefCounted or equivalent

### DIFF
--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -55,7 +55,7 @@
         return nil;
 
     _page = WTFMove(page);
-    _observer = makeUnique<WebKit::PageLoadStateObserver>(self, @"URL");
+    _observer = makeUniqueWithoutRefCountedCheck<WebKit::PageLoadStateObserver>(self, @"URL");
     _page->pageLoadState().addObserver(*_observer);
 
     return self;

--- a/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
@@ -38,6 +38,9 @@ public:
     {
     }
 
+    void ref() const final;
+    void deref() const final;
+
     void clearObject()
     {
         m_object = nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -612,7 +612,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _page = WebKit::toImpl(pageRef);
 
-    _pageLoadStateObserver = makeUnique<WebKit::PageLoadStateObserver>(self);
+    _pageLoadStateObserver = makeUniqueWithoutRefCountedCheck<WebKit::PageLoadStateObserver>(self);
     _page->pageLoadState().addObserver(*_pageLoadStateObserver);
 
     ASSERT(!browsingContextControllerMap().contains(*_page));
@@ -753,3 +753,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 @end
 ALLOW_DEPRECATED_DECLARATIONS_END
+
+namespace WebKit {
+
+void PageLoadStateObserver::ref() const
+{
+    [m_object.get() retain];
+}
+
+void PageLoadStateObserver::deref() const
+{
+    [m_object.get() release];
+}
+
+}

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -410,7 +410,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 
     _page->setApplicationNameForDesktopUserAgent(configuration._applicationNameForDesktopUserAgent);
 
-    _navigationState = makeUnique<WebKit::NavigationState>(self);
+    _navigationState = makeUniqueWithoutRefCountedCheck<WebKit::NavigationState>(self);
     _page->setNavigationClient(_navigationState->createNavigationClient());
 
     _uiDelegate = makeUnique<WebKit::UIDelegate>(self);

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -43,16 +43,6 @@
 @protocol WKHistoryDelegatePrivate;
 @protocol WKNavigationDelegate;
 
-namespace WebKit {
-class NavigationState;
-class WebPageLoadTiming;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::NavigationState> : std::true_type { };
-}
-
 namespace API {
 class Navigation;
 }
@@ -64,12 +54,16 @@ class SecurityOriginData;
 namespace WebKit {
 
 struct WebNavigationDataStore;
+class WebPageLoadTiming;
 
 class NavigationState final : public PageLoadState::Observer {
     WTF_MAKE_TZONE_ALLOCATED(NavigationState);
 public:
     explicit NavigationState(WKWebView *);
     ~NavigationState();
+
+    void ref() const final;
+    void deref() const final;
 
     static NavigationState* fromWebPage(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -150,6 +150,16 @@ NavigationState::~NavigationState()
     }
 }
 
+void NavigationState::ref() const
+{
+    [m_webView.get() retain];
+}
+
+void NavigationState::deref() const
+{
+    [m_webView.get() release];
+}
+
 NavigationState* NavigationState::fromWebPage(WebPageProxy& webPageProxy)
 {
     ASSERT(navigationStates().contains(webPageProxy));

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -519,7 +519,7 @@ void PageLoadState::callObserverCallback(void (Observer::*callback)())
     for (auto& observer : copyToVector(m_observers)) {
         // This appears potentially inefficient on the surface (searching in a Vector)
         // but in practice - using only API - there will only ever be (1) observer.
-        if (!observer || !m_observers.contains(*observer))
+        if (RefPtr protectedObserver = observer.get(); !protectedObserver || !m_observers.contains(*protectedObserver))
             continue;
 
         ((*observer).*callback)();

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -33,21 +33,14 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
-class PageLoadStateObserverBase;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PageLoadStateObserverBase> : std::true_type { };
-}
-
-namespace WebKit {
 
 class WebPageProxy;
 
 class PageLoadStateObserverBase : public CanMakeWeakPtr<PageLoadStateObserverBase> {
 public:
     virtual ~PageLoadStateObserverBase() = default;
+
+    DECLARE_VIRTUAL_REFCOUNTED;
 
     virtual void willChangeIsLoading() = 0;
     virtual void didChangeIsLoading() = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1096,7 +1096,7 @@ void WebPageProxy::setIconLoadingClient(std::unique_ptr<API::IconLoadingClient>&
     send(Messages::WebPage::SetUseIconLoadingClient(hasClient));
 }
 
-void WebPageProxy::setPageLoadStateObserver(std::unique_ptr<PageLoadState::Observer>&& observer)
+void WebPageProxy::setPageLoadStateObserver(RefPtr<PageLoadState::Observer>&& observer)
 {
     if (m_pageLoadStateObserver)
         pageLoadState().removeObserver(*m_pageLoadStateObserver);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -803,7 +803,7 @@ public:
     API::IconLoadingClient& iconLoadingClient() { return *m_iconLoadingClient; }
     void setIconLoadingClient(std::unique_ptr<API::IconLoadingClient>&&);
 
-    void setPageLoadStateObserver(std::unique_ptr<PageLoadStateObserverBase>&&);
+    void setPageLoadStateObserver(RefPtr<PageLoadStateObserverBase>&&);
 
     void initializeWebPage(const WebCore::Site&, WebCore::SandboxFlags);
     void setDrawingArea(std::unique_ptr<DrawingAreaProxy>&&);
@@ -3192,7 +3192,7 @@ private:
     std::unique_ptr<API::ContextMenuClient> m_contextMenuClient;
 #endif
     std::unique_ptr<WebPageInjectedBundleClient> m_injectedBundleClient;
-    std::unique_ptr<PageLoadStateObserverBase> m_pageLoadStateObserver;
+    RefPtr<PageLoadStateObserverBase> m_pageLoadStateObserver;
 
     std::unique_ptr<WebNavigationState> m_navigationState;
     String m_failingProvisionalLoadURL;


### PR DESCRIPTION
#### 0eadc6960dc578b3e8c3cc5a7bbcda543ccd0876
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make PageLoadState and related classes RefCounted or equivalent
<a href="https://bugs.webkit.org/show_bug.cgi?id=280282">https://bugs.webkit.org/show_bug.cgi?id=280282</a>

Reviewed by Chris Dumez.

Those classes are CanMakeWeakPtr so that need to be lifecycle manageable.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageStateClient):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState initWithPage:]):
* Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController _initWithPageRef:]):
(WebKit::PageLoadStateObserver::ref const):
(WebKit::PageLoadStateObserver::deref const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
(webkitWebViewDispose):
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::ref const):
(WebKit::NavigationState::deref const):
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::callObserverCallback):
* Source/WebKit/UIProcess/PageLoadState.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setPageLoadStateObserver):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/284380@main">https://commits.webkit.org/284380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3e7f0a9dbe5d0387c4a2cb0cde470eebb9d27ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55004 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40951 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18647 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62658 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4169 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->