### PR TITLE
[css-anchor-position-1] Evaluate anchor() in calc()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-fallback-expected.txt
@@ -10,9 +10,7 @@ PASS .target 6
 PASS .target 7
 PASS .target 8
 PASS .target 9
-FAIL .target 10 assert_equals:
-<div class="target" style="top: anchor(--a1 left, calc((anchor(--a1 bottom) + anchor(--a2 top)) / 2))" data-offset-y="75"></div>
-offsetTop expected 75 but got 0
+PASS .target 10
 FAIL .target 11 assert_equals:
 <div class="target" style="width: anchor-size(--inexist-anchor width, 50%)" data-expected-width="150"></div>
 width expected 150 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-typed-om-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-typed-om-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL anchor() computes to pixels assert_equals: expected 35 but got 0
+PASS anchor() computes to pixels
 FAIL anchor-size() computes to pixels assert_true: expected true got false
 

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -38,13 +38,14 @@
 
 namespace WebCore {
 
-CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, const Style::BuilderContext& builderContext)
+CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, const Style::BuilderState& builderState)
     : m_style(&style)
-    , m_rootStyle(builderContext.rootElementStyle)
-    , m_parentStyle(&builderContext.parentStyle)
-    , m_renderView(builderContext.document->renderView())
-    , m_elementForContainerUnitResolution(builderContext.element)
+    , m_rootStyle(builderState.rootElementStyle())
+    , m_parentStyle(&builderState.parentStyle())
+    , m_renderView(builderState.document().renderView())
+    , m_elementForContainerUnitResolution(builderState.element())
     , m_viewportDependencyDetectionStyle(const_cast<RenderStyle*>(m_style))
