### PR TITLE
Adopt more smart pointers in GPUProcess/media files

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
@@ -48,19 +48,21 @@ RemoteMediaResourceLoader::~RemoteMediaResourceLoader()
 RefPtr<PlatformMediaResource> RemoteMediaResourceLoader::requestResource(ResourceRequest&& request, LoadOptions options)
 {
     ASSERT(isMainRunLoop());
-    if (!m_remoteMediaPlayerProxy)
+    RefPtr remoteMediaPlayerProxy = m_remoteMediaPlayerProxy.get();
+    if (!remoteMediaPlayerProxy)
         return nullptr;
 
-    return m_remoteMediaPlayerProxy->requestResource(WTFMove(request), options);
+    return remoteMediaPlayerProxy->requestResource(WTFMove(request), options);
 }
 
 void RemoteMediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler)
 {
     ASSERT(isMainRunLoop());
-    if (!m_remoteMediaPlayerProxy)
+    RefPtr remoteMediaPlayerProxy = m_remoteMediaPlayerProxy.get();
+    if (!remoteMediaPlayerProxy)
         return completionHandler(makeUnexpected(internalError(url)));
     
-    m_remoteMediaPlayerProxy->sendH2Ping(url, WTFMove(completionHandler));
+    remoteMediaPlayerProxy->sendH2Ping(url, WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -51,44 +51,42 @@ RemoteTextTrackProxy::RemoteTextTrackProxy(GPUConnectionToWebProcess& connection
     m_clientId = trackPrivate.addClient([](auto&& task) {
         ensureOnMainThread(WTFMove(task));
     }, *this);
-    connectionToWebProcess.connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteTextTrack(configuration()), m_mediaPlayerIdentifier);
+    connectionToWebProcess.protectedConnection()->send(Messages::MediaPlayerPrivateRemote::AddRemoteTextTrack(configuration()), m_mediaPlayerIdentifier);
 }
 
 RemoteTextTrackProxy::~RemoteTextTrackProxy()
 {
-    m_trackPrivate->removeClient(m_clientId);
+    Ref { m_trackPrivate }->removeClient(m_clientId);
 }
 
 TextTrackPrivateRemoteConfiguration& RemoteTextTrackProxy::configuration()
 {
     static NeverDestroyed<TextTrackPrivateRemoteConfiguration> configuration;
 
-    configuration->trackId = m_trackPrivate->id();
-    configuration->label = m_trackPrivate->label();
-    configuration->language = m_trackPrivate->language();
-    configuration->trackIndex = m_trackPrivate->trackIndex();
-    configuration->inBandMetadataTrackDispatchType = m_trackPrivate->inBandMetadataTrackDispatchType();
-    configuration->startTimeVariance = m_trackPrivate->startTimeVariance();
+    Ref trackPrivate = m_trackPrivate;
+    configuration->trackId = trackPrivate->id();
+    configuration->label = trackPrivate->label();
+    configuration->language = trackPrivate->language();
+    configuration->trackIndex = trackPrivate->trackIndex();
+    configuration->inBandMetadataTrackDispatchType = trackPrivate->inBandMetadataTrackDispatchType();
+    configuration->startTimeVariance = trackPrivate->startTimeVariance();
 
-    configuration->cueFormat = m_trackPrivate->cueFormat();
-    configuration->isClosedCaptions = m_trackPrivate->isClosedCaptions();
-    configuration->isSDH = m_trackPrivate->isSDH();
-    configuration->containsOnlyForcedSubtitles = m_trackPrivate->containsOnlyForcedSubtitles();
-    configuration->isMainProgramContent = m_trackPrivate->isMainProgramContent();
-    configuration->isEasyToRead = m_trackPrivate->isEasyToRead();
-    configuration->isDefault = m_trackPrivate->isDefault();
-    configuration->kind = m_trackPrivate->kind();
+    configuration->cueFormat = trackPrivate->cueFormat();
+    configuration->isClosedCaptions = trackPrivate->isClosedCaptions();
+    configuration->isSDH = trackPrivate->isSDH();
+    configuration->containsOnlyForcedSubtitles = trackPrivate->containsOnlyForcedSubtitles();
+    configuration->isMainProgramContent = trackPrivate->isMainProgramContent();
+    configuration->isEasyToRead = trackPrivate->isEasyToRead();
+    configuration->isDefault = trackPrivate->isDefault();
+    configuration->kind = trackPrivate->kind();
 
     return configuration.get();
 }
 
 void RemoteTextTrackProxy::configurationChanged()
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::RemoteTextTrackConfigurationChanged(std::exchange(m_id, m_trackPrivate->id()), configuration()), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::RemoteTextTrackConfigurationChanged(std::exchange(m_id, m_trackPrivate->id()), configuration()), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::willRemove()
@@ -113,84 +111,64 @@ void RemoteTextTrackProxy::languageChanged(const AtomString&)
 
 void RemoteTextTrackProxy::addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::AddDataCue(m_trackPrivate->id(), start, end, data), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::AddDataCue(m_trackPrivate->id(), start, end, data), m_mediaPlayerIdentifier);
 }
 
 #if ENABLE(DATACUE_VALUE)
 void RemoteTextTrackProxy::addDataCue(const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&& cueData, const String& type)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::AddDataCueWithType(m_trackPrivate->id(), start, end, cueData->encodableValue(), type), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::AddDataCueWithType(m_trackPrivate->id(), start, end, cueData->encodableValue(), type), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::updateDataCue(const MediaTime& start, const MediaTime& end, SerializedPlatformDataCue& cueData)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::UpdateDataCue(m_trackPrivate->id(), start, end, cueData.encodableValue()), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::UpdateDataCue(m_trackPrivate->id(), start, end, cueData.encodableValue()), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::removeDataCue(const MediaTime& start, const MediaTime& end, SerializedPlatformDataCue& cueData)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::RemoveDataCue(m_trackPrivate->id(), start, end, cueData.encodableValue()), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::RemoveDataCue(m_trackPrivate->id(), start, end, cueData.encodableValue()), m_mediaPlayerIdentifier);
 }
 #endif
 
 void RemoteTextTrackProxy::addGenericCue(InbandGenericCue& cue)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::AddGenericCue(m_trackPrivate->id(), cue.cueData()), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::AddGenericCue(m_trackPrivate->id(), cue.cueData()), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::updateGenericCue(InbandGenericCue& cue)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::UpdateGenericCue(m_trackPrivate->id(), cue.cueData()), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::UpdateGenericCue(m_trackPrivate->id(), cue.cueData()), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::removeGenericCue(InbandGenericCue& cue)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::RemoveGenericCue(m_trackPrivate->id(), cue.cueData()), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::RemoveGenericCue(m_trackPrivate->id(), cue.cueData()), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::parseWebVTTFileHeader(String&& header)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::ParseWebVTTFileHeader(m_trackPrivate->id(), header), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::ParseWebVTTFileHeader(m_trackPrivate->id(), header), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::parseWebVTTCueData(std::span<const uint8_t> data)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::ParseWebVTTCueData(m_trackPrivate->id(), data), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::ParseWebVTTCueData(m_trackPrivate->id(), data), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::parseWebVTTCueData(ISOWebVTTCue&& cueData)
 {
-    auto connection = m_connectionToWebProcess.get();
-    if (!connection)
-        return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::ParseWebVTTCueDataStruct(m_trackPrivate->id(), cueData), m_mediaPlayerIdentifier);
+    if (RefPtr connection = m_connectionToWebProcess.get())
+        connection->protectedConnection()->send(Messages::MediaPlayerPrivateRemote::ParseWebVTTCueDataStruct(m_trackPrivate->id(), cueData), m_mediaPlayerIdentifier);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 196e7e8346777164305d31111a3484c88c7ff67e
<pre>
Adopt more smart pointers in GPUProcess/media files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280358">https://bugs.webkit.org/show_bug.cgi?id=280358</a>
<a href="https://rdar.apple.com/136710828">rdar://136710828</a>

