### PR TITLE
Fix Wasm LLInt's marshalling of i32 args to JS

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -380,7 +380,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, 
                 else
                     *access.operator()<uint64_t>(calleeFrame, dst) = raw;
             } else {
-                auto raw = *access.operator()<uint64_t>(argumentRegisters, wasmParam.jsr().payloadGPR() * sizeof(UCPURegister));
+                auto raw = *access.operator()<uint64_t>(argumentRegisters, gprToIndex(wasmParam.jsr().payloadGPR()) * sizeof(UCPURegister));
 #if USE(JSVALUE64)
                 if (argType.isI32())
                     *access.operator()<uint64_t>(calleeFrame, dst) = static_cast<uint32_t>(raw) | JSValue::NumberTag;
@@ -670,7 +670,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValu
 
             auto rep = wasmCC.results[index];
             if (rep.location.isGPR())
-                *access.operator()<uint64_t>(registerSpace, rep.location.jsr().payloadGPR() * sizeof(UCPURegister)) = unboxedValue;
+                *access.operator()<uint64_t>(registerSpace, gprToIndex(rep.location.jsr().payloadGPR()) * sizeof(UCPURegister)) = unboxedValue;
             else if (rep.location.isFPR())
                 *access.operator()<uint64_t>(registerSpace, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(rep.location.fpr()) * bytesForWidth(Width::Width64)) = unboxedValue;
             else


### PR DESCRIPTION
#### f4cd23d010b72c590f2deb0b201dab0cdd7e465d
<pre>
Fix Wasm LLInt&apos;s marshalling of i32 args to JS
<a href="https://bugs.webkit.org/show_bug.cgi?id=280326">https://bugs.webkit.org/show_bug.cgi?id=280326</a>

Reviewed by Yusuke Suzuki and Keith Miller.

Wasm LLInt is currently unable to correctly pass (non-stack) i32 arguments to a JS function,
as we&apos;re indexing with the implicit integer value of each GPR instead of consciously converting it to an index.

For example, if we pass `41, 42, 43, 44, 45, 46` from Wasm, our JS function will receive something like this on x86_64:

    0                   from %rdi (implicit value 7, should be index 0)
    1                   from %rsi (implicit value 6, should be index 1)
    43                  from %rdx (implicit value 2, should be index 2)
    42                  from %rcx (implicit value 1, should be index 3)
    7308604759965200997 from %r8  (implicit value 8, should be index 4)
    1644930307          from %r9  (implicit value 9, should be index 5)

...and we&apos;ll see a similar situation when using multiple return values from that JS function.

Ultimately, we just need a gprToIndex() call; kind of interesting that only the (non-stack) i32 path has this issue.

* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/284262@main">https://commits.webkit.org/284262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4fb57b7d52cecd3dc33f007e6fce3d724e4a0b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21592 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19926 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/72999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71985 "Build is in progress. Recent messages:OS: Sonoma (14.6), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59504 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/72999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40787 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18452 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/62036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74703 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68166 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12902 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62426 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10404 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44122 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15941 "Found 41 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/es5/TypeConversions.js.default, ChakraCore.yaml/ChakraCore/test/strict/16.catch_sm.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-mutated-structure.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-osr-exit-multiple-blocks.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-branch-logical-not-peephole-around-osr-exit.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-both-proven-final-object.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-proven-final-object.js.layout, stress/arguments-define-property.js.dfg-eager ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46393 "Built successfully") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->