### PR TITLE
Unreviewed. Fix non-unified build

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <algorithm>
+#include <climits>
 #include <concepts>
 #include <cstring>
 #include <functional>

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -30,6 +30,7 @@
 #include <WebCore/IDBConnectionToServer.h>
 #include <WebCore/IDBObjectStoreIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <optional>
 
 namespace WebKit {
 


### PR DESCRIPTION
#### 61f945b3da18769f9cd5d179e3b90f9f29a5fc29
<pre>
Unreviewed. Fix non-unified build

* Source/WTF/wtf/StdLibExtras.h:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:

Canonical link: <a href="https://commits.webkit.org/284220@main">https://commits.webkit.org/284220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ffb65e74874447a1d0c002425cf0024ef711670

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19924 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19740 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59387 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18282 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61897 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74543 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68027 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16406 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59469 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3913 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89806 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10482 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43972 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15908 "Found 2 new JSC binary failures: testapi, testb3, Found 4815 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_splice_515632.js.default, ChakraCore.yaml/ChakraCore/test/Basics/ArrayConcat.js.default, ChakraCore.yaml/ChakraCore/test/Boolean/property_and_index_of_boolean.js.default, ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, ChakraCore.yaml/ChakraCore/test/RWC/OneNote.ribbon.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->