### PR TITLE
[TZone] Annotate subclasses of TrackBase

### DIFF
--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -41,8 +41,11 @@
 #include "CommonAtomStrings.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrack);
 
 const AtomString& AudioTrack::descriptionKeyword()
 {

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -30,6 +30,7 @@
 
 #include "AudioTrackPrivateClient.h"
 #include "TrackBase.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -39,6 +40,7 @@ class AudioTrackConfiguration;
 class AudioTrackList;
 
 class AudioTrack final : public MediaTrackBase, private AudioTrackPrivateClient {
+    WTF_MAKE_TZONE_ALLOCATED(AudioTrack);
 public:
     static Ref<AudioTrack> create(ScriptExecutionContext* context, AudioTrackPrivate& trackPrivate)
     {

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -33,6 +33,7 @@
 #include "TrackPrivateBase.h"
 #include "TrackPrivateBaseClient.h"
 #include <wtf/Language.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -40,6 +41,9 @@
 #if ENABLE(VIDEO)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TrackBase);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaTrackBase);
 
 static int s_uniqueId = 0;
 

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -30,6 +30,7 @@
 #include "ContextDestructionObserver.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
@@ -48,6 +49,7 @@ class TrackBase
     , private LoggerHelper
 #endif
 {
+    WTF_MAKE_TZONE_ALLOCATED(TrackBase);
 public:
     virtual ~TrackBase();
 
@@ -118,6 +120,7 @@ private:
 };
 
 class MediaTrackBase : public TrackBase {
+    WTF_MAKE_TZONE_ALLOCATED(MediaTrackBase);
 public:
     const AtomString& kind() const { return m_kind; }
     virtual void setKind(const AtomString&);

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -41,12 +41,15 @@
 #include "VideoTrackList.h"
 #include "VideoTrackPrivate.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_SOURCE)
 #include "SourceBuffer.h"
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrack);
 
 const AtomString& VideoTrack::signKeyword()
 {

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -30,6 +30,7 @@
 
 #include "TrackBase.h"
 #include "VideoTrackPrivateClient.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -42,6 +43,7 @@ class VideoTrackList;
 class VideoTrackPrivate;
 
 class VideoTrack final : public MediaTrackBase, private VideoTrackPrivateClient {
+    WTF_MAKE_TZONE_ALLOCATED(VideoTrack);
 public:
     static Ref<VideoTrack> create(ScriptExecutionContext* context, VideoTrackPrivate& trackPrivate)
     {

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -29,6 +29,7 @@
 #include "PlatformAudioTrackConfiguration.h"
 #include "TrackPrivateBase.h"
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(VIDEO)
 
@@ -37,6 +38,7 @@ namespace WebCore {
 struct AudioInfo;
 
 class AudioTrackPrivate : public TrackPrivateBase {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioTrackPrivate);
 public:
     virtual void setEnabled(bool enabled)
     {

--- a/Source/WebCore/platform/graphics/AudioTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivateClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "TrackPrivateBaseClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(VIDEO)
 
@@ -35,6 +36,7 @@ class AudioTrackPrivate;
 struct PlatformAudioTrackConfiguration;
 
 class AudioTrackPrivateClient : public TrackPrivateBaseClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioTrackPrivateClient);
 public:
     constexpr Type type() const final { return Type::Audio; }
     virtual void enabledChanged(bool) = 0;

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include "InbandTextTrackPrivateClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -38,6 +39,7 @@ enum class InbandTextTrackPrivateMode : uint8_t {
 };
 
 class InbandTextTrackPrivate : public TrackPrivateBase {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InbandTextTrackPrivate);
 public:
     enum class CueFormat : uint8_t {
         Data,

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
@@ -32,6 +32,7 @@
 #include "TrackPrivateBase.h"
 #include <wtf/JSONValues.h>
 #include <wtf/MediaTime.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(DATACUE_VALUE)
 #include "SerializedPlatformDataCue.h"
@@ -43,6 +44,7 @@ class InbandTextTrackPrivate;
 class ISOWebVTTCue;
 
 class InbandTextTrackPrivateClient : public TrackPrivateBaseClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InbandTextTrackPrivateClient);
 public:
     virtual ~InbandTextTrackPrivateClient() = default;
 

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -31,12 +31,14 @@
 #include "TrackPrivateBase.h"
 #include "VideoTrackPrivateClient.h"
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 struct VideoInfo;
 
 class VideoTrackPrivate : public TrackPrivateBase {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(VideoTrackPrivate);
 public:
     virtual void setSelected(bool selected)
     {

--- a/Source/WebCore/platform/graphics/VideoTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivateClient.h
@@ -28,12 +28,14 @@
 #if ENABLE(VIDEO)
 
 #include "TrackPrivateBaseClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 struct PlatformVideoTrackConfiguration;
 
 class VideoTrackPrivateClient : public TrackPrivateBaseClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(VideoTrackPrivateClient);
 public:
     constexpr Type type() const final { return Type::Video; }
     virtual void selectedChanged(bool) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
@@ -28,10 +28,12 @@
 #if ENABLE(VIDEO)
 
 #include "AudioTrackPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class AudioTrackPrivateAVF : public AudioTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioTrackPrivateAVF);
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateAVF)
 public:
     Kind kind() const override { return m_kind; }

--- a/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
@@ -32,11 +32,14 @@
 #include "Logging.h"
 #include "MediaPlayer.h"
 #include <CoreMedia/CoreMedia.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InbandMetadataTextTrackPrivateAVF);
 
 Ref<InbandMetadataTextTrackPrivateAVF> InbandMetadataTextTrackPrivateAVF::create(InbandTextTrackPrivate::Kind kind, TrackID id, InbandTextTrackPrivate::CueFormat cueFormat)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 #include "InbandTextTrackPrivate.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -40,6 +41,7 @@ struct IncompleteMetaDataCue {
 #endif
 
 class InbandMetadataTextTrackPrivateAVF : public InbandTextTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(InbandMetadataTextTrackPrivateAVF);
 public:
     static Ref<InbandMetadataTextTrackPrivateAVF> create(Kind, TrackID, CueFormat);
 

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -38,6 +38,7 @@
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
 #include <wtf/MediaTime.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -48,6 +49,8 @@
 #include <pal/cf/CoreMediaSoftLink.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InbandTextTrackPrivateAVF);
 
 AVFInbandTrackParent::~AVFInbandTrackParent() = default;
 

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
@@ -30,6 +30,7 @@
 
 #include "InbandTextTrackPrivate.h"
 #include "InbandTextTrackPrivateClient.h"
+#include <wtf/TZoneMalloc.h>
 
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;
 
@@ -47,6 +48,7 @@ public:
 };
 
 class InbandTextTrackPrivateAVF : public InbandTextTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(InbandTextTrackPrivateAVF);
 public:
     virtual ~InbandTextTrackPrivateAVF();
 

--- a/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
@@ -28,10 +28,12 @@
 #if ENABLE(VIDEO)
 
 #include "VideoTrackPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class VideoTrackPrivateAVF : public VideoTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(VideoTrackPrivateAVF);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateAVF)
 public:
     int trackIndex() const override { return m_index; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -30,6 +30,7 @@
 
 #include "AudioTrackPrivateAVF.h"
 #include <wtf/Observer.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVAssetTrack;
 OBJC_CLASS AVPlayerItem;
@@ -43,6 +44,7 @@ class AVTrackPrivateAVFObjCImpl;
 class MediaSelectionOptionAVFObjC;
 
 class AudioTrackPrivateAVFObjC : public AudioTrackPrivateAVF {
+    WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateAVFObjC);
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateAVFObjC)
 public:
     static RefPtr<AudioTrackPrivateAVFObjC> create(AVPlayerItemTrack* track)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -27,10 +27,13 @@
 #import "AudioTrackPrivateAVFObjC.h"
 #import "AVTrackPrivateAVFObjCImpl.h"
 #import "MediaSelectionGroupAVFObjC.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(VIDEO)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateAVFObjC);
 
 AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(AVPlayerItemTrack* track)
     : AudioTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(track))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -25,12 +25,15 @@
 
 #include "config.h"
 #include "AudioTrackPrivateMediaSourceAVFObjC.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_SOURCE)
 
 #include "AVTrackPrivateAVFObjCImpl.h"
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateMediaSourceAVFObjC);
 
 AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
     : m_impl(makeUnique<AVTrackPrivateAVFObjCImpl>(track))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AudioTrackPrivateAVF.h"
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(MEDIA_SOURCE)
 
@@ -37,6 +38,7 @@ class AVTrackPrivateAVFObjCImpl;
 class SourceBufferPrivateAVFObjC;
 
 class AudioTrackPrivateMediaSourceAVFObjC final : public AudioTrackPrivateAVF {
+    WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateMediaSourceAVFObjC);
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateMediaSourceAVFObjC)
 public:
     static Ref<AudioTrackPrivateMediaSourceAVFObjC> create(AVAssetTrack *track)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
@@ -29,6 +29,7 @@
 
 #include "InbandTextTrackPrivate.h"
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS AVTimedMetadataGroup;
@@ -37,6 +38,7 @@ OBJC_CLASS NSLocale;
 namespace WebCore {
 
 class InbandChapterTrackPrivateAVFObjC : public InbandTextTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(InbandChapterTrackPrivateAVFObjC);
 public:
     static Ref<InbandChapterTrackPrivateAVFObjC> create(RetainPtr<NSLocale> locale, TrackID trackID)
     {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
@@ -32,6 +32,7 @@
 #import "InbandTextTrackPrivateClient.h"
 #import <AVFoundation/AVMetadataItem.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/WTFString.h>
 
@@ -39,6 +40,8 @@
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InbandChapterTrackPrivateAVFObjC);
 
 InbandChapterTrackPrivateAVFObjC::InbandChapterTrackPrivateAVFObjC(RetainPtr<NSLocale> locale, TrackID trackID)
     : InbandTextTrackPrivate(CueFormat::WebVTT)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
@@ -29,6 +29,7 @@
 
 #include "InbandTextTrackPrivateAVF.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVAsset;
 OBJC_CLASS AVMediaSelectionGroup;
@@ -37,6 +38,7 @@ OBJC_CLASS AVMediaSelectionOption;
 namespace WebCore {
 
 class InbandTextTrackPrivateAVFObjC : public InbandTextTrackPrivateAVF {
+    WTF_MAKE_TZONE_ALLOCATED(InbandTextTrackPrivateAVFObjC);
 public:
     static Ref<InbandTextTrackPrivateAVFObjC> create(AVFInbandTrackParent* player,  AVMediaSelectionGroup *group, AVMediaSelectionOption *selection, TrackID trackID, InbandTextTrackPrivate::CueFormat format)
     {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
@@ -39,6 +39,7 @@
 #import <AVFoundation/AVPlayerItem.h>
 #import <AVFoundation/AVPlayerItemOutput.h>
 #import <objc/runtime.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
@@ -48,6 +49,8 @@
 @end
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InbandTextTrackPrivateAVFObjC);
 
 InbandTextTrackPrivateAVFObjC::InbandTextTrackPrivateAVFObjC(AVFInbandTrackParent* player, AVMediaSelectionGroup *group, AVMediaSelectionOption *selection, TrackID trackID, InbandTextTrackPrivate::CueFormat format)
     : InbandTextTrackPrivateAVF(player, trackID, format)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -31,8 +31,11 @@
 #import "AVTrackPrivateAVFObjCImpl.h"
 #import "MediaSelectionGroupAVFObjC.h"
 #import "PlatformVideoTrackConfiguration.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateAVFObjC);
 
 VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(AVPlayerItemTrack* track)
     : VideoTrackPrivateAVFObjC(makeUnique<AVTrackPrivateAVFObjCImpl>(track))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
@@ -30,6 +30,7 @@
 
 #include "VideoTrackPrivateAVF.h"
 #include <wtf/Observer.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVAssetTrack;
 OBJC_CLASS AVPlayerItem;
@@ -43,6 +44,7 @@ class AVTrackPrivateAVFObjCImpl;
 class MediaSelectionOptionAVFObjC;
 
 class VideoTrackPrivateAVFObjC final : public VideoTrackPrivateAVF {
+    WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateAVFObjC);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateAVFObjC)
 public:
     static RefPtr<VideoTrackPrivateAVFObjC> create(AVPlayerItemTrack* track)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
@@ -28,6 +28,7 @@
 
 #include "IntSize.h"
 #include "VideoTrackPrivateAVF.h"
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(MEDIA_SOURCE)
 
@@ -40,6 +41,7 @@ class AVTrackPrivateAVFObjCImpl;
 class SourceBufferPrivateAVFObjC;
 
 class VideoTrackPrivateMediaSourceAVFObjC final : public VideoTrackPrivateAVF {
+    WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateMediaSourceAVFObjC);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateMediaSourceAVFObjC)
 public:
     static Ref<VideoTrackPrivateMediaSourceAVFObjC> create(AVAssetTrack* track)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -31,8 +31,11 @@
 #import "AVTrackPrivateAVFObjCImpl.h"
 #import "SourceBufferPrivateAVFObjC.h"
 #import <AVFoundation/AVAssetTrack.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateMediaSourceAVFObjC);
 
 VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
     : m_impl(makeUnique<AVTrackPrivateAVFObjCImpl>(track))

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -25,12 +25,15 @@
 
 #include "config.h"
 #include "AudioTrackPrivateWebM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_SOURCE)
 
 #include "MediaSample.h"
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateWebM);
 
 Ref<AudioTrackPrivateWebM> AudioTrackPrivateWebM::create(webm::TrackEntry&& trackEntry)
 {

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
@@ -29,12 +29,14 @@
 
 #include "AudioTrackPrivate.h"
 #include <webm/dom_types.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 struct AudioInfo;
 
 class AudioTrackPrivateWebM final : public AudioTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateWebM);
 public:
     static Ref<AudioTrackPrivateWebM> create(webm::TrackEntry&&);
     virtual ~AudioTrackPrivateWebM() = default;

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -25,12 +25,15 @@
 
 #include "config.h"
 #include "VideoTrackPrivateWebM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_SOURCE)
 
 #include "MediaSample.h"
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateWebM);
 
 Ref<VideoTrackPrivateWebM> VideoTrackPrivateWebM::create(webm::TrackEntry&& trackEntry)
 {

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
@@ -29,12 +29,14 @@
 
 #include "VideoTrackPrivate.h"
 #include <webm/dom_types.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 struct VideoInfo;
 
 class VideoTrackPrivateWebM final : public VideoTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateWebM);
 public:
     static Ref<VideoTrackPrivateWebM> create(webm::TrackEntry&&);
     virtual ~VideoTrackPrivateWebM() = default;

--- a/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
@@ -29,11 +29,13 @@
 
 #include "MediaStreamTrackPrivate.h"
 #include "VideoTrackPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
 class VideoTrackPrivateMediaStream final : public VideoTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(VideoTrackPrivateMediaStream);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateMediaStream)
 public:
     static Ref<VideoTrackPrivateMediaStream> create(MediaStreamTrackPrivate& streamTrack)

--- a/Source/WebCore/platform/mock/mediasource/MockTracks.h
+++ b/Source/WebCore/platform/mock/mediasource/MockTracks.h
@@ -31,10 +31,12 @@
 #include "InbandTextTrackPrivate.h"
 #include "MockBox.h"
 #include "VideoTrackPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class MockAudioTrackPrivate : public AudioTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MockAudioTrackPrivate);
 public:
     static Ref<MockAudioTrackPrivate> create(const MockTrackBox& box) { return adoptRef(*new MockAudioTrackPrivate(box)); }
     virtual ~MockAudioTrackPrivate() = default;
@@ -52,6 +54,7 @@ protected:
 };
 
 class MockTextTrackPrivate : public InbandTextTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MockTextTrackPrivate);
 public:
     static Ref<MockTextTrackPrivate> create(const MockTrackBox& box) { return adoptRef(*new MockTextTrackPrivate(box)); }
     virtual ~MockTextTrackPrivate() = default;
