### PR TITLE
[WebGPU] Check offset plus format size is valid

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/webgpu_oob_attribute_offset-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/webgpu_oob_attribute_offset-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/webgpu_oob_attribute_offset.html
+++ b/LayoutTests/fast/webgpu/nocrash/webgpu_oob_attribute_offset.html
@@ -1,0 +1,365 @@
+<!doctype html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>WebGPU Lif2</title>
+  </head>
+  <body>
+    <canvas width="1024" height="1024"></canvas>
+    <script type="module">
+        const GRID_SIZE = 100;
+        const WORKGROUP_SIZE = 8;
+
+        const BUFFER_SIZE = 1024;
+
+
+        const canvas = document.querySelector("canvas");
+        const UPDATE_INTERVAL = 200; // Update every 200ms (5 times/sec)
+        let step = 0; // Track how many simulation steps have been run
+
+        // Your WebGPU code will begin here!
+        if (!navigator.gpu) {
+            throw new Error("WebGPU not supported on this browser.");
+        }
+
+        const adapter = await navigator.gpu.requestAdapter();
+        if (!adapter) {
+            throw new Error("No appropriate GPUAdapter found.");
+        }
+
+        const device = await adapter.requestDevice();
+        device.pushErrorScope('validation');
+
+        const context = canvas.getContext("webgpu");
+        const canvasFormat = navigator.gpu.getPreferredCanvasFormat();
+        context.configure({
+            device: device,
+            format: canvasFormat,
+        });
+
+        const vertices = new Float32Array([
+          -0.8, -0.8, // Triangle 1 (Blue)
+          0.8, -0.8,
+          0.8,  0.8,
+
+          -0.8, -0.8, // Triangle 2 (Red)
+          0.8,  0.8,
+          -0.8,  0.8,
+        ]);
+
+        const vertexBuffer = device.createBuffer({
+          label: "Cell vertices",
+          size: vertices.byteLength,
+          usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+        });
+
+
+
+
+        
+
+        const vertexBufferLayout = {
+          arrayStride: 8,
+          attributes: [{
+            format: "float32x2",
+            offset: 0xfffffffffffff,
+            shaderLocation: 0, // Position, see vertex shader
+          }],
+        };
+
+        // Create a uniform buffer that describes the grid.
+        const uniformArray = new Float32Array([GRID_SIZE, GRID_SIZE]);
+        const uniformBuffer = device.createBuffer({
+          label: "Grid Uniforms",
+          size: uniformArray.byteLength,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+        device.queue.writeBuffer(uniformBuffer, 0, uniformArray);
+
+        // Create an array representing the active state of each cell.
+        const cellStateArray = new Uint32Array(GRID_SIZE * GRID_SIZE);
+
+        // Create a storage buffer to hold the cell state.
+        // Create two storage buffers to hold the cell state.
+        const cellStateStorage = [
+          device.createBuffer({
+            label: "Cell State A",
+            size: cellStateArray.byteLength,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+          }),
+          device.createBuffer({
+            label: "Cell State B",
+            size: cellStateArray.byteLength,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+          })
+        ];
+
+// Set each cell to a random state, then copy the JavaScript array 
+// into the storage buffer.
+for (let i = 0; i < cellStateArray.length; ++i) {
+  cellStateArray[i] = Math.random() > 0.6 ? 1 : 0;
+}
+device.queue.writeBuffer(cellStateStorage[0], 0, cellStateArray);
+
+      // Mark every other cell of the second grid as active.
+      // for (let i = 0; i < cellStateArray.length; i++) {
+      //   cellStateArray[i] = i % 2;
+      // }
+      // device.queue.writeBuffer(cellStateStorage[1], 0, cellStateArray);
+
+
+        const cellShaderModule = device.createShaderModule({
+          label: "Cell shader",
+          code: `
+            struct VertexInput {
+              @location(0) pos: vec2f,
+              @builtin(instance_index) instance: u32,
+            };
+
+            struct VertexOutput {
+              @builtin(position) pos: vec4f,
+              @location(0) cell: vec2f, // New line!
+            };
+
+            @group(0) @binding(0) var<uniform> grid: vec2f;
+            @group(0) @binding(1) var<storage> cellState: array<u32>; // New!
+
+
+              @vertex
+              fn vertexMain(@location(0) pos: vec2f,
+                            @builtin(instance_index) instance: u32) -> VertexOutput {
+                let i = f32(instance);
+                let cell = vec2f(i % grid.x, floor(i / grid.x));
+                let state = f32(cellState[instance]); // New line!
+
+                let cellOffset = cell / grid * 2;
+                // New: Scale the position by the cell's active state.
+                let gridPos = (pos*state+1) / grid - 1 + cellOffset;
+
+                var output: VertexOutput;
+                output.pos = vec4f(gridPos, 0, 1);
+                output.cell = cell;
+                return output;
+              }
+
+            
+            @fragment
+            fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
+              let c = input.cell / grid;
+              return vec4f(c, 1-c.x, 1);
+            }
+          `
+        });
+
+        const simulationShaderModule = device.createShaderModule({
+  label: "Life simulation shader",
+  code: `
+    @group(0) @binding(0) var<uniform> grid: vec2f;
+
+    @group(0) @binding(1) var<storage> cellStateIn: array<u32>;
+    @group(0) @binding(2) var<storage, read_write> cellStateOut: array<u32>;
+
+    fn cellIndex(cell: vec2u) -> u32 {
+      return (cell.y % u32(grid.y)) * u32(grid.x) +
+              (cell.x % u32(grid.x));
+    }
+
+    fn cellActive(x: u32, y: u32) -> u32 {
+      return cellStateIn[cellIndex(vec2(x, y))];
+    }
+
+    @compute @workgroup_size(${WORKGROUP_SIZE}, ${WORKGROUP_SIZE})
+    fn computeMain(@builtin(global_invocation_id) cell: vec3u) {
+      // Determine how many active neighbors this cell has.
+      let activeNeighbors = cellActive(cell.x+1, cell.y+1) +
+                            cellActive(cell.x+1, cell.y) +
+                            cellActive(cell.x+1, cell.y-1) +
+                            cellActive(cell.x, cell.y-1) +
+                            cellActive(cell.x-1, cell.y-1) +
+                            cellActive(cell.x-1, cell.y) +
+                            cellActive(cell.x-1, cell.y+1) +
+                            cellActive(cell.x, cell.y+1);
+
+      let i = cellIndex(cell.xy);
+
+      // Conway's game of life rules:
+      switch activeNeighbors {
+        case 2: {
+          cellStateOut[i] = cellStateIn[i];
+        }
+        case 3: {
+          cellStateOut[i] = 1;
+        }
+        default: {
+          cellStateOut[i] = 0;
+        }
+      }
+    }
+  `
+});
+        
+
+// Create the bind group layout and pipeline layout.
+const bindGroupLayout = device.createBindGroupLayout({
+  label: "Cell Bind Group Layout",
+  entries: [{
+    binding: 0,
+    // Add GPUShaderStage.FRAGMENT here if you are using the `grid` uniform in the fragment shader.
+    visibility: GPUShaderStage.VERTEX | GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+    buffer: {} // Grid uniform buffer
+  }, {
+    binding: 1,
+    visibility: GPUShaderStage.VERTEX | GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+    buffer: { type: "read-only-storage"} // Cell state input buffer
+  }, {
+    binding: 2,
+    visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+    buffer: { type: "storage"} // Cell state output buffer
+  }]
+});
+
+const pipelineLayout = device.createPipelineLayout({
+  label: "Cell Pipeline Layout",
+  bindGroupLayouts: [ bindGroupLayout ],
+});
+
+
+const cellPipeline = device.createRenderPipeline({
+  label: "Cell pipeline",
+  layout: pipelineLayout, // Updated!
+  vertex: {
+    module: cellShaderModule,
+    entryPoint: "vertexMain",
+    buffers: [vertexBufferLayout]
+  },
+  fragment: {
+    module: cellShaderModule,
+    entryPoint: "fragmentMain",
+    targets: [{
+      format: canvasFormat
+    }]
+  }
+});
+
+// Create a compute pipeline that updates the game state.
+const simulationPipeline = device.createComputePipeline({
+  label: "Simulation pipeline",
+  layout: pipelineLayout,
+  compute: {
+    module: simulationShaderModule,
+    entryPoint: "computeMain",
+  }
+});
+
+      //   const bindGroup = device.createBindGroup({
+      //   label: "Cell renderer bind group",
+      //   layout: cellPipeline.getBindGroupLayout(0),
+      //   entries: [{
+      //     binding: 0,
+      //     resource: { buffer: uniformBuffer }
+      //   },
+      //   {
+      //     binding: 1,
+      //     resource: { buffer: cellStateStorage }
+      //   }
+      //   ],
+      // });
+
+
+// Create a bind group to pass the grid uniforms into the pipeline
+const bindGroups = [
+  device.createBindGroup({
+    label: "Cell renderer bind group A",
+    layout: bindGroupLayout, // Updated Line
+    entries: [{
+      binding: 0,
+      resource: { buffer: uniformBuffer }
+    }, {
+      binding: 1,
+      resource: { buffer: cellStateStorage[0] }
+    }, {
+      binding: 2, // New Entry
+      resource: { buffer: cellStateStorage[1] }
+    }],
+  }),
+  device.createBindGroup({
+    label: "Cell renderer bind group B",
+    layout: bindGroupLayout, // Updated Line
+
+    entries: [{
+      binding: 0,
+      resource: { buffer: uniformBuffer }
+    }, {
+      binding: 1,
+      resource: { buffer: cellStateStorage[1] }
+    }, {
+      binding: 2, // New Entry
+      resource: { buffer: cellStateStorage[0] }
+    }],
+  }),
+];
+
+
+
+        device.queue.writeBuffer(vertexBuffer, /*bufferOffset=*/0, vertices);
+
+   
+
+
+      // Move all of our rendering code into a function
+function updateGrid() {
+  const encoder = device.createCommandEncoder();
+
+  const computePass = encoder.beginComputePass();
+
+  computePass.setPipeline(simulationPipeline);
+computePass.setBindGroup(0, bindGroups[step % 2]);
+
+// New lines
+const workgroupCount = Math.ceil(GRID_SIZE / WORKGROUP_SIZE);
+computePass.dispatchWorkgroups(workgroupCount, workgroupCount);
+
+const output = device.createBuffer({
+  size: BUFFER_SIZE,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+});
+computePass.dispatchWorkgroupsIndirect(output, 4);
+
+
+
+computePass.end();
+  
+  step++; // Increment the step count
+  
+  // Start a render pass 
+  const pass = encoder.beginRenderPass({
+    colorAttachments: [{
+      view: context.getCurrentTexture().createView(),
+      loadOp: "clear",
+      clearValue: { r: 0, g: 0, b: 0.4, a: 1.0 },
+      storeOp: "store",
+    }]
+  });
+
+  // Draw the grid.
+  pass.setPipeline(cellPipeline);
+  pass.setBindGroup(0, bindGroups[step % 2]); // Updated!
+  pass.setVertexBuffer(0, vertexBuffer);
+  pass.draw(vertices.length / 2, GRID_SIZE * GRID_SIZE);
+
+
+  
+
+  // End the render pass and submit the command buffer
+  pass.end();
+  device.queue.submit([encoder.finish()]);
+}
+
+// Schedule updateGrid() to run repeatedly
+setInterval(updateGrid, UPDATE_INTERVAL);
+
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
#### ef779cb00ce3c33cab65e99235302c90c1f591b4
<pre>
[WebGPU] Check offset plus format size is valid
<a href="https://bugs.webkit.org/show_bug.cgi?id=280290">https://bugs.webkit.org/show_bug.cgi?id=280290</a>
<a href="https://rdar.apple.com/136576097">rdar://136576097</a>

Reviewed by Tadeu Zagallo.

Passing values exceeding 2^53 - 1 could result in an
overflow and lead to an out of bounds access in the shader.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::createVertexDescriptor):
Use checked arithmetic.

* LayoutTests/fast/webgpu/nocrash/webgpu_oob_attribute_offset-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/webgpu_oob_attribute_offset.html: Added.
Add regression test.

Canonical link: <a href="https://commits.webkit.org/284294@main">https://commits.webkit.org/284294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce75a3667c8bd7d1252a3347568e6982da8eeea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19831 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54757 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13185 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62313 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15303 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3836 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43879 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->