### PR TITLE
Excessive repainting when scrolling position:sticky in some configurations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -256,6 +256,9 @@ imported/w3c/web-platform-tests/fs/ [ Skip ]
 storage/filesystemaccess/ [ Skip ]
 storage/storagemanager/ [ Skip ]
 
+# Tests that require wheel events
+compositing/repaint/sticky-repaint-on-scroll.html [ Skip ]
+
 # app-privacy-report tests are iOS only.
 http/tests/app-privacy-report/ [ Skip ]
 
@@ -269,7 +272,6 @@ imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-f
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-worker-owner.https.html
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cache-storage-reporting-document.https.html [ Skip ]
 
-# This test is a bit slow.
 fast/frames/frame-append-body-child-crash.html [ Slow ]
 
 # This test is failing in all major browser engines as of Sept 2022. The reason is that the Reporting-Endpoints header

--- a/LayoutTests/compositing/repaint/sticky-repaint-on-scroll-expected.txt
+++ b/LayoutTests/compositing/repaint/sticky-repaint-on-scroll-expected.txt
@@ -1,0 +1,8 @@
+A
+A
+A
+PASS repaintCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/compositing/repaint/sticky-repaint-on-scroll.html
+++ b/LayoutTests/compositing/repaint/sticky-repaint-on-scroll.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 4000px;
+        }
+        
+        .sticky {
+            position: sticky;
+            top: 200px;
+            height: 1000px;
+        }
+
+        .layer.child {
+            position: relative;
+            margin: 20px;
+        }
+        
+        #layout-trigger {
+            position: absolute;
+            top: 10px;
+            left: 0;
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>    
+    <script>
+        var jsTestIsAsync = true;
+
+        window.addEventListener('load', async () => {
+            window.onscroll = () => {
+                document.getElementById('layout-trigger').style.left = `${window.scrollY / 4}px`;
+            }
+            
+            await UIHelper.renderingUpdate();
+            await UIHelper.statelessMouseWheelScrollAt(10, 10, 0, -1);
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                window.internals.startTrackingRepaints();
+
+            await Promise.all([
+                UIHelper.waitForEvent(window, 'scroll'),
+                UIHelper.statelessMouseWheelScrollAt(10, 10, 0, -1)
+            ]);
+
+            const layerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+            repaintCount = (layerTree.match(/\(rect 0\.00 0\.00 769\.00 1000\.00\)/g) || []).length
+            shouldBe('repaintCount', '1');
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="layout-trigger"></div>
+    <div class="sticky">
+        <div class="layer child">A</div>
+        <div class="layer child">A</div>
+        <div class="layer child">A</div>
+    </div>
+<div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -78,6 +78,9 @@ imported/w3c/web-platform-tests/payment-request/payment-request-hasenrolledinstr
 imported/w3c/web-platform-tests/css/css-pseudo/selection-over-highlight-001.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html [ Pass ]
 
+# Tests that require wheel events
+compositing/repaint/sticky-repaint-on-scroll.html [ Pass ]
+
 # These tests are checking that WebContent is terminated when performing an invalid IPC operation for WK2.
 # They crash in debug (as expected) so we skip them there. <rdar://problem/117742950>
 [ Debug ] ipc/restrictedendpoints/mac/deny-access-modelElement.html [ Skip ]

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1202,7 +1202,7 @@ void RenderLayer::recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier 
     }
 
     auto repaintIfNecessary = [&](bool checkForRepaint) {
-        if (!m_hasVisibleContent || !isSelfPaintingLayer()) {
+        if (isVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer()) {
             LAYER_POSITIONS_ASSERT_IMPLIES(mode == Verify, !repaintRects());
             clearRepaintRects();
             return;
@@ -1394,7 +1394,7 @@ void RenderLayer::computeRepaintRects(const RenderLayerModelObject* repaintConta
 {
     ASSERT(!m_visibleContentStatusDirty);
 
-    if (!m_hasVisibleContent || !isSelfPaintingLayer())
+    if (isVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer())
         clearRepaintRects();
     else
         setRepaintRects(renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes));
@@ -5757,6 +5757,11 @@ bool RenderLayer::hasVisibleBoxDecorations() const
         return false;
 
     return hasVisibleBoxDecorationsOrBackground() || (m_scrollableArea && m_scrollableArea->hasOverflowControls());
+}
+
+bool RenderLayer::isVisibilityHiddenOrOpacityZero() const
+{
+    return !hasVisibleContent() || !renderer().style().opacity();
 }
 
 bool RenderLayer::isVisuallyNonEmpty(PaintedContentRequest* request) const

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -575,6 +575,8 @@ public:
         RequestState hasPaintedContent { RequestState::Unknown };
     };
 
+    bool isVisibilityHiddenOrOpacityZero() const;
+
     // Returns true if this layer has visible content (ignoring any child layers).
     bool isVisuallyNonEmpty(PaintedContentRequest* = nullptr) const;
     // True if this layer container renderers that paint.


### PR DESCRIPTION
#### 6a6822efc75ae88b07a8290a19b27eea03cdba8b
<pre>
Excessive repainting when scrolling position:sticky in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=280316">https://bugs.webkit.org/show_bug.cgi?id=280316</a>
<a href="https://rdar.apple.com/120280327">rdar://120280327</a>

Reviewed by Alan Baradlay.

<a href="https://www.stripe.press/poor-charlies-almanack/talk-one">https://www.stripe.press/poor-charlies-almanack/talk-one</a> has a tiled `position:sticky` element
which repaints on every scroll. This happens when `RenderLayer::recursiveUpdateLayerPositionsAfterScroll()`
and `RenderLayer::recursiveUpdateLayerPositions()` have different criteria for the `clearRepaintRects()`
condition; the former was testing `!isVisuallyNonEmpty()` and the latter just `m_hasVisibleContent`.

The fix is to have both code paths use a new `isVisibilityHiddenOrOpacityZero()` which just does the
simple check for the visibility and opacity properties. This shouldn&apos;t cause much new repainting, because
`recursiveUpdateLayerPositionsAfterScroll()` was doing the stricter check, and we&apos;ll almost always do layout
after scroll.

The test requires async scrolling (programmatic scrolling triggers layouts on every scroll as the layout viewport changes).

* LayoutTests/TestExpectations:
* LayoutTests/compositing/repaint/sticky-repaint-on-scroll-expected.txt: Added.
* LayoutTests/compositing/repaint/sticky-repaint-on-scroll.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/284802@main">https://commits.webkit.org/284802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34b9b261e7c3f6f27547ea463bcd10e44fd321ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21553 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14353 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60806 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18241 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63610 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63545 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11586 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5230 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45743 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/510 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46817 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->