### PR TITLE
Annotate ApplePay message endpoints with feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -605,6 +605,7 @@ ApplePayEnabled:
     WebCore:
       "ENABLE(APPLE_PAY_REMOTE_UI)": true
       default: false
+  sharedPreferenceForWebProcess: true
 
 # FIXME: This is on by default in WebKit2 PLATFORM(COCOA). Perhaps we should consider turning it on for WebKitLegacy as well.
 AsyncClipboardAPIEnabled:

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -461,6 +461,7 @@ private:
     void paymentCoordinatorRemoveMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName) final;
     void getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) final;
     CocoaWindow *paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) const final;
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebPaymentMessages() const final;
 #endif // ENABLE(APPLE_PAY_REMOTE_UI)
 
     Ref<IPC::Connection> m_connection;

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -71,6 +71,11 @@ CocoaWindow *NetworkConnectionToWebProcess::paymentCoordinatorPresentingWindow(c
     return nil;
 }
 
+const SharedPreferencesForWebProcess& NetworkConnectionToWebProcess::sharedPreferencesForWebPaymentMessages() const
+{
+    return m_sharedPreferencesForWebProcess;
+}
+
 const String& NetworkConnectionToWebProcess::paymentCoordinatorBoundInterfaceIdentifier(const WebPaymentCoordinatorProxy&)
 {
     if (auto* session = static_cast<NetworkSessionCocoa*>(networkSession()))

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -86,6 +86,7 @@ namespace WebKit {
 
 class PaymentSetupConfiguration;
 class PaymentSetupFeatures;
+struct SharedPreferencesForWebProcess;
 
 class WebPaymentCoordinatorProxy
     : public IPC::MessageReceiver
@@ -112,6 +113,7 @@ public:
 #endif
         virtual CocoaWindow *paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) const = 0;
         virtual void getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) = 0;
+        virtual const SharedPreferencesForWebProcess& sharedPreferencesForWebPaymentMessages() const = 0;
     };
 
     friend class NetworkConnectionToWebProcess;
@@ -119,6 +121,7 @@ public:
     ~WebPaymentCoordinatorProxy();
 
     void webProcessExited();
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const { return m_client.sharedPreferencesForWebPaymentMessages(); }
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
@@ -24,6 +24,7 @@
 
 #if ENABLE(APPLE_PAY)
 
+[EnabledBy=ApplePayEnabled]
 messages -> WebPaymentCoordinatorProxy NotRefCounted {
 
     CanMakePayments() -> (bool result) Synchronous

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -486,6 +486,11 @@ WebPageProxy::Internals::~Internals() = default;
 
 #if ENABLE(APPLE_PAY)
 
+const SharedPreferencesForWebProcess& WebPageProxy::Internals::sharedPreferencesForWebPaymentMessages() const
+{
+    return page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
+}
+
 IPC::Connection* WebPageProxy::Internals::paymentCoordinatorConnection(const WebPaymentCoordinatorProxy&)
 {
     return &page->legacyMainFrameProcess().connection();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -607,8 +607,8 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(APPLE_PAY_AMS_UI)
-    StartApplePayAMSUISession(URL originatingURL, struct WebCore::ApplePayAMSUIRequest request) -> (std::optional<bool> result)
-    AbortApplePayAMSUISession()
+    [EnabledBy=ApplePayEnabled] StartApplePayAMSUISession(URL originatingURL, struct WebCore::ApplePayAMSUIRequest request) -> (std::optional<bool> result)
+    [EnabledBy=ApplePayEnabled] AbortApplePayAMSUISession()
 #endif
 
 #if USE(SYSTEM_PREVIEW)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -443,6 +443,7 @@ public:
     void paymentCoordinatorAddMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName, IPC::MessageReceiver&) final;
     void paymentCoordinatorRemoveMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName) final;
     void getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) final;
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebPaymentMessages() const final;
 #endif
 #if ENABLE(APPLE_PAY) && PLATFORM(IOS_FAMILY)
     UIViewController *paymentCoordinatorPresentingViewController(const WebPaymentCoordinatorProxy&) final;


### PR DESCRIPTION
#### e74ea348172d4175c797314deb7a293fc547da23
<pre>
Annotate ApplePay message endpoints with feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=280305">https://bugs.webkit.org/show_bug.cgi?id=280305</a>
<a href="https://rdar.apple.com/136631464">rdar://136631464</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

Make sure ApplePay message endpoints are disabled when feature is disabled.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm:
(WebKit::NetworkConnectionToWebProcess::sharedPreferencesForWebPaymentMessages const):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
(WebKit::WebPaymentCoordinatorProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::Internals::sharedPreferencesForWebPaymentMessages const):
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/284390@main">https://commits.webkit.org/284390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5c56026750b64b392d7a482e809676ec6a2f13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20243 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54991 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18617 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62201 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74877 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68331 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62540 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4145 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90112 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44289 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15980 "Found 2 new JSC binary failures: testapi, testb3, Found 4887 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_splice_515632.js.default, ChakraCore.yaml/ChakraCore/test/Basics/ArrayConcat.js.default, ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, ChakraCore.yaml/ChakraCore/test/RWC/OneNote.ribbon.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/Strings/HTMLHelpers.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->