### PR TITLE
[scroll-animations] Add Animation.rangeStart and Animation.rangeEnd API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt
@@ -1,10 +1,12 @@
 
-FAIL All property keys are recognized assert_in_array: Test property 'rangeStart' should be one of the properties on  Animation value "rangeStart" not in array ["id", "effect", "timeline", "startTime", "currentTime", "playbackRate", "frameRate", "playState", "replaceState", "pending", "onfinish", "oncancel", "onremove", "ready", "finished", "cancel", "finish", "play", "pause", "updatePlaybackRate", "reverse", "persist", "commitStyles", "Animation constructor"]
+FAIL All property keys are recognized assert_in_array: Test property 'progress' should be one of the properties on  Animation value "progress" not in array ["id", "effect", "timeline", "startTime", "currentTime", "rangeStart", "rangeEnd", "playbackRate", "frameRate", "playState", "replaceState", "pending", "onfinish", "oncancel", "onremove", "ready", "finished", "cancel", "finish", "play", "pause", "updatePlaybackRate", "reverse", "persist", "commitStyles", "Animation constructor"]
 PASS Animation.id produces expected style change events
 PASS Animation.effect produces expected style change events
 PASS Animation.timeline produces expected style change events
 PASS Animation.startTime produces expected style change events
 PASS Animation.currentTime produces expected style change events
