### PR TITLE
[GLib] Update the libsysprof-capture source tree to version 47.0

### DIFF
--- a/Source/ThirdParty/libsysprof-capture/README.WebKit
+++ b/Source/ThirdParty/libsysprof-capture/README.WebKit
@@ -2,7 +2,7 @@ This directory contains a copy of libsysprof-capture from the
 official Sysprof repository.
 
   - URL: https://gitlab.gnome.org/GNOME/sysprof
-  - Commit: 594a3037c0e7cc1bf97f162a392aa4f8989c9dce (tag: 46.0)
+  - Commit: 5513868c49b54151b1df3f752a210709322e630c (tag: 47.0)
 
 The simplest way of updating its contents is to re-create the directory
 from scratch, and restoring the needed files with Git. Example commands:

--- a/Source/ThirdParty/libsysprof-capture/sysprof-capture-writer.c
+++ b/Source/ThirdParty/libsysprof-capture/sysprof-capture-writer.c
@@ -1697,7 +1697,7 @@ sysprof_capture_writer_add_allocation (SysprofCaptureWriter  *self,
 {
   SysprofCaptureAllocation *ev;
   size_t len;
-  unsigned int n_addrs;
+  int n_addrs;
 
   assert (self != NULL);
   assert (backtrace_func != NULL);
@@ -1706,6 +1706,9 @@ sysprof_capture_writer_add_allocation (SysprofCaptureWriter  *self,
   ev = (SysprofCaptureAllocation *)sysprof_capture_writer_allocate (self, &len);
   if (!ev)
     return false;
+
+  if ((n_addrs = backtrace_func (ev->addrs, MAX_UNWIND_DEPTH, backtrace_data)) < 0)
+    n_addrs = 0;
 
   sysprof_capture_writer_frame_init (&ev->frame,
                                      len,
@@ -1719,8 +1722,6 @@ sysprof_capture_writer_add_allocation (SysprofCaptureWriter  *self,
   ev->padding1 = 0;
   ev->tid = tid;
   ev->n_addrs = 0;
-
-  n_addrs = backtrace_func (ev->addrs, MAX_UNWIND_DEPTH, backtrace_data);
 
   if (n_addrs <= MAX_UNWIND_DEPTH)
     ev->n_addrs = n_addrs;

--- a/Source/ThirdParty/libsysprof-capture/sysprof-collector.c
+++ b/Source/ThirdParty/libsysprof-capture/sysprof-collector.c
@@ -58,6 +58,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <pthread.h>
 #ifdef __linux__
@@ -140,7 +141,7 @@ set_fd_blocking (int fd)
 {
 #ifdef F_GETFL
   long fcntl_flags;
-  fcntl_flags = fcntl (peer_fd, F_GETFL);
+  fcntl_flags = fcntl (fd, F_GETFL);
 
   if (fcntl_flags == -1)
     return false;
@@ -151,7 +152,7 @@ set_fd_blocking (int fd)
   fcntl_flags &= ~O_NDELAY;
 #endif
 
-  if (fcntl (peer_fd, F_SETFL, fcntl_flags) == -1)
+  if (fcntl (fd, F_SETFL, fcntl_flags) == -1)
     return false;
 
   return true;
@@ -522,6 +523,9 @@ sysprof_collector_allocate (SysprofCaptureAddress   alloc_addr,
         if (backtrace_func)
           n_addrs = backtrace_func (ev->addrs, MAX_UNWIND_DEPTH, backtrace_data);
         else
+          n_addrs = 0;
+
+        if (n_addrs < 0)
           n_addrs = 0;
 
         ev->n_addrs = ((n_addrs < 0) ? 0 : (n_addrs > MAX_UNWIND_DEPTH) ? MAX_UNWIND_DEPTH : n_addrs);

--- a/Source/ThirdParty/libsysprof-capture/sysprof-version.h
+++ b/Source/ThirdParty/libsysprof-capture/sysprof-version.h
@@ -69,7 +69,7 @@
  *
  * sysprof major version component (e.g. 1 if %SYSPROF_VERSION is 1.2.3)
  */
-#define SYSPROF_MAJOR_VERSION (46)
+#define SYSPROF_MAJOR_VERSION (47)
 
 /**
  * SYSPROF_MINOR_VERSION:
@@ -90,7 +90,7 @@
  *
  * sysprof version.
  */
-#define SYSPROF_VERSION (46.0)
+#define SYSPROF_VERSION (47.0)
 
 /**
  * SYSPROF_VERSION_S:
@@ -98,7 +98,7 @@
  * sysprof version, encoded as a string, useful for printing and
  * concatenation.
  */
-#define SYSPROF_VERSION_S "46.0"
+#define SYSPROF_VERSION_S "47.0"
 
 #define SYSPROF_ENCODE_VERSION(major,minor,micro) \
         ((major) << 24 | (minor) << 16 | (micro) << 8)


### PR DESCRIPTION
#### 87f8bc0a850cf8d902ad6d26f9b89671e0515cb5
<pre>
[GLib] Update the libsysprof-capture source tree to version 47.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=280179">https://bugs.webkit.org/show_bug.cgi?id=280179</a>

Reviewed by Nikolas Zimmermann.

Includes the following upstream changes:

git log --pretty=oneline --abbrev-commit 46.0...47.0 -- src/libsysprof-capture

c228634f libsysprof-capture: handle unwind length &lt; 0 gracefully
10217bb0 libsysprof-capture: fix set_fd_blocking()
Canonical link: <a href="https://commits.webkit.org/284248@main">https://commits.webkit.org/284248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3163bf7d566b403313f90102c0af3be0fb4305d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13296 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74602 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12810 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62378 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10350 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/3960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10503 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44028 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->