### PR TITLE
[TZone] Annotate the XML subclasses of XPathExpression

### DIFF
--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -39,11 +39,14 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 namespace XPath {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Function);
 
 static inline bool isWhitespace(UChar c)
 {
@@ -68,6 +71,7 @@ private:
 };
 
 class FunLast final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunLast);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 public:
@@ -75,6 +79,7 @@ public:
 };
 
 class FunPosition final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunPosition);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 public:
@@ -82,16 +87,19 @@ public:
 };
 
 class FunCount final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunCount);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunId final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunId);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::NodeSet; }
 };
 
 class FunLocalName final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunLocalName);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 public:
@@ -99,6 +107,7 @@ public:
 };
 
 class FunNamespaceURI final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNamespaceURI);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 public:
@@ -106,6 +115,7 @@ public:
 };
 
 class FunName final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunName);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 public:
@@ -113,6 +123,7 @@ public:
 };
 
 class FunString final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunString);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 public:
@@ -120,36 +131,43 @@ public:
 };
 
 class FunConcat final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunConcat);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunStartsWith final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunStartsWith);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunContains final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunContains);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunSubstringBefore final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSubstringBefore);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunSubstringAfter final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSubstringAfter);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunSubstring final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSubstring);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunStringLength final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunStringLength);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 public:
@@ -157,6 +175,7 @@ public:
 };
 
 class FunNormalizeSpace final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNormalizeSpace);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 public:
@@ -164,31 +183,37 @@ public:
 };
 
 class FunTranslate final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunTranslate);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunBoolean final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunBoolean);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunNot : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNot);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunTrue final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunTrue);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunFalse final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunFalse);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunLang final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunLang);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Boolean; }
 public:
@@ -196,6 +221,7 @@ public:
 };
 
 class FunNumber final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNumber);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 public:
@@ -203,21 +229,25 @@ public:
 };
 
 class FunSum final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSum);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunFloor final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunFloor);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunCeiling final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunCeiling);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunRound final : public Function {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunRound);
     Value evaluate() const override;
     Value::Type resultType() const override { return Value::Type::Number; }
 public:

--- a/Source/WebCore/xml/XPathFunctions.h
+++ b/Source/WebCore/xml/XPathFunctions.h
@@ -27,11 +27,13 @@
 #pragma once
 
 #include "XPathExpressionNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 namespace XPath {
 
 class Function : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(Function);
 public:
     static std::unique_ptr<Function> create(const String& name);
     static std::unique_ptr<Function> create(const String& name, Vector<std::unique_ptr<Expression>> arguments);

--- a/Source/WebCore/xml/XPathPath.cpp
+++ b/Source/WebCore/xml/XPathPath.cpp
@@ -31,9 +31,15 @@
 #include "Document.h"
 #include "XPathPredicate.h"
 #include "XPathStep.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace XPath {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Filter);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocationPath);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Path);
+
         
 Filter::Filter(std::unique_ptr<Expression> expression, Vector<std::unique_ptr<Expression>> predicates)
     : m_expression(WTFMove(expression)), m_predicates(WTFMove(predicates))

--- a/Source/WebCore/xml/XPathPath.h
+++ b/Source/WebCore/xml/XPathPath.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "XPathExpressionNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 namespace XPath {
@@ -34,6 +35,7 @@ namespace XPath {
 class Step;
 
 class Filter final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(Filter);
 public:
     Filter(std::unique_ptr<Expression>, Vector<std::unique_ptr<Expression>> predicates);
 
@@ -46,6 +48,7 @@ private:
 };
 
 class LocationPath final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(LocationPath);
 public:
     LocationPath();
 
@@ -65,6 +68,7 @@ private:
 };
 
 class Path final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(Path);
 public:
     Path(std::unique_ptr<Expression> filter, std::unique_ptr<LocationPath>);
 

