### PR TITLE
Reduce use of LegacyNullableAtomicObjectIdentifier

### DIFF
--- a/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
+++ b/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
@@ -31,6 +31,6 @@
 namespace WebCore {
 
 enum class DOMCacheIdentifierType { };
-using DOMCacheIdentifier = ProcessQualified<LegacyNullableAtomicObjectIdentifier<DOMCacheIdentifierType>>;
+using DOMCacheIdentifier = ProcessQualified<AtomicObjectIdentifier<DOMCacheIdentifierType>>;
 
 }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum class FileSystemSyncAccessHandleIdentifierType { };
-using FileSystemSyncAccessHandleIdentifier = LegacyNullableAtomicObjectIdentifier<FileSystemSyncAccessHandleIdentifierType>;
+using FileSystemSyncAccessHandleIdentifier = AtomicObjectIdentifier<FileSystemSyncAccessHandleIdentifierType>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
@@ -93,8 +93,7 @@ void RTCDataChannelRemoteHandler::readyToSend()
 void RTCDataChannelRemoteHandler::setClient(RTCDataChannelHandlerClient& client, ScriptExecutionContextIdentifier contextIdentifier)
 {
     m_client = &client;
-    ASSERT(m_localIdentifier.channelIdentifier);
-    m_connection->connectToSource(*this, contextIdentifier, m_localIdentifier, m_remoteIdentifier);
+    m_connection->connectToSource(*this, contextIdentifier, *m_localIdentifier, m_remoteIdentifier);
 }
 
 bool RTCDataChannelRemoteHandler::sendStringData(const CString& text)

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
@@ -75,7 +75,7 @@ private:
     void close() final;
 
     RTCDataChannelIdentifier m_remoteIdentifier;
-    RTCDataChannelIdentifier m_localIdentifier;
+    Markable<RTCDataChannelIdentifier> m_localIdentifier;
 
     RTCDataChannelHandlerClient* m_client { nullptr };
     Ref<RTCDataChannelRemoteHandlerConnection> m_connection;

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -51,7 +51,7 @@ class WritableStream;
 struct MessageWithMessagePorts;
 
 enum class RTCRtpScriptTransformerIdentifierType { };
-using RTCRtpScriptTransformerIdentifier = LegacyNullableAtomicObjectIdentifier<RTCRtpScriptTransformerIdentifierType>;
+using RTCRtpScriptTransformerIdentifier = AtomicObjectIdentifier<RTCRtpScriptTransformerIdentifierType>;
 
 class RTCRtpScriptTransformer
     : public RefCounted<RTCRtpScriptTransformer>

--- a/Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h
@@ -24,14 +24,11 @@
 
 #pragma once
 
