### PR TITLE
Debug assertion on https://www.browserbench.org/MotionMark1.3.1/developer.html

### DIFF
--- a/Source/WebCore/platform/graphics/SystemImage.h
+++ b/Source/WebCore/platform/graphics/SystemImage.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
@@ -45,7 +45,7 @@ enum class SystemImageType : uint8_t {
 #endif
 };
 
-class WEBCORE_EXPORT SystemImage : public RefCounted<SystemImage> {
+class WEBCORE_EXPORT SystemImage : public ThreadSafeRefCounted<SystemImage> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SystemImage);
 public:
     virtual ~SystemImage() = default;

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -29,7 +29,7 @@
 #include "ControlFactory.h"
 #include "PlatformControl.h"
 #include "StyleAppearance.h"
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
@@ -37,7 +37,7 @@ class FloatRect;
 class GraphicsContext;
 class ControlFactory;
 
-class ControlPart : public RefCounted<ControlPart> {
+class ControlPart : public ThreadSafeRefCounted<ControlPart> {
 public:
     virtual ~ControlPart() = default;
 


### PR DESCRIPTION
#### f9961c9edb08ac769918287772cc1e0167c05918
<pre>
Debug assertion on <a href="https://www.browserbench.org/MotionMark1.3.1/developer.html">https://www.browserbench.org/MotionMark1.3.1/developer.html</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280214">https://bugs.webkit.org/show_bug.cgi?id=280214</a>

Reviewed by Said Abou-Hallawa.

When using threaded CPU rendering on WPE, clicking the  &apos;Run Benchmark&apos;
button on MotionMark developer.html fires an assertion. The ControlPart
object, associated with the button, is constructed during DisplayList
replay on a secondary thread, but destructed in the render tree teardown
phase during layout() on the main thread -- this leads to an assertion
in debug builds, that the construction/destruction thread is not
matched. Fix that by making ControlPart ThreadSafeRefCounted.

Covered by existing tests on WPE, in CPU rendering mode.

* Source/WebCore/platform/graphics/SystemImage.h:
* Source/WebCore/platform/graphics/controls/ControlPart.h:

Canonical link: <a href="https://commits.webkit.org/284244@main">https://commits.webkit.org/284244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf7885cb48a63db2499c1790095dc36cda7aed5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13277 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16839 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74569 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62325 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62363 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10324 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3937 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43995 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->