### PR TITLE
Change UserActionElementSet to use a  WeakHashMap instead of a HashMap

### DIFF
--- a/Source/WebCore/dom/UserActionElementSet.cpp
+++ b/Source/WebCore/dom/UserActionElementSet.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 void UserActionElementSet::clear()
 {
     for (auto iterator = m_elements.begin(); iterator != m_elements.end(); ++iterator)
-        iterator->key->setUserActionElement(false);
+        iterator->key.setUserActionElement(false);
     m_elements.clear();
 }
 
@@ -44,7 +44,7 @@ bool UserActionElementSet::hasFlag(const Element& element, Flag flag) const
     // Caller has the responsibility to check isUserActionElement before calling this.
     ASSERT(element.isUserActionElement());
 
-    return m_elements.get(&const_cast<Element&>(element)).contains(flag);
+    return m_elements.get(element).contains(flag);
 }
 
 void UserActionElementSet::clearFlags(Element& element, OptionSet<Flag> flags)
@@ -54,7 +54,7 @@ void UserActionElementSet::clearFlags(Element& element, OptionSet<Flag> flags)
     if (!element.isUserActionElement())
         return;
 
-    auto iterator = m_elements.find(&element);
+    auto iterator = m_elements.find(element);
     ASSERT(iterator != m_elements.end());
     auto updatedFlags = iterator->value - flags;
     if (updatedFlags.isEmpty()) {
@@ -68,7 +68,7 @@ void UserActionElementSet::setFlags(Element& element, OptionSet<Flag> flags)
 {
     ASSERT(!flags.isEmpty());
 
-    m_elements.ensure(&element, [] {
+    m_elements.ensure(element, [] {
         return OptionSet<Flag>();
     }).iterator->value.add(flags);
 

--- a/Source/WebCore/dom/UserActionElementSet.h
+++ b/Source/WebCore/dom/UserActionElementSet.h
@@ -28,13 +28,14 @@
 #pragma once
 
 #include <wtf/Forward.h>
-#include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
 class Element;
+class WeakPtrImplWithEventTargetData;
 
 class UserActionElementSet {
 public:
@@ -75,7 +76,7 @@ private:
     void clearFlags(Element&, OptionSet<Flag>);
     bool hasFlag(const Element&, Flag) const;
 
-    HashMap<RefPtr<Element>, OptionSet<Flag>> m_elements;
+    WeakHashMap<Element, OptionSet<Flag>, WeakPtrImplWithEventTargetData> m_elements;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 59b78d354f38cab97c5897169ce99a9edbf471ec
<pre>
Change UserActionElementSet to use a  WeakHashMap instead of a HashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=280351">https://bugs.webkit.org/show_bug.cgi?id=280351</a>
<a href="https://rdar.apple.com/136382242">rdar://136382242</a>

Reviewed by Chris Dumez.

Make the reference to the Element a WeakPtr by using a WeakHashmap instead of a strong reference.
I observed a website where the RefPtr&lt;Element&gt; keys stored in m_elements map in the UserActionElementSet were never decremented once inserted, even after deallocation of all Elements should have occured. The Document owns an instance of UserActionElementSet, which I believe causes a reference cycle between the Nodes that reference the document and the Document itself. Break this reference cycle.

* Source/WebCore/dom/UserActionElementSet.cpp:
(WebCore::UserActionElementSet::clear):
(WebCore::UserActionElementSet::hasFlag const):
(WebCore::UserActionElementSet::clearFlags):
(WebCore::UserActionElementSet::setFlags):
* Source/WebCore/dom/UserActionElementSet.h:

Canonical link: <a href="https://commits.webkit.org/284260@main">https://commits.webkit.org/284260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3beb4c25b38c5d57c5c34fd2028d77e8a4ebab6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54865 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16880 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74625 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62353 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3971 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44051 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->