### PR TITLE
Distinguish always/trivially compactible allocations in libpas/bmalloc

### DIFF
--- a/Source/bmalloc/bmalloc/CompactAllocationMode.h
+++ b/Source/bmalloc/bmalloc/CompactAllocationMode.h
@@ -35,8 +35,8 @@
 namespace bmalloc {
 
 enum class CompactAllocationMode {
-    Compact,
-    NonCompact
+    NonCompact,
+    Compact
 };
 
 static constexpr unsigned numAllocationModes = 2;
@@ -46,10 +46,10 @@ static constexpr unsigned numAllocationModes = 2;
 BINLINE constexpr pas_allocation_mode asPasAllocationMode(CompactAllocationMode mode)
 {
     switch (mode) {
-    case CompactAllocationMode::Compact:
-        return pas_compact_allocation_mode;
     case CompactAllocationMode::NonCompact:
         return pas_non_compact_allocation_mode;
+    case CompactAllocationMode::Compact:
+        return pas_maybe_compact_allocation_mode;
     }
     RELEASE_BASSERT_NOT_REACHED();
 }

--- a/Source/bmalloc/bmalloc/IsoHeap.cpp
+++ b/Source/bmalloc/bmalloc/IsoHeap.cpp
@@ -87,7 +87,7 @@ void* isoAllocateCompact(pas_heap_ref& heapRef)
         }
     }
 
-    void* result = bmalloc_iso_allocate_inline(&heapRef, pas_compact_allocation_mode);
+    void* result = bmalloc_iso_allocate_inline(&heapRef, pas_maybe_compact_allocation_mode);
     BPROFILE_ALLOCATION(COMPACTIBLE, result, typeSize);
     return result;
 }
@@ -103,7 +103,7 @@ void* isoTryAllocateCompact(pas_heap_ref& heapRef)
         }
     }
 
-    void* result = bmalloc_try_iso_allocate_inline(&heapRef, pas_compact_allocation_mode);
+    void* result = bmalloc_try_iso_allocate_inline(&heapRef, pas_maybe_compact_allocation_mode);
     BPROFILE_TRY_ALLOCATION(COMPACTIBLE, result, typeSize);
     return result;
 }

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -79,7 +79,7 @@ void* tzoneAllocateCompact(pas_heap_ref& heapRef)
         }
     }
 
-    return bmalloc_iso_allocate_inline(&heapRef, pas_compact_allocation_mode);
+    return bmalloc_iso_allocate_inline(&heapRef, pas_maybe_compact_allocation_mode);
 }
 
 void* tzoneTryAllocateCompact(pas_heap_ref& heapRef)
@@ -92,7 +92,7 @@ void* tzoneTryAllocateCompact(pas_heap_ref& heapRef)
             return result.ptr;
     }
 
-    return bmalloc_try_iso_allocate_inline(&heapRef, pas_compact_allocation_mode);
+    return bmalloc_try_iso_allocate_inline(&heapRef, pas_maybe_compact_allocation_mode);
 }
 
 void tzoneDeallocate(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/jit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap.c
@@ -78,7 +78,7 @@ void* jit_heap_try_allocate(size_t size)
     void* result;
     if (verbose)
         pas_log("going to allocate in jit\n");
-    result = (void*)jit_try_allocate_common_primitive_impl(size, 1, pas_compact_allocation_mode).begin;
+    result = (void*)jit_try_allocate_common_primitive_impl(size, 1, pas_always_compact_allocation_mode).begin;
     if (verbose)
         pas_log("done allocating in jit, returning %p\n", result);
     return result;

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
@@ -31,13 +31,18 @@
 PAS_BEGIN_EXTERN_C;
 
 enum pas_allocation_mode {
-    /* We are allocating an object and intend to store its address as a compact
-       pointer. */
-    pas_compact_allocation_mode,
-
-    /* We are allocating an ordinary object and will not store its address in
-       any compact pointer type. */
+    /* We are allocating an object from ordinary memory and don't plan on
+       compacting its address. */
     pas_non_compact_allocation_mode,
+
+    /* We are allocating an object from ordinary memory and expect to
+       be able to compact its address, but don't expect all addresses in
+       that memory to be trivially compactible. */
+    pas_maybe_compact_allocation_mode,
+
+    /* We are allocating an object from memory where all addresses within
+       that memory are trivially compactible, like in the immortal heap. */
+    pas_always_compact_allocation_mode,
 };
 
 typedef enum pas_allocation_mode pas_allocation_mode;
@@ -46,10 +51,12 @@ typedef enum pas_allocation_mode __pas_allocation_mode;
 static inline const char* pas_allocation_mode_get_string(pas_allocation_mode allocation_mode)
 {
     switch (allocation_mode) {
-    case pas_compact_allocation_mode:
-        return "compact";
     case pas_non_compact_allocation_mode:
         return "non-compact";
+    case pas_maybe_compact_allocation_mode:
+        return "maybe compact";
+    case pas_always_compact_allocation_mode:
+        return "always compact";
     }
     PAS_ASSERT(!"Should not be reached");
     return NULL;

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap.c
@@ -121,7 +121,7 @@ void* pas_utility_heap_try_allocate_with_alignment(
         allocator,
         aligned_size,
         alignment,
-        pas_compact_allocation_mode,
+        pas_always_compact_allocation_mode,
         PAS_UTILITY_HEAP_CONFIG,
         &pas_utility_allocator_counts,
         pas_allocation_result_identity).begin;


### PR DESCRIPTION
#### 2d71c4b7c91e0c0bde284c99ada0ae797f2ed15c
<pre>
Distinguish always/trivially compactible allocations in libpas/bmalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=280294">https://bugs.webkit.org/show_bug.cgi?id=280294</a>
<a href="https://rdar.apple.com/136616671">rdar://136616671</a>

Reviewed by Keith Miller.

Creates a new pas_always_compact_allocation_mode, used for allocations
from memory spans that are known to be contiguous and specially managed
and for which pointer compression is particularly simple. We adopt this
mode for the libpas bootstrap heap and JIT reservation.

* Source/bmalloc/bmalloc/CompactAllocationMode.h:
(bmalloc::asPasAllocationMode):
* Source/bmalloc/bmalloc/IsoHeap.cpp:
(bmalloc::api::isoAllocateCompact):
(bmalloc::api::isoTryAllocateCompact):
* Source/bmalloc/bmalloc/TZoneHeap.cpp:
(bmalloc::api::tzoneAllocateCompact):
(bmalloc::api::tzoneTryAllocateCompact):
* Source/bmalloc/libpas/src/libpas/jit_heap.c:
(jit_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h:
(pas_allocation_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_utility_heap.c:

Canonical link: <a href="https://commits.webkit.org/284395@main">https://commits.webkit.org/284395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c80c01623b541960c4a2720341b1f909f10a874

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19998 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54863 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71918 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44077 "Found 1 new test failure: fast/events/ios/contenteditable-autocapitalize.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16877 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18360 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61969 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74618 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68099 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16510 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62356 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62398 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15373 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3968 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89878 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44044 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15925 "Found 2 new JSC binary failures: testapi, testb3, Found 4812 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_splice_515632.js.default, ChakraCore.yaml/ChakraCore/test/Basics/ArrayConcat.js.default, ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, ChakraCore.yaml/ChakraCore/test/RWC/OneNote.ribbon.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/Strings/HTMLHelpers.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->