### PR TITLE
Make IPC::Connection synchronous message cancellation consistent

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1066,73 +1066,80 @@ bool GPUConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, IPC
     return messageReceiverMap().dispatchMessage(connection, decoder);
 }
 
-bool GPUConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool GPUConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
 #if ENABLE(VIDEO)
     if (decoder.messageReceiverName() == Messages::RemoteMediaPlayerManagerProxy::messageReceiverName()) {
-        return protectedRemoteMediaPlayerManagerProxy()->didReceiveSyncMessageFromWebProcess(connection, decoder, replyEncoder);
+        protectedRemoteMediaPlayerManagerProxy()->didReceiveSyncMessageFromWebProcess(connection, decoder);
+        return decoder.isHandled();
     }
     if (decoder.messageReceiverName() == Messages::RemoteMediaPlayerProxy::messageReceiverName()) {
-        return protectedRemoteMediaPlayerManagerProxy()->didReceiveSyncPlayerMessage(connection, decoder, replyEncoder);
+        protectedRemoteMediaPlayerManagerProxy()->didReceiveSyncPlayerMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     if (decoder.messageReceiverName() == Messages::UserMediaCaptureManagerProxy::messageReceiverName()) {
-        userMediaCaptureManagerProxy().didReceiveSyncMessage(connection, decoder, replyEncoder);
-        return true;
+        userMediaCaptureManagerProxy().didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
     if (decoder.messageReceiverName() == Messages::RemoteCDMFactoryProxy::messageReceiverName()) {
-        return protectedCdmFactoryProxy()->didReceiveSyncMessageFromWebProcess(connection, decoder, replyEncoder);
+        protectedCdmFactoryProxy()->didReceiveSyncMessageFromWebProcess(connection, decoder);
+        return decoder.isHandled();
     }
 
     if (decoder.messageReceiverName() == Messages::RemoteCDMProxy::messageReceiverName()) {
-        return protectedCdmFactoryProxy()->didReceiveSyncCDMMessage(connection, decoder, replyEncoder);
+        protectedCdmFactoryProxy()->didReceiveSyncCDMMessage(connection, decoder);
+        return decoder.isHandled();
     }
 
     if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceProxy::messageReceiverName()) {
-        return protectedCdmFactoryProxy()->didReceiveSyncCDMInstanceMessage(connection, decoder, replyEncoder);
+        protectedCdmFactoryProxy()->didReceiveSyncCDMInstanceMessage(connection, decoder);
+        return decoder.isHandled();
     }
 
     if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceSessionProxy::messageReceiverName()) {
-        return protectedCdmFactoryProxy()->didReceiveSyncCDMInstanceSessionMessage(connection, decoder, replyEncoder);
+        protectedCdmFactoryProxy()->didReceiveSyncCDMInstanceSessionMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
 #if USE(AUDIO_SESSION)
     if (decoder.messageReceiverName() == Messages::RemoteAudioSessionProxy::messageReceiverName()) {
-        return protectedAudioSessionProxy()->didReceiveSyncMessage(connection, decoder, replyEncoder);
+        protectedAudioSessionProxy()->didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMFactoryProxy::messageReceiverName()) {
-        return protectedLegacyCdmFactoryProxy()->didReceiveSyncMessageFromWebProcess(connection, decoder, replyEncoder);
+        protectedLegacyCdmFactoryProxy()->didReceiveSyncMessageFromWebProcess(connection, decoder);
+        return decoder.isHandled();
     }
 
     if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMProxy::messageReceiverName()) {
-        return protectedLegacyCdmFactoryProxy()->didReceiveSyncCDMMessage(connection, decoder, replyEncoder);
+        protectedLegacyCdmFactoryProxy()->didReceiveSyncCDMMessage(connection, decoder);
+        return decoder.isHandled();
     }
 
     if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMSessionProxy::messageReceiverName()) {
-        return protectedLegacyCdmFactoryProxy()->didReceiveSyncCDMSessionMessage(connection, decoder, replyEncoder);
+        protectedLegacyCdmFactoryProxy()->didReceiveSyncCDMSessionMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
 #if HAVE(AVASSETREADER)
     if (decoder.messageReceiverName() == Messages::RemoteImageDecoderAVFProxy::messageReceiverName()) {
-        return imageDecoderAVFProxy().didReceiveSyncMessage(connection, decoder, replyEncoder);
+        imageDecoderAVFProxy().didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
-#endif
-#if ENABLE(WEBGL)
-    if (decoder.messageReceiverName() == Messages::RemoteGraphicsContextGL::messageReceiverName())
-        // Skip messages for already removed receivers.
-        return true;
 #endif
 #if ENABLE(IPC_TESTING_API)
     if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName()) {
-        return m_ipcTester.didReceiveSyncMessage(connection, decoder, replyEncoder);
+        m_ipcTester.didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
-    return messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder);
+    return messageReceiverMap().dispatchSyncMessage(connection, decoder);
 }
 
 const String& GPUConnectionToWebProcess::mediaCacheDirectory() const

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -339,10 +339,10 @@ private:
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) final;
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     // NowPlayingManagerClient
     void didReceiveRemoteControlCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -78,7 +78,7 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -111,25 +111,22 @@ void RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage(IPC::Connection&
         session->didReceiveMessage(connection, decoder);
 }
 
-bool RemoteCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemoteCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (RefPtr proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
-        return proxy->didReceiveSyncMessage(connection, decoder, encoder);
-    return false;
+        proxy->didReceiveSyncMessage(connection, decoder);
 }
 
-bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (auto* instance = m_instances.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
-        return instance->didReceiveSyncMessage(connection, decoder, encoder);
-    return false;
+        instance->didReceiveSyncMessage(connection, decoder);
 }
 
-bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (auto* session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        return session->didReceiveSyncMessage(connection, decoder, encoder);
-    return false;
+        session->didReceiveSyncMessage(connection, decoder);
 }
 
 void RemoteCDMFactoryProxy::addProxy(const RemoteCDMIdentifier& identifier, RefPtr<RemoteCDMProxy>&& proxy)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -58,13 +58,13 @@ public:
     void clear();
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
+    void didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { return didReceiveSyncMessage(connection, decoder); }
     void didReceiveCDMMessage(IPC::Connection&, IPC::Decoder&);
     void didReceiveCDMInstanceMessage(IPC::Connection&, IPC::Decoder&);
     void didReceiveCDMInstanceSessionMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-    bool didReceiveSyncCDMInstanceMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-    bool didReceiveSyncCDMInstanceSessionMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveSyncCDMInstanceMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveSyncCDMInstanceSessionMessage(IPC::Connection&, IPC::Decoder&);
 
     void addProxy(const RemoteCDMIdentifier&, RefPtr<RemoteCDMProxy>&&);
     void removeProxy(const RemoteCDMIdentifier&);
