### PR TITLE
Use more smart pointers in IndexedDB code

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
@@ -96,8 +96,8 @@ void IDBOpenDBRequest::fireSuccessAfterVersionChangeCommit()
     ASSERT(hasPendingActivity());
     m_transaction->addRequest(*this);
 
-    auto event = IDBRequestCompletionEvent::create(eventNames().successEvent, Event::CanBubble::No, Event::IsCancelable::No, *this);
-    m_openDatabaseSuccessEvent = &event.get();
+    Ref event = IDBRequestCompletionEvent::create(eventNames().successEvent, Event::CanBubble::No, Event::IsCancelable::No, *this);
+    m_openDatabaseSuccessEvent = event.get();
 
     enqueueEvent(WTFMove(event));
 }

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -323,7 +323,7 @@ void IDBRequest::dispatchEvent(Event& event)
         targets = { this, m_transaction.get(), &m_transaction->database() };
 
     {
-        TransactionActivator activator(m_transaction.get());
+        TransactionActivator activator(transaction().get());
         EventDispatcher::dispatchEvent(targets, event);
     }
 

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -177,7 +177,7 @@ protected:
     // Consider adding protected helper functions and making these private.
     RefPtr<IDBTransaction> m_transaction;
     RefPtr<DOMException> m_domError;
-    Event* m_openDatabaseSuccessEvent { nullptr };
+    WeakPtr<Event> m_openDatabaseSuccessEvent;
 
 private:
     IDBCursor* resultCursor();

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -277,18 +277,18 @@ public:
     TransactionActivator(IDBTransaction* transaction)
         : m_transaction(transaction)
     {
-        if (m_transaction)
-            m_transaction->activate();
+        if (transaction)
+            transaction->activate();
     }
 
     ~TransactionActivator()
     {
-        if (m_transaction)
-            m_transaction->deactivate();
+        if (RefPtr transaction = m_transaction)
+            transaction->deactivate();
     }
 
 private:
-    IDBTransaction* m_transaction;
+    RefPtr<IDBTransaction> m_transaction;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
@@ -85,7 +85,7 @@ public:
 private:
     IDBConnectionToClient(IDBConnectionToClientDelegate&);
     
