### PR TITLE
[WPE][GTK] Handle EINTR in recvmsg() in IPC socket on Linux

### DIFF
--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -634,7 +634,12 @@ pid_t readPIDFromPeer(int socket)
     message.msg_control = controlMessage.buffer;
     message.msg_controllen = controlLength;
 
-    if (recvmsg(socket, &message, 0) == -1)
+    int ret = 0;
+    do {
+        ret = recvmsg(socket, &message, 0);
+    } while (ret == -1 && errno == EINTR);
+
+    if (ret == -1)
         g_error("readPIDFromPeer: Failed to read pid from PID socket: %s", g_strerror(errno));
 
     if (message.msg_controllen <= 0)


### PR DESCRIPTION
#### 57a73ac7aa737d6fc8364eb591060f885923ee41
<pre>
[WPE][GTK] Handle EINTR in recvmsg() in IPC socket on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=280366">https://bugs.webkit.org/show_bug.cgi?id=280366</a>

Reviewed by Adrian Perez de Castro.

recvmsg() may fail with EINTR in case it is interrupted by a signal.
In the referred bug this happens due to a child process exiting (with a
zero exit code indicating success). This causes SIGCHLD signal which
just happens to occur during the time recvmsg was waiting for a message.
As recvmsg invocation has no handling for EINTR it will fail, bringing
down whole application with it.

Handling EINTR in a while loop is a canonical solution used in
many places across WebKit codebase already.

* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::readPIDFromPeer):

Canonical link: <a href="https://commits.webkit.org/284274@main">https://commits.webkit.org/284274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56343d485f9bed780487bf72292d5e61a47311fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40773 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62459 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59563 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62416 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3996 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44083 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->