@@ -93,7 +93,7 @@ private:
     friend class GPUProcessConnection;
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages
     void createCDM(const String& keySystem, CompletionHandler<void(RemoteCDMIdentifier&&, RemoteCDMConfiguration&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -75,7 +75,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     using SuccessValue = WebCore::CDMInstance::SuccessValue;
     using AllowDistinctiveIdentifiers = WebCore::CDMInstance::AllowDistinctiveIdentifiers;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -76,7 +76,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages
     void getSupportedConfiguration(WebCore::CDMKeySystemConfiguration&&, WebCore::CDMPrivate::LocalStorageAccess, CompletionHandler<void(std::optional<WebCore::CDMKeySystemConfiguration>)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
@@ -54,7 +54,7 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     bool allowsExitUnderMemoryPressure() const;
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -108,18 +108,16 @@ void RemoteLegacyCDMFactoryProxy::didReceiveCDMSessionMessage(IPC::Connection& c
         session->didReceiveMessage(connection, decoder);
 }
 
-bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (auto* proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
-        return proxy->didReceiveSyncMessage(connection, decoder, encoder);
-    return false;
+        proxy->didReceiveSyncMessage(connection, decoder);
 }
 
-bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (auto* session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
-        return session->didReceiveSyncMessage(connection, decoder, encoder);
-    return false;
+        session->didReceiveSyncMessage(connection, decoder);
 }
 
 void RemoteLegacyCDMFactoryProxy::addProxy(RemoteLegacyCDMIdentifier identifier, std::unique_ptr<RemoteLegacyCDMProxy>&& proxy)

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -56,11 +56,11 @@ public:
     void clear();
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
+    void didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveSyncMessage(connection, decoder); }
     void didReceiveCDMMessage(IPC::Connection&, IPC::Decoder&);
     void didReceiveCDMSessionMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-    bool didReceiveSyncCDMSessionMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveSyncCDMSessionMessage(IPC::Connection&, IPC::Decoder&);
 
     void addProxy(RemoteLegacyCDMIdentifier, std::unique_ptr<RemoteLegacyCDMProxy>&&);
     void removeProxy(RemoteLegacyCDMIdentifier);
@@ -84,7 +84,7 @@ private:
     friend class GPUProcessConnection;
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages
     void createCDM(const String& keySystem, std::optional<WebCore::MediaPlayerIdentifier>&&, CompletionHandler<void(RemoteLegacyCDMIdentifier&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -53,7 +53,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages
     using SupportsMIMETypeCallback = CompletionHandler<void(bool)>;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -66,7 +66,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // LegacyCDMSessionClient
     void sendMessage(Uint8Array*, String destinationURL) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -155,12 +155,11 @@ void RemoteMediaPlayerManagerProxy::didReceivePlayerMessage(IPC::Connection& con
         player->didReceiveMessage(connection, decoder);
 }
 
-bool RemoteMediaPlayerManagerProxy::didReceiveSyncPlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemoteMediaPlayerManagerProxy::didReceiveSyncPlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     ASSERT(RunLoop::isMain());
     if (RefPtr player = m_proxies.get(LegacyNullableObjectIdentifier<MediaPlayerIdentifierType>(decoder.destinationID())))
-        return player->didReceiveSyncMessage(connection, decoder, encoder);
-    return false;
+        player->didReceiveSyncMessage(connection, decoder);
 }
 
 RefPtr<MediaPlayer> RemoteMediaPlayerManagerProxy::mediaPlayer(const MediaPlayerIdentifier& identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -81,9 +81,9 @@ public:
 #endif
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
+    void didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveSyncMessage(connection, decoder); }
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncPlayerMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncPlayerMessage(IPC::Connection&, IPC::Decoder&);
 
     RefPtr<WebCore::MediaPlayer> mediaPlayer(const WebCore::MediaPlayerIdentifier&);
 
@@ -105,7 +105,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     void createMediaPlayer(WebCore::MediaPlayerIdentifier, WebCore::MediaPlayerClientIdentifier, WebCore::MediaPlayerEnums::MediaEngineIdentifier, RemoteMediaPlayerProxyConfiguration&&);
     void deleteMediaPlayer(WebCore::MediaPlayerIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -137,7 +137,7 @@ public:
 #endif
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     void getConfiguration(RemoteMediaPlayerConfiguration&);
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -81,7 +81,7 @@ public:
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     using AddSourceBufferCallback = CompletionHandler<void(WebCore::MediaSourcePrivate::AddStatus, std::optional<RemoteSourceBufferIdentifier>)>;
     void addSourceBuffer(const WebCore::ContentType&, AddSourceBufferCallback&&);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -84,7 +84,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     void setActive(bool);
     void canSwitchToType(const WebCore::ContentType&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -61,7 +61,7 @@ private:
 
     // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages.
     void releaseVideoFrame(RemoteVideoFrameWriteReference&&);

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -197,15 +197,15 @@ bool ModelConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, I
     return messageReceiverMap().dispatchMessage(connection, decoder);
 }
 
-bool ModelConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool ModelConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
 #if ENABLE(IPC_TESTING_API)
     if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName()) {
-        m_ipcTester.didReceiveSyncMessage(connection, decoder, replyEncoder);
-        return true;
+        m_ipcTester.didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
-    return messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder);
+    return messageReceiverMap().dispatchSyncMessage(connection, decoder);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -109,10 +109,10 @@ private:
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) final;
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     static uint64_t gObjectCountForTesting;
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -267,13 +267,13 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) override;
 
     // Message handlers.
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
     void scheduleResourceLoad(NetworkResourceLoadParameters&&, std::optional<NetworkResourceLoadIdentifier> existingLoaderToResume);
     void performSynchronousLoad(NetworkResourceLoadParameters&&, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse, Vector<uint8_t>&&)>&&);
     void testProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebPageProxyIdentifier, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -461,7 +461,7 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
     void didClose(IPC::Connection&) override;
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
 
@@ -473,7 +473,7 @@ private:
     AuthenticationManager& downloadsAuthenticationManager() override;
 
     // Message Handlers
-    bool didReceiveSyncNetworkProcessMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncNetworkProcessMessage(IPC::Connection&, IPC::Decoder&);
     void initializeNetworkProcess(NetworkProcessCreationParameters&&, CompletionHandler<void()>&&);
     void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&,  CompletionHandler<void(std::optional<IPC::Connection::Handle>&&, WebCore::HTTPCookieAcceptPolicy)>&&);
     void sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier, SharedPreferencesForWebProcess&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -161,7 +161,7 @@ private:
 
     // IPC::MessageReceiver (implemented by generated code)
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>& replyEncoder);
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     // Message handlers for FileSystem.
     void persisted(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -94,6 +94,12 @@ Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeal
     if (UNLIKELY(!destinationID))
         return;
     m_destinationID = WTFMove(*destinationID);
+    if (messageIsSync(m_messageName)) {
+        auto replyID = decode<ReplyID>();
+        if (UNLIKELY(!replyID))
+            return;
+        m_syncReplyID = replyID;
+    }
 }
 
 Decoder::Decoder(std::span<const uint8_t> stream, uint64_t destinationID)
@@ -106,6 +112,12 @@ Decoder::Decoder(std::span<const uint8_t> stream, uint64_t destinationID)
     if (UNLIKELY(!messageName))
         return;
     m_messageName = WTFMove(*messageName);
+    if (messageIsSync(m_messageName)) {
+        auto replyID = decode<ReplyID>();
+        if (UNLIKELY(!replyID))
+            return;
+        m_syncReplyID = replyID;
+    }
 }
 
 Decoder::~Decoder()
@@ -133,13 +145,6 @@ bool Decoder::shouldMaintainOrderingWithAsyncMessages() const
 {
     return m_messageFlags.contains(MessageFlags::MaintainOrderingWithAsyncMessages);
 }
-
-#if ENABLE(IPC_TESTING_API)
-bool Decoder::hasSyncMessageDeserializationFailure() const
-{
-    return m_messageFlags.contains(MessageFlags::SyncMessageDeserializationFailure);
-}
-#endif
 
 #if PLATFORM(MAC)
 void Decoder::setImportanceAssertion(ImportanceAssertion&& assertion)

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -111,13 +111,6 @@ void Encoder::setFullySynchronousModeForTesting()
     messageFlags().add(MessageFlags::UseFullySynchronousModeForTesting);
 }
 
-#if ENABLE(IPC_TESTING_API)
-void Encoder::setSyncMessageDeserializationFailure()
-{
-    messageFlags().add(MessageFlags::SyncMessageDeserializationFailure);
-}
-#endif
-
 void Encoder::setShouldMaintainOrderingWithAsyncMessages()
 {
     messageFlags().add(MessageFlags::MaintainOrderingWithAsyncMessages);

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -66,9 +66,6 @@ public:
     void setShouldMaintainOrderingWithAsyncMessages();
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || isFullySynchronousModeForTesting(); }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
-#if ENABLE(IPC_TESTING_API)
-    void setSyncMessageDeserializationFailure();
-#endif
 
     void wrapForTesting(UniqueRef<Encoder>&&);
 

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -133,15 +133,18 @@ bool MessageReceiverMap::dispatchMessage(Connection& connection, Decoder& decode
     return false;
 }
 
-bool MessageReceiverMap::dispatchSyncMessage(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder)
+bool MessageReceiverMap::dispatchSyncMessage(Connection& connection, Decoder& decoder)
 {
     if (auto messageReceiver = m_globalMessageReceivers.get(decoder.messageReceiverName())) {
         ASSERT(!decoder.destinationID());
-        return messageReceiver->didReceiveSyncMessage(connection, decoder, replyEncoder);
+        messageReceiver->didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 
-    if (auto messageReceiver = m_messageReceivers.get(std::make_pair(decoder.messageReceiverName(), decoder.destinationID())))
-        return messageReceiver->didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (auto messageReceiver = m_messageReceivers.get(std::make_pair(decoder.messageReceiverName(), decoder.destinationID()))) {
+        messageReceiver->didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
+    }
 
     return false;
 }

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.h
@@ -52,7 +52,7 @@ public:
     void invalidate();
 
     bool dispatchMessage(Connection&, Decoder&);
-    bool dispatchSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&);
+    bool dispatchSyncMessage(Connection&, Decoder&);
 
 private:
     // Message receivers that don't require a destination ID.

--- a/Source/WebKit/Platform/IPC/ReplyID.h
+++ b/Source/WebKit/Platform/IPC/ReplyID.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,67 +25,11 @@
 
 #pragma once
 