+    , m_styleBuilderState(&builderState)
 {
 }
 

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -44,13 +44,13 @@ class RenderStyle;
 class RenderView;
 
 namespace Style {
-struct BuilderContext;
+class BuilderState;
 };
 
 class CSSToLengthConversionData {
 public:
     // This is used during style building. The 'zoom' property is taken into account.
-    CSSToLengthConversionData(const RenderStyle&, const Style::BuilderContext&);
+    CSSToLengthConversionData(const RenderStyle&, const Style::BuilderState&);
     // This constructor ignores the `zoom` property.
     CSSToLengthConversionData(const RenderStyle&, const RenderStyle* rootStyle, const RenderStyle* parentStyle, const RenderView*, const Element* elementForContainerUnitResolution = nullptr);
 
@@ -99,6 +99,8 @@ public:
 
     void setUsesContainerUnits() const;
 
+    const Style::BuilderState* styleBuilderState() const { return m_styleBuilderState; }
+
 private:
     const RenderStyle* m_style { nullptr };
     const RenderStyle* m_rootStyle { nullptr };
@@ -109,6 +111,8 @@ private:
     std::optional<CSSPropertyID> m_propertyToCompute;
     // FIXME: Remove this hack.
     RenderStyle* m_viewportDependencyDetectionStyle { nullptr };
+
+    const Style::BuilderState* m_styleBuilderState { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -626,8 +626,9 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
         if (sideIdent)
             return sideIdent;
 
+        // FIXME: Parse as <percentage> instead of <percentage-token>.
         if (tokens.peek().type() == PercentageToken)
-            return tokens.consumeIncludingWhitespace().numericValue();
+            return tokens.consumeIncludingWhitespace().numericValue() / 100;
 
         return { };
     }();

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -375,8 +375,8 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<A
     WTF::switchOn(anchor->side,
         [&](CSSValueID valueID) {
             builder.append(nameLiteralForSerialization(valueID));
-        }, [&](double percentage) {
-            builder.append(percentage, '%');
+        }, [&](double value) {
+            formatCSSNumberValue(builder, value * 100, CSSPrimitiveValue::unitTypeString(CSSUnitType::CSS_PERCENTAGE));
         }
     );
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "CSSCalcTree+Simplification.h"
 
+#include "AnchorPositionEvaluator.h"
 #include "CSSCalcSymbolTable.h"
 #include "CSSCalcTree+NumericIdentity.h"
 #include "CSSCalcTree+Traversal.h"
@@ -1281,16 +1282,16 @@ std::optional<Child> simplify(Sign& root, const SimplificationOptions& options)
 
 std::optional<Child> simplify(Anchor& anchor, const SimplificationOptions& options)
 {
-    if (!options.conversionData || !options.conversionData->style())
+    if (!options.conversionData || !options.conversionData->styleBuilderState())
         return { };
 
-    // FIXME: Evaluate the anchor.
-    bool isValid = !anchor.elementName.isNull() || !options.conversionData->style()->positionAnchor().isNull();
-    if (!isValid && anchor.fallback) {
+    auto result = Style::AnchorPositionEvaluator::evaluate(*options.conversionData->styleBuilderState(), anchor);
+    if (!result) {
+        // FIXME: Invalid anchor without valid fallback should make the declaration invalid at computed-value time.
         // Replace the anchor node with the fallback node.
         return std::exchange(anchor.fallback, { });
     }
-    return CanonicalDimension { .value = 0, .dimension = CanonicalDimension::Dimension::Length };
+    return CanonicalDimension { .value = *result, .dimension = CanonicalDimension::Dimension::Length };
 }
 
 // MARK: Copy & Simplify.

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSAnchorValue.h"
+#include "CSSCalcTree.h"
 #include "EventTarget.h"
 #include <memory>
 #include <wtf/HashMap.h>
@@ -63,6 +64,11 @@ class AnchorPositionEvaluator {
 public:
     static Length resolveAnchorValue(const BuilderState&, const CSSAnchorValue&);
     static void findAnchorsForAnchorPositionedElement(Ref<const Element> anchorPositionedElement);
+
+    static std::optional<double> evaluate(const BuilderState&, const CSSCalc::Anchor&);
+
+private:
+    static std::optional<LayoutUnit> resolveAnchorValue(const BuilderState&, AtomString, CSSCalc::Anchor::Side);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -76,7 +76,7 @@ BuilderState::BuilderState(Builder& builder, RenderStyle& style, BuilderContext&
     , m_styleMap(*this)
     , m_style(style)
     , m_context(WTFMove(context))
-    , m_cssToLengthConversionData(style, m_context)
+    , m_cssToLengthConversionData(style, *this)
 {
 }
 
@@ -278,8 +278,7 @@ void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float si
 
 CSSPropertyID BuilderState::cssPropertyID() const
 {
-    ASSERT(m_currentProperty);
-    return m_currentProperty->id;
+    return m_currentProperty ? m_currentProperty->id : CSSPropertyInvalid;
 }
 
 }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -69,6 +69,7 @@ enum class RuleMatchingBehavior: uint8_t {
 
 namespace Style {
 
+struct BuilderContext;
 struct ResolvedStyle;
 struct SelectorMatchingState;
 


### PR DESCRIPTION
#### 7240fde26436fed0bf903826c90f596c0207c5ae
<pre>
[css-anchor-position-1] Evaluate anchor() in calc()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280328">https://bugs.webkit.org/show_bug.cgi?id=280328</a>
<a href="https://rdar.apple.com/problem/136659879">rdar://problem/136659879</a>

Reviewed by Sam Weinig.

calc(anchor(--foo)) evaluation support.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-typed-om-expected.txt:
* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::CSSToLengthConversionData):
* Source/WebCore/css/CSSToLengthConversionData.h:

Add Style::BuilderState to the conversion data. This is used for resolving anchor() functions.
It is only available when the conversion is invoked from Style::Builder but that is also the
time when anchor references must be resolved.

(WebCore::CSSToLengthConversionData::styleBuilderState const):
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeAnchor):
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::serializeMathFunctionArguments):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::computeInsetValue):
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
(WebCore::Style::AnchorPositionEvaluator::evaluate):

Refactor a bit so when can share the code between the old CSSAnchorValue implementation and
the new calc() based implementation.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::BuilderState):
(WebCore::Style::BuilderState::cssPropertyID const):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/284271@main">https://commits.webkit.org/284271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa23b8f971150c7b4602daa47e9f6752b75551f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19945 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13355 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72004 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59521 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40803 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74726 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12921 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10421 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4029 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->