-    IDBConnectionToClientDelegate* m_delegate;
+    CheckedPtr<IDBConnectionToClientDelegate> m_delegate;
     HashSet<UniqueIDBDatabaseConnection*> m_databaseConnections;
     bool m_isClosed { false };
 };

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClientDelegate.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClientDelegate.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IDBResourceIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,7 +41,9 @@ namespace IDBServer {
 
 class UniqueIDBDatabaseConnection;
 
-class IDBConnectionToClientDelegate {
+class IDBConnectionToClientDelegate : public CanMakeThreadSafeCheckedPtr<IDBConnectionToClientDelegate> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBConnectionToClientDelegate);
 public:
     virtual ~IDBConnectionToClientDelegate() = default;
     

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
@@ -28,6 +28,7 @@
 #include "IDBCursorInfo.h"
 #include "IDBKeyData.h"
 #include "IndexValueEntry.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -43,8 +44,9 @@ class MemoryIndex;
 
 typedef HashMap<IDBKeyData, std::unique_ptr<IndexValueEntry>, IDBKeyDataHash, IDBKeyDataHashTraits> IndexKeyValueMap;
 
-class IndexValueStore {
+class IndexValueStore final : public CanMakeThreadSafeCheckedPtr<IndexValueStore> {
     WTF_MAKE_TZONE_ALLOCATED(IndexValueStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IndexValueStore);
 public:
     explicit IndexValueStore(bool unique);
 
@@ -80,7 +82,7 @@ public:
         Iterator& nextIndexEntry();
 
     private:
-        IndexValueStore* m_store { nullptr };
+        CheckedPtr<IndexValueStore> m_store;
         bool m_forward { true };
         CursorDuplicity m_duplicity { CursorDuplicity::Duplicates };
         IDBKeyDataSet::iterator m_forwardIterator;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -44,8 +44,9 @@ class MemoryObjectStore;
 
 typedef HashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
 
-class MemoryBackingStoreTransaction {
+class MemoryBackingStoreTransaction final : public CanMakeThreadSafeCheckedPtr<MemoryBackingStoreTransaction> {
     WTF_MAKE_TZONE_ALLOCATED(MemoryBackingStoreTransaction);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MemoryBackingStoreTransaction);
 public:
     static std::unique_ptr<MemoryBackingStoreTransaction> create(MemoryIDBBackingStore&, const IDBTransactionInfo&);
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -80,6 +80,11 @@ void MemoryObjectStore::writeTransactionFinished(MemoryBackingStoreTransaction& 
     m_writeTransaction = nullptr;
 }
 
+MemoryBackingStoreTransaction* MemoryObjectStore::writeTransaction()
+{
+    return m_writeTransaction.get();
+}
+
 IDBError MemoryObjectStore::createIndex(MemoryBackingStoreTransaction& transaction, const IDBIndexInfo& info)
 {
     LOG(IndexedDB, "MemoryObjectStore::createIndex");

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -63,7 +63,7 @@ public:
 
     void writeTransactionStarted(MemoryBackingStoreTransaction&);
     void writeTransactionFinished(MemoryBackingStoreTransaction&);
-    MemoryBackingStoreTransaction* writeTransaction() { return m_writeTransaction; }
+    MemoryBackingStoreTransaction* writeTransaction();
 
     IDBError createIndex(MemoryBackingStoreTransaction&, const IDBIndexInfo&);
     IDBError deleteIndex(MemoryBackingStoreTransaction&, uint64_t indexIdentifier);
@@ -119,7 +119,7 @@ private:
 
     IDBObjectStoreInfo m_info;
 
-    MemoryBackingStoreTransaction* m_writeTransaction { nullptr };
+    CheckedPtr<MemoryBackingStoreTransaction> m_writeTransaction;
     uint64_t m_keyGeneratorValue { 1 };
 
     std::unique_ptr<KeyValueMap> m_keyValueStore;

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -100,6 +100,11 @@ SQLiteIDBCursor::~SQLiteIDBCursor()
         m_transaction->closeCursor(*this);
 }
 
+SQLiteIDBTransaction* SQLiteIDBCursor::transaction() const
+{
+    return m_transaction.get();
+}
+
 void SQLiteIDBCursor::currentData(IDBGetResult& result, const std::optional<IDBKeyPath>& keyPath, ShouldIncludePrefetchedRecords shouldIncludePrefetchedRecords)
 {
     ASSERT(!m_fetchedRecords.isEmpty());

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
@@ -33,6 +33,7 @@
 #include "IDBResourceIdentifier.h"
 #include "IDBValue.h"
 #include "SQLiteStatement.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -59,7 +60,7 @@ public:
     ~SQLiteIDBCursor();
 
     const IDBResourceIdentifier& identifier() const { return m_cursorIdentifier; }
-    SQLiteIDBTransaction* transaction() const { return m_transaction; }
+    SQLiteIDBTransaction* transaction() const;
 
     IDBObjectStoreIdentifier objectStoreID() const { return m_objectStoreID; }
     int64_t currentRecordRowID() const;
@@ -113,7 +114,7 @@ private:
 
     void increaseCountToPrefetch();
 
-    SQLiteIDBTransaction* m_transaction;
+    CheckedPtr<SQLiteIDBTransaction> m_transaction;
     IDBResourceIdentifier m_cursorIdentifier;
     IDBObjectStoreIdentifier m_objectStoreID;
     int64_t m_indexID { IDBIndexInfo::InvalidId };

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
@@ -30,6 +30,7 @@
 #include "IDBResourceIdentifier.h"
 #include "IDBTransactionInfo.h"
 #include "IndexedDB.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RobinHoodHashSet.h>
@@ -47,9 +48,10 @@ namespace IDBServer {
 class SQLiteIDBBackingStore;
 class SQLiteIDBCursor;
 
-class SQLiteIDBTransaction {
+class SQLiteIDBTransaction : public CanMakeThreadSafeCheckedPtr<SQLiteIDBTransaction> {
     WTF_MAKE_TZONE_ALLOCATED(SQLiteIDBTransaction);
     WTF_MAKE_NONCOPYABLE(SQLiteIDBTransaction);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteIDBTransaction);
 public:
     SQLiteIDBTransaction(SQLiteIDBBackingStore&, const IDBTransactionInfo&);
     ~SQLiteIDBTransaction();

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -30,6 +30,7 @@
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/MonotonicTime.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -44,7 +45,7 @@ class EventPath;
 class EventTarget;
 class ScriptExecutionContext;
 
-class Event : public ScriptWrappable, public RefCounted<Event> {
+class Event : public ScriptWrappable, public RefCountedAndCanMakeWeakPtr<Event> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Event);
 public:
     using IsTrusted = EventIsTrusted;

--- a/Source/WebCore/workers/service/ExtendableEvent.h
+++ b/Source/WebCore/workers/service/ExtendableEvent.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class DOMPromise;
 
-class ExtendableEvent : public Event, public CanMakeWeakPtr<ExtendableEvent> {
+class ExtendableEvent : public Event {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ExtendableEvent);
 public:
     static Ref<ExtendableEvent> create(const AtomString& type, const ExtendableEventInit& initializer, IsTrusted isTrusted = IsTrusted::No)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -34,6 +34,7 @@ namespace WebKit {
 
 class IDBStorageConnectionToClient final : public WebCore::IDBServer::IDBConnectionToClientDelegate {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageConnectionToClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBStorageConnectionToClient);
 public:
     IDBStorageConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
     ~IDBStorageConnectionToClient();

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -54,8 +54,9 @@ class IDBServer;
 } // namespace WebCore
 
 class InProcessIDBServer final : public WebCore::IDBClient::IDBConnectionToServerDelegate, public WebCore::IDBServer::IDBConnectionToClientDelegate, public ThreadSafeRefCounted<InProcessIDBServer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InProcessIDBServer);
 public:
-
     static Ref<InProcessIDBServer> create(PAL::SessionID);
     static Ref<InProcessIDBServer> create(PAL::SessionID, const String& databaseDirectoryPath);
 


### PR DESCRIPTION
#### 895a15c1e738b7a39eb09818bf40ff936c4bba62
<pre>
Use more smart pointers in IndexedDB code
<a href="https://bugs.webkit.org/show_bug.cgi?id=280319">https://bugs.webkit.org/show_bug.cgi?id=280319</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp:
(WebCore::IDBOpenDBRequest::fireSuccessAfterVersionChangeCommit):
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::dispatchEvent):
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
(WebCore::TransactionActivator::TransactionActivator):
(WebCore::TransactionActivator::~TransactionActivator):
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h:
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClientDelegate.h:
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.h:
(WebCore::IDBServer::IndexValueStore::Iterator::Iterator): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
(WebCore::IDBServer::MemoryBackingStoreTransaction::isVersionChange const): Deleted.
(WebCore::IDBServer::MemoryBackingStoreTransaction::isWriting const): Deleted.
(WebCore::IDBServer::MemoryBackingStoreTransaction::isAborting const): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::writeTransaction):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
(WebCore::IDBServer::MemoryObjectStore::writeTransaction): Deleted.
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::transaction const):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h:
(WebCore::IDBServer::SQLiteIDBCursor::transaction const): Deleted.
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h:
* Source/WebCore/dom/Event.h:
* Source/WebCore/workers/service/ExtendableEvent.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/284226@main">https://commits.webkit.org/284226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559c2be54b8225c694de593cc2335fd85aa3b612

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19753 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16821 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16420 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3921 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10486 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43980 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->