-#include <wtf/Assertions.h>
-#include <wtf/WeakPtr.h>
-
-namespace IPC {
-class MessageReceiver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<IPC::MessageReceiver> : std::true_type { };
-}
+#include <wtf/ObjectIdentifier.h>
 
 namespace IPC {
 
-class Connection;
-class Decoder;
-class Encoder;
+enum class ReplyIDType { };
+using ReplyID = AtomicObjectIdentifier<ReplyIDType>;
 
-class MessageReceiver : public CanMakeWeakPtr<MessageReceiver> {
-public:
-    virtual ~MessageReceiver()
-    {
-        ASSERT(!m_messageReceiverMapCount);
-    }
-
-    virtual void didReceiveMessage(Connection&, Decoder&)
-    {
-        ASSERT_NOT_REACHED();
-    }
-
-    virtual void didReceiveMessageWithReplyHandler(Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&)
-    {
-        ASSERT_NOT_REACHED();
-    }
-
-    virtual void didReceiveSyncMessage(Connection&, Decoder&)
-    {
-        ASSERT_NOT_REACHED();
-    }
-
-private:
-    friend class MessageReceiverMap;
-
-    void willBeAddedToMessageReceiverMap()
-    {
-#if ASSERT_ENABLED
-        m_messageReceiverMapCount++;
-#endif
-    }
-
-    void willBeRemovedFromMessageReceiverMap()
-    {
-        ASSERT(m_messageReceiverMapCount);
-#if ASSERT_ENABLED
-        m_messageReceiverMapCount--;
-#endif
-    }
-
-#if ASSERT_ENABLED
-    unsigned m_messageReceiverMapCount { 0 };
-#endif
-};
-
-} // namespace IPC
+}

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -43,9 +43,9 @@ void StreamClientConnection::DedicatedConnectionClient::didReceiveMessage(Connec
     m_receiver.didReceiveMessage(connection, decoder);
 }
 
-bool StreamClientConnection::DedicatedConnectionClient::didReceiveSyncMessage(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder)
+void StreamClientConnection::DedicatedConnectionClient::didReceiveSyncMessage(Connection& connection, Decoder& decoder)
 {
-    return m_receiver.didReceiveSyncMessage(connection, decoder, replyEncoder);
+    return m_receiver.didReceiveSyncMessage(connection, decoder);
 }
 
 void StreamClientConnection::DedicatedConnectionClient::didClose(Connection& connection)

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -116,11 +116,10 @@ void StreamServerConnection::didReceiveMessage(Connection&, Decoder&)
     // All messages go to message queue.
     ASSERT_NOT_REACHED();
 }
-bool StreamServerConnection::didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&)
+void StreamServerConnection::didReceiveSyncMessage(Connection&, Decoder&)
 {
     // All messages go to message queue.
     ASSERT_NOT_REACHED();
-    return false;
 }
 
 void StreamServerConnection::didClose(Connection&)
@@ -224,7 +223,7 @@ bool StreamServerConnection::dispatchStreamMessage(Decoder&& decoder, StreamMess
     if (decoder.isSyncMessage()) {
         result = m_buffer.releaseAll();
         if (m_syncReplyToDispatch)
-            protectedConnection()->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTFMove(m_syncReplyToDispatch)));
+            protectedConnection()->sendMessage(makeUniqueRefFromNonNullUniquePtr(WTFMove(m_syncReplyToDispatch)), { });
     } else
         result = m_buffer.release(decoder.currentBufferOffset());
     if (result == WakeUpClient::Yes)
@@ -273,15 +272,5 @@ RefPtr<StreamConnectionWorkQueue> StreamServerConnection::protectedWorkQueue() c
 {
     return m_workQueue;
 }
-
-#if ENABLE(IPC_TESTING_API)
-void StreamServerConnection::sendDeserializationErrorSyncReply(Connection::SyncRequestID syncRequestID)
-{
-    auto encoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());
-    encoder->setSyncMessageDeserializationFailure();
-    m_connection->sendSyncReply(WTFMove(encoder));
-}
-#endif
-
 
 }

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -83,6 +83,7 @@ class Parameter(object):
 ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, receiver_enabled_by_conjunction=None, shared_preferences_needs_connection=False, messages=[
     Message('WrappedAsyncMessageForTesting', [], [], attributes=[BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE], condition=None),
     Message('SyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('CancelSyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('InitializeConnection', [], [], attributes=[BUILTIN_ATTRIBUTE], condition="PLATFORM(COCOA)"),
     Message('LegacySessionState', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('SetStreamDestinationID', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -142,6 +142,7 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithoutUsingIPCConnection_MessageWithoutArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
     { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
     { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "CancelSyncMessageReply"_s, ReceiverName::IPC, false, false },
 #if PLATFORM(COCOA)
     { "InitializeConnection"_s, ReceiverName::IPC, false, false },
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -172,6 +172,7 @@ enum class MessageName : uint16_t {
     TestWithoutUsingIPCConnection_MessageWithoutArgument,
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply,
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument,
+    CancelSyncMessageReply,
 #if PLATFORM(COCOA)
     InitializeConnection,
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -45,10 +45,14 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
 {
     Ref protectedThis { *this };
 #if USE(AVFOUNDATION)
-    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name())
-        return IPC::handleMessage<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::sendCVPixelBuffer);
-    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name())
-        return IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
+    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name()) {
+        IPC::handleMessage<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::sendCVPixelBuffer);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name()) {
+        IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
+        return;
+    }
 #endif
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
@@ -51,8 +51,10 @@ void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connect
         return;
     }
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithEnabledByAndConjunction::AlwaysEnabled::name())
-        return IPC::handleMessage<Messages::TestWithEnabledByAndConjunction::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledByAndConjunction::alwaysEnabled);
+    if (decoder.messageName() == Messages::TestWithEnabledByAndConjunction::AlwaysEnabled::name()) {
+        IPC::handleMessage<Messages::TestWithEnabledByAndConjunction::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledByAndConjunction::alwaysEnabled);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp
@@ -43,14 +43,22 @@ void TestWithEnabledBy::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     auto& sharedPreferences = sharedPreferencesForWebProcess(connection);
     UNUSED_VARIABLE(sharedPreferences);
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithEnabledBy::AlwaysEnabled::name())
-        return IPC::handleMessage<Messages::TestWithEnabledBy::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledBy::alwaysEnabled);
-    if (decoder.messageName() == Messages::TestWithEnabledBy::ConditionallyEnabled::name() && sharedPreferences.someFeature)
-        return IPC::handleMessage<Messages::TestWithEnabledBy::ConditionallyEnabled>(connection, decoder, this, &TestWithEnabledBy::conditionallyEnabled);
-    if (decoder.messageName() == Messages::TestWithEnabledBy::ConditionallyEnabledAnd::name() && (sharedPreferences.someFeature && sharedPreferences.otherFeature))
-        return IPC::handleMessage<Messages::TestWithEnabledBy::ConditionallyEnabledAnd>(connection, decoder, this, &TestWithEnabledBy::conditionallyEnabledAnd);
-    if (decoder.messageName() == Messages::TestWithEnabledBy::ConditionallyEnabledOr::name() && (sharedPreferences.someFeature || sharedPreferences.otherFeature))
-        return IPC::handleMessage<Messages::TestWithEnabledBy::ConditionallyEnabledOr>(connection, decoder, this, &TestWithEnabledBy::conditionallyEnabledOr);
+    if (decoder.messageName() == Messages::TestWithEnabledBy::AlwaysEnabled::name()) {
+        IPC::handleMessage<Messages::TestWithEnabledBy::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledBy::alwaysEnabled);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithEnabledBy::ConditionallyEnabled::name() && sharedPreferences.someFeature) {
+        IPC::handleMessage<Messages::TestWithEnabledBy::ConditionallyEnabled>(connection, decoder, this, &TestWithEnabledBy::conditionallyEnabled);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithEnabledBy::ConditionallyEnabledAnd::name() && (sharedPreferences.someFeature && sharedPreferences.otherFeature)) {
+        IPC::handleMessage<Messages::TestWithEnabledBy::ConditionallyEnabledAnd>(connection, decoder, this, &TestWithEnabledBy::conditionallyEnabledAnd);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithEnabledBy::ConditionallyEnabledOr::name() && (sharedPreferences.someFeature || sharedPreferences.otherFeature)) {
+        IPC::handleMessage<Messages::TestWithEnabledBy::ConditionallyEnabledOr>(connection, decoder, this, &TestWithEnabledBy::conditionallyEnabledOr);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
@@ -51,8 +51,10 @@ void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connecti
         return;
     }
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithEnabledByOrConjunction::AlwaysEnabled::name())
-        return IPC::handleMessage<Messages::TestWithEnabledByOrConjunction::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledByOrConjunction::alwaysEnabled);
+    if (decoder.messageName() == Messages::TestWithEnabledByOrConjunction::AlwaysEnabled::name()) {
+        IPC::handleMessage<Messages::TestWithEnabledByOrConjunction::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledByOrConjunction::alwaysEnabled);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
@@ -51,10 +51,14 @@ void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Deco
         return;
     }
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithEnabledIf::AlwaysEnabled::name())
-        return IPC::handleMessage<Messages::TestWithEnabledIf::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledIf::alwaysEnabled);
-    if (decoder.messageName() == Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled::name() && featureEnabled())
-        return IPC::handleMessage<Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled>(connection, decoder, this, &TestWithEnabledIf::onlyEnabledIfFeatureEnabled);
+    if (decoder.messageName() == Messages::TestWithEnabledIf::AlwaysEnabled::name()) {
+        IPC::handleMessage<Messages::TestWithEnabledIf::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledIf::alwaysEnabled);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled::name() && featureEnabled()) {
+        IPC::handleMessage<Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled>(connection, decoder, this, &TestWithEnabledIf::onlyEnabledIfFeatureEnabled);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
@@ -45,12 +45,16 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 {
     Ref protectedThis { *this };
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
+    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
+        return;
+    }
 #endif
 #if PLATFORM(GTK)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
+    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
+        return;
+    }
 #endif
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -42,10 +42,14 @@ namespace WebKit {
 void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithImageData::SendImageData::name())