--- a/Source/WebCore/xml/XPathPredicate.cpp
+++ b/Source/WebCore/xml/XPathPredicate.cpp
@@ -33,10 +33,19 @@
 #include <math.h>
 #include <wtf/MathExtras.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace XPath {
-        
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Number);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StringExpression);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Negative);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NumericOp);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EqTestOp);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LogicalOp);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Union);
+
 Number::Number(double value)
     : m_value(value)
 {

--- a/Source/WebCore/xml/XPathPredicate.h
+++ b/Source/WebCore/xml/XPathPredicate.h
@@ -27,11 +27,13 @@
 #pragma once
 
 #include "XPathExpressionNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 namespace XPath {
 
 class Number final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(Number);
 public:
     explicit Number(double);
 
@@ -43,6 +45,7 @@ private:
 };
 
 class StringExpression final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(StringExpression);
 public:
     explicit StringExpression(String&&);
 
@@ -54,6 +57,7 @@ private:
 };
 
 class Negative final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(Negative);
 public:
     explicit Negative(std::unique_ptr<Expression>);
 
@@ -63,6 +67,7 @@ private:
 };
 
 class NumericOp final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(NumericOp);
 public:
     enum Opcode { OP_Add, OP_Sub, OP_Mul, OP_Div, OP_Mod };
     NumericOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
@@ -75,6 +80,7 @@ private:
 };
 
 class EqTestOp final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(EqTestOp);
 public:
     enum Opcode { OP_EQ, OP_NE, OP_GT, OP_LT, OP_GE, OP_LE };
     EqTestOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
@@ -88,6 +94,7 @@ private:
 };
 
 class LogicalOp final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(LogicalOp);
 public:
     enum Opcode { OP_And, OP_Or };
     LogicalOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
@@ -101,6 +108,7 @@ private:
 };
 
 class Union final : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(Union);
 public:
     Union(std::unique_ptr<Expression>, std::unique_ptr<Expression>);
 

--- a/Source/WebCore/xml/XPathVariableReference.cpp
+++ b/Source/WebCore/xml/XPathVariableReference.cpp
@@ -26,11 +26,13 @@
 
 #include "config.h"
 #include "XPathVariableReference.h"
-
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace XPath {
-    
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VariableReference);
+
 VariableReference::VariableReference(const String& name)
     : m_name(name)
 {

--- a/Source/WebCore/xml/XPathVariableReference.h
+++ b/Source/WebCore/xml/XPathVariableReference.h
@@ -27,12 +27,14 @@
 #pragma once
 
 #include "XPathExpressionNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 namespace XPath {
 
 // Variable references are not used with XPathEvaluator.
 class VariableReference : public Expression {
+    WTF_MAKE_TZONE_ALLOCATED(VariableReference);
 public:
     explicit VariableReference(const String& name);
 private:


### PR DESCRIPTION
#### 7799a8e94a6ded765354bfb5dc72af4321764bbb
<pre>
[TZone] Annotate the XML subclasses of XPathExpression
<a href="https://bugs.webkit.org/show_bug.cgi?id=280361">https://bugs.webkit.org/show_bug.cgi?id=280361</a>
<a href="https://rdar.apple.com/136713956">rdar://136713956</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Added TZone annotations to the classes that inherit from XPathExpression.

* Source/WebCore/xml/XPathFunctions.cpp:
* Source/WebCore/xml/XPathFunctions.h:
* Source/WebCore/xml/XPathPath.cpp:
* Source/WebCore/xml/XPathPath.h:
* Source/WebCore/xml/XPathPredicate.cpp:
* Source/WebCore/xml/XPathPredicate.h:
* Source/WebCore/xml/XPathVariableReference.cpp:
* Source/WebCore/xml/XPathVariableReference.h:

Canonical link: <a href="https://commits.webkit.org/284327@main">https://commits.webkit.org/284327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f843a4f74733c93b29b8316cf62220c6450fb69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35344 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18383 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74641 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12849 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62620 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62403 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3990 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44067 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45144 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->