@@ -71,6 +74,7 @@ protected:
 
 
 class MockVideoTrackPrivate : public VideoTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MockVideoTrackPrivate);
 public:
     static Ref<MockVideoTrackPrivate> create(const MockTrackBox& box) { return adoptRef(*new MockVideoTrackPrivate(box)); }
     virtual ~MockVideoTrackPrivate() = default;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -34,8 +34,11 @@
 #include "GPUConnectionToWebProcess.h"
 #include "MediaPlayerPrivateRemoteMessages.h"
 #include "RemoteMediaPlayerProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioTrackProxy);
 
 using namespace WebCore;
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/TrackBase.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -49,6 +50,7 @@ struct AudioTrackPrivateRemoteConfiguration;
 class RemoteAudioTrackProxy final
     : public ThreadSafeRefCounted<RemoteAudioTrackProxy, WTF::DestructionThread::Main>
     , public WebCore::AudioTrackPrivateClient {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAudioTrackProxy);
 public:
     static Ref<RemoteAudioTrackProxy> create(GPUConnectionToWebProcess& connectionToWebProcess, WebCore::AudioTrackPrivate& trackPrivate, WebCore::MediaPlayerIdentifier mediaPlayerIdentifier)
     {

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -37,8 +37,11 @@
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/ISOVTTCue.h>
 #include <WebCore/NotImplemented.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextTrackProxy);
 
 using namespace WebCore;
 

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/TrackBase.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -49,6 +50,7 @@ struct TextTrackPrivateRemoteConfiguration;
 class RemoteTextTrackProxy final
     : public ThreadSafeRefCounted<RemoteTextTrackProxy, WTF::DestructionThread::Main>
     , private WebCore::InbandTextTrackPrivateClient {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteTextTrackProxy);
 public:
     static Ref<RemoteTextTrackProxy> create(GPUConnectionToWebProcess& connectionToWebProcess, WebCore::InbandTextTrackPrivate& trackPrivate, WebCore::MediaPlayerIdentifier mediaPlayerIdentifier)
     {

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -34,8 +34,11 @@
 #include "MediaPlayerPrivateRemoteMessages.h"
 #include "RemoteMediaPlayerProxy.h"
 #include "VideoTrackPrivateRemoteConfiguration.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteVideoTrackProxy);
 
 using namespace WebCore;
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/TrackBase.h>
 #include <WebCore/VideoTrackPrivate.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -49,6 +50,7 @@ struct VideoTrackPrivateRemoteConfiguration;
 class RemoteVideoTrackProxy final
     : public ThreadSafeRefCounted<RemoteVideoTrackProxy, WTF::DestructionThread::Main>
     , private WebCore::VideoTrackPrivateClient {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteVideoTrackProxy);
 public:
     static Ref<RemoteVideoTrackProxy> create(GPUConnectionToWebProcess& connectionToWebProcess, WebCore::VideoTrackPrivate& trackPrivate, WebCore::MediaPlayerIdentifier mediaPlayerIdentifier)
     {

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
@@ -34,8 +34,11 @@
 #include "MediaPlayerPrivateRemote.h"
 #include "RemoteMediaPlayerProxyMessages.h"
 #include <wtf/CrossThreadCopier.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateRemote);
 
 AudioTrackPrivateRemote::AudioTrackPrivateRemote(GPUProcessConnection& gpuProcessConnection, WebCore::MediaPlayerIdentifier playerIdentifier, AudioTrackPrivateRemoteConfiguration&& configuration)
     : m_gpuProcessConnection(gpuProcessConnection)

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/AudioTrackPrivate.h>
 #include <WebCore/MediaPlayerIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -38,6 +39,7 @@ class MediaPlayerPrivateRemote;
 struct AudioTrackPrivateRemoteConfiguration;
 
 class AudioTrackPrivateRemote final : public WebCore::AudioTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateRemote);
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateRemote)
 public:
     static Ref<AudioTrackPrivateRemote> create(GPUProcessConnection& gpuProcessConnection, WebCore::MediaPlayerIdentifier playerIdentifier, AudioTrackPrivateRemoteConfiguration&& configuration)

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -33,8 +33,12 @@
 #include "MediaPlayerPrivateRemote.h"
 #include "RemoteMediaPlayerProxyMessages.h"
 #include <wtf/CrossThreadCopier.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextTrackPrivateRemote);
+
 using namespace WebCore;
 
 TextTrackPrivateRemote::TextTrackPrivateRemote(GPUProcessConnection& gpuProcessConnection, MediaPlayerIdentifier playerIdentifier, TextTrackPrivateRemoteConfiguration&& configuration)

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
@@ -31,6 +31,7 @@
 #include "TextTrackPrivateRemoteConfiguration.h"
 #include <WebCore/InbandTextTrackPrivate.h>
 #include <WebCore/MediaPlayerIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class InbandGenericCue;
@@ -43,6 +44,7 @@ class GPUProcessConnection;
 class MediaPlayerPrivateRemote;
 
 class TextTrackPrivateRemote final : public WebCore::InbandTextTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(TextTrackPrivateRemote);
     WTF_MAKE_NONCOPYABLE(TextTrackPrivateRemote)
 public:
 

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
@@ -34,8 +34,11 @@
 #include "RemoteMediaPlayerProxyMessages.h"
 #include "VideoTrackPrivateRemoteConfiguration.h"
 #include <wtf/CrossThreadCopier.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateRemote);
 
 VideoTrackPrivateRemote::VideoTrackPrivateRemote(GPUProcessConnection& gpuProcessConnection, WebCore::MediaPlayerIdentifier playerIdentifier, VideoTrackPrivateRemoteConfiguration&& configuration)
     : m_gpuProcessConnection(gpuProcessConnection)

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/VideoTrackPrivate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -39,6 +40,7 @@ struct VideoTrackPrivateRemoteConfiguration;
 
 class VideoTrackPrivateRemote
     : public WebCore::VideoTrackPrivate {
+    WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateRemote);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateRemote)
 public:
     static Ref<VideoTrackPrivateRemote> create(GPUProcessConnection& gpuProcessConnection, WebCore::MediaPlayerIdentifier playerIdentifier, VideoTrackPrivateRemoteConfiguration&& configuration)


### PR DESCRIPTION
#### 3223242428f4af26bf20b469f7e50c1d6196a14c
<pre>
[TZone] Annotate subclasses of TrackBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=280360">https://bugs.webkit.org/show_bug.cgi?id=280360</a>
<a href="https://rdar.apple.com/136713440">rdar://136713440</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Added TZone annotations to the subclasses below TrackBase.

* Source/WebCore/html/track/AudioTrack.cpp:
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/TrackBase.cpp:
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/VideoTrack.cpp:
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
* Source/WebCore/platform/graphics/AudioTrackPrivateClient.h:
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
* Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
* Source/WebCore/platform/graphics/VideoTrackPrivateClient.h:
* Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp:
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h:
* Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h:
* Source/WebCore/platform/mock/mediasource/MockTracks.h:
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp:
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp:
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp:
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/284312@main">https://commits.webkit.org/284312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/342ae74b1c92246080f3e147eb76b1712720c57d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20019 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13317 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12847 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62404 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15320 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3985 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44065 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45142 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->