-        return IPC::handleMessage<Messages::TestWithImageData::SendImageData>(connection, decoder, this, &TestWithImageData::sendImageData);
-    if (decoder.messageName() == Messages::TestWithImageData::ReceiveImageData::name())
-        return IPC::handleMessageAsync<Messages::TestWithImageData::ReceiveImageData>(connection, decoder, this, &TestWithImageData::receiveImageData);
+    if (decoder.messageName() == Messages::TestWithImageData::SendImageData::name()) {
+        IPC::handleMessage<Messages::TestWithImageData::SendImageData>(connection, decoder, this, &TestWithImageData::sendImageData);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithImageData::ReceiveImageData::name()) {
+        IPC::handleMessageAsync<Messages::TestWithImageData::ReceiveImageData>(connection, decoder, this, &TestWithImageData::receiveImageData);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -68,59 +68,99 @@ namespace WebKit {
 void TestWithLegacyReceiver::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadURL>(connection, decoder, this, &TestWithLegacyReceiver::loadURL);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadURL>(connection, decoder, this, &TestWithLegacyReceiver::loadURL);
+        return;
+    }
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomething::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomething>(connection, decoder, this, &TestWithLegacyReceiver::loadSomething);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomething::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomething>(connection, decoder, this, &TestWithLegacyReceiver::loadSomething);
+        return;
+    }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TouchEvent::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TouchEvent>(connection, decoder, this, &TestWithLegacyReceiver::touchEvent);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TouchEvent::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::TouchEvent>(connection, decoder, this, &TestWithLegacyReceiver::touchEvent);
+        return;
+    }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::AddEvent::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::AddEvent>(connection, decoder, this, &TestWithLegacyReceiver::addEvent);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::AddEvent::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::AddEvent>(connection, decoder, this, &TestWithLegacyReceiver::addEvent);
+        return;
+    }
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomethingElse::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomethingElse>(connection, decoder, this, &TestWithLegacyReceiver::loadSomethingElse);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomethingElse::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomethingElse>(connection, decoder, this, &TestWithLegacyReceiver::loadSomethingElse);
+        return;
+    }
 #endif
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision>(connection, decoder, this, &TestWithLegacyReceiver::didReceivePolicyDecision);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::Close::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::Close>(connection, decoder, this, &TestWithLegacyReceiver::close);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::PreferencesDidChange::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::PreferencesDidChange>(connection, decoder, this, &TestWithLegacyReceiver::preferencesDidChange);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendDoubleAndFloat::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendDoubleAndFloat>(connection, decoder, this, &TestWithLegacyReceiver::sendDoubleAndFloat);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendInts::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendInts>(connection, decoder, this, &TestWithLegacyReceiver::sendInts);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::CreatePlugin::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::CreatePlugin>(connection, decoder, this, &TestWithLegacyReceiver::createPlugin);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::RunJavaScriptAlert::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::RunJavaScriptAlert>(connection, decoder, this, &TestWithLegacyReceiver::runJavaScriptAlert);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPlugins::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::GetPlugins>(connection, decoder, this, &TestWithLegacyReceiver::getPlugins);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestParameterAttributes::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TestParameterAttributes>(connection, decoder, this, &TestWithLegacyReceiver::testParameterAttributes);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TemplateTest::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TemplateTest>(connection, decoder, this, &TestWithLegacyReceiver::templateTest);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SetVideoLayerID::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SetVideoLayerID>(connection, decoder, this, &TestWithLegacyReceiver::setVideoLayerID);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision>(connection, decoder, this, &TestWithLegacyReceiver::didReceivePolicyDecision);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::Close::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::Close>(connection, decoder, this, &TestWithLegacyReceiver::close);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::PreferencesDidChange::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::PreferencesDidChange>(connection, decoder, this, &TestWithLegacyReceiver::preferencesDidChange);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendDoubleAndFloat::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::SendDoubleAndFloat>(connection, decoder, this, &TestWithLegacyReceiver::sendDoubleAndFloat);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendInts::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::SendInts>(connection, decoder, this, &TestWithLegacyReceiver::sendInts);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::CreatePlugin::name()) {
+        IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::CreatePlugin>(connection, decoder, this, &TestWithLegacyReceiver::createPlugin);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::RunJavaScriptAlert::name()) {
+        IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::RunJavaScriptAlert>(connection, decoder, this, &TestWithLegacyReceiver::runJavaScriptAlert);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPlugins::name()) {
+        IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::GetPlugins>(connection, decoder, this, &TestWithLegacyReceiver::getPlugins);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestParameterAttributes::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::TestParameterAttributes>(connection, decoder, this, &TestWithLegacyReceiver::testParameterAttributes);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TemplateTest::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::TemplateTest>(connection, decoder, this, &TestWithLegacyReceiver::templateTest);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SetVideoLayerID::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::SetVideoLayerID>(connection, decoder, this, &TestWithLegacyReceiver::setVideoLayerID);
+        return;
+    }
 #if PLATFORM(MAC)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::InterpretKeyEvent::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::InterpretKeyEvent>(connection, decoder, this, &TestWithLegacyReceiver::interpretKeyEvent);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::InterpretKeyEvent::name()) {
+        IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::InterpretKeyEvent>(connection, decoder, this, &TestWithLegacyReceiver::interpretKeyEvent);
+        return;
+    }
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DeprecatedOperation::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DeprecatedOperation>(connection, decoder, this, &TestWithLegacyReceiver::deprecatedOperation);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DeprecatedOperation::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::DeprecatedOperation>(connection, decoder, this, &TestWithLegacyReceiver::deprecatedOperation);
+        return;
+    }
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::ExperimentalOperation::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::ExperimentalOperation>(connection, decoder, this, &TestWithLegacyReceiver::experimentalOperation);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::ExperimentalOperation::name()) {
+        IPC::handleMessage<Messages::TestWithLegacyReceiver::ExperimentalOperation>(connection, decoder, this, &TestWithLegacyReceiver::experimentalOperation);
+        return;
+    }
 #endif
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
@@ -131,22 +171,25 @@ void TestWithLegacyReceiver::didReceiveMessage(IPC::Connection& connection, IPC:
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
-bool TestWithLegacyReceiver::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithLegacyReceiver::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::getPluginProcessConnection);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::GetPluginProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::getPluginProcessConnection);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
-    UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
-        return false;
+        return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
-    return false;
+    return;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -39,10 +39,14 @@ namespace WebKit {
 void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSemaphore::SendSemaphore::name())
-        return IPC::handleMessage<Messages::TestWithSemaphore::SendSemaphore>(connection, decoder, this, &TestWithSemaphore::sendSemaphore);
-    if (decoder.messageName() == Messages::TestWithSemaphore::ReceiveSemaphore::name())
-        return IPC::handleMessageAsync<Messages::TestWithSemaphore::ReceiveSemaphore>(connection, decoder, this, &TestWithSemaphore::receiveSemaphore);
+    if (decoder.messageName() == Messages::TestWithSemaphore::SendSemaphore::name()) {
+        IPC::handleMessage<Messages::TestWithSemaphore::SendSemaphore>(connection, decoder, this, &TestWithSemaphore::sendSemaphore);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithSemaphore::ReceiveSemaphore::name()) {
+        IPC::handleMessageAsync<Messages::TestWithSemaphore::ReceiveSemaphore>(connection, decoder, this, &TestWithSemaphore::receiveSemaphore);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -39,8 +39,10 @@ namespace WebKit {
 
 void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
 {
-    if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name())
-        return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection, decoder, this, &TestWithStreamBatched::sendString);
+    if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name()) {
+        IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection, decoder, this, &TestWithStreamBatched::sendString);
+        return;
+    }
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(connection);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -39,8 +39,10 @@ namespace WebKit {
 void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithStreamBuffer::SendStreamBuffer::name())
