### PR TITLE
[TZone] Annotate the class subtree that inherits from ScrollingTreeNode

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
@@ -36,9 +36,12 @@
 #include "ScrollingTreeOverflowScrollingNode.h"
 #include "ScrollingTreePositionedNode.h"
 #include "ScrollingTreeStickyNode.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFixedNode);
 
 ScrollingTreeFixedNode::ScrollingTreeFixedNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Fixed, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
@@ -31,12 +31,14 @@
 #include "ScrollingPlatformLayer.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class FixedPositionViewportConstraints;
 
 class ScrollingTreeFixedNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeFixedNode);
 public:
     virtual ~ScrollingTreeFixedNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -32,9 +32,12 @@
 #include "ScrollingStateFrameHostingNode.h"
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameHostingNode);
 
 Ref<ScrollingTreeFrameHostingNode> ScrollingTreeFrameHostingNode::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
 {

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -28,12 +28,14 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTree;
 
 class ScrollingTreeFrameHostingNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeFrameHostingNode, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreeFrameHostingNode> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreeFrameHostingNode();

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
@@ -33,9 +33,12 @@
 #include "ScrollingStateFrameScrollingNode.h"
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameScrollingNode);
 
 ScrollingTreeFrameScrollingNode::ScrollingTreeFrameScrollingNode(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
     : ScrollingTreeScrollingNode(scrollingTree, nodeType, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -28,6 +28,7 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeScrollingNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,6 +36,7 @@ class PlatformWheelEvent;
 class ScrollingTree;
 
 class WEBCORE_EXPORT ScrollingTreeFrameScrollingNode : public ScrollingTreeScrollingNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeFrameScrollingNode, WEBCORE_EXPORT);
 public:
     virtual ~ScrollingTreeFrameScrollingNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -32,8 +32,11 @@
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeOverflowScrollingNode.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeOverflowScrollProxyNode);
 
 ScrollingTreeOverflowScrollProxyNode::ScrollingTreeOverflowScrollProxyNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, ScrollingNodeType::OverflowProxy, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.h
@@ -29,10 +29,12 @@
 
 #include "ScrollingPlatformLayer.h"
 #include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreeOverflowScrollProxyNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeOverflowScrollProxyNode, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT virtual ~ScrollingTreeOverflowScrollProxyNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.cpp
@@ -30,9 +30,12 @@
 
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeOverflowScrollingNode);
 
 ScrollingTreeOverflowScrollingNode::ScrollingTreeOverflowScrollingNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeScrollingNode(scrollingTree, ScrollingNodeType::Overflow, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.h
@@ -28,10 +28,12 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeScrollingNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreeOverflowScrollingNode : public ScrollingTreeScrollingNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeOverflowScrollingNode, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT virtual ~ScrollingTreeOverflowScrollingNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.cpp
@@ -32,9 +32,12 @@
 #include "ScrollingStatePluginHostingNode.h"
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreePluginHostingNode);
 
 Ref<ScrollingTreePluginHostingNode> ScrollingTreePluginHostingNode::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
 {

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h
@@ -28,12 +28,14 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTree;
 
 class ScrollingTreePluginHostingNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreePluginHostingNode, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreePluginHostingNode> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreePluginHostingNode();

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.cpp
@@ -33,9 +33,12 @@
 #include "ScrollingStatePluginScrollingNode.h"
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreePluginScrollingNode);
 
 ScrollingTreePluginScrollingNode::ScrollingTreePluginScrollingNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeScrollingNode(scrollingTree, ScrollingNodeType::PluginScrolling, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h
@@ -28,6 +28,7 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeScrollingNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,6 +36,7 @@ class PlatformWheelEvent;
 class ScrollingTree;
 
 class WEBCORE_EXPORT ScrollingTreePluginScrollingNode : public ScrollingTreeScrollingNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreePluginScrollingNode, WEBCORE_EXPORT);
 public:
     virtual ~ScrollingTreePluginScrollingNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
