### PR TITLE
Adopt more smart pointers in some GPUProcess/graphics files

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -178,37 +178,37 @@ const Vector<CaptureDevice>& CoreAudioCaptureSourceFactory::speakerDevices() con
 
 void CoreAudioCaptureSourceFactory::enableMutedSpeechActivityEventListener(Function<void()>&& callback)
 {
-    CoreAudioSharedUnit::unit().enableMutedSpeechActivityEventListener(WTFMove(callback));
+    CoreAudioSharedUnit::singleton().enableMutedSpeechActivityEventListener(WTFMove(callback));
 }
 
 void CoreAudioCaptureSourceFactory::disableMutedSpeechActivityEventListener()
 {
-    CoreAudioSharedUnit::unit().disableMutedSpeechActivityEventListener();
+    CoreAudioSharedUnit::singleton().disableMutedSpeechActivityEventListener();
 }
 
 void CoreAudioCaptureSourceFactory::registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
-    CoreAudioSharedUnit::unit().registerSpeakerSamplesProducer(producer);
+    CoreAudioSharedUnit::singleton().registerSpeakerSamplesProducer(producer);
 }
 
 void CoreAudioCaptureSourceFactory::unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
-    CoreAudioSharedUnit::unit().unregisterSpeakerSamplesProducer(producer);
+    CoreAudioSharedUnit::singleton().unregisterSpeakerSamplesProducer(producer);
 }
 
 bool CoreAudioCaptureSourceFactory::isAudioCaptureUnitRunning()
 {
-    return CoreAudioSharedUnit::unit().isRunning();
+    return CoreAudioSharedUnit::singleton().isRunning();
 }
 
 void CoreAudioCaptureSourceFactory::whenAudioCaptureUnitIsNotRunning(Function<void()>&& callback)
 {
-    return CoreAudioSharedUnit::unit().whenAudioCaptureUnitIsNotRunning(WTFMove(callback));
+    return CoreAudioSharedUnit::singleton().whenAudioCaptureUnitIsNotRunning(WTFMove(callback));
 }
 
 bool CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio()
 {
-    auto& unit = CoreAudioSharedUnit::unit();
+    auto& unit = CoreAudioSharedUnit::singleton();
 #if PLATFORM(IOS_FAMILY)
     return unit.isRunning();
 #else
@@ -349,7 +349,7 @@ void CoreAudioCaptureSource::delaySamples(Seconds seconds)
 void CoreAudioCaptureSource::setIsInBackground(bool value)
 {
     if (isProducingData())
-        CoreAudioSharedUnit::unit().setIsInBackground(value);
+        CoreAudioSharedUnit::singleton().setIsInBackground(value);
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -115,7 +115,7 @@ Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioShared
 {
 #if PLATFORM(MAC)
     if (shouldUseVPIO) {
-        if (auto ioUnit = CoreAudioSharedUnit::unit().takeStoredVPIOUnit()) {
+        if (auto ioUnit = CoreAudioSharedUnit::singleton().takeStoredVPIOUnit()) {
             RELEASE_LOG(WebRTC, "Creating a CoreAudioSharedInternalUnit with a stored VPIO unit");
             UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(WTFMove(ioUnit), shouldUseVPIO);
             return result;
@@ -142,7 +142,7 @@ CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit()
 {
 #if PLATFORM(MAC)
     if (m_shouldUseVPIO)
-        CoreAudioSharedUnit::unit().setStoredVPIOUnit(std::exchange(m_audioUnit, { }));
+        CoreAudioSharedUnit::singleton().setStoredVPIOUnit(std::exchange(m_audioUnit, { }));
 #endif
 }
 
@@ -213,7 +213,7 @@ OSStatus CoreAudioSharedInternalUnit::defaultOutputDevice(uint32_t* deviceID)
     return -1;
 }
 
-CoreAudioSharedUnit& CoreAudioSharedUnit::unit()
+CoreAudioSharedUnit& CoreAudioSharedUnit::singleton()
 {
     static NeverDestroyed<Ref<CoreAudioSharedUnit>> singleton(adoptRef(*new CoreAudioSharedUnit));
     return singleton.get();

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -87,8 +87,7 @@ public:
         virtual bool setVoiceActivityDetection(bool) = 0;
     };
 
-    WEBCORE_EXPORT static CoreAudioSharedUnit& unit();
-    static BaseAudioSharedUnit& singleton()  { return unit(); }
+    WEBCORE_EXPORT static CoreAudioSharedUnit& singleton();
     ~CoreAudioSharedUnit();
 
     using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>(bool enableEchoCancellation)>;
@@ -123,6 +122,7 @@ public:
 
 #if PLATFORM(MAC)
     static void processVoiceActivityEvent(uint32_t);
+    WEBCORE_EXPORT void prewarmAudioUnitCreation(CompletionHandler<void()>&&) final;
 #endif
 
     WEBCORE_EXPORT void setMuteStatusChangedCallback(Function<void(bool)>&&);
@@ -154,7 +154,6 @@ private:
     void validateOutputDevice(uint32_t deviceID) final;
 #if PLATFORM(MAC)
     bool migrateToNewDefaultDevice(const CaptureDevice&) final;
-    void prewarmAudioUnitCreation(CompletionHandler<void()>&&) final;
     void deallocateStoredVPIOUnit();
 #endif
     int actualSampleRate() const final;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -71,7 +71,7 @@ void unregisterAudioInputMuteChangeListener(WebCoreAudioInputMuteChangeListener*
 - (void)handleMuteStatusChangedNotification:(NSNotification*)notification
 {
     NSNumber* newMuteState = [notification.userInfo valueForKey:AVAudioApplicationMuteStateKey];
-    WebCore::CoreAudioSharedUnit::unit().handleMuteStatusChangedNotification(newMuteState.boolValue);
+    WebCore::CoreAudioSharedUnit::singleton().handleMuteStatusChangedNotification(newMuteState.boolValue);
 }
 
 @end
@@ -188,7 +188,7 @@ void CoreAudioSharedUnit::processVoiceActivityEvent(AudioObjectID deviceID)
         return;
 
     callOnMainRunLoop([] {
-        CoreAudioSharedUnit::unit().voiceActivityDetected();
+        CoreAudioSharedUnit::singleton().voiceActivityDetected();
     });
 }
 #endif // PLATFORM(MAC) && HAVE(VOICEACTIVITYDETECTION)
@@ -197,7 +197,7 @@ bool CoreAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
 {
 #if HAVE(VOICEACTIVITYDETECTION)
 #if PLATFORM(MAC)
-    auto deviceID = CoreAudioSharedUnit::unit().captureDeviceID();
+    auto deviceID = CoreAudioSharedUnit::singleton().captureDeviceID();
     if (!deviceID) {
         if (auto err = defaultInputDevice(&deviceID))
             return false;
@@ -208,7 +208,7 @@ bool CoreAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
     AUVoiceIOMutedSpeechActivityEventListener listener = ^(AUVoiceIOSpeechActivityEvent event) {
         if (event == kAUVoiceIOSpeechActivityHasStarted) {
             callOnMainThread([] {
-                CoreAudioSharedUnit::unit().voiceActivityDetected();
+                CoreAudioSharedUnit::singleton().voiceActivityDetected();
             });
         }
     };

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -237,7 +237,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters,
     SandboxExtension::consumePermanently(parameters.microphoneSandboxExtensionHandle);
 #endif
 #if PLATFORM(IOS_FAMILY)
-    CoreAudioSharedUnit::unit().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
+    CoreAudioSharedUnit::singleton().setStatusBarWasTappedCallback([weakProcess = WeakPtr { *this }] (auto completionHandler) {
         if (RefPtr process = weakProcess.get())
             process->parentProcessConnection()->sendWithAsyncReply(Messages::GPUProcessProxy::StatusBarWasTapped(), [] { }, 0);
         completionHandler();
@@ -436,7 +436,7 @@ void GPUProcess::setOrientationForMediaCapture(WebCore::IntDegrees orientation)
 void GPUProcess::enableMicrophoneMuteStatusAPI()
 {
 #if PLATFORM(COCOA)
-    CoreAudioSharedUnit::unit().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
+    CoreAudioSharedUnit::singleton().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
         if (RefPtr process = weakProcess.get())
             process->protectedParentProcessConnection()->send(Messages::GPUProcessProxy::MicrophoneMuteStatusChanged(isMuting), 0);
     });

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -199,7 +199,7 @@ void RemoteGraphicsContextGL::ensureExtensionEnabled(String&& extension)
 void RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBufferIdentifier, CompletionHandler<void()>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    m_context->withBufferAsNativeImage(buffer, [&](NativeImage& image) {
+    protectedContext()->withBufferAsNativeImage(buffer, [&](NativeImage& image) {
         paintNativeImageToImageBuffer(image, imageBufferIdentifier);
     });
     completionHandler();
@@ -210,7 +210,7 @@ void RemoteGraphicsContextGL::surfaceBufferToVideoFrame(WebCore::GraphicsContext
 {
     assertIsCurrent(workQueue());
     std::optional<WebKit::RemoteVideoFrameProxy::Properties> result;
-    if (auto videoFrame = m_context->surfaceBufferToVideoFrame(buffer))
+    if (auto videoFrame = protectedContext()->surfaceBufferToVideoFrame(buffer))
         result = m_videoFrameObjectHeap->add(videoFrame.releaseNonNull());
     completionHandler(WTFMove(result));
 }
@@ -285,8 +285,9 @@ void RemoteGraphicsContextGL::getBufferSubDataInline(uint32_t target, uint64_t o
     assertIsCurrent(workQueue());
     static constexpr size_t getBufferSubDataInlineSizeLimit = 64 * KB; // NOTE: when changing, change the value in RemoteGraphicsContextGLProxy too.
 
+    RefPtr context = m_context;
     if (!dataSize || dataSize > getBufferSubDataInlineSizeLimit) {
-        m_context->addError(GCGLErrorCode::InvalidOperation);
+        context->addError(GCGLErrorCode::InvalidOperation);
         completionHandler({ });
         return;
     }
@@ -296,10 +297,10 @@ void RemoteGraphicsContextGL::getBufferSubDataInline(uint32_t target, uint64_t o
     bufferStore = MallocPtr<uint8_t>::tryMalloc(dataSize);
     if (bufferStore) {
         bufferData = { bufferStore.get(), dataSize };
-        if (!protectedContext()->getBufferSubDataWithStatus(target, offset, bufferData))
+        if (!context->getBufferSubDataWithStatus(target, offset, bufferData))
             bufferData = { };
     } else
-        m_context->addError(GCGLErrorCode::OutOfMemory);
+        context->addError(GCGLErrorCode::OutOfMemory);
 
     completionHandler(bufferData);
 }
@@ -316,12 +317,14 @@ void RemoteGraphicsContextGL::getBufferSubDataSharedMemory(uint32_t target, uint
         return;
     }
 
+    RefPtr context = m_context;
+
     handle.setOwnershipOfMemory(m_sharedResourceCache->resourceOwner(), WebKit::MemoryLedger::Default);
     auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite);
     if (buffer && dataSize <= buffer->size())
-        validBufferData = protectedContext()->getBufferSubDataWithStatus(target, offset, buffer->mutableSpan().subspan(0, dataSize));
+        validBufferData = context->getBufferSubDataWithStatus(target, offset, buffer->mutableSpan().subspan(0, dataSize));
     else
-        m_context->addError(GCGLErrorCode::InvalidOperation);
+        context->addError(GCGLErrorCode::InvalidOperation);
 
     completionHandler(validBufferData);
 }
@@ -343,11 +346,13 @@ void RemoteGraphicsContextGL::readPixelsInline(WebCore::IntRect rect, uint32_t f
         if (pixelsStore)
             pixels = { pixelsStore.get(), replyImageBytes };
     }
+
+    RefPtr context = m_context;
     std::optional<WebCore::IntSize> readArea;
     if (pixels.size() == replyImageBytes)
-        readArea = protectedContext()->readPixelsWithStatus(rect, format, type, packReverseRowOrder, pixels);
+        readArea = context->readPixelsWithStatus(rect, format, type, packReverseRowOrder, pixels);
     else
-        m_context->addError(GCGLErrorCode::OutOfMemory);
+        context->addError(GCGLErrorCode::OutOfMemory);
     if (!readArea) {
         pixels = { };
         pixelsStore = { };
@@ -361,11 +366,12 @@ void RemoteGraphicsContextGL::readPixelsSharedMemory(WebCore::IntRect rect, uint
     assertIsCurrent(workQueue());
     std::optional<WebCore::IntSize> readArea;
 
+    RefPtr context = m_context;
     handle.setOwnershipOfMemory(m_sharedResourceCache->resourceOwner(), WebKit::MemoryLedger::Default);
     if (auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite))
-        readArea = protectedContext()->readPixelsWithStatus(rect, format, type, packReverseRowOrder, buffer->mutableSpan());
+        readArea = context->readPixelsWithStatus(rect, format, type, packReverseRowOrder, buffer->mutableSpan());
     else
-        m_context->addError(GCGLErrorCode::InvalidOperation);
+        context->addError(GCGLErrorCode::InvalidOperation);
 
     completionHandler(readArea);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -53,7 +53,7 @@ RemoteBindGroup::~RemoteBindGroup() = default;
 
 void RemoteBindGroup::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protectedObjectHeap()->removeObject(m_identifier);
 }
 
 void RemoteBindGroup::updateExternalTextures(WebGPUIdentifier externalTextureIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -52,7 +52,7 @@ RemoteBindGroupLayout::~RemoteBindGroupLayout() = default;
 
 void RemoteBindGroupLayout::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteBindGroupLayout::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -55,7 +55,7 @@ RemoteComputePassEncoder::~RemoteComputePassEncoder() = default;
 
 void RemoteComputePassEncoder::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    protectedObjectHeap()->removeObject(m_identifier);
 }
 
 void RemoteComputePassEncoder::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -106,6 +106,7 @@ private:
 
     void initialize();
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
+    Ref<IPC::StreamConnectionWorkQueue> protectedWorkQueue() const { return m_workQueue; }
     void workQueueInitialize();
     void workQueueUninitialize();
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -279,7 +279,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitIsSt
 void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitHasStopped()
 {
     // Capture unit has stopped and audio will no longer be rendered through it so start the local unit.
-    if (m_isPlaying && !WebCore::CoreAudioSharedUnit::unit().isSuspended())
+    if (m_isPlaying && !WebCore::CoreAudioSharedUnit::singleton().isSuspended())
         m_localUnit->start();
 }
 
@@ -300,7 +300,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::endAudioSession
     if (!m_isPlaying)
         return;
 
-    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioSharedUnit::unit().isRunning() || WebCore::CoreAudioSharedUnit::unit().isSuspended()))
+    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioSharedUnit::singleton().isRunning() || WebCore::CoreAudioSharedUnit::singleton().isSuspended()))
         return;
 
     m_localUnit->start();


### PR DESCRIPTION
#### 79e4ba7417b545be856b78df6875e1c966e44425
<pre>
Adopt more smart pointers in some GPUProcess/graphics files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280347">https://bugs.webkit.org/show_bug.cgi?id=280347</a>
<a href="https://rdar.apple.com/136702392">rdar://136702392</a>

Reviewed by Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(WebCore::AVAudioSessionCaptureDeviceManager::retrieveAudioSessionCaptureDevices const):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::unit):
(WebCore::CoreAudioCaptureSource::unit const):
(WebCore::CoreAudioCaptureSourceFactory::unit):
(WebCore::CoreAudioCaptureSourceFactory::scheduleReconfiguration):
(WebCore::CoreAudioCaptureSourceFactory::enableMutedSpeechActivityEventListener):
(WebCore::CoreAudioCaptureSourceFactory::disableMutedSpeechActivityEventListener):
(WebCore::CoreAudioCaptureSourceFactory::registerSpeakerSamplesProducer):
(WebCore::CoreAudioCaptureSourceFactory::unregisterSpeakerSamplesProducer):
(WebCore::CoreAudioCaptureSourceFactory::isAudioCaptureUnitRunning):
(WebCore::CoreAudioCaptureSourceFactory::whenAudioCaptureUnitIsNotRunning):
(WebCore::CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio):
(WebCore::CoreAudioCaptureSource::setIsInBackground):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedInternalUnit::create):
(WebCore::CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedUnit::unitSingleton):
(WebCore::CoreAudioSharedUnit::unit): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(-[WebCoreAudioInputMuteChangeListener handleMuteStatusChangedNotification:]):
(WebCore::CoreAudioSharedUnit::processVoiceActivityEvent):
(WebCore::CoreAudioSharedInternalUnit::setVoiceActivityDetection):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::updateCaptureAccess):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
(WebKit::GPUProcess::enableMicrophoneMuteStatusAPI):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer):
(WebKit::RemoteGraphicsContextGL::surfaceBufferToVideoFrame):
(WebKit::RemoteGraphicsContextGL::getBufferSubDataInline):
(WebKit::RemoteGraphicsContextGL::getBufferSubDataSharedMemory):
(WebKit::RemoteGraphicsContextGL::readPixelsInline):
(WebKit::RemoteGraphicsContextGL::readPixelsSharedMemory):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp:
(WebKit::RemoteBindGroupLayout::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::initialize):
(WebKit::RemoteGPU::stopListeningForIPC):
(WebKit::RemoteGPU::workQueueInitialize):
(WebKit::RemoteGPU::isValid):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitHasStopped):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::endAudioSessionInterruption):

Canonical link: <a href="https://commits.webkit.org/284293@main">https://commits.webkit.org/284293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abf4ea1345c309ff3229eb99d4af7848fe6dfac7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54862 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16878 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62527 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62391 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15305 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3969 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44049 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->