### PR TITLE
Poison AssemblerBuffer's inline buffer on x86

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -154,17 +154,17 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
                     uint64_t chunk = *reinterpret_cast<const uint64_t*>(buffer + i);
                     if (!chunk) {
                         runLength += sizeof(chunk);
-                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer);
+                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer, n, i);
                     } else {
                         runLength += (std::countr_zero(chunk) / 8);
-                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer);
+                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer, n, i);
                         runLength = std::countl_zero(chunk) / 8;
                     }
                 }
                 for (; i < n; i++) {
                     if (!(buffer[i])) {
                         runLength++;
-                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer);
+                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer, n, i);
                     }
                 }
             }


### PR DESCRIPTION
#### 60a72b8caf511451d8acd82fde1a35ff0a322e7f
<pre>
Poison AssemblerBuffer&apos;s inline buffer on x86
<a href="https://bugs.webkit.org/show_bug.cgi?id=280354">https://bugs.webkit.org/show_bug.cgi?id=280354</a>
<a href="https://rdar.apple.com/136706743">rdar://136706743</a>

Reviewed by Yusuke Suzuki.

JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES is a feature enabled on X86 that
scans the assembler buffer for excessive strings of zeroes at link-time.
We would like to be able to distinguish between two cases:
 1. The zeroes were written into the buffer (either intentionally or
    unintentionally)
 2. The zeroes were left there by someone who forgot to write over a
    chunk of code, and are thus just left over from initialization
By poisoning m_inlineBuffer inside the constructor, we mostly achieve
this -- we&apos;d like to poison the out-of-line buffers too, but it&apos;s more
likely that that will have too high of a performance cost and inline
buffers are the ones most likely to be corrupted regardless (being on
the stack, and thus most vulnerable to buffer overruns and the like).

* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerDataImpl::AssemblerDataImpl):
(JSC::AssemblerDataImpl::poisonInlineBuffer):
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::performJITMemcpy):

Canonical link: <a href="https://commits.webkit.org/284300@main">https://commits.webkit.org/284300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/874a85f0e7e93bf354ca16a898801fcef43db8f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19996 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35328 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18358 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61967 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74616 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68097 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62388 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3967 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89876 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10538 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44042 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15928 "Found 47 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/es6/expo.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-both-proven-final-object.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-div-neg2tothe31-by-one-and-then-or-zero-with-interesting-reg-alloc.js.layout, stress/async-iteration-for-await-of-syntax.js.bytecode-cache, stress/escaped-keyword-identifiers.js.bytecode-cache, stress/hashbang.js.bytecode-cache, stress/intl-locale-exceptions.js.dfg-eager, stress/iterator-from.js.dfg-eager, stress/iterator-prototype-find.js.dfg-eager ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45119 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->