-#include "ProcessIdentifier.h"
+#include "ProcessQualified.h"
 #include "RTCDataChannelLocalIdentifier.h"
 
 namespace WebCore {
 
-struct RTCDataChannelIdentifier {
-    ProcessIdentifier processIdentifier;
-    RTCDataChannelLocalIdentifier channelIdentifier;
-};
+using RTCDataChannelIdentifier = ProcessQualified<RTCDataChannelLocalIdentifier>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
@@ -29,6 +29,6 @@
 namespace WebCore {
 
 enum class RTCDataChannelLocalIdentifierType { };
-using RTCDataChannelLocalIdentifier = LegacyNullableAtomicObjectIdentifier<RTCDataChannelLocalIdentifierType>;
+using RTCDataChannelLocalIdentifier = AtomicObjectIdentifier<RTCDataChannelLocalIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class LibWebRTCSocketIdentifierType { };
-using LibWebRTCSocketIdentifier = LegacyNullableAtomicObjectIdentifier<LibWebRTCSocketIdentifierType>;
+using LibWebRTCSocketIdentifier = AtomicObjectIdentifier<LibWebRTCSocketIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -358,7 +358,7 @@ void NetworkConnectionToWebProcess::createRTCProvider(CompletionHandler<void()>&
 #if ENABLE(WEB_RTC)
 void NetworkConnectionToWebProcess::connectToRTCDataChannelRemoteSource(WebCore::RTCDataChannelIdentifier localIdentifier, WebCore::RTCDataChannelIdentifier remoteIdentifier, CompletionHandler<void(std::optional<bool>)>&& callback)
 {
-    RefPtr connectionToWebProcess = protectedNetworkProcess()->webProcessConnection(remoteIdentifier.processIdentifier);
+    RefPtr connectionToWebProcess = protectedNetworkProcess()->webProcessConnection(remoteIdentifier.processIdentifier());
     if (!connectionToWebProcess) {
         callback(false);
         return;

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
@@ -58,37 +58,37 @@ void RTCDataChannelRemoteManagerProxy::unregisterConnectionToWebProcess(NetworkC
 
 void RTCDataChannelRemoteManagerProxy::sendData(WebCore::RTCDataChannelIdentifier identifier, bool isRaw, std::span<const uint8_t> data)
 {
-    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier))
+    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier()))
         IPC::Connection::send(connectionID, Messages::RTCDataChannelRemoteManager::SendData { identifier, isRaw, data }, 0);
 }
 
 void RTCDataChannelRemoteManagerProxy::close(WebCore::RTCDataChannelIdentifier identifier)
 {
-    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier))
+    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier()))
         IPC::Connection::send(connectionID, Messages::RTCDataChannelRemoteManager::Close { identifier }, 0);
 }
 
 void RTCDataChannelRemoteManagerProxy::changeReadyState(WebCore::RTCDataChannelIdentifier identifier, WebCore::RTCDataChannelState state)
 {
-    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier))
+    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier()))
         IPC::Connection::send(connectionID, Messages::RTCDataChannelRemoteManager::ChangeReadyState { identifier, state }, 0);
 }
 
 void RTCDataChannelRemoteManagerProxy::receiveData(WebCore::RTCDataChannelIdentifier identifier, bool isRaw, std::span<const uint8_t> data)
 {
-    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier))
+    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier()))
         IPC::Connection::send(connectionID, Messages::RTCDataChannelRemoteManager::ReceiveData { identifier, isRaw, data }, 0);
 }
 
 void RTCDataChannelRemoteManagerProxy::detectError(WebCore::RTCDataChannelIdentifier identifier, WebCore::RTCErrorDetailType detail, const String& message)
 {
-    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier))
+    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier()))
         IPC::Connection::send(connectionID, Messages::RTCDataChannelRemoteManager::DetectError { identifier, detail, message }, 0);
 }
 
 void RTCDataChannelRemoteManagerProxy::bufferedAmountIsDecreasing(WebCore::RTCDataChannelIdentifier identifier, size_t amount)
 {
-    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier))
+    if (auto connectionID = m_webProcessConnections.get(identifier.processIdentifier()))
         IPC::Connection::send(connectionID, Messages::RTCDataChannelRemoteManager::BufferedAmountIsDecreasing { identifier, amount }, 0);
 }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -473,6 +473,7 @@ def types_that_cannot_be_forward_declared():
         'WebCore::PlatformLayerIdentifier',
         'WebCore::PluginLoadClientPolicy',
         'WebCore::PointerID',
+        'WebCore::RTCDataChannelIdentifier',
         'WebCore::RenderingMode',
         'WebCore::RenderingPurpose',
         'WebCore::SandboxFlags',

