### PR TITLE
Adopt more smart pointers in WebPageProxyCocoa.mm

### DIFF
--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -89,6 +89,7 @@ private:
 class WTF_CAPABILITY("is current") WTF_EXPORT_PRIVATE WorkQueue : public WorkQueueBase, public RefCountedSerialFunctionDispatcher {
 public:
     static WorkQueue& main();
+    static Ref<WorkQueue> protectedMain() { return main(); }
     static Ref<WorkQueue> create(ASCIILiteral name, QOS = QOS::Default);
     void dispatch(Function<void()>&&) override;
     bool isCurrent() const override;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10824,7 +10824,7 @@ static bool shouldBlockIOKit(const WebPreferences& preferences, DrawingAreaType 
 #if !PLATFORM(COCOA)
 bool WebPageProxy::useGPUProcessForDOMRenderingEnabled() const
 {
-    return preferences().useGPUProcessForDOMRenderingEnabled();
+    return protectedPreferences()->useGPUProcessForDOMRenderingEnabled();
 }
 #endif
 


### PR DESCRIPTION
#### 14f320dd03601d111ea53d4ac6d80c47d087123d
<pre>
Adopt more smart pointers in WebPageProxyCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=280362">https://bugs.webkit.org/show_bug.cgi?id=280362</a>
<a href="https://rdar.apple.com/136714038">rdar://136714038</a>

Reviewed by Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WTF/wtf/WorkQueue.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::grantAccessToCurrentPasteboardData):
(WebKit::WebPageProxy::beginSafeBrowsingCheck):
(WebKit::WebPageProxy::createSandboxExtensionsIfNeeded):
(WebKit::WebPageProxy::performDictionaryLookupAtLocation):
(WebKit::WebPageProxy::performDictionaryLookupOfCurrentSelection):
(WebKit::WebPageProxy::insertDictatedTextAsync):
(WebKit::WebPageProxy::addDictationAlternative):
(WebKit::WebPageProxy::dictationAlternativesAtSelection):
(WebKit::WebPageProxy::clearDictationAlternatives):
(WebKit::WebPageProxy::Internals::paymentCoordinatorPresentingWindow const):
(WebKit::WebPageProxy::updateFullscreenVideoTextRecognition):
(WebKit::WebPageProxy::requestThumbnail):
(WebKit::WebPageProxy::updateIconForDirectory):
(WebKit::WebPageProxy::scheduleActivityStateUpdate):
(WebKit::WebPageProxy::createAppHighlightInSelectedRange):
(WebKit::WebPageProxy::restoreAppHighlightsAndScrollToIndex):
(WebKit::WebPageProxy::setAppHighlightsVisibility):
(WebKit::WebPageProxy::requestActiveNowPlayingSessionInfo):
(WebKit::WebPageProxy::lastNavigationWasAppInitiated):
(WebKit::WebPageProxy::grantAccessToAssetServices):
(WebKit::WebPageProxy::revokeAccessToAssetServices):
(WebKit::WebPageProxy::disableURLSchemeCheckInDataDetectors const):
(WebKit::WebPageProxy::switchFromStaticFontRegistryToUserFontRegistry):
(WebKit::WebPageProxy::contentsOfUserInterfaceItem):
(WebKit::WebPageProxy::insertMultiRepresentationHEIC):
(WebKit::WebPageProxy::replaceSelectionWithPasteboardData):
(WebKit::WebPageProxy::replaceImageForRemoveBackground):
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::willBeginWritingToolsSession):
(WebKit::WebPageProxy::didBeginWritingToolsSession):
(WebKit::WebPageProxy::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion):
(WebKit::WebPageProxy::didEndWritingToolsSession):
(WebKit::WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange):
(WebKit::WebPageProxy::writingToolsSessionDidReceiveAction):
(WebKit::WebPageProxy::enableSourceTextAnimationAfterElementWithID):
(WebKit::WebPageProxy::enableTextAnimationTypeForElementWithID):
(WebKit::WebPageProxy::getTextIndicatorForID):
(WebKit::WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::WebPageProxy::intelligenceTextAnimationsDidComplete):
(WebKit::WebPageProxy::playPredominantOrNowPlayingMediaSession):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):

Canonical link: <a href="https://commits.webkit.org/284295@main">https://commits.webkit.org/284295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2602e65854ce335568cede3805163f7b4da969db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20020 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54871 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13319 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16895 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18382 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61991 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74640 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68121 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12848 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62397 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62408 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/15309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10371 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3984 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89900 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44066 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15942 "Failed to compile JSC") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->