### PR TITLE
Have dedicated spatial button when watching spatial video

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1708,6 +1708,9 @@
 /* Validation message for input form controls with value higher than allowed maximum */
 "Value must be less than or equal to %s" = "Value must be less than or equal to %s";
 
+/* Title for View Spatial action button while in fullscreen */
+"View Spatial" = "View Spatial";
+
 /* Title for View Spatial Photo action button */
 "View Spatial Photo" = "View Spatial Photo";
 

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1590,4 +1590,11 @@ String contextMenuItemTagCopyLinkWithHighlight()
     return WEB_UI_STRING("Copy Link with Highlight", "Copy link with highlight context menu item");
 }
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+String fullscreenControllerViewSpatial()
+{
+    return WEB_UI_STRING("View Spatial", "Title for View Spatial action button while in fullscreen");
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -426,6 +426,10 @@ namespace WebCore {
     WEBCORE_EXPORT String pdfPasswordFormSubtitle();
     WEBCORE_EXPORT String pdfPasswordFormInvalidPasswordSubtitle();
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    WEBCORE_EXPORT String fullscreenControllerViewSpatial();
+#endif
+
 #if PLATFORM(COCOA)
 #define WEB_UI_STRING(string, description) WebCore::localizedString(CFSTR(string))
 #define WEB_UI_STRING_KEY(string, key, description) WebCore::localizedString(CFSTR(key))


### PR DESCRIPTION
#### ff192283031ceff6bf50dd3af562d740082a479e
<pre>
Have dedicated spatial button when watching spatial video
<a href="https://bugs.webkit.org/show_bug.cgi?id=280323">https://bugs.webkit.org/show_bug.cgi?id=280323</a>
<a href="https://rdar.apple.com/136541301">rdar://136541301</a>

Reviewed by Jer Noble, Ada Chan, and Aditya Keerthi.

Follow-up on 283297@main where we either showed the button to enter spatial portal if video had spatial metadata
or docking mode instead.

In this change we will always to display the docking button when in element fullscreen
and the spatial button will be displayed as necessary at the top/middle of the video instead.
The docking button will continue to go to docking environment if in element fullscreen.

Manually tested.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::fullscreenControllerViewSpatial):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController showUI]):
(-[WKFullScreenViewController hideUI]):
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):
(-[WKFullScreenViewController _removeEnvironmentFullscreenVideoButtonView]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _createButtonWithExtrinsicContentSize:]):
(-[WKFullScreenViewController _setupButton:]):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(SwiftOnlyData.enteredFromInline):
(WKSLinearMediaPlayer.maybeCreateSpatialEntity):
(WKSLinearMediaPlayer.willEnterFullscreen):
(WKSLinearMediaPlayer.didCompleteExitFullscreen(_:any:)):
(WKSLinearMediaPlayer.makeDefaultEntity):

Canonical link: <a href="https://commits.webkit.org/284342@main">https://commits.webkit.org/284342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caad93a95a91557015494787df69a4ed3bd05af4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20130 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35491 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74915 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13105 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59755 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4174 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44327 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45400 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->