### PR TITLE
Add more PAS_PROFILE invocations to libpas

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
@@ -123,6 +123,7 @@ static PAS_ALWAYS_INLINE size_t pas_get_allocation_size(void* ptr,
         entry = pas_large_map_find(begin);
         
         if (!pas_large_map_entry_is_empty(entry)) {
+            PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, entry.begin, entry.end);
             PAS_ASSERT(entry.begin == begin);
             PAS_ASSERT(entry.end > begin);
             

--- a/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
@@ -109,6 +109,7 @@ static PAS_ALWAYS_INLINE pas_heap* pas_get_heap(void* ptr,
         entry = pas_large_map_find(begin);
         
         PAS_ASSERT(!pas_large_map_entry_is_empty(entry));
+        PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, entry.begin, entry.end);
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -226,7 +226,8 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
 
         return false;
     }
-    
+
+    PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, map_entry.begin, map_entry.end);
     PAS_ASSERT(pas_heap_config_kind_get_config(
                    pas_heap_for_large_heap(map_entry.heap)->config_kind)
                == heap_config);
@@ -269,6 +270,7 @@ bool pas_large_heap_try_shrink(uintptr_t begin,
     if (pas_large_map_entry_is_empty(map_entry))
         return false;
 
+    PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, map_entry.begin, map_entry.end);
     heap = map_entry.heap;
     type = pas_heap_for_large_heap(heap)->type;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -1028,6 +1028,8 @@ void pas_large_sharing_pool_boot_free(
 {
     uint64_t epoch;
 
+    PAS_PROFILE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
+
     if (!pas_large_sharing_pool_enabled)
         return;
     
@@ -1040,6 +1042,8 @@ void pas_large_sharing_pool_free(pas_range range,
                                  pas_mmap_capability mmap_capability)
 {
     uint64_t epoch;
+
+    PAS_PROFILE(LARGE_SHARING_POOL_FREE, range.begin, range.end);
 
     if (!pas_large_sharing_pool_enabled)
         return;
@@ -1056,6 +1060,8 @@ bool pas_large_sharing_pool_allocate_and_commit(
     pas_mmap_capability mmap_capability)
 {
     static const bool verbose = false;
+
+    PAS_PROFILE(LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT, range.begin, range.end);
     
     pas_large_free_heap_deferred_commit_log commit_log;
     uint64_t epoch;
@@ -1202,6 +1208,8 @@ pas_large_sharing_pool_compute_summary(
 {
     pas_large_sharing_node* node;
     pas_heap_summary result;
+
+    PAS_PROFILE(LARGE_SHARING_POOL_COMPUTE_SUMMARY, range.begin, range.end);
 
     pas_zero_memory(&result, sizeof(result));
     

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
@@ -119,6 +119,8 @@ static pas_aligned_allocation_result megapage_cache_allocate_aligned(size_t size
     }
     
     begin = (uintptr_t)base_before_exclusion;
+    PAS_PROFILE(MEGAPAGE_SET, begin);
+
     end = begin + new_size;
 
     PAS_ASSERT(pas_alignment_is_ptr_aligned(cache_config->allocation_alignment, begin));

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
@@ -68,17 +68,18 @@ typedef struct {
         switch (arguments.header_placement_mode) { \
         case pas_page_header_at_head_of_page: { \
             uintptr_t ptr = (uintptr_t)boundary; \
-            PAS_PROFILE(PAGE_HEADER, ptr); \
+            PAS_PROFILE(PAGE_BASE_FROM_BOUNDARY, ptr); \
             return (pas_page_base*)ptr; \
         } \
         \
         case pas_page_header_in_table: { \
-            pas_page_base* page_base; \
+            uintptr_t page_base; \
             \
-            page_base = pas_page_header_table_get_for_boundary( \
+            page_base = (uintptr_t)pas_page_header_table_get_for_boundary( \
                 arguments.header_table, config.page_size, boundary); \
             PAS_TESTING_ASSERT(page_base); \
-            return page_base; \
+            PAS_PROFILE(PAGE_BASE_FROM_TABLE, page_base); \
+            return (pas_page_base*)page_base; \
         } } \
         \
         PAS_ASSERT(!"Should not be reached"); \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
@@ -50,20 +50,23 @@ typedef struct {
         switch (name ## _header_placement_mode) { \
         case pas_page_header_at_head_of_page: { \
             uintptr_t ptr = (uintptr_t)boundary; \
-            PAS_PROFILE(PAGE_HEADER, ptr); \
+            PAS_PROFILE(PAGE_BASE_FROM_BOUNDARY, ptr); \
             return (pas_page_base*)ptr; \
         } \
         \
         case pas_page_header_in_table: { \
             pas_basic_heap_config_enumerator_data* data; \
             pas_heap_config_kind kind; \
+            uintptr_t page_base; \
             \
             kind = arguments.page_config.heap_config_ptr->kind; \
             PAS_ASSERT((unsigned)kind < (unsigned)pas_heap_config_kind_num_kinds); \
             data = (pas_basic_heap_config_enumerator_data*)enumerator->heap_config_datas[kind]; \
             PAS_ASSERT(data); \
             \
-            return (pas_page_base*)pas_ptr_hash_map_get(&data->page_header_table, boundary).value; \
+            page_base = (uintptr_t)pas_ptr_hash_map_get(&data->page_header_table, boundary).value; \
+            PAS_PROFILE(PAGE_BASE_FROM_BOUNDARY, page_base); \
+            return (pas_page_base*)page_base; \
         } } \
         \
         PAS_ASSERT(!"Should not be reached"); \

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -350,6 +350,7 @@ pas_try_reallocate(void* old_ptr,
                 pas_reallocation_did_fail("Source object not allocated", NULL, heap, old_ptr, 0, new_size);
         }
 
+        PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, entry.begin, entry.end);
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         PAS_ASSERT(entry.heap);


### PR DESCRIPTION
#### 5f38f0401b71d26066fcc95dddb22924e7d8759d
<pre>
Add more PAS_PROFILE invocations to libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=280297">https://bugs.webkit.org/show_bug.cgi?id=280297</a>
<a href="https://rdar.apple.com/136614456">rdar://136614456</a>

Reviewed by Keith Miller.

Adds more PAS_PROFILE macro invocations, providing hooks for
profiling more parts of libpas.

* Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h:
(pas_get_allocation_size):
* Source/bmalloc/libpas/src/libpas/pas_get_heap.h:
(pas_get_heap):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(pas_large_heap_try_deallocate):
(pas_large_heap_try_shrink):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c:
(pas_large_sharing_pool_boot_free):
(pas_large_sharing_pool_free):
(pas_large_sharing_pool_allocate_and_commit):
(pas_large_sharing_pool_compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c:
(megapage_cache_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):

Canonical link: <a href="https://commits.webkit.org/284393@main">https://commits.webkit.org/284393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9bd4c8335a64d51b938c487bc657b329e6e31a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68695 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19840 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13189 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16736 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18198 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61813 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74458 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67943 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16332 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62242 "Found 40 new test failures: fast/text/crash-letter-spacing-infinite.html imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child-translated.html imported/w3c/web-platform-tests/css/css-view-transitions/content-visibility-auto-shared-element.html imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-paint-order-with-entry.html imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-paint-order.html imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-shared-element.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/inline-element-size.html imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3842 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43888 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15894 "Found 40 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/sets.js.default, ChakraCore.yaml/ChakraCore/test/es6/ProxySetPrototypeOf.js.default, ChakraCore.yaml/ChakraCore/test/es6/weakmap_basic.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-bool-to-int32-reuse.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-both-proven-final-object.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-int52-change-format.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-not-string.js.layout, stress/arguments-non-configurable.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->