-        return IPC::handleMessage<Messages::TestWithStreamBuffer::SendStreamBuffer>(connection, decoder, this, &TestWithStreamBuffer::sendStreamBuffer);
+    if (decoder.messageName() == Messages::TestWithStreamBuffer::SendStreamBuffer::name()) {
+        IPC::handleMessage<Messages::TestWithStreamBuffer::SendStreamBuffer>(connection, decoder, this, &TestWithStreamBuffer::sendStreamBuffer);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -42,23 +42,37 @@ namespace WebKit {
 
 void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
 {
-    if (decoder.messageName() == Messages::TestWithStream::SendString::name())
-        return IPC::handleMessage<Messages::TestWithStream::SendString>(connection, decoder, this, &TestWithStream::sendString);
-    if (decoder.messageName() == Messages::TestWithStream::SendStringAsync::name())
-        return IPC::handleMessageAsync<Messages::TestWithStream::SendStringAsync>(connection, decoder, this, &TestWithStream::sendStringAsync);
-    if (decoder.messageName() == Messages::TestWithStream::CallWithIdentifier::name())
-        return IPC::handleMessageAsyncWithReplyID<Messages::TestWithStream::CallWithIdentifier>(connection, decoder, this, &TestWithStream::callWithIdentifier);
+    if (decoder.messageName() == Messages::TestWithStream::SendString::name()) {
+        IPC::handleMessage<Messages::TestWithStream::SendString>(connection, decoder, this, &TestWithStream::sendString);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithStream::SendStringAsync::name()) {
+        IPC::handleMessageAsync<Messages::TestWithStream::SendStringAsync>(connection, decoder, this, &TestWithStream::sendStringAsync);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithStream::CallWithIdentifier::name()) {
+        IPC::handleMessageAsyncWithReplyID<Messages::TestWithStream::CallWithIdentifier>(connection, decoder, this, &TestWithStream::callWithIdentifier);
+        return;
+    }
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithStream::SendMachSendRight::name())
-        return IPC::handleMessage<Messages::TestWithStream::SendMachSendRight>(connection, decoder, this, &TestWithStream::sendMachSendRight);
+    if (decoder.messageName() == Messages::TestWithStream::SendMachSendRight::name()) {
+        IPC::handleMessage<Messages::TestWithStream::SendMachSendRight>(connection, decoder, this, &TestWithStream::sendMachSendRight);
+        return;
+    }
 #endif
-    if (decoder.messageName() == Messages::TestWithStream::SendStringSync::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendStringSync>(connection, decoder, this, &TestWithStream::sendStringSync);
+    if (decoder.messageName() == Messages::TestWithStream::SendStringSync::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithStream::SendStringSync>(connection, decoder, this, &TestWithStream::sendStringSync);
+        return;
+    }
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithStream::ReceiveMachSendRight::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithStream::ReceiveMachSendRight>(connection, decoder, this, &TestWithStream::receiveMachSendRight);
-    if (decoder.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
+    if (decoder.messageName() == Messages::TestWithStream::ReceiveMachSendRight::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithStream::ReceiveMachSendRight>(connection, decoder, this, &TestWithStream::receiveMachSendRight);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
+        return;
+    }
 #endif
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(connection);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
@@ -39,8 +39,10 @@ namespace WebKit {
 void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::name())
-        return IPC::handleMessage<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection>(connection, decoder, this, &TestWithStreamServerConnectionHandle::sendStreamServerConnection);
+    if (decoder.messageName() == Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::name()) {
+        IPC::handleMessage<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection>(connection, decoder, this, &TestWithStreamServerConnectionHandle::sendStreamServerConnection);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessageReceiver.cpp
@@ -40,19 +40,23 @@ namespace WebKit {
 void TestWithSuperclassAndWantsAsyncDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL>(connection, decoder, this, &TestWithSuperclassAndWantsAsyncDispatch::loadURL);
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithSuperclassAndWantsAsyncDispatch::LoadURL>(connection, decoder, this, &TestWithSuperclassAndWantsAsyncDispatch::loadURL);
+        return;
+    }
     if (dispatchMessage(connection, decoder))
         return;
     WebPageBase::didReceiveMessage(connection, decoder);
 }
 
-bool TestWithSuperclassAndWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithSuperclassAndWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclassAndWantsAsyncDispatch::testSyncMessage);
-    return WebPageBase::didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithSuperclassAndWantsAsyncDispatch::TestSyncMessage>(connection, decoder, this, &TestWithSuperclassAndWantsAsyncDispatch::testSyncMessage);
+        return;
+    }
+    return WebPageBase::didReceiveSyncMessage(connection, decoder);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessageReceiver.cpp
@@ -40,21 +40,25 @@ namespace WebKit {
 void TestWithSuperclassAndWantsDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsDispatch::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithSuperclassAndWantsDispatch::LoadURL>(connection, decoder, this, &TestWithSuperclassAndWantsDispatch::loadURL);
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsDispatch::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithSuperclassAndWantsDispatch::LoadURL>(connection, decoder, this, &TestWithSuperclassAndWantsDispatch::loadURL);
+        return;
+    }
     if (dispatchMessage(connection, decoder))
         return;
     WebPageBase::didReceiveMessage(connection, decoder);
 }
 
-bool TestWithSuperclassAndWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithSuperclassAndWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclassAndWantsDispatch::testSyncMessage);
-    if (dispatchSyncMessage(connection, decoder, replyEncoder))
-        return true;
-    return WebPageBase::didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (decoder.messageName() == Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithSuperclassAndWantsDispatch::TestSyncMessage>(connection, decoder, this, &TestWithSuperclassAndWantsDispatch::testSyncMessage);
+        return;
+    }
+    if (dispatchSyncMessage(connection, decoder))
+        return;
+    return WebPageBase::didReceiveSyncMessage(connection, decoder);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -45,29 +45,43 @@ namespace WebKit {
 void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclass::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithSuperclass::LoadURL>(connection, decoder, this, &TestWithSuperclass::loadURL);
+    if (decoder.messageName() == Messages::TestWithSuperclass::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithSuperclass::LoadURL>(connection, decoder, this, &TestWithSuperclass::loadURL);
+        return;
+    }
 #if ENABLE(TEST_FEATURE)
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessage::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessage>(connection, decoder, this, &TestWithSuperclass::testAsyncMessage);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithNoArguments);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessage::name()) {
+        IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessage>(connection, decoder, this, &TestWithSuperclass::testAsyncMessage);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name()) {
+        IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithNoArguments);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name()) {
+        IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name()) {
+        IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
+        return;
+    }
 #endif
     WebPageBase::didReceiveMessage(connection, decoder);
 }
 
-bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSyncMessage);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestSynchronousMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSynchronousMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSynchronousMessage);
-    return WebPageBase::didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestSyncMessage::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSyncMessage>(connection, decoder, this, &TestWithSuperclass::testSyncMessage);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithSuperclass::TestSynchronousMessage::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSynchronousMessage>(connection, decoder, this, &TestWithSuperclass::testSynchronousMessage);
+        return;
+    }
+    return WebPageBase::didReceiveSyncMessage(connection, decoder);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp
@@ -40,8 +40,10 @@ namespace WebKit {
 void TestWithWantsAsyncDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestMessage::name())
-        return IPC::handleMessage<Messages::TestWithWantsAsyncDispatch::TestMessage>(connection, decoder, this, &TestWithWantsAsyncDispatch::testMessage);
+    if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestMessage::name()) {
+        IPC::handleMessage<Messages::TestWithWantsAsyncDispatch::TestMessage>(connection, decoder, this, &TestWithWantsAsyncDispatch::testMessage);
+        return;
+    }
     if (dispatchMessage(connection, decoder))
         return;
     UNUSED_PARAM(connection);
@@ -53,20 +55,21 @@ void TestWithWantsAsyncDispatch::didReceiveMessage(IPC::Connection& connection, 
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
-bool TestWithWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithWantsAsyncDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithWantsAsyncDispatch::testSyncMessage);
+    if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestSyncMessage::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithWantsAsyncDispatch::TestSyncMessage>(connection, decoder, this, &TestWithWantsAsyncDispatch::testSyncMessage);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
-    UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
-        return false;
+        return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
-    return false;
+    return;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp
@@ -40,8 +40,10 @@ namespace WebKit {
 void TestWithWantsDispatch::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithWantsDispatch::TestMessage::name())
-        return IPC::handleMessage<Messages::TestWithWantsDispatch::TestMessage>(connection, decoder, this, &TestWithWantsDispatch::testMessage);
+    if (decoder.messageName() == Messages::TestWithWantsDispatch::TestMessage::name()) {
+        IPC::handleMessage<Messages::TestWithWantsDispatch::TestMessage>(connection, decoder, this, &TestWithWantsDispatch::testMessage);
+        return;
+    }
     if (dispatchMessage(connection, decoder))
         return;
     UNUSED_PARAM(connection);
@@ -53,22 +55,23 @@ void TestWithWantsDispatch::didReceiveMessage(IPC::Connection& connection, IPC::
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
-bool TestWithWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithWantsDispatch::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithWantsDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithWantsDispatch::testSyncMessage);
-    if (dispatchSyncMessage(connection, decoder, replyEncoder))
-        return true;
+    if (decoder.messageName() == Messages::TestWithWantsDispatch::TestSyncMessage::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithWantsDispatch::TestSyncMessage>(connection, decoder, this, &TestWithWantsDispatch::testSyncMessage);
+        return;
+    }
+    if (dispatchSyncMessage(connection, decoder))
+        return;
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
-    UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
-        return false;
+        return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
-    return false;
+    return;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp
@@ -40,8 +40,10 @@ namespace WebKit {
 void TestWithWantsDispatchNoSyncMessages::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::name())
-        return IPC::handleMessage<Messages::TestWithWantsDispatchNoSyncMessages::TestMessage>(connection, decoder, this, &TestWithWantsDispatchNoSyncMessages::testMessage);
+    if (decoder.messageName() == Messages::TestWithWantsDispatchNoSyncMessages::TestMessage::name()) {
+        IPC::handleMessage<Messages::TestWithWantsDispatchNoSyncMessages::TestMessage>(connection, decoder, this, &TestWithWantsDispatchNoSyncMessages::testMessage);
+        return;
+    }
     if (dispatchMessage(connection, decoder))
         return;
     UNUSED_PARAM(connection);
