### PR TITLE
2x TestWebKitAPI.LockdownMode* (api-tests) are constant failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm
@@ -28,6 +28,7 @@
 #import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
+#include <pal/cf/CoreTextSoftLink.h>
 
 namespace TestWebKitAPI {
 
@@ -52,12 +53,7 @@ TEST(LockdownMode, SVGFonts)
     EXPECT_EQ(target2Result, referenceResult);
 }
 
-// rdar://136524076
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(LockdownMode, DISABLED_NotAllowedFontLoadingAPI)
-#else
 TEST(LockdownMode, NotAllowedFontLoadingAPI)
-#endif
 {
     @autoreleasepool {
         auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
@@ -90,7 +86,10 @@ TEST(LockdownMode, NotAllowedFontLoadingAPI)
         auto referenceResult = static_cast<NSNumber *>([webView objectByEvaluatingJavaScript:@"reference.offsetWidth"]).intValue;
 
         EXPECT_NE(beforeTargetResult, targetResult);
-        EXPECT_EQ(targetResult, referenceResult);
+        if (!PAL::canLoad_CoreText_CTFontManagerCreateMemorySafeFontDescriptorFromData())
+            EXPECT_EQ(targetResult, referenceResult);
+        else
+            EXPECT_NE(targetResult, referenceResult);
     }
 }
 
@@ -151,12 +150,7 @@ TEST(LockdownMode, AllowedFont)
     }
 }
 
-// rdar://136524076
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(LockdownMode, DISABLED_NotAllowedFont)
-#else
 TEST(LockdownMode, NotAllowedFont)
-#endif
 {
     @autoreleasepool {
         auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
@@ -175,7 +169,10 @@ TEST(LockdownMode, NotAllowedFont)
 #if PLATFORM(WATCHOS)
         EXPECT_NE(targetResult, referenceResult);
 #else
+    if (!PAL::canLoad_CoreText_CTFontManagerCreateMemorySafeFontDescriptorFromData())
         EXPECT_EQ(targetResult, referenceResult);
+    else
+        EXPECT_NE(targetResult, referenceResult);
 #endif
     }
 }


### PR DESCRIPTION
#### 30c166307261e211f6d80fd19c9e57c232b2d705
<pre>
2x TestWebKitAPI.LockdownMode* (api-tests) are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=280201">https://bugs.webkit.org/show_bug.cgi?id=280201</a>
<a href="https://rdar.apple.com/136524076">rdar://136524076</a>

Reviewed by Brent Fulgham.

Our behavior changes according to the fact if the new
font parser is available or not, which is controlled
by the fact that we can or cannot soft link against
the relevant CoreText API.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm:
(TestWebKitAPI::TEST(LockdownMode, NotAllowedFontLoadingAPI)):
(TestWebKitAPI::TEST(LockdownMode, NotAllowedFont)):

Canonical link: <a href="https://commits.webkit.org/284204@main">https://commits.webkit.org/284204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/204b6ca1b68e0b05c856e0f98a5e48bc70fecc36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19874 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19690 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16358 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62292 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10255 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3866 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43922 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46190 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->