### PR TITLE
[Text Directionality] REGRESSION(282648@main): Updating the auto text directionality of the element's ancestors is very expensive

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2756,7 +2756,7 @@ void Element::updateEffectiveTextDirection()
 void Element::dirAttributeChanged(const AtomString& newValue)
 {
     auto textDirectionState = parseTextDirectionState(newValue);
-    updateEffectiveTextDirectionState(*this, textDirectionState);
+    textDirectionStateChanged(*this, textDirectionState);
 }
 
 void Element::updateEffectiveLangStateFromParent()

--- a/Source/WebCore/dom/ElementTextDirection.h
+++ b/Source/WebCore/dom/ElementTextDirection.h
@@ -54,8 +54,10 @@ bool elementHasAutoTextDirectionState(const Element&);
 std::optional<TextDirection> computeAutoDirectionality(const Element&);
 std::optional<TextDirection> computeTextDirectionIfDirIsAuto(const Element&);
 
+void textDirectionStateChanged(Element&, TextDirectionState);
+
 void updateEffectiveTextDirectionState(Element&, TextDirectionState, Element* initiator = nullptr);
 void updateEffectiveTextDirectionOfDescendants(Element&, std::optional<TextDirection>, Element* initiator = nullptr);
-void updateEffectiveTextDirectionOfAncestors(Element&, Element* initiator = nullptr);
+void updateEffectiveTextDirectionOfAncestors(Element&, Element* initiator);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 53c053e2da00fb71456baf69d1388b8c1158d38e
<pre>
[Text Directionality] REGRESSION(282648@main): Updating the auto text directionality of the element&apos;s ancestors is very expensive
<a href="https://bugs.webkit.org/show_bug.cgi?id=280309">https://bugs.webkit.org/show_bug.cgi?id=280309</a>
<a href="https://rdar.apple.com/136385909">rdar://136385909</a>

Reviewed by Ryosuke Niwa.

Skip updating the element&apos;s ancestors if the dir attribute was not changed and
its effective direction is the same as its parent&apos;s effective direction. This
element won&apos;t affect its ancestors&apos; effective direction.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dirAttributeChanged):
* Source/WebCore/dom/ElementTextDirection.cpp:
(WebCore::updateEffectiveTextDirectionOfElementAndDescendants):
(WebCore::textDirectionStateChanged):
(WebCore::updateEffectiveTextDirectionState):
* Source/WebCore/dom/ElementTextDirection.h:

Canonical link: <a href="https://commits.webkit.org/284339@main">https://commits.webkit.org/284339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14bb40d1b77caff96023fc7bcc509923159ccfec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35420 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16977 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74760 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4056 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44176 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45249 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->