@@ -33,9 +33,12 @@
 #include "ScrollingTree.h"
 #include "ScrollingTreeOverflowScrollingNode.h"
 #include "ScrollingTreeScrollingNode.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreePositionedNode);
 
 ScrollingTreePositionedNode::ScrollingTreePositionedNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Positioned, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h
@@ -30,10 +30,12 @@
 #include "ScrollingConstraints.h"
 #include "ScrollingPlatformLayer.h"
 #include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreePositionedNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreePositionedNode);
 public:
     virtual ~ScrollingTreePositionedNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -37,9 +37,12 @@
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeScrollingNodeDelegate.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeScrollingNode);
 
 ScrollingTreeScrollingNode::ScrollingTreeScrollingNode(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, nodeType, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -32,6 +32,7 @@
 #include "ScrollableArea.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -46,6 +47,7 @@ struct ScrollPropagationInfo {
 };
 
 class WEBCORE_EXPORT ScrollingTreeScrollingNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeScrollingNode, WEBCORE_EXPORT);
     friend class ScrollingTreeScrollingNodeDelegate;
 #if PLATFORM(MAC)
     friend class ScrollingTreeScrollingNodeDelegateMac;

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -38,9 +38,12 @@
 #include "ScrollingTreeFrameScrollingNode.h"
 #include "ScrollingTreeOverflowScrollProxyNode.h"
 #include "ScrollingTreeOverflowScrollingNode.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeStickyNode);
 
 ScrollingTreeStickyNode::ScrollingTreeStickyNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
     : ScrollingTreeNode(scrollingTree, ScrollingNodeType::Sticky, nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -34,10 +34,12 @@
 #include "ScrollingPlatformLayer.h"
 #include "ScrollingTreeNode.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreeStickyNode : public ScrollingTreeNode {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeStickyNode);
 public:
     virtual ~ScrollingTreeStickyNode();
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -29,12 +29,14 @@
 
 #include "ScrollingTreeFixedNode.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS CALayer;
 
 namespace WebCore {
 
 class ScrollingTreeFixedNodeCocoa : public ScrollingTreeFixedNode {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeFixedNodeCocoa);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreeFixedNodeCocoa> create(ScrollingTree&, ScrollingNodeID);
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -32,9 +32,12 @@
 #import "ScrollingStateFixedNode.h"
 #import "ScrollingThread.h"
 #import "WebCoreCALayerExtras.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFixedNodeCocoa);
 
 Ref<ScrollingTreeFixedNodeCocoa> ScrollingTreeFixedNodeCocoa::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
 {

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
@@ -28,10 +28,12 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeOverflowScrollProxyNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreeOverflowScrollProxyNodeCocoa : public ScrollingTreeOverflowScrollProxyNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeOverflowScrollProxyNodeCocoa, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreeOverflowScrollProxyNodeCocoa> create(ScrollingTree&, ScrollingNodeID);
     WEBCORE_EXPORT virtual ~ScrollingTreeOverflowScrollProxyNodeCocoa();

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
@@ -31,8 +31,11 @@
 #import "ScrollingStateOverflowScrollProxyNode.h"
 #import "ScrollingStateTree.h"
 #import "WebCoreCALayerExtras.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeOverflowScrollProxyNodeCocoa);
 
 Ref<ScrollingTreeOverflowScrollProxyNodeCocoa> ScrollingTreeOverflowScrollProxyNodeCocoa::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
 {

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
@@ -29,10 +29,12 @@
 
 #include "ScrollingTreePositionedNode.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreePositionedNodeCocoa : public ScrollingTreePositionedNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreePositionedNodeCocoa, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreePositionedNodeCocoa> create(ScrollingTree&, ScrollingNodeID);
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
@@ -31,8 +31,11 @@
 #import "Logging.h"
 #import "ScrollingStatePositionedNode.h"
 #import "WebCoreCALayerExtras.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreePositionedNodeCocoa);
 
 Ref<ScrollingTreePositionedNodeCocoa> ScrollingTreePositionedNodeCocoa::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
 {

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -31,10 +31,12 @@
 #include "ScrollingTree.h"
 #include "ScrollingTreeStickyNode.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingTreeStickyNodeCocoa : public ScrollingTreeStickyNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeStickyNodeCocoa, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<ScrollingTreeStickyNodeCocoa> create(ScrollingTree&, ScrollingNodeID);
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -33,9 +33,12 @@
 #import "ScrollingThread.h"
 #import "ScrollingTree.h"
 #import "WebCoreCALayerExtras.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeStickyNodeCocoa);
 
 Ref<ScrollingTreeStickyNodeCocoa> ScrollingTreeStickyNodeCocoa::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
 {

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -32,6 +32,7 @@
 #include "ScrollingTreeFrameScrollingNode.h"
 #include "ScrollingTreeScrollingNodeDelegateMac.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS CALayer;
 
@@ -40,6 +41,7 @@ namespace WebCore {
 class ScrollingTreeScrollingNodeDelegateMac;
 
 class WEBCORE_EXPORT ScrollingTreeFrameScrollingNodeMac : public ScrollingTreeFrameScrollingNode {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeFrameScrollingNodeMac, WEBCORE_EXPORT);
 public:
     static Ref<ScrollingTreeFrameScrollingNode> create(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
     virtual ~ScrollingTreeFrameScrollingNodeMac();

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -42,10 +42,13 @@
 #import "WebCoreCALayerExtras.h"
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/Deque.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameScrollingNodeMac);
 
 Ref<ScrollingTreeFrameScrollingNode> ScrollingTreeFrameScrollingNodeMac::create(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -30,12 +30,14 @@
 OBJC_CLASS WKBaseScrollView;
 
 #include <WebCore/ScrollingTreeFrameScrollingNode.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ScrollingTreeScrollingNodeDelegateIOS;
 
 class ScrollingTreeFrameScrollingNodeRemoteIOS : public WebCore::ScrollingTreeFrameScrollingNode {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeFrameScrollingNodeRemoteIOS);
 public:
     static Ref<ScrollingTreeFrameScrollingNodeRemoteIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeFrameScrollingNodeRemoteIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -33,8 +33,12 @@
 #import <WebCore/ScrollingStateScrollingNode.h>
 #import <WebCore/ScrollingTree.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameScrollingNodeRemoteIOS);
+
 using namespace WebCore;
 
 Ref<ScrollingTreeFrameScrollingNodeRemoteIOS> ScrollingTreeFrameScrollingNodeRemoteIOS::create(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -25,12 +25,16 @@
 
 #include "config.h"
 #include "ScrollingTreeFrameScrollingNodeRemoteMac.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include "RemoteScrollingTree.h"
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameScrollingNodeRemoteMac);
+
 using namespace WebCore;
 
 ScrollingTreeFrameScrollingNodeRemoteMac::ScrollingTreeFrameScrollingNodeRemoteMac(ScrollingTree& tree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -28,12 +28,14 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include <WebCore/ScrollingTreeFrameScrollingNodeMac.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ScrollerPairMac;
 
 class ScrollingTreeFrameScrollingNodeRemoteMac : public WebCore::ScrollingTreeFrameScrollingNodeMac {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeFrameScrollingNodeRemoteMac);
 public:
     static Ref<ScrollingTreeFrameScrollingNodeRemoteMac> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeFrameScrollingNodeRemoteMac();


### PR DESCRIPTION
#### 4343122d150e407f37f8a3cd37a5d74017bcbd8c
<pre>
[TZone] Annotate the class subtree that inherits from ScrollingTreeNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=280363">https://bugs.webkit.org/show_bug.cgi?id=280363</a>
<a href="https://rdar.apple.com/136714668">rdar://136714668</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Added TZone annotations to the class hierarchy that inherits from ScrollingTreeNode.

* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:

Canonical link: <a href="https://commits.webkit.org/284317@main">https://commits.webkit.org/284317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12ba83331a96c1a376cb31ab42dc3f357f1f2ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16898 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12852 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62363 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15319 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3987 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44070 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45147 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->