### PR TITLE
Adopt more smart pointers in WorkerThread.h

### DIFF
--- a/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
+++ b/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
@@ -34,6 +34,12 @@ public:
     virtual ~WorkerBadgeProxy() = default;
 
     virtual void setAppBadge(std::optional<uint64_t>) = 0;
+
+    // CanMakeCheckedPtr.
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -38,7 +38,9 @@ class AudioWorklet;
 class AudioWorkletThread;
 class Document;
 
-class AudioWorkletMessagingProxy : public WorkletGlobalScopeProxy, public WorkerLoaderProxy {
+class AudioWorkletMessagingProxy : public WorkletGlobalScopeProxy, public WorkerLoaderProxy, public CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioWorkletMessagingProxy);
 public:
     static Ref<AudioWorkletMessagingProxy> create(AudioWorklet& worklet)
     {
@@ -54,6 +56,11 @@ public:
 
     void postTaskToAudioWorklet(Function<void(AudioWorklet&)>&&);
     ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
+
+    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::incrementPtrCount(); }
+    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::decrementPtrCount(); }
 
 private:
     explicit AudioWorkletMessagingProxy(AudioWorklet&);

--- a/Source/WebCore/workers/WorkerDebuggerProxy.h
+++ b/Source/WebCore/workers/WorkerDebuggerProxy.h
@@ -39,6 +39,12 @@ public:
     virtual ~WorkerDebuggerProxy() = default;
     virtual void postMessageToDebugger(const String&) = 0;
     virtual void setResourceCachingDisabledByWebInspector(bool) = 0;
+
+    // CanMakeCheckedPtr.
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerLoaderProxy.h
+++ b/Source/WebCore/workers/WorkerLoaderProxy.h
@@ -56,6 +56,12 @@ public:
 
     // Posts a task to the thread which runs the loading code (normally, the main thread).
     virtual void postTaskToLoader(ScriptExecutionContext::Task&&) = 0;
+
+    // CanMakeCheckedPtr.
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -30,6 +30,7 @@
 #include "WorkerDebuggerProxy.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerObjectProxy.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -40,11 +41,17 @@ class DedicatedWorkerThread;
 class WorkerInspectorProxy;
 class WorkerUserGestureForwarder;
 
-class WorkerMessagingProxy final : public ThreadSafeRefCounted<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
+class WorkerMessagingProxy final : public ThreadSafeRefCounted<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerMessagingProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerMessagingProxy);
 public:
     explicit WorkerMessagingProxy(Worker&);
     virtual ~WorkerMessagingProxy();
+
+    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::incrementPtrCount(); }
+    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy>::decrementPtrCount(); }
 
 private:
     // Implementations of WorkerGlobalScopeProxy.

--- a/Source/WebCore/workers/WorkerObjectProxy.h
+++ b/Source/WebCore/workers/WorkerObjectProxy.h
@@ -42,6 +42,8 @@ class Worker;
 
 // A proxy to talk to the worker object.
 class WorkerObjectProxy : public WorkerReportingProxy {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerObjectProxy);
 public:
     virtual void postMessageToWorkerObject(MessageWithMessagePorts&&) = 0;
     virtual void postTaskToWorkerObject(Function<void(Worker&)>&&) { }

