### PR TITLE
[TZone] Annotate subclasses in GPU and UI process code

### DIFF
--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -35,6 +35,7 @@
 #include "GeometryUtilities.h"
 #include <math.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -44,6 +45,7 @@ public:
     FloatPointGraph() = default;
 
     class Node : public FloatPoint {
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(Node);
         WTF_MAKE_NONCOPYABLE(Node);
     public:
         Node(FloatPoint point)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteMediaPlayerProxy.h"
 #include <WebCore/ResourceError.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaResourceLoader);
 
 using namespace WebCore;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
@@ -30,6 +30,7 @@
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
 
@@ -39,6 +40,7 @@ class RemoteMediaPlayerProxy;
 
 class RemoteMediaResourceLoader final
     : public WebCore::PlatformMediaResourceLoader {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaResourceLoader);
 public:
     static Ref<RemoteMediaResourceLoader> create(RemoteMediaPlayerProxy& proxy) { return adoptRef(*new RemoteMediaResourceLoader(proxy)); }
     ~RemoteMediaResourceLoader();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -62,6 +62,7 @@
 #import <WebCore/ServiceWorkerClientData.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
@@ -81,6 +82,7 @@
 @end
 
 class WebsiteDataStoreClient final : public WebKit::WebsiteDataStoreClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebsiteDataStoreClient);
 public:
     WebsiteDataStoreClient(WKWebsiteDataStore *dataStore, id<_WKWebsiteDataStoreDelegate> delegate)
         : m_dataStore(dataStore)

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.h
@@ -29,6 +29,7 @@
 #import "LegacyCustomProtocolID.h"
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKCustomProtocolLoader;
 
@@ -41,6 +42,7 @@ namespace WebKit {
 class LegacyCustomProtocolManagerProxy;
 
 class LegacyCustomProtocolManagerClient final : public API::CustomProtocolManagerClient {
+    WTF_MAKE_TZONE_ALLOCATED(LegacyCustomProtocolManagerClient);
 public:
     void startLoading(LegacyCustomProtocolManagerProxy&, LegacyCustomProtocolID, const WebCore::ResourceRequest&) final;
     void stopLoading(LegacyCustomProtocolManagerProxy&, LegacyCustomProtocolID) final;

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
@@ -31,6 +31,7 @@
 #import <WebCore/ResourceError.h>
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/ResourceResponse.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 @interface WKCustomProtocolLoader : NSObject <NSURLConnectionDelegate> {
@@ -136,6 +137,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 @end
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyCustomProtocolManagerClient);
+
 using namespace WebCore;
 
 void LegacyCustomProtocolManagerClient::startLoading(LegacyCustomProtocolManagerProxy& manager, WebKit::LegacyCustomProtocolID customProtocolID, const ResourceRequest& coreRequest)

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -57,6 +57,7 @@ ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessAssertion);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessAndUIAssertion);
 
 void ProcessAssertion::aquireAssertion(Mode mode, CompletionHandler<void()>&& acquisisionHandler)
 {

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -132,6 +132,7 @@ private:
 };
 
 class ProcessAndUIAssertion final : public ProcessAssertion {
+    WTF_MAKE_TZONE_ALLOCATED(ProcessAndUIAssertion);
 public:
     static Ref<ProcessAndUIAssertion> create(AuxiliaryProcessProxy& process, const String& reason, ProcessAssertionType type, Mode mode = Mode::Async, CompletionHandler<void()>&& acquisisionHandler = nullptr)
     {


### PR DESCRIPTION
#### b593a15b2986f0765de6817afebbe57814e59e98
<pre>
[TZone] Annotate subclasses in GPU and UI process code
<a href="https://bugs.webkit.org/show_bug.cgi?id=280369">https://bugs.webkit.org/show_bug.cgi?id=280369</a>
<a href="https://rdar.apple.com/136716073">rdar://136716073</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Added annotations to GPU and UI process code found while testing on iOS.
Also added a TZone annotation to the nested class FloatPointGraph::Node in PathUtilities.cpp.

* Source/WebCore/platform/graphics/PathUtilities.cpp:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.h:
* Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm:
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
* Source/WebKit/UIProcess/ProcessAssertion.h:

Canonical link: <a href="https://commits.webkit.org/284314@main">https://commits.webkit.org/284314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e257eca3d40045f198ebc7dad9c35adcbc33b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54880 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13326 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74648 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12856 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62412 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15318 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3994 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44074 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->