--- a/Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.h
+++ b/Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.h
@@ -27,11 +27,12 @@
 
 #include "SharedFileHandle.h"
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
+#include <wtf/Markable.h>
 
 namespace WebKit {
 
 struct FileSystemSyncAccessHandleInfo {
-    WebCore::FileSystemSyncAccessHandleIdentifier identifier;
+    Markable<WebCore::FileSystemSyncAccessHandleIdentifier> identifier;
     IPC::SharedFileHandle handle;
     uint64_t capacity { 0 };
 };

--- a/Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.serialization.in
+++ b/Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.serialization.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct WebKit::FileSystemSyncAccessHandleInfo {
-    WebCore::FileSystemSyncAccessHandleIdentifier identifier;
+    Markable<WebCore::FileSystemSyncAccessHandleIdentifier> identifier;
     IPC::SharedFileHandle handle;
     uint64_t capacity;
 }

--- a/Source/WebKit/Shared/ProcessQualified.serialization.in
+++ b/Source/WebKit/Shared/ProcessQualified.serialization.in
@@ -22,10 +22,11 @@
 
 
 additional_forward_declaration: namespace WebCore { using BackForwardItemIdentifierID = LegacyNullableObjectIdentifier<BackForwardItemIdentifierType>; }
-additional_forward_declaration: namespace WebCore { using DOMCacheIdentifierID = LegacyNullableAtomicObjectIdentifier<DOMCacheIdentifierType>; }
+additional_forward_declaration: namespace WebCore { using DOMCacheIdentifierID = AtomicObjectIdentifier<DOMCacheIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using FrameIdentifierID = ObjectIdentifier<FrameIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using OpaqueOriginIdentifier = AtomicObjectIdentifier<OpaqueOriginIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using PlatformLayerIdentifierID = ObjectIdentifier<PlatformLayerIdentifierType>; }
+additional_forward_declaration: namespace WebCore { using RTCDataChannelLocalIdentifier =  AtomicObjectIdentifier<RTCDataChannelLocalIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using ScrollingNodeIdentifier = LegacyNullableObjectIdentifier<ScrollingNodeIDType>; }
 additional_forward_declaration: namespace WebCore { using SharedWorkerObjectIdentifierID = LegacyNullableObjectIdentifier<SharedWorkerObjectIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using WebLockIdentifierID = AtomicObjectIdentifier<WebLockIdentifierType>; }
@@ -53,6 +54,11 @@ header: <WebCore/ProcessQualified.h>
 
 [Alias=class ProcessQualified<PlatformLayerIdentifierID>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebCore::PlatformLayerIdentifier {
     WebCore::PlatformLayerIdentifierID object();
+    WebCore::ProcessIdentifier processIdentifier();
+};
+
+[Alias=class ProcessQualified<RTCDataChannelLocalIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebCore::RTCDataChannelIdentifier {
+    WebCore::RTCDataChannelLocalIdentifier object();
     WebCore::ProcessIdentifier processIdentifier();
 };
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -166,12 +166,6 @@ template: struct WebKit::WebExtensionWindowIdentifierType
 }
 
 header: <wtf/ObjectIdentifier.h>
-template: enum class IPC::ConnectionSyncRequestIDType
-template: enum class WebCore::DOMCacheIdentifierType
-template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
-template: enum class WebCore::LibWebRTCSocketIdentifierType
-template: enum class WebCore::RTCDataChannelLocalIdentifierType
-template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
 template: enum class WebCore::RenderingResourceIdentifierType
 template: enum class WebCore::ServiceWorkerIdentifierType
 template: enum class WebCore::IDBDatabaseConnectionIdentifierType
@@ -191,14 +185,20 @@ template: enum class TestWebKitAPI::TestedObjectIdentifierType
 header: <wtf/ObjectIdentifier.h>
 template: class WebCore::ResourceLoader
 template: class WebCore::WebSocketChannel
+template: enum class IPC::ConnectionSyncRequestIDType
 template: enum class JSC::MicrotaskIdentifierType
+template: enum class WebCore::DOMCacheIdentifierType
 template: enum class WebCore::WebSocketIdentifierType
 template: enum class WebCore::BroadcastChannelIdentifierType
 template: enum class WebCore::FileSystemHandleIdentifierType
+template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
 template: enum class WebCore::IDBObjectStoreIdentifierType
+template: enum class WebCore::LibWebRTCSocketIdentifierType
 template: enum class WebCore::MainThreadPermissionObserverIdentifierType
 template: enum class WebCore::OpaqueOriginIdentifierType
 template: enum class WebCore::PortIdentifierType
+template: enum class WebCore::RTCDataChannelLocalIdentifierType
+template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
 template: enum class WebCore::ServiceWorkerJobIdentifierType
 template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
 template: enum class WebCore::WebLockIdentifierType

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5608,11 +5608,6 @@ header: <WebCore/RTCDataChannelHandler.h>
     WebCore::RTCPriorityType priority;
 };
 
-struct WebCore::RTCDataChannelIdentifier {
-    WebCore::ProcessIdentifier processIdentifier;
-    WebCore::RTCDataChannelLocalIdentifier channelIdentifier;
-};
-
 #endif // ENABLE(WEB_RTC)
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -145,7 +145,7 @@ void WebFileSystemStorageConnection::createSyncAccessHandle(WebCore::FileSystemH
         if (!result)
             return completionHandler(convertToException(result.error()));
 
-        completionHandler(WebCore::FileSystemStorageConnection::SyncAccessHandleInfo { result->identifier, result->handle.release(), result->capacity });
+        completionHandler(WebCore::FileSystemStorageConnection::SyncAccessHandleInfo { *result->identifier, result->handle.release(), result->capacity });
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -560,8 +560,7 @@ static JSValueRef jsSendWithAsyncReply(IPC::Connection& connection, uint64_t des
 
 static JSValueRef jsSendSync(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, IPC::Timeout timeout, JSContextRef context, const JSValueRef messageArguments, JSValueRef* exception)
 {
-    IPC::Connection::SyncRequestID syncRequestID;
-    auto encoder = connection.createSyncMessageEncoder(messageName, destinationID, syncRequestID);
+    auto [encoder, syncRequestID] = connection.createSyncMessageEncoder(messageName, destinationID);
     if (messageArguments && !encodeArgument(encoder.get(), context, messageArguments, exception))
         return JSValueMakeUndefined(context);
     auto replyDecoderOrError = connection.sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });


### PR DESCRIPTION
#### a5d8fdd2178b5c8e456c46ccf9d78b69a68a9dfb
<pre>
Reduce use of LegacyNullableAtomicObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=280346">https://bugs.webkit.org/show_bug.cgi?id=280346</a>

Reviewed by Sihui Liu.

* Source/WebCore/Modules/cache/DOMCacheIdentifier.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::RTCDataChannel):
(WebCore::RTCDataChannel::detach):
(WebCore::RTCDataChannel::removeFromDataChannelLocalMapIfNeeded):
(WebCore::RTCDataChannel::create):
(WebCore::m_contextIdentifier): Deleted.
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp:
(WebCore::RTCDataChannelRemoteHandler::setClient):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h:
* Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::connectToRTCDataChannelRemoteSource):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp:
(WebKit::RTCDataChannelRemoteManagerProxy::sendData):
(WebKit::RTCDataChannelRemoteManagerProxy::close):
(WebKit::RTCDataChannelRemoteManagerProxy::changeReadyState):
(WebKit::RTCDataChannelRemoteManagerProxy::receiveData):
(WebKit::RTCDataChannelRemoteManagerProxy::detectError):
(WebKit::RTCDataChannelRemoteManagerProxy::bufferedAmountIsDecreasing):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::createSyncMessageEncoder):
(IPC::Connection::sendMessageImpl):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::processIncomingSyncReply):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.h:
* Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.serialization.in:
* Source/WebKit/Shared/ProcessQualified.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::connectToRemoteSource):
(WebKit::RTCDataChannelRemoteManager::postTaskToHandler):
(WebKit::RTCDataChannelRemoteManager::sourceFromIdentifier):
(WebKit::RTCDataChannelRemoteManager::RemoteHandlerConnection::connectToSource):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::createSyncAccessHandle):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::jsSendSync):

Canonical link: <a href="https://commits.webkit.org/284259@main">https://commits.webkit.org/284259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/532d6578dc856106333c5cfbea264f44a589496a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13294 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35320 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/68345 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16864 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74601 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16458 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62377 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3958 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->