@@ -53,20 +55,19 @@ void TestWithWantsDispatchNoSyncMessages::didReceiveMessage(IPC::Connection& con
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
-bool TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (dispatchSyncMessage(connection, decoder, replyEncoder))
-        return true;
+    if (dispatchSyncMessage(connection, decoder))
+        return;
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
-    UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
-        return false;
+        return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
-    return false;
+    return;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -68,59 +68,99 @@ namespace WebKit {
 void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadURL>(connection, decoder, this, &TestWithoutAttributes::loadURL);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadURL::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::LoadURL>(connection, decoder, this, &TestWithoutAttributes::loadURL);
+        return;
+    }
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomething::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomething>(connection, decoder, this, &TestWithoutAttributes::loadSomething);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomething::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomething>(connection, decoder, this, &TestWithoutAttributes::loadSomething);
+        return;
+    }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TouchEvent::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TouchEvent>(connection, decoder, this, &TestWithoutAttributes::touchEvent);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::TouchEvent::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::TouchEvent>(connection, decoder, this, &TestWithoutAttributes::touchEvent);
+        return;
+    }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithoutAttributes::AddEvent::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::AddEvent>(connection, decoder, this, &TestWithoutAttributes::addEvent);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::AddEvent::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::AddEvent>(connection, decoder, this, &TestWithoutAttributes::addEvent);
+        return;
+    }
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomethingElse::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomethingElse>(connection, decoder, this, &TestWithoutAttributes::loadSomethingElse);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomethingElse::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomethingElse>(connection, decoder, this, &TestWithoutAttributes::loadSomethingElse);
+        return;
+    }
 #endif
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DidReceivePolicyDecision::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DidReceivePolicyDecision>(connection, decoder, this, &TestWithoutAttributes::didReceivePolicyDecision);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::Close::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::Close>(connection, decoder, this, &TestWithoutAttributes::close);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::PreferencesDidChange::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::PreferencesDidChange>(connection, decoder, this, &TestWithoutAttributes::preferencesDidChange);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SendDoubleAndFloat::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SendDoubleAndFloat>(connection, decoder, this, &TestWithoutAttributes::sendDoubleAndFloat);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SendInts::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SendInts>(connection, decoder, this, &TestWithoutAttributes::sendInts);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::CreatePlugin::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::CreatePlugin>(connection, decoder, this, &TestWithoutAttributes::createPlugin);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::RunJavaScriptAlert::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::RunJavaScriptAlert>(connection, decoder, this, &TestWithoutAttributes::runJavaScriptAlert);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPlugins::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::GetPlugins>(connection, decoder, this, &TestWithoutAttributes::getPlugins);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TestParameterAttributes::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TestParameterAttributes>(connection, decoder, this, &TestWithoutAttributes::testParameterAttributes);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TemplateTest::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TemplateTest>(connection, decoder, this, &TestWithoutAttributes::templateTest);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SetVideoLayerID::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SetVideoLayerID>(connection, decoder, this, &TestWithoutAttributes::setVideoLayerID);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::DidReceivePolicyDecision::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::DidReceivePolicyDecision>(connection, decoder, this, &TestWithoutAttributes::didReceivePolicyDecision);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::Close::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::Close>(connection, decoder, this, &TestWithoutAttributes::close);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::PreferencesDidChange::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::PreferencesDidChange>(connection, decoder, this, &TestWithoutAttributes::preferencesDidChange);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::SendDoubleAndFloat::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::SendDoubleAndFloat>(connection, decoder, this, &TestWithoutAttributes::sendDoubleAndFloat);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::SendInts::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::SendInts>(connection, decoder, this, &TestWithoutAttributes::sendInts);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::CreatePlugin::name()) {
+        IPC::handleMessageAsync<Messages::TestWithoutAttributes::CreatePlugin>(connection, decoder, this, &TestWithoutAttributes::createPlugin);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::RunJavaScriptAlert::name()) {
+        IPC::handleMessageAsync<Messages::TestWithoutAttributes::RunJavaScriptAlert>(connection, decoder, this, &TestWithoutAttributes::runJavaScriptAlert);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPlugins::name()) {
+        IPC::handleMessageAsync<Messages::TestWithoutAttributes::GetPlugins>(connection, decoder, this, &TestWithoutAttributes::getPlugins);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::TestParameterAttributes::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::TestParameterAttributes>(connection, decoder, this, &TestWithoutAttributes::testParameterAttributes);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::TemplateTest::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::TemplateTest>(connection, decoder, this, &TestWithoutAttributes::templateTest);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::SetVideoLayerID::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::SetVideoLayerID>(connection, decoder, this, &TestWithoutAttributes::setVideoLayerID);
+        return;
+    }
 #if PLATFORM(MAC)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithoutAttributes::didCreateWebProcessConnection);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::InterpretKeyEvent::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::InterpretKeyEvent>(connection, decoder, this, &TestWithoutAttributes::interpretKeyEvent);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithoutAttributes::didCreateWebProcessConnection);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::InterpretKeyEvent::name()) {
+        IPC::handleMessageAsync<Messages::TestWithoutAttributes::InterpretKeyEvent>(connection, decoder, this, &TestWithoutAttributes::interpretKeyEvent);
+        return;
+    }
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DeprecatedOperation::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DeprecatedOperation>(connection, decoder, this, &TestWithoutAttributes::deprecatedOperation);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::DeprecatedOperation::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::DeprecatedOperation>(connection, decoder, this, &TestWithoutAttributes::deprecatedOperation);
+        return;
+    }
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::ExperimentalOperation::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::ExperimentalOperation>(connection, decoder, this, &TestWithoutAttributes::experimentalOperation);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::ExperimentalOperation::name()) {
+        IPC::handleMessage<Messages::TestWithoutAttributes::ExperimentalOperation>(connection, decoder, this, &TestWithoutAttributes::experimentalOperation);
+        return;
+    }
 #endif
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
@@ -131,22 +171,25 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
-bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPluginProcessConnection::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::getPluginProcessConnection);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
+    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPluginProcessConnection::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::GetPluginProcessConnection>(connection, decoder, this, &TestWithoutAttributes::getPluginProcessConnection);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name()) {
+        IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, this, &TestWithoutAttributes::testMultipleAttributes);
+        return;
+    }
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
-    UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
-        return false;
+        return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
-    return false;
+    return;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -40,18 +40,30 @@ namespace WebKit {
 void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decoder& decoder, Function<void(UniqueRef<IPC::Encoder>&&)>&& replyHandler)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::name())
-        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithoutArgument);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name())
-        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithArgument);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::name()) {
+        IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithoutArgument);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name()) {
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name()) {
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name()) {
+        IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithArgument);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name()) {
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
+        return;
+    }
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name()) {
+        IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
+        return;
+    }
     UNUSED_PARAM(decoder);
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -123,7 +123,7 @@ public:
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -135,9 +135,9 @@ bool AuxiliaryProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder
     return m_messageReceiverMap.dispatchMessage(connection, decoder);
 }
 
-bool AuxiliaryProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool AuxiliaryProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
+    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder);
 }
 
 void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName, IPC::MessageReceiver& messageReceiver)

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -142,9 +142,9 @@ protected:
 #endif
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
 #if OS(LINUX)
     void didReceiveMemoryPressureEvent(bool isCritical);

--- a/Source/WebKit/Shared/IPCConnectionTester.h
+++ b/Source/WebKit/Shared/IPCConnectionTester.h
@@ -55,7 +55,7 @@ private:
 
     // IPC::Connection::Client overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t) final;
 

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -58,7 +58,7 @@ public:
 
     // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 private:
     // Messages.
     void startMessageTesting(IPC::Connection&, String&& driverName);

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -55,7 +55,7 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -166,7 +166,6 @@ template: struct WebKit::WebExtensionWindowIdentifierType
 }
 
 header: <wtf/ObjectIdentifier.h>
-template: enum class IPC::ConnectionSyncRequestIDType
 template: enum class WebCore::DOMCacheIdentifierType
 template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
 template: enum class WebCore::LibWebRTCSocketIdentifierType
@@ -189,6 +188,7 @@ template: enum class TestWebKitAPI::TestedObjectIdentifierType
 }
 
 header: <wtf/ObjectIdentifier.h>
+template: enum class IPC::ReplyIDType
 template: class WebCore::ResourceLoader
 template: class WebCore::WebSocketChannel
 template: enum class JSC::MicrotaskIdentifierType

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -310,9 +310,9 @@ bool AuxiliaryProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::De
     return m_messageReceiverMap.dispatchMessage(connection, decoder);
 }
 
-bool AuxiliaryProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool AuxiliaryProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
+    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder);
 }
 
 void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier connectionIdentifier)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -256,7 +256,7 @@ protected:
     void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     void logInvalidMessage(IPC::Connection&, IPC::MessageName);
     virtual ASCIILiteral processName() const = 0;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -93,7 +93,7 @@ public:
     void rotationAngleForCaptureDeviceChanged(const String&, WebCore::VideoFrameRotation);
 
     void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     bool hasSourceProxies() const;
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -81,9 +81,6 @@ public:
     void invalidate();
     void processDidClose();
 
-    void didReceiveDownloadProxyMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncDownloadProxyMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-
     WebPageProxy* originatingPage() const;
 
     void setRedirectChain(Vector<URL>&& redirectChain) { m_redirectChain = WTFMove(redirectChain); }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -356,7 +356,7 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) override;
     // Note: uses dispatchMessage, dispatchSyncMessage from superclass.

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -720,15 +720,19 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
     LOG(ProcessSwapping, "Unhandled message %s from provisional process", description(decoder.messageName()).characters());
 }
 
-bool ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+void ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (decoder.messageName() == Messages::WebPageProxy::BackForwardGoToItem::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::BackForwardGoToItem>(connection, decoder, replyEncoder, this, &ProvisionalPageProxy::backForwardGoToItem);
+    if (decoder.messageName() == Messages::WebPageProxy::BackForwardGoToItem::name()) {
+        IPC::handleMessageSynchronous<Messages::WebPageProxy::BackForwardGoToItem>(connection, decoder, this, &ProvisionalPageProxy::backForwardGoToItem);
+        return;
+    }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, replyEncoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionSync);
+    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name()) {
+        IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionSync);
+        return;
+    }
 
-    return m_page->didReceiveSyncMessage(connection, decoder, replyEncoder);
+    return m_page->didReceiveSyncMessage(connection, decoder);
 }
 
 IPC::Connection* ProvisionalPageProxy::messageSenderConnection() const

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -157,7 +157,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -65,12 +65,13 @@ void RemotePageDrawingAreaProxy::didReceiveMessage(IPC::Connection& connection, 
         m_drawingArea->didReceiveMessage(connection, decoder);
 }
 
-bool RemotePageDrawingAreaProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemotePageDrawingAreaProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (m_drawingArea)
-        return m_drawingArea->didReceiveSyncMessage(connection, decoder, encoder);
+    if (m_drawingArea) {
+        m_drawingArea->didReceiveSyncMessage(connection, decoder);
+        return;
+    }
     ASSERT_NOT_REACHED();
-    return false;
 }
 
 }

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -55,7 +55,7 @@ public:
 
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     WeakPtr<DrawingAreaProxy> m_drawingArea;
     DrawingAreaIdentifier m_identifier;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -211,15 +211,17 @@ void RemotePageProxy::didChangeProvisionalURLForFrame(WebCore::FrameIdentifier f
     m_page->didChangeProvisionalURLForFrameShared(m_process.copyRef(), frameID, navigationID, WTFMove(url));
 }
 
-bool RemotePageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+void RemotePageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, encoder, this, &RemotePageProxy::decidePolicyForNavigationActionSync);
+    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name()) {
+        IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, this, &RemotePageProxy::decidePolicyForNavigationActionSync);
+        return;
+    }
 
-    if (m_page)
-        return m_page->didReceiveSyncMessage(connection, decoder, encoder);
-
-    return false;
+    if (m_page) {
+        m_page->didReceiveSyncMessage(connection, decoder);
+        return;
+    }
 }
 
 Ref<WebProcessProxy> RemotePageProxy::protectedProcess() const

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -103,7 +103,7 @@ public:
 
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
     void decidePolicyForResponse(FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
     void didCommitLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
     void decidePolicyForNavigationActionAsync(NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -299,9 +299,8 @@ void SuspendedPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Dec
 #endif
 }
 
-bool SuspendedPageProxy::didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&)
+void SuspendedPageProxy::didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&)
 {
-    return false;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -104,7 +104,7 @@ private:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     template<typename T> void sendToAllProcesses(T&&);
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -132,7 +132,7 @@ private:
     void callCloseCompletionHandlers();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2089,7 +2089,7 @@ public:
     // IPC::MessageReceiver
     // Implemented in generated WebPageProxyMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     void requestStorageSpace(WebCore::FrameIdentifier, const String& originIdentifier, const String& databaseName, const String& displayName, uint64_t currentQuota, uint64_t currentOriginUsage, uint64_t currentDatabaseUsage, uint64_t expectedUsage, WTF::CompletionHandler<void(uint64_t)>&&);
 

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -82,7 +82,7 @@ private:
     WebPasteboardProxy();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
     RefPtr<WebProcessProxy> webProcessProxyForConnection(IPC::Connection&) const;
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1574,9 +1574,9 @@ bool WebProcessPool::dispatchMessage(IPC::Connection& connection, IPC::Decoder& 
     return m_messageReceiverMap.dispatchMessage(connection, decoder);
 }
 
-bool WebProcessPool::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool WebProcessPool::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
+    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder);
 }
 
 void WebProcessPool::setEnhancedAccessibility(bool flag)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -211,7 +211,7 @@ public:
     }
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     void initializeClient(const WKContextClientBase*);
     void setInjectedBundleClient(std::unique_ptr<API::InjectedBundleClient>&&);
@@ -628,7 +628,7 @@ private:
     // IPC::MessageReceiver.
     // Implemented in generated WebProcessPoolMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
 #if PLATFORM(COCOA)
     void addCFNotificationObserver(CFNotificationCallback, CFStringRef name, CFNotificationCenterRef = CFNotificationCenterGetDarwinNotifyCenter());

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1216,21 +1216,15 @@ bool WebProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::Decoder&
     return true;
 }
 
-bool WebProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool WebProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     // If AuxiliaryProcessProxy gets .messages.in, use WantsDispatchMessages and remove this.
-    if (AuxiliaryProcessProxy::dispatchSyncMessage(connection, decoder, replyEncoder))
+    if (AuxiliaryProcessProxy::dispatchSyncMessage(connection, decoder))
         return true;
-    if (protectedProcessPool()->dispatchSyncMessage(connection, decoder, replyEncoder))
+    if (protectedProcessPool()->dispatchSyncMessage(connection, decoder))
         return true;
     // WebProcessProxy will receive messages to instances that were removed from
     // the message receiver map. Filter these out by sending the cancel reply.
-#if ENABLE(IPC_TESTING_API)
-    if (!decoder.isValid())
-        replyEncoder->setSyncMessageDeserializationFailure();
-#endif
-    connection.sendSyncReply(WTFMove(replyEncoder));
-
     return true;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -582,11 +582,11 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) override;
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     // ResponsivenessTimer::Client
     void didBecomeUnresponsive() override;

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -49,7 +49,7 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
 
     void unlockIfNecessary();
 

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -48,7 +48,7 @@ private:
 
     // IPC::Connection::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
     void secItemRequest(IPC::Connection&, const SecItemRequestData&, CompletionHandler<void(std::optional<SecItemResponseData>&&)>&&);
     void secItemRequestSync(IPC::Connection&, const SecItemRequestData&, CompletionHandler<void(std::optional<SecItemResponseData>&&)>&&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6526,6 +6526,7 @@
 		7B22007029B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp; sourceTree = "<group>"; };
 		7B22007129B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.h; sourceTree = "<group>"; };
 		7B2DDD5E27CCD9710060ABAB /* IPCStreamTesterProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTesterProxy.h; sourceTree = "<group>"; };
+		7B2E73472CA2C611002C1A84 /* ReplyID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReplyID.h; sourceTree = "<group>"; };
 		7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueueMap.h; sourceTree = "<group>"; };
 		7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueue.h; sourceTree = "<group>"; };
 		7B483F1D25CDDA9B00120486 /* MessageReceiveQueueMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageReceiveQueueMap.cpp; sourceTree = "<group>"; };
@@ -9748,6 +9749,7 @@
 				3D3C75952B6452300013828A /* ObjectIdentifierReference.serialization.in */,
 				7B5A3DC527AE501A006C6F97 /* ObjectIdentifierReferenceTracker.h */,
 				7BE9326227F5C75A00D5FEFB /* ReceiverMatcher.h */,
+				7B2E73472CA2C611002C1A84 /* ReplyID.h */,
 				7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */,
 				2DC18001D90DDD15FC6991A9 /* SharedBufferReference.cpp */,
 				5CC5DB9121488E16006CB8A8 /* SharedBufferReference.h */,

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -289,9 +289,9 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
     return false;
 }
 
-bool GPUProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool GPUProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    return messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder);
+    return messageReceiverMap().dispatchSyncMessage(connection, decoder);
 }
 
 void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>&& info)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -143,11 +143,11 @@ private:
     // IPC::Connection::Client
     void didClose(IPC::Connection&) override;
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) override;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     // Messages.
     void didReceiveRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -514,7 +514,7 @@ bool RemoteRenderingBackendProxy::dispatchMessage(IPC::Connection& connection, I
     return false;
 }
 
