### PR TITLE
[scroll-animations] Implement currentTime for ScrollTimeline and ViewTimeline

### DIFF
--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -27,6 +27,7 @@
 #include "ScrollTimeline.h"
 
 #include "AnimationTimelinesController.h"
+#include "CSSNumericFactory.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSScrollValue.h"
 #include "CSSValuePool.h"
@@ -171,6 +172,12 @@ ScrollTimeline::Data ScrollTimeline::computeScrollTimelineData() const
     float scrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
 
     return { maxScrollOffset, scrollOffset };
+}
+
+std::optional<CSSNumberishTime> ScrollTimeline::currentTime()
+{
+    auto data = computeScrollTimelineData();
+    return CSSNumberishTime(CSSNumericFactory::percent(data.scrollOffset / data.maxScrollOffset));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -60,6 +60,7 @@ public:
 
     AnimationTimelinesController* controller() const override;
     static ScrollableArea* scrollableAreaForSourceRenderer(RenderElement*, Ref<Document>);
+    std::optional<CSSNumberishTime> currentTime() override;
 
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -203,4 +203,10 @@ ViewTimeline::Data ViewTimeline::computeViewTimelineData() const
     return { scrollContainerSize, subjectOffset, currentScrollOffset, coverRangeEnd };
 }
 
+std::optional<CSSNumberishTime> ViewTimeline::currentTime()
+{
+    auto data = computeViewTimelineData();
+    return CSSNumberishTime(CSSNumericFactory::percent((data.scrollContainerSize - (data.subjectOffset - data.currentScrollOffset)) / data.coverRangeEnd));
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -62,6 +62,8 @@ public:
     RenderBox* sourceRenderer() const;
     Element* source() const override;
 
+    std::optional<CSSNumberishTime> currentTime() override;
+
 private:
     struct Data {
         float scrollContainerSize { 0 };


### PR DESCRIPTION
#### 2175f86aedc6d001b9a30e7be0b6ebd7060670bd
<pre>
[scroll-animations] Implement currentTime for ScrollTimeline and ViewTimeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=280301">https://bugs.webkit.org/show_bug.cgi?id=280301</a>
<a href="https://rdar.apple.com/136628435">rdar://136628435</a>

Reviewed by NOBODY (OOPS!).

Implement currentTime for ScrollTimeline and ViewTimeline.

* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::currentTime):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::currentTime):
* Source/WebCore/animation/ViewTimeline.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2175f86aedc6d001b9a30e7be0b6ebd7060670bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19670 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54768 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13196 "Found 5 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35232 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40614 "Found 7 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62563 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17097 "Found 7 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12680 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16340 "Found 10 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-current-time-range-name.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element.html imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62251 "Found 7 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62279 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10234 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3853 "Found 7 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-nan.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-writing-modes.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject.html imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43902 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->