### PR TITLE
REGRESSION(284194@main): lld-link: error: duplicate symbol: public: __cdecl WTF::CanMakeCheckedPtrBase<class WTF::SingleThreadIntegralWrapper<unsigned int>, ...>

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
@@ -37,12 +37,12 @@ namespace Inspector {
 
 class InspectorTarget;
 
-class JS_EXPORT_PRIVATE InspectorTargetAgent final : public InspectorAgentBase, public TargetBackendDispatcherHandler, public CanMakeCheckedPtr<InspectorTargetAgent> {
+class InspectorTargetAgent final : public InspectorAgentBase, public TargetBackendDispatcherHandler, public CanMakeCheckedPtr<InspectorTargetAgent> {
     WTF_MAKE_NONCOPYABLE(InspectorTargetAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorTargetAgent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorTargetAgent);
 public:
-    InspectorTargetAgent(FrontendRouter&, BackendDispatcher&);
+    JS_EXPORT_PRIVATE InspectorTargetAgent(FrontendRouter&, BackendDispatcher&);
     ~InspectorTargetAgent() final;
 
     // InspectorAgentBase
@@ -55,12 +55,12 @@ public:
     Protocol::ErrorStringOr<void> sendMessageToTarget(const String& targetId, const String& message) final;
 
     // Target lifecycle.
-    void targetCreated(InspectorTarget&);
-    void targetDestroyed(InspectorTarget&);
-    void didCommitProvisionalTarget(const String& oldTargetID, const String& committedTargetID);
+    JS_EXPORT_PRIVATE void targetCreated(InspectorTarget&);
+    JS_EXPORT_PRIVATE void targetDestroyed(InspectorTarget&);
+    JS_EXPORT_PRIVATE void didCommitProvisionalTarget(const String& oldTargetID, const String& committedTargetID);
 
     // Target messages.
-    void sendMessageFromTargetToFrontend(const String& targetId, const String& message);
+    JS_EXPORT_PRIVATE void sendMessageFromTargetToFrontend(const String& targetId, const String& message);
 
 private:
     // FrontendChannel


### PR DESCRIPTION
#### 44b0cec9cd0a04ca90b8aae0a8fc79c4f0c029fd
<pre>
REGRESSION(284194@main): lld-link: error: duplicate symbol: public: __cdecl WTF::CanMakeCheckedPtrBase&lt;class WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;, ...&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=280324">https://bugs.webkit.org/show_bug.cgi?id=280324</a>

Unreviewed build fix.
Windows port couldn&apos;t link WebKit2.dll.

&gt; lld-link: error: duplicate symbol: public: __cdecl WTF::CanMakeCheckedPtrBase&lt;class WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;, unsigned int, 0&gt;
&gt;     ::CanMakeCheckedPtrBase&lt;class WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;, unsigned int, 0&gt;
&gt;        (class WTF::CanMakeCheckedPtrBase&lt;class WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;, unsigned int, 0&gt; const &amp;)

* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h:
Added JS_EXPORT_PRIVATE to InspectorTargetAgent methods instead of the whole class.

Canonical link: <a href="https://commits.webkit.org/284214@main">https://commits.webkit.org/284214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4e43d4e0729eda880c2da786aaa2bceeed015bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71825 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/43993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40658 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18261 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61876 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74521 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68006 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16386 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59449 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10280 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3893 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89785 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10481 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43951 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/15900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->