### PR TITLE
[TZone] Annotate subclasses of BaseClickableWithKeyInputType

### DIFF
--- a/Source/WebCore/html/BaseButtonInputType.cpp
+++ b/Source/WebCore/html/BaseButtonInputType.cpp
@@ -35,8 +35,11 @@
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
 #include "RenderButton.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BaseButtonInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/BaseButtonInputType.h
+++ b/Source/WebCore/html/BaseButtonInputType.h
@@ -31,11 +31,13 @@
 #pragma once
 
 #include "BaseClickableWithKeyInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 // Base of button, file, image, reset, and submit types.
 class BaseButtonInputType : public BaseClickableWithKeyInputType {
+    WTF_MAKE_TZONE_ALLOCATED(BaseButtonInputType);
 protected:
     explicit BaseButtonInputType(Type type, HTMLInputElement& element)
         : BaseClickableWithKeyInputType(type, element)

--- a/Source/WebCore/html/ButtonInputType.cpp
+++ b/Source/WebCore/html/ButtonInputType.cpp
@@ -32,8 +32,11 @@
 #include "ButtonInputType.h"
 
 #include "InputTypeNames.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ButtonInputType);
 
 const AtomString& ButtonInputType::formControlType() const
 {

--- a/Source/WebCore/html/ButtonInputType.h
+++ b/Source/WebCore/html/ButtonInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseButtonInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ButtonInputType final : public BaseButtonInputType {
+    WTF_MAKE_TZONE_ALLOCATED(ButtonInputType);
 public:
     static Ref<ButtonInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -56,8 +56,11 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UserAgentParts.h"
 #include "UserGestureIndicator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ColorInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -36,11 +36,12 @@
 #include "BaseClickableWithKeyInputType.h"
 #include "ColorChooser.h"
 #include "ColorChooserClient.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ColorInputType final : public BaseClickableWithKeyInputType, private ColorChooserClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ColorInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ColorInputType);
 public:
     static Ref<ColorInputType> create(HTMLInputElement& element)

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -59,6 +59,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FileInputType);
+
 using namespace HTMLNames;
 
 FileInputType::FileInputType(HTMLInputElement& element)

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -35,6 +35,7 @@
 #include "FileChooser.h"
 #include "FileIconLoader.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -45,6 +46,7 @@ class FileList;
 class Icon;
 
 class FileInputType final : public BaseClickableWithKeyInputType, private FileChooserClient, private FileIconLoaderClient, public CanMakeWeakPtr<FileInputType> {
+    WTF_MAKE_TZONE_ALLOCATED(FileInputType);
 public:
     static Ref<FileInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -37,9 +37,12 @@
 #include "RenderElementInlines.h"
 #include "RenderImage.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/ImageInputType.h
+++ b/Source/WebCore/html/ImageInputType.h
@@ -34,10 +34,12 @@
 
 #include "BaseButtonInputType.h"
 #include "IntPoint.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ImageInputType final : public BaseButtonInputType {
+    WTF_MAKE_TZONE_ALLOCATED(ImageInputType);
 public:
     static Ref<ImageInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/ResetInputType.cpp
+++ b/Source/WebCore/html/ResetInputType.cpp
@@ -38,8 +38,11 @@
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
 #include "LocalizedStrings.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ResetInputType);
 
 const AtomString& ResetInputType::formControlType() const
 {

--- a/Source/WebCore/html/ResetInputType.h
+++ b/Source/WebCore/html/ResetInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseButtonInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ResetInputType final : public BaseButtonInputType {
+    WTF_MAKE_TZONE_ALLOCATED(ResetInputType);
 public:
     static Ref<ResetInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/SubmitInputType.cpp
+++ b/Source/WebCore/html/SubmitInputType.cpp
@@ -40,8 +40,11 @@
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
 #include "LocalizedStrings.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SubmitInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/SubmitInputType.h
+++ b/Source/WebCore/html/SubmitInputType.h
@@ -31,10 +31,12 @@
 #pragma once
 
 #include "BaseButtonInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class SubmitInputType final : public BaseButtonInputType {
+    WTF_MAKE_TZONE_ALLOCATED(SubmitInputType);
 public:
     static Ref<SubmitInputType> create(HTMLInputElement& element)
     {


### PR DESCRIPTION
#### b85c8ab49b14414086cd0bf309b5a5ee0e18bf6a
<pre>
[TZone] Annotate subclasses of BaseClickableWithKeyInputType
<a href="https://bugs.webkit.org/show_bug.cgi?id=280359">https://bugs.webkit.org/show_bug.cgi?id=280359</a>
<a href="https://rdar.apple.com/136712793">rdar://136712793</a>

Reviewed by Yusuke Suzuki.

Added TZone annotations for the subclass tree below BaseClickableWithKeyInputType.

* Source/WebCore/html/BaseButtonInputType.cpp:
* Source/WebCore/html/BaseButtonInputType.h:
* Source/WebCore/html/ButtonInputType.cpp:
* Source/WebCore/html/ButtonInputType.h:
* Source/WebCore/html/ColorInputType.cpp:
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/html/FileInputType.cpp:
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/ImageInputType.cpp:
* Source/WebCore/html/ImageInputType.h:
* Source/WebCore/html/ResetInputType.cpp:
* Source/WebCore/html/ResetInputType.h:
* Source/WebCore/html/SubmitInputType.cpp:
* Source/WebCore/html/SubmitInputType.h:

Canonical link: <a href="https://commits.webkit.org/284289@main">https://commits.webkit.org/284289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3216de3edf3fb77b2e45b6e541f97094ddc9e021

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21533 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72955 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54873 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16884 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74637 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16508 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62358 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62400 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3975 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10531 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44063 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->