### PR TITLE
Adopt more smart pointers in WebPageProxyMac.mm

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
@@ -46,19 +46,24 @@ void WebPageProxyMessageReceiverRegistration::startReceivingMessages(WebProcessP
 void WebPageProxyMessageReceiverRegistration::stopReceivingMessages()
 {
     if (auto data = std::exchange(m_data, std::nullopt))
-        data->process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
+        data->protectedProcess()->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
 }
 
 void WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom(WebPageProxyMessageReceiverRegistration& oldRegistration, IPC::MessageReceiver& newReceiver)
 {
     ASSERT(!m_data);
     if (auto data = std::exchange(oldRegistration.m_data, std::nullopt)) {
-        data->process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
+        data->protectedProcess()->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
         startReceivingMessages(data->process, data->webPageID, newReceiver);
     } else {
         stopReceivingMessages();
         ASSERT_NOT_REACHED();
     }
+}
+
+Ref<WebProcessProxy> WebPageProxyMessageReceiverRegistration::Data::protectedProcess()
+{
+    return process;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h
@@ -45,6 +45,8 @@ private:
     struct Data {
         WebCore::PageIdentifier webPageID;
         Ref<WebProcessProxy> process;
+
+        Ref<WebProcessProxy> protectedProcess();
     };
     std::optional<Data> m_data;
 };

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -80,7 +80,7 @@ void WebPageProxyTesting::setDefersLoading(bool defersLoading)
 
 void WebPageProxyTesting::dispatchActivityStateUpdate()
 {
-    RunLoop::current().dispatch([protectedPage = protectedPage()] {
+    RunLoop::protectedCurrent()->dispatch([protectedPage = protectedPage()] {
         protectedPage->updateActivityState();
         protectedPage->dispatchActivityStateChange();
     });

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -750,7 +750,7 @@ void WebPageProxy::registerWebProcessAccessibilityToken(std::span<const uint8_t>
 {
     // Note: The WebFrameProxy with this FrameIdentifier might not exist in the UI process. See rdar://130998804.
     if (RefPtr pageClient = this->pageClient())
-        pageClient->accessibilityWebProcessTokenReceived(data, legacyMainFrameProcess().connection().remoteProcessID());
+        pageClient->accessibilityWebProcessTokenReceived(data, protectedLegacyMainFrameProcess()->protectedConnection()->remoteProcessID());
 }
 
 void WebPageProxy::relayAccessibilityNotification(const String& notificationName, std::span<const uint8_t> data)


### PR DESCRIPTION
#### d7e96fa0c746a0c4e5f945a21158603041e4c17c
<pre>
Adopt more smart pointers in WebPageProxyMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=280372">https://bugs.webkit.org/show_bug.cgi?id=280372</a>
<a href="https://rdar.apple.com/136716929">rdar://136716929</a>

Reviewed by Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp:
(WebKit::WebPageProxyMessageReceiverRegistration::stopReceivingMessages):
(WebKit::WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom):
(WebKit::WebPageProxyMessageReceiverRegistration::Data::protectedProcess):
* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::dispatchActivityStateUpdate):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::windowAndViewFramesChanged):
(WebKit::WebPageProxy::setMainFrameIsScrollable):
(WebKit::WebPageProxy::attributedSubstringForCharacterRangeAsync):
(WebKit::WebPageProxy::stringSelectionForPasteboard):
(WebKit::WebPageProxy::dataSelectionForPasteboard):
(WebKit::WebPageProxy::readSelectionFromPasteboard):
(WebKit::WebPageProxy::setSmartInsertDeleteEnabled):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::semanticContextDidChange):
(WebKit::WebPageProxy::registerUIProcessAccessibilityTokens):
(WebKit::WebPageProxy::shouldDelayWindowOrderingForEvent):
(WebKit::WebPageProxy::acceptsFirstMouse):
(WebKit::WebPageProxy::platformWindow):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::activeContextMenu const):
(WebKit::WebPageProxy::Internals::platformView const):
(WebKit::WebPageProxy::pdfZoomIn):
(WebKit::WebPageProxy::pdfZoomOut):
(WebKit::WebPageProxy::pdfSaveToPDF):
(WebKit::WebPageProxy::pdfOpenWithPreview):
(WebKit::WebPageProxy::handleContextMenuLookUpImage):
(WebKit::WebPageProxy::handleContextMenuCopySubject):

Canonical link: <a href="https://commits.webkit.org/284309@main">https://commits.webkit.org/284309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb218e863a98569f367546f3a9c9b44610db9231

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21547 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72965 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40765 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62414 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15315 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3991 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44077 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->