### PR TITLE
[TZone] Add TZone annotations to the platform classes for device motion, scrolling and orientation

### DIFF
--- a/Source/WebCore/dom/DeviceMotionClient.h
+++ b/Source/WebCore/dom/DeviceMotionClient.h
@@ -36,6 +36,7 @@ class DeviceMotionData;
 class Page;
 
 class DeviceMotionClient : public DeviceClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DeviceMotionClient);
     WTF_MAKE_NONCOPYABLE(DeviceMotionClient);
 public:
     DeviceMotionClient() = default;

--- a/Source/WebCore/dom/DeviceOrientationClient.h
+++ b/Source/WebCore/dom/DeviceOrientationClient.h
@@ -29,6 +29,7 @@
 #include "DeviceClient.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -37,6 +38,7 @@ class DeviceOrientationData;
 class Page;
 
 class DeviceOrientationClient : public DeviceClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DeviceOrientationClient);
     WTF_MAKE_NONCOPYABLE(DeviceOrientationClient);
 public:
     DeviceOrientationClient() = default;

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
@@ -33,12 +33,14 @@
 #include "DeviceOrientationUpdateProvider.h"
 #include "MotionManagerClient.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WebCoreMotionManager;
 
 namespace WebCore {
 
 class DeviceMotionClientIOS : public DeviceMotionClient, public MotionManagerClient {
+    WTF_MAKE_TZONE_ALLOCATED(DeviceMotionClientIOS);
 public:
     DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceMotionClientIOS() override;

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
@@ -28,10 +28,13 @@
 #import "DeviceMotionClientIOS.h"
 
 #import "WebCoreMotionManager.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceMotionClientIOS);
 
 DeviceMotionClientIOS::DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvider>&& deviceOrientationUpdateProvider)
     : DeviceMotionClient()

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
@@ -33,12 +33,14 @@
 #include "DeviceOrientationUpdateProvider.h"
 #include "MotionManagerClient.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WebCoreMotionManager;
 
 namespace WebCore {
 
 class DeviceOrientationClientIOS : public DeviceOrientationClient, public MotionManagerClient {
+    WTF_MAKE_TZONE_ALLOCATED(DeviceOrientationClientIOS);
 public:
     DeviceOrientationClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceOrientationClientIOS() override;

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
@@ -28,10 +28,13 @@
 #import "DeviceOrientationClientIOS.h"
 
 #import "WebCoreMotionManager.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationClientIOS);
 
 DeviceOrientationClientIOS::DeviceOrientationClientIOS(RefPtr<DeviceOrientationUpdateProvider>&& deviceOrientationUpdateProvider)
     : DeviceOrientationClient()

--- a/Source/WebCore/platform/ios/MotionManagerClient.h
+++ b/Source/WebCore/platform/ios/MotionManagerClient.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -41,6 +42,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MotionManage
 namespace WebCore {
 
 class MotionManagerClient : public CanMakeWeakPtr<MotionManagerClient> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MotionManagerClient);
 public:
     virtual ~MotionManagerClient() { };
 

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.h
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.h
@@ -30,12 +30,14 @@
 #include "ScrollAnimator.h"
 
 #include "IntPoint.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class PlatformTouchEvent;
 
 class ScrollAnimatorIOS : public ScrollAnimator {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimatorIOS);
 public:
     ScrollAnimatorIOS(ScrollableArea&);
     virtual ~ScrollAnimatorIOS();

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -32,12 +32,15 @@
 #import "RenderLayer.h"
 #import "ScrollableArea.h"
 #import "ScrollingEffectsController.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(TOUCH_EVENTS)
 #import "PlatformTouchEventIOS.h"
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimatorIOS);
 
 std::unique_ptr<ScrollAnimator> ScrollAnimator::create(ScrollableArea& scrollableArea)
 {

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.h
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.h
@@ -32,12 +32,14 @@
 #include "FloatSize.h"
 #include "ScrollAnimator.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Scrollbar;
 
 class ScrollAnimatorMac final : public ScrollAnimator {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimatorMac);
 public:
     ScrollAnimatorMac(ScrollableArea&);
     virtual ~ScrollAnimatorMac();

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
@@ -35,9 +35,12 @@
 #import "ScrollView.h"
 #import "ScrollableArea.h"
 #import "ScrollbarsController.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimatorMac);
 
 std::unique_ptr<ScrollAnimator> ScrollAnimator::create(ScrollableArea& scrollableArea)
 {

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
@@ -27,8 +27,11 @@
 #include "DeviceOrientationClientMock.h"
 
 #include "DeviceOrientationController.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationClientMock);
 
 DeviceOrientationClientMock::DeviceOrientationClientMock()
     : m_controller(0)

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -31,6 +31,7 @@
 #include "Timer.h"
 
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -40,6 +41,7 @@ class DeviceOrientationController;
 // DumpRenderTree. Embedders should should configure the Page object to use this
 // client when running DumpRenderTree.
 class DeviceOrientationClientMock : public DeviceOrientationClient {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(DeviceOrientationClientMock, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT DeviceOrientationClientMock();
 


### PR DESCRIPTION
#### 5d40aae3f7f862af44e8868fd4d77a95790d5335
<pre>
[TZone] Add TZone annotations to the platform classes for device motion, scrolling and orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=280367">https://bugs.webkit.org/show_bug.cgi?id=280367</a>
<a href="https://rdar.apple.com/136715489">rdar://136715489</a>

Reviewed by Yusuke Suzuki.

Added TZone annotations for the device classes that inherit from DeviceClient.

* Source/WebCore/dom/DeviceMotionClient.h:
* Source/WebCore/dom/DeviceOrientationClient.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.mm:
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.h:
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm:
* Source/WebCore/platform/ios/MotionManagerClient.h:
* Source/WebCore/platform/ios/ScrollAnimatorIOS.h:
* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:
* Source/WebCore/platform/mac/ScrollAnimatorMac.h:
* Source/WebCore/platform/mac/ScrollAnimatorMac.mm:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:

Canonical link: <a href="https://commits.webkit.org/284363@main">https://commits.webkit.org/284363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60cfbd977800053739ee625db57fd339ef4008b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54998 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13444 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17084 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18633 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10546 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4156 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44305 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46574 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->