### PR TITLE
Use a smart pointer for GeolocationPermissionRequestProxy::m_manager

### DIFF
--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
@@ -49,7 +49,7 @@ void GeolocationPermissionRequestManagerProxy::invalidateRequests()
 
 Ref<GeolocationPermissionRequestProxy> GeolocationPermissionRequestManagerProxy::createRequest(GeolocationIdentifier geolocationID, WebProcessProxy& process)
 {
-    auto request = GeolocationPermissionRequestProxy::create(this, geolocationID, process);
+    Ref request = GeolocationPermissionRequestProxy::create(*this, geolocationID, process);
     m_pendingRequests.add(geolocationID, request.ptr());
     return request;
 }
@@ -87,6 +87,16 @@ void GeolocationPermissionRequestManagerProxy::revokeAuthorizationToken(const St
     if (!isValidAuthorizationToken(authorizationToken))
         return;
     m_validAuthorizationTokens.remove(authorizationToken);
+}
+
+void GeolocationPermissionRequestManagerProxy::ref() const
+{
+    m_page->ref();
+}
+
+void GeolocationPermissionRequestManagerProxy::deref() const
+{
+    m_page->deref();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
@@ -30,6 +30,7 @@
 #include "GeolocationPermissionRequestProxy.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -37,11 +38,14 @@ namespace WebKit {
 class WebPageProxy;
 class WebProcessProxy;
 
-class GeolocationPermissionRequestManagerProxy {
+class GeolocationPermissionRequestManagerProxy : public CanMakeWeakPtr<GeolocationPermissionRequestManagerProxy> {
 public:
     explicit GeolocationPermissionRequestManagerProxy(WebPageProxy&);
 
     void invalidateRequests();
+
+    void ref() const;
+    void deref() const;
 
     // Create a request to be presented to the user.
     Ref<GeolocationPermissionRequestProxy> createRequest(GeolocationIdentifier, WebProcessProxy&);

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.cpp
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy* manager, GeolocationIdentifier geolocationID, WebProcessProxy& process)
+GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy& manager, GeolocationIdentifier geolocationID, WebProcessProxy& process)
     : m_manager(manager)
     , m_geolocationID(geolocationID)
     , m_process(process)
@@ -40,20 +40,14 @@ GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy(Geolocation
 
 void GeolocationPermissionRequestProxy::allow()
 {
-    if (!m_manager)
-        return;
-
-    m_manager->didReceiveGeolocationPermissionDecision(m_geolocationID, true);
-    m_manager = nullptr;
+    if (RefPtr manager = std::exchange(m_manager, nullptr).get())
+        manager->didReceiveGeolocationPermissionDecision(m_geolocationID, true);
 }
 
 void GeolocationPermissionRequestProxy::deny()
 {
-    if (!m_manager)
-        return;
-    
-    m_manager->didReceiveGeolocationPermissionDecision(m_geolocationID, false);
-    m_manager = nullptr;
+    if (RefPtr manager = std::exchange(m_manager, nullptr).get())
+        manager->didReceiveGeolocationPermissionDecision(m_geolocationID, false);
 }
 
 void GeolocationPermissionRequestProxy::invalidate()

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
@@ -37,7 +37,7 @@ class WebProcessProxy;
 
 class GeolocationPermissionRequestProxy : public RefCounted<GeolocationPermissionRequestProxy> {
 public:
-    static Ref<GeolocationPermissionRequestProxy> create(GeolocationPermissionRequestManagerProxy* manager, GeolocationIdentifier geolocationID, WebProcessProxy& process)
+    static Ref<GeolocationPermissionRequestProxy> create(GeolocationPermissionRequestManagerProxy& manager, GeolocationIdentifier geolocationID, WebProcessProxy& process)
     {
         return adoptRef(*new GeolocationPermissionRequestProxy(manager, geolocationID, process));
     }
@@ -50,9 +50,9 @@ public:
     WebProcessProxy* process() const;
 
 private:
-    GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy*, GeolocationIdentifier, WebProcessProxy&);
+    GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy&, GeolocationIdentifier, WebProcessProxy&);
 
-    GeolocationPermissionRequestManagerProxy* m_manager;
+    WeakPtr<GeolocationPermissionRequestManagerProxy> m_manager;
     GeolocationIdentifier m_geolocationID;
     WeakPtr<WebProcessProxy> m_process;
 };


### PR DESCRIPTION
#### 8bac10aa5b34def64db6d3d3cdabd4f75482b42c
<pre>
Use a smart pointer for GeolocationPermissionRequestProxy::m_manager
<a href="https://bugs.webkit.org/show_bug.cgi?id=280298">https://bugs.webkit.org/show_bug.cgi?id=280298</a>

Reviewed by Youenn Fablet.

* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp:
(WebKit::GeolocationPermissionRequestManagerProxy::createRequest):
(WebKit::GeolocationPermissionRequestManagerProxy::ref const):
(WebKit::GeolocationPermissionRequestManagerProxy::deref const):
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.cpp:
(WebKit::GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy):
(WebKit::GeolocationPermissionRequestProxy::allow):
(WebKit::GeolocationPermissionRequestProxy::deny):
* Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h:
(WebKit::GeolocationPermissionRequestProxy::create):

Canonical link: <a href="https://commits.webkit.org/284196@main">https://commits.webkit.org/284196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8421eecd635746df5e537f0e95950a4dfc226190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21391 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19693 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59341 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18235 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74495 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12703 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59423 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10257 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->