-bool RemoteRenderingBackendProxy::dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&)
+bool RemoteRenderingBackendProxy::dispatchSyncMessage(IPC::Connection&, IPC::Decoder&)
 {
     return false;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -108,7 +108,7 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // Messages to be sent.
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat, OptionSet<WebCore::ImageBufferOptions>);
@@ -193,7 +193,7 @@ private:
     void ensureGPUProcessConnection();
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     // Returns std::nullopt if no update is needed or allocation failed.
     // Returns handle if that should be sent to the receiver process.

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
@@ -122,9 +122,9 @@ bool ModelProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::D
     return false;
 }
 
-bool ModelProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool ModelProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    return messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder);
+    return messageReceiverMap().dispatchSyncMessage(connection, decoder);
 }
 
 void ModelProcessConnection::didInitialize(std::optional<ModelProcessConnectionInfo>&& info)

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
@@ -86,11 +86,11 @@ private:
     // IPC::Connection::Client
     void didClose(IPC::Connection&) override;
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t indexOfObjectFailingDecoding) override;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     // Messages.
     void didInitialize(std::optional<ModelProcessConnectionInfo>&&);

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -185,20 +185,20 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
     return false;
 }
 
-bool NetworkProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool NetworkProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {
         ASSERT(SWContextManager::singleton().connection());
         if (auto* contextManagerConnection = SWContextManager::singleton().connection())
-            return static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveSyncMessage(connection, decoder, replyEncoder);
-        return false;
+            static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 
 #if ENABLE(APPLE_PAY_REMOTE_UI)
     if (decoder.messageReceiverName() == Messages::WebPaymentCoordinator::messageReceiverName()) {
         if (auto webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(decoder.destinationID())))
-            return webPage->paymentCoordinator()->didReceiveSyncMessage(connection, decoder, replyEncoder);
-        return false;
+            webPage->paymentCoordinator()->didReceiveSyncMessage(connection, decoder);
+        return decoder.isHandled();
     }
 #endif
     return false;

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -97,11 +97,11 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, int32_t) override;
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&);
 
     void didFinishPingLoad(WebCore::ResourceLoaderIdentifier pingLoadIdentifier, WebCore::ResourceError&&, WebCore::ResourceResponse&&);
     void didFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, WebCore::ResourceError&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -630,7 +630,7 @@ public:
     void setActiveOpenPanelResultListener(Ref<WebOpenPanelResultListener>&&);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // -- InjectedBundle methods
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -51,7 +51,7 @@ public:
 
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&) override;
 
     void setDefersLoading(bool);
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);


### PR DESCRIPTION
#### 3dc42913b8d71c107d8ac4069ffd6181cf0289c0
<pre>
Make IPC::Connection synchronous message cancellation consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=280271">https://bugs.webkit.org/show_bug.cgi?id=280271</a>
<a href="https://rdar.apple.com/136584036">rdar://136584036</a>

Reviewed by NOBODY (OOPS!).

For IPC::Connection, when a sync message is not handled, it is intended
to be cancelled, so that the caller does not hang indefinitively.
However, the cancel was sync message reply with no parameters. This
would result in accepted reply if the reply does not have parameters.
This would result in decode error if the reply has parameters.

Fix by following steps:

Introduce a new message, CancelSyncMessageReply to signify that the
message was cancelled.

Change the message handling interface
bool MessageReceiver::didReceiveSyncMessage(Connection&amp;&amp;, Decoder&amp;, UniqueRef&lt;Encoder&gt;&amp;&amp;)
to
void MessageReceiver::didReceiveSyncMessage(Connection&amp;&amp;, Decoder&amp;)

Remove the bool return value. This was used for two purposes:
 - Returning true would stop the search for the handler.
 - Returning true would mark the message as handled, and no cancel
   would be sent.

This produced errors, as parameter decode error during message handler
should stop the search (should return true, returned false)
but also should signify that the cancel message should be sent
(should return false).

Instead, mark the message as handled when the overrider obtains the
replyID via Decoder::markHandledSyncReply()
or when the overrider runs into a decode error.

Remove the UniqueRef&lt;Encoder&gt;&amp;&amp;. This was used to pass the reply id
to the message handler function. However, as at the start of message
routing process, we do not know will the message handler be found or
will the decode be successful. Instead, decode the reply ID as part
of the message metadata as early as possible, during Decoder::Decoder().
At the message handler success sites, obtain the reply id from the
decoder via Decoder::markHandledSyncReply(), marking the message as
handled at the same time.

Changes SyncRequestID to more appropriate name ReplyID and moves it to
its own header, to be included from Decoder.h. The name anticipates the
future patches where AsyncReplyID will use the same shared ReplyID.

Replaces SyncMessageDeserializationFailure with sending the
CancelSyncMessageReply. This is used in IPC JS testing API to be able
to send multiple arbitrary incorrect messages, while avoiding timeouts.

Removes stream IPC variant of SyncMessageDeserializationFailure, as it
was implemented incorrectly and not used. The decode failure in stream
causes the stream to time out because further messages cannot be
decoded, so cancelling is not useful there.

The same structure will be used for future to implement the same cancel
feature for asynchronous messages.

This is work towards fixing leaks of asynchronous message handlers,
thread-safe sendSync/waitForAsyncReplyAndDispatchImmediately and
unification of sync/async message receive implementations.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::didReceiveSyncPlayerMessage):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
(WebKit::RemoteMediaPlayerManagerProxy::didReceiveSyncMessageFromWebProcess):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::ModelConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::PendingSyncReply::PendingSyncReply):
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::createSyncMessageEncoder):
(IPC::Connection::sendMessageImpl):
(IPC::Connection::pushPendingSyncRequestID):
(IPC::Connection::popPendingSyncRequestID):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::processIncomingSyncReply):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::dispatchSyncMessage):
(IPC::errorAsString):
(IPC::Connection::sendSyncReply): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
(IPC::Connection::sendSyncReply):
(IPC::Connection::sendCancelSyncReply):
(IPC::Connection::sendAsyncReply):
(IPC::Connection::makeSyncRequestID): Deleted.
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::hasSyncMessageDeserializationFailure const): Deleted.
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::syncReplyID const):
(IPC::Decoder::isHandled const):
(IPC::Decoder::markHandledSyncReply):
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::setSyncMessageDeserializationFailure): Deleted.
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
* Source/WebKit/Platform/IPC/MessageReceiver.h:
(IPC::MessageReceiver::didReceiveSyncMessage):
* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::dispatchSyncMessage):
* Source/WebKit/Platform/IPC/MessageReceiverMap.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::DedicatedConnectionClient::didReceiveSyncMessage):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::didReceiveSyncMessage):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::sendDeserializationErrorSyncReply): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendSyncReply):
(IPC::StreamServerConnection::sendCancelSyncReply):
* Source/WebKit/Scripts/webkit/messages.py:
(async_message_statement):
(sync_message_statement):
(generate_message_handler):
* Source/WebKit/Scripts/webkit/model.py:
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByAndConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp:
(WebKit::TestWithEnabledBy::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByOrConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
(WebKit::TestWithIfMessage::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
(WebKit::TestWithImageData::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveMessage):
(WebKit::TestWithLegacyReceiver::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
(WebKit::TestWithSemaphore::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
(WebKit::TestWithStreamBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp:
(WebKit::TestWithStreamServerConnectionHandle::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsAsyncDispatchMessageReceiver.cpp:
(WebKit::TestWithSuperclassAndWantsAsyncDispatch::didReceiveMessage):
(WebKit::TestWithSuperclassAndWantsAsyncDispatch::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassAndWantsDispatchMessageReceiver.cpp:
(WebKit::TestWithSuperclassAndWantsDispatch::didReceiveMessage):
(WebKit::TestWithSuperclassAndWantsDispatch::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveMessage):
(WebKit::TestWithSuperclass::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp:
(WebKit::TestWithWantsAsyncDispatch::didReceiveMessage):
(WebKit::TestWithWantsAsyncDispatch::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp:
(WebKit::TestWithWantsDispatch::didReceiveMessage):
(WebKit::TestWithWantsDispatch::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp:
(WebKit::TestWithWantsDispatchNoSyncMessages::didReceiveMessage):
(WebKit::TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp:
(WebKit::TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::dispatchSyncMessage):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/IPCConnectionTester.h:
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::dispatchSyncMessage):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
(WebKit::RemotePageDrawingAreaProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::dispatchSyncMessage):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::dispatchSyncMessage):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::dispatchSyncMessage):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::dispatchSyncMessage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp:
(WebKit::ModelProcessConnection::dispatchSyncMessage):
* Source/WebKit/WebProcess/Model/ModelProcessConnection.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::dispatchSyncMessage):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::jsSendSync):
(WebKit::IPCTestingAPI::JSIPCConnection::didReceiveSyncMessage):
(WebKit::IPCTestingAPI::jsResultFromReplyDecoder):
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dc42913b8d71c107d8ac4069ffd6181cf0289c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54815 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13248 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35282 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/68284 "Found 2 webkitpy test failures: webkit.messages_unittest.GeneratedFileContentsTest.test_message_argument_description, webkit.messages_unittest.GeneratedFileContentsTest.test_receiver") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40670 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16809 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18276 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17157 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74537 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12744 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16401 "Found 1 new test failure: ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/74537 "Failed to compile WebKit") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59465 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/74537 "Failed to compile WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3909 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43966 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->