--- a/Source/WebCore/workers/WorkerReportingProxy.h
+++ b/Source/WebCore/workers/WorkerReportingProxy.h
@@ -30,9 +30,13 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
+
 namespace WebCore {
 
-class WorkerReportingProxy {
+class WorkerReportingProxy : public CanMakeThreadSafeCheckedPtr<WorkerReportingProxy> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerReportingProxy);
 public:
     virtual ~WorkerReportingProxy() = default;
 
@@ -45,6 +49,12 @@ public:
 
     // Invoked when the thread has stopped.
     virtual void workerGlobalScopeDestroyed() = 0;
+
+    // CanMakeCheckedPtr.
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -32,7 +32,11 @@
 #include "ScriptSourceCode.h"
 #include "SecurityOrigin.h"
 #include "SocketProvider.h"
+#include "WorkerBadgeProxy.h"
+#include "WorkerDebuggerProxy.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerLoaderProxy.h"
+#include "WorkerReportingProxy.h"
 #include "WorkerScriptFetcher.h"
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <wtf/SetForScope.h>
@@ -114,6 +118,26 @@ WorkerThread::~WorkerThread()
 {
     ASSERT(workerThreadCounter);
     --workerThreadCounter;
+}
+
+WorkerLoaderProxy* WorkerThread::workerLoaderProxy()
+{
+    return m_workerLoaderProxy.get();
+}
+
+WorkerBadgeProxy* WorkerThread::workerBadgeProxy() const
+{
+    return m_workerBadgeProxy.get();
+}
+
+WorkerDebuggerProxy* WorkerThread::workerDebuggerProxy() const
+{
+    return m_workerDebuggerProxy.get();
+}
+
+WorkerReportingProxy* WorkerThread::workerReportingProxy() const
+{
+    return m_workerReportingProxy.get();
 }
 
 Ref<Thread> WorkerThread::createThread()

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/RuntimeFlags.h>
 #include <memory>
 #include <pal/SessionID.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -96,11 +97,10 @@ class WorkerThread : public WorkerOrWorkletThread {
 public:
     virtual ~WorkerThread();
 
-    WorkerBadgeProxy* workerBadgeProxy() const { return m_workerBadgeProxy; }
-    WorkerDebuggerProxy* workerDebuggerProxy() const final { return m_workerDebuggerProxy; }
-    WorkerLoaderProxy* workerLoaderProxy() final { return m_workerLoaderProxy; }
-    WorkerReportingProxy* workerReportingProxy() const { return m_workerReportingProxy; }
-
+    WorkerBadgeProxy* workerBadgeProxy() const;
+    WorkerDebuggerProxy* workerDebuggerProxy() const final;
+    WorkerLoaderProxy* workerLoaderProxy() final;
+    WorkerReportingProxy* workerReportingProxy() const;
 
     // Number of active worker threads.
     WEBCORE_EXPORT static unsigned workerThreadCount();
@@ -139,10 +139,10 @@ private:
     void evaluateScriptIfNecessary(String& exceptionMessage) final;
     bool shouldWaitForWebInspectorOnStartup() const final;
 
-    WorkerLoaderProxy* m_workerLoaderProxy; // FIXME: Use CheckedPtr.
-    WorkerDebuggerProxy* m_workerDebuggerProxy; // FIXME: Use CheckedPtr.
-    WorkerReportingProxy* m_workerReportingProxy; // FIXME: Use CheckedPtr.
-    WorkerBadgeProxy* m_workerBadgeProxy; // FIXME: Use CheckedPtr.
+    CheckedPtr<WorkerLoaderProxy> m_workerLoaderProxy;
+    CheckedPtr<WorkerDebuggerProxy> m_workerDebuggerProxy;
+    CheckedPtr<WorkerReportingProxy> m_workerReportingProxy;
+    CheckedPtr<WorkerBadgeProxy> m_workerBadgeProxy;
     JSC::RuntimeFlags m_runtimeFlags;
 
     std::unique_ptr<WorkerThreadStartupData> m_startupData;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -64,13 +64,21 @@ using namespace PAL;
 
 namespace WebCore {
 
-class DummyServiceWorkerThreadProxy : public WorkerObjectProxy {
+class DummyServiceWorkerThreadProxy final : public WorkerObjectProxy, public CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DummyServiceWorkerThreadProxy);
 public:
     static DummyServiceWorkerThreadProxy& shared()
     {
         static NeverDestroyed<DummyServiceWorkerThreadProxy> proxy;
         return proxy;
     }
+
+    // CanMakeCheckedPtr.
+    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::incrementPtrCount(); }
+    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<DummyServiceWorkerThreadProxy>::decrementPtrCount(); }
 
 private:
     void postExceptionToWorkerObject(const String&, int, int, const String&) final { };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -38,6 +38,7 @@
 #include "WorkerBadgeProxy.h"
 #include "WorkerDebuggerProxy.h"
 #include "WorkerLoaderProxy.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/URLHash.h>
 