+PASS Animation.rangeStart produces expected style change events
+PASS Animation.rangeEnd produces expected style change events
 PASS Animation.playbackRate produces expected style change events
 FAIL Animation.frameRate produces expected style change events assert_own_property: Should have a test for 'frameRate' property expected property "frameRate" missing
 PASS Animation.playState produces expected style change events

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -882,6 +882,7 @@ set(WebCore_NON_SVG_IDL_FILES
     animation/ScrollAxis.idl
     animation/ScrollTimeline.idl
     animation/ScrollTimelineOptions.idl
+    animation/TimelineRangeOffset.idl
     animation/ViewTimeline.idl
     animation/ViewTimelineOptions.idl
     animation/WebAnimation.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1191,6 +1191,7 @@ $(PROJECT_DIR)/animation/PlaybackDirection.idl
 $(PROJECT_DIR)/animation/ScrollAxis.idl
 $(PROJECT_DIR)/animation/ScrollTimeline.idl
 $(PROJECT_DIR)/animation/ScrollTimelineOptions.idl
+$(PROJECT_DIR)/animation/TimelineRangeOffset.idl
 $(PROJECT_DIR)/animation/TransitionEvent.idl
 $(PROJECT_DIR)/animation/ViewTimeline.idl
 $(PROJECT_DIR)/animation/ViewTimelineOptions.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2971,6 +2971,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTextTrackList.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTextTrackList.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTimeRanges.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTimeRanges.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTimelineRangeOffset.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTimelineRangeOffset.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSToggleEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSToggleEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTrackEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -921,6 +921,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/animation/ScrollAxis.idl \
     $(WebCore)/animation/ScrollTimeline.idl \
     $(WebCore)/animation/ScrollTimelineOptions.idl \
+    $(WebCore)/animation/TimelineRangeOffset.idl \
     $(WebCore)/animation/ViewTimeline.idl \
     $(WebCore)/animation/ViewTimelineOptions.idl \
     $(WebCore)/animation/WebAnimation.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4537,6 +4537,7 @@ JSTextTrackCueGeneric.cpp
 JSTextTrackCueList.cpp
 JSTextTrackList.cpp
 JSTimeRanges.cpp
+JSTimelineRangeOffset.cpp
 JSToggleEvent.cpp
 JSTrackEvent.cpp
 JSTransferFunction.cpp

--- a/Source/WebCore/animation/KeyframeAnimationOptions.h
+++ b/Source/WebCore/animation/KeyframeAnimationOptions.h
@@ -28,7 +28,9 @@
 #include "AnimationFrameRate.h"
 #include "AnimationFrameRatePreset.h"
 #include "AnimationTimeline.h"
+#include "CSSKeywordValue.h"
 #include "KeyframeEffectOptions.h"
+#include "TimelineRangeOffset.h"
 
 namespace WebCore {
 
@@ -36,6 +38,8 @@ struct KeyframeAnimationOptions : KeyframeEffectOptions {
     String id;
     std::optional<RefPtr<AnimationTimeline>> timeline;
     std::variant<FramesPerSecond, AnimationFrameRatePreset> frameRate;
+    TimelineRangeValue rangeStart;
+    TimelineRangeValue rangeEnd;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeAnimationOptions.idl
+++ b/Source/WebCore/animation/KeyframeAnimationOptions.idl
@@ -29,4 +29,6 @@ dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
     DOMString id = "";
     AnimationTimeline? timeline;
     [EnabledBySetting=WebAnimationsCustomFrameRateEnabled] (FramesPerSecond or AnimationFrameRatePreset) frameRate = "auto";
+    [EnabledBySetting=ScrollDrivenAnimationsEnabled] (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart = "normal";
+    [EnabledBySetting=ScrollDrivenAnimationsEnabled] (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd = "normal";
 };

--- a/Source/WebCore/animation/TimelineRangeOffset.h
+++ b/Source/WebCore/animation/TimelineRangeOffset.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSNumericValue.h"
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct TimelineRangeOffset {
+    String rangeName;
+    RefPtr<CSSNumericValue> offset;
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/animation/TimelineRangeOffset.idl
+++ b/Source/WebCore/animation/TimelineRangeOffset.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=ScrollDrivenAnimationsEnabled,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary TimelineRangeOffset {
+    DOMString rangeName;
+    CSSNumericValue offset;
+};

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -28,12 +28,14 @@
 #include "ActiveDOMObject.h"
 #include "AnimationFrameRate.h"
 #include "AnimationFrameRatePreset.h"
+#include "CSSKeywordValue.h"
 #include "CSSNumericValue.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "Styleable.h"
+#include "TimelineRangeOffset.h"
 #include "WebAnimationTypes.h"
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
@@ -133,6 +135,11 @@ public:
     virtual std::variant<FramesPerSecond, AnimationFrameRatePreset> bindingsFrameRate() const { return m_bindingsFrameRate; }
     virtual void setBindingsFrameRate(std::variant<FramesPerSecond, AnimationFrameRatePreset>&&);
     std::optional<FramesPerSecond> frameRate() const { return m_effectiveFrameRate; }
+
+    TimelineRangeValue rangeStart() const { return m_rangeStart; }
+    TimelineRangeValue rangeEnd() const { return m_rangeEnd; }
+    void setRangeStart(TimelineRangeValue&& rangeStart) { m_rangeStart = WTFMove(rangeStart); }
+    void setRangeEnd(TimelineRangeValue&& rangeEnd) { m_rangeEnd = WTFMove(rangeEnd); }
 
     bool needsTick() const;
     virtual void tick();
@@ -236,6 +243,8 @@ private:
     TimeToRunPendingTask m_timeToRunPendingPauseTask { TimeToRunPendingTask::NotScheduled };
     ReplaceState m_replaceState { ReplaceState::Active };
     uint64_t m_globalPosition { 0 };
+    TimelineRangeValue m_rangeStart { "normal"_s };
+    TimelineRangeValue m_rangeEnd { "normal"_s };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -54,6 +54,8 @@ typedef (double or CSSNumericValue) CSSNumberish;
     attribute AnimationTimeline? timeline;
     [ImplementedAs=bindingsStartTime] attribute CSSNumberish? startTime;
     [ImplementedAs=bindingsCurrentTime] attribute CSSNumberish? currentTime;
+    [EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
+    [EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
     attribute double playbackRate;
     [ImplementedAs=bindingsFrameRate, EnabledBySetting=WebAnimationsCustomFrameRateEnabled] attribute (FramesPerSecond or AnimationFrameRatePreset) frameRate;
     [ImplementedAs=bindingsPlayState] readonly attribute AnimationPlayState playState;

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -43,9 +43,12 @@ namespace WebCore {
 class AnimationEventBase;
 class AnimationList;
 class CSSAnimation;
+class CSSKeywordValue;
 class CSSTransition;
 class StyleOriginatedAnimation;
 class WebAnimation;
+
+struct TimelineRangeOffset;
 
 struct WebAnimationsMarkableDoubleTraits {
     static bool isEmptyValue(double value)
@@ -109,6 +112,8 @@ constexpr OptionSet<AcceleratedEffectProperty> transformRelatedAcceleratedProper
 struct CSSPropertiesBitSet {
     WTF::BitSet<numCSSProperties> m_properties { };
 };
+
+using TimelineRangeValue = std::variant<TimelineRangeOffset, RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>, String>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5653,6 +5653,8 @@ ExceptionOr<Ref<WebAnimation>> Element::animate(JSC::JSGlobalObject& lexicalGlob
     std::optional<RefPtr<AnimationTimeline>> timeline;
     std::variant<FramesPerSecond, AnimationFrameRatePreset> frameRate = AnimationFrameRatePreset::Auto;
     std::optional<std::variant<double, KeyframeEffectOptions>> keyframeEffectOptions;
+    TimelineRangeValue animationRangeStart;
+    TimelineRangeValue animationRangeEnd;
     if (options) {
         auto optionsValue = options.value();
         std::variant<double, KeyframeEffectOptions> keyframeEffectOptionsVariant;
@@ -5663,6 +5665,8 @@ ExceptionOr<Ref<WebAnimation>> Element::animate(JSC::JSGlobalObject& lexicalGlob
             id = keyframeEffectOptions.id;
             frameRate = keyframeEffectOptions.frameRate;
             timeline = keyframeEffectOptions.timeline;
+            animationRangeStart = keyframeEffectOptions.rangeStart;
+            animationRangeEnd = keyframeEffectOptions.rangeEnd;
             keyframeEffectOptionsVariant = WTFMove(keyframeEffectOptions);
         }
         keyframeEffectOptions = keyframeEffectOptionsVariant;
@@ -5678,6 +5682,8 @@ ExceptionOr<Ref<WebAnimation>> Element::animate(JSC::JSGlobalObject& lexicalGlob
     if (timeline)
         animation->setTimeline(timeline->get());
     animation->setBindingsFrameRate(WTFMove(frameRate));
+    animation->setRangeStart(WTFMove(animationRangeStart));
+    animation->setRangeEnd(WTFMove(animationRangeEnd));
 
     auto animationPlayResult = animation->play();
     if (animationPlayResult.hasException())


### PR DESCRIPTION
#### 6950f6db7b42ae69add723c4656a556e8b317357
<pre>
[scroll-animations] Add Animation.rangeStart and Animation.rangeEnd API
<a href="https://bugs.webkit.org/show_bug.cgi?id=280300">https://bugs.webkit.org/show_bug.cgi?id=280300</a>
<a href="https://rdar.apple.com/136626109">rdar://136626109</a>

Reviewed by Antoine Quint.

Add Animation.rangeStart and Animation.rangeEnd API.

* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setBindingsRangeStart):
(WebCore::WebAnimation::setBindingsRangeEnd):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::bindingsRangeStart const):
(WebCore::WebAnimation::bindingsRangeEnd const):
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/284367@main">https://commits.webkit.org/284367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d7b9ea3ea216df58ac9fe3404df077dd8cdd49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54954 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13409 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35428 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18537 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62597 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62494 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4083 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10564 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44209 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->