Reviewed by Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::commitAllTransactions):
(WebKit::RemoteMediaPlayerProxy::loadMediaSource):
(WebKit::RemoteMediaPlayerProxy::requestResource):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerMediaKeysStorageDirectory const):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerMediaCacheDirectory const):
(WebKit::RemoteMediaPlayerProxy::addRemoteAudioTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteVideoTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteTextTrackProxy):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCachedKeyForKeyId const):
(WebKit::RemoteMediaPlayerProxy::setLegacyCDMSession):
(WebKit::RemoteMediaPlayerProxy::cdmInstanceAttached):
(WebKit::RemoteMediaPlayerProxy::cdmInstanceDetached):
(WebKit::RemoteMediaPlayerProxy::attemptToDecryptWithInstance):
(WebKit::RemoteMediaPlayerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp:
(WebKit::RemoteMediaResourceLoader::requestResource):
(WebKit::RemoteMediaResourceLoader::sendH2Ping):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::RemoteTextTrackProxy):
(WebKit::RemoteTextTrackProxy::~RemoteTextTrackProxy):
(WebKit::RemoteTextTrackProxy::configuration):
(WebKit::RemoteTextTrackProxy::configurationChanged):
(WebKit::RemoteTextTrackProxy::addDataCue):
(WebKit::RemoteTextTrackProxy::updateDataCue):
(WebKit::RemoteTextTrackProxy::removeDataCue):
(WebKit::RemoteTextTrackProxy::addGenericCue):
(WebKit::RemoteTextTrackProxy::updateGenericCue):
(WebKit::RemoteTextTrackProxy::removeGenericCue):
(WebKit::RemoteTextTrackProxy::parseWebVTTFileHeader):
(WebKit::RemoteTextTrackProxy::parseWebVTTCueData):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
(WebKit::RemoteVideoTrackProxy::RemoteVideoTrackProxy):
(WebKit::RemoteVideoTrackProxy::~RemoteVideoTrackProxy):
(WebKit::RemoteVideoTrackProxy::configuration):
(WebKit::RemoteVideoTrackProxy::updateConfiguration):

Canonical link: <a href="https://commits.webkit.org/284264@main">https://commits.webkit.org/284264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80cafe62c9a5426094a333a63d8dbedb6fcf2a81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54864 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13311 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40748 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18370 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62357 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62399 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3974 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44054 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->