### PR TITLE
Add method for observing web process state via WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -83,6 +83,15 @@ typedef NS_ENUM(NSInteger, _WKShouldOpenExternalURLsPolicy) {
     _WKShouldOpenExternalURLsPolicyAllowExternalSchemesButNotAppLinks,
 } WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
+typedef NS_ENUM(NSInteger, _WKWebProcessState) {
+    _WKWebProcessStateNotRunning,
+    _WKWebProcessStateForeground,
+    _WKWebProcessStateBackground,
+    _WKWebProcessStateSuspended,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
+#define HAVE_WK_WEB_PROCESS_STATE 1
+
 #if TARGET_OS_IPHONE
 
 typedef NS_ENUM(NSUInteger, _WKDragInteractionPolicy) {
@@ -570,6 +579,9 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 - (void)_simulateClickOverFirstMatchingTextInViewportWithUserInteraction:(NSString *)targetText completionHandler:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, setter=_setDontResetTransientActivationAfterRunJavaScript:) BOOL _dontResetTransientActivationAfterRunJavaScript WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+// This property is KVO compliant.
+@property (nonatomic, readonly) _WKWebProcessState _webProcessState WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -141,6 +141,8 @@ public:
 
     CocoaWindow *platformWindow() const final;
 
+    void processDidUpdateThrottleState() final;
+
 protected:
     RetainPtr<WKWebView> webView() const { return m_webView.get(); }
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -359,4 +359,10 @@ CocoaWindow *PageClientImplCocoa::platformWindow() const
     return [m_webView window];
 }
 
+void PageClientImplCocoa::processDidUpdateThrottleState()
+{
+    [m_webView willChangeValueForKey:@"_webProcessState"];
+    [m_webView didChangeValueForKey:@"_webProcessState"];
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -298,6 +298,7 @@ public:
     virtual void processDidExit() = 0;
     virtual void processWillSwap() { processDidExit(); }
     virtual void didRelaunchProcess() = 0;
+    virtual void processDidUpdateThrottleState() { }
     virtual void pageClosed() = 0;
 
     virtual void preferencesDidChange() = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7189,6 +7189,13 @@ void WebPageProxy::didReceiveTitleForFrame(IPC::Connection& connection, FrameIde
 #endif
 }
 
+void WebPageProxy::processDidUpdateThrottleState()
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->processDidUpdateThrottleState();
+}
+
+
 void WebPageProxy::didFirstLayoutForFrame(FrameIdentifier, const UserData& userData)
 {
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1534,6 +1534,8 @@ public:
     void processWillBecomeForeground();
 #endif
 
+    void processDidUpdateThrottleState();
+
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID);
     LayerHostingContextID contextIDForVisibilityPropagationInWebProcess() const { return m_contextIDForVisibilityPropagationInWebProcess; }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -594,6 +594,9 @@ public:
     HardwareKeyboardState cachedHardwareKeyboardState() const;
 #endif
 
+    bool webProcessStateUpdatesForPageClientEnabled() const { return m_webProcessStateUpdatesForPageClientEnabled; }
+    void setWebProcessStateUpdatesForPageClientEnabled(bool enabled) { m_webProcessStateUpdatesForPageClientEnabled = enabled; }
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);
@@ -923,6 +926,8 @@ private:
     RefPtr<ListDataObserver> m_storageAccessPromptQuirksDataUpdateObserver;
     RefPtr<ListDataObserver> m_scriptTelemetryDataUpdateObserver;
 #endif
+
+    bool m_webProcessStateUpdatesForPageClientEnabled { false };
 };
 
 template<typename T>

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2857,6 +2857,13 @@ void WebProcessProxy::updateRuntimeStatistics()
 
     m_throttleStateForStatistics = newState;
     m_throttleStateForStatisticsTimestamp = newTimestamp;
+
+    if (RefPtr pool = m_processPool.get()) {
+        if (pool->webProcessStateUpdatesForPageClientEnabled()) {
+            for (Ref page : mainPages())
+                page->processDidUpdateThrottleState();
+        }
+    }
 }
 
 TextStream& operator<<(TextStream& ts, const WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -500,6 +500,7 @@ public:
 
     void resetState();
 
+    ProcessThrottleState throttleStateForStatistics() const { return m_throttleStateForStatistics; }
     Seconds totalForegroundTime() const;
     Seconds totalBackgroundTime() const;
     Seconds totalSuspendedTime() const;


### PR DESCRIPTION
#### eb81577b89c438828700491a6fd52306b678ac2f
<pre>
Add method for observing web process state via WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=280355">https://bugs.webkit.org/show_bug.cgi?id=280355</a>
<a href="https://rdar.apple.com/136707641">rdar://136707641</a>

Reviewed by Brady Eidson.

For debugging purposes, it can be useful for the embedder to be able to observe process state
changes. For instance, the embedder might use this to add debug info to the tab title to let a user
quickly know if a tab is associated with a process that is in the foreground, background, or
suspended.

I did this by adding a `_webProcessState` property to WKWebView. The property is KVO-compliant. To
avoid perf issues, we only start shipping process state updates back to the embedder if the embedder
actually registers for KVO notifications on that property.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView addObserver:forKeyPath:options:context:]):
(-[WKWebView _webProcessState]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::processDidUpdateThrottleState):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::processDidUpdateThrottleState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::processDidUpdateThrottleState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::updateRuntimeStatistics):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/284261@main">https://commits.webkit.org/284261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e46873fd0ed7320fa8772777d4e4e3a969e3a874

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20002 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54861 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35329 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40739 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74622 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62349 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62390 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15287 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Checked out pull request; Reviewed by Brady Eidson; Compiled WebKit (warnings); Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10360 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44048 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->