### PR TITLE
Rename: SafeFontParser is not a FallbackParser

### DIFF
--- a/Source/WebCore/loader/cache/TrustedFonts.cpp
+++ b/Source/WebCore/loader/cache/TrustedFonts.cpp
@@ -881,7 +881,7 @@ FontParsingPolicy fontBinaryParsingPolicy(std::span<const uint8_t> data, Downloa
         RELEASE_LOG(Fonts, "[Lockdown Mode] A font with a forbidden type has been blocked from being parsed by system font parser.");
         return FontParsingPolicy::Deny;
     }
-    case DownloadableBinaryFontTrustedTypes::FallbackParser:
+    case DownloadableBinaryFontTrustedTypes::SafeFontParser:
         return FontParsingPolicy::LoadWithSafeFontParser;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/loader/cache/TrustedFonts.h
+++ b/Source/WebCore/loader/cache/TrustedFonts.h
@@ -34,12 +34,12 @@ namespace WebCore {
 // using the default, possibly-unsafe font parser.
 // Any: any font binary will be downloaded, no checks will be done during load.
 // Restricted: any font binary will be downloaded but just binaries listed by WebKit are trusted to load through the system font parser. A not allowed binary will be deleted after the check is done.
-// FallbackParser: any font binary will be downloaded. Binaries listed by WebKit are trusted to load through the system font parser. WebKit will attempt to load fonts that are not trusted with the fallback font parser, which is assumed to be safe.
+// SafeFontParser: any font binary will be downloaded. Binaries listed by WebKit are trusted to load through the safe font parser.
 // None: No font binary will be downloaded or loaded.
 enum class DownloadableBinaryFontTrustedTypes : uint8_t {
     Any,
     Restricted,
-    FallbackParser,
+    SafeFontParser,
     None
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4646,7 +4646,7 @@ void WebPage::adjustSettingsForLockdownMode(Settings& settings, const WebPrefere
     if (settings.downloadableBinaryFontTrustedTypes() != DownloadableBinaryFontTrustedTypes::None) {
         settings.setDownloadableBinaryFontTrustedTypes(
             (settings.lockdownFontParserEnabled() && PAL::canLoad_CoreText_CTFontManagerCreateMemorySafeFontDescriptorFromData())
-                ? DownloadableBinaryFontTrustedTypes::FallbackParser
+                ? DownloadableBinaryFontTrustedTypes::SafeFontParser
                 : DownloadableBinaryFontTrustedTypes::Restricted);
     }
 #endif


### PR DESCRIPTION
#### a977e4e73bbfe375570bbf2ef67b00cc59f71a12
<pre>
Rename: SafeFontParser is not a FallbackParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=280339">https://bugs.webkit.org/show_bug.cgi?id=280339</a>
<a href="https://rdar.apple.com/136682879">rdar://136682879</a>

Reviewed by Brent Fulgham.

Originally the Safe Font Parser was intended to be used
as a fallback parser for when there was a restriction
(imposed by lockdown mode) on dowloading font binaries
and a binary was not listed as trusted.

However, after [1], if we are restricted to download font
binaries and a binary is not trusted the font is denied
and we won&apos;t fallback. Therefore, the Safe Font Parser
is no longer used as a fallback parser.

The current patch renames the DownloadableBinaryFontTrustedTypes
value and update comments accordingly.

[1] <a href="https://commits.webkit.org/277717@main">https://commits.webkit.org/277717@main</a>

* Source/WebCore/loader/cache/TrustedFonts.cpp:
(WebCore::fontBinaryParsingPolicy):
* Source/WebCore/loader/cache/TrustedFonts.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::adjustSettingsForLockdownMode):

Canonical link: <a href="https://commits.webkit.org/284228@main">https://commits.webkit.org/284228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e121531b1a01a769903bada09d9492b5f4d38431

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19764 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13273 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59405 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40695 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18307 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74565 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16429 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59487 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10319 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43991 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->