@@ -53,7 +54,9 @@ struct NotificationPayload;
 struct ServiceWorkerContextData;
 enum class WorkerThreadMode : bool;
 
-class ServiceWorkerThreadProxy final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ServiceWorkerThreadProxy, WTF::DestructionThread::Main>, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
+class ServiceWorkerThreadProxy final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ServiceWorkerThreadProxy, WTF::DestructionThread::Main>, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ServiceWorkerThreadProxy);
 public:
     template<typename... Args> static Ref<ServiceWorkerThreadProxy> create(Args&&... args)
     {
@@ -96,6 +99,11 @@ public:
     WEBCORE_EXPORT bool lastNavigationWasAppInitiated();
 
     WEBCORE_EXPORT void setInspectable(bool);
+
+    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::incrementPtrCount(); }
+    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::decrementPtrCount(); }
 
 private:
     WEBCORE_EXPORT ServiceWorkerThreadProxy(Ref<Page>&&, ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, CacheStorageProvider&, std::unique_ptr<NotificationClient>&&);

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -32,6 +32,7 @@
 #include "WorkerLoaderProxy.h"
 #include "WorkerObjectProxy.h"
 #include "WorkerOptions.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -44,7 +45,9 @@ class SharedWorkerThread;
 struct WorkerFetchResult;
 struct WorkerInitializationData;
 
-class SharedWorkerThreadProxy final : public ThreadSafeRefCounted<SharedWorkerThreadProxy>, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeWeakPtr<SharedWorkerThreadProxy> {
+class SharedWorkerThreadProxy final : public ThreadSafeRefCounted<SharedWorkerThreadProxy>, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeWeakPtr<SharedWorkerThreadProxy>, public CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SharedWorkerThreadProxy);
 public:
     template<typename... Args> static Ref<SharedWorkerThreadProxy> create(Args&&... args) { return adoptRef(*new SharedWorkerThreadProxy(std::forward<Args>(args)...)); }
     WEBCORE_EXPORT ~SharedWorkerThreadProxy();
@@ -57,6 +60,11 @@ public:
 
     bool isTerminatingOrTerminated() const { return m_isTerminatingOrTerminated; }
     void setAsTerminatingOrTerminated() { m_isTerminatingOrTerminated = true; }
+
+    uint32_t ptrCount() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::incrementPtrCount(); }
+    void decrementPtrCount() const { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::decrementPtrCount(); }
 
 private:
     WEBCORE_EXPORT SharedWorkerThreadProxy(Ref<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, CacheStorageProvider&);


### PR DESCRIPTION
#### f1b5ef5dc10f965db16c2cf2b70757cc4f76b004
<pre>
Adopt more smart pointers in WorkerThread.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=280315">https://bugs.webkit.org/show_bug.cgi?id=280315</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/Modules/badge/WorkerBadgeProxy.h:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
(WebCore::AudioWorkletMessagingProxy::ptrCount const):
(WebCore::AudioWorkletMessagingProxy::ptrCountWithoutThreadCheck const):
(WebCore::AudioWorkletMessagingProxy::incrementPtrCount const):
(WebCore::AudioWorkletMessagingProxy::decrementPtrCount const):
* Source/WebCore/workers/WorkerDebuggerProxy.h:
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerObjectProxy.h:
* Source/WebCore/workers/WorkerReportingProxy.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::workerLoaderProxy):
(WebCore::WorkerThread::workerBadgeProxy const):
(WebCore::WorkerThread::workerDebuggerProxy const):
(WebCore::WorkerThread::workerReportingProxy const):
* Source/WebCore/workers/WorkerThread.h:
(WebCore::WorkerThread::workerBadgeProxy const): Deleted.
(WebCore::WorkerThread::workerReportingProxy const): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::DummyServiceWorkerThreadProxy::shared): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:

Canonical link: <a href="https://commits.webkit.org/284222@main">https://commits.webkit.org/284222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a048b9b343abc0f59f8217cbc6f665f33ccbbe98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74493 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62264 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62297 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3868 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43923 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44997 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->