### PR TITLE
Upstream proxy config additions to WebKit's Swift overlay

### DIFF
--- a/Source/WebKit/SwiftOverlay/WebKitSwiftOverlay.xcodeproj/project.pbxproj
+++ b/Source/WebKit/SwiftOverlay/WebKitSwiftOverlay.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		516A9BFB2A00A626006C9125 /* WebKitSwiftOverlayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516A9BF92A00A626006C9125 /* WebKitSwiftOverlayAdditions.swift */; };
-		5172437C2A1BF3DB00F0F6D8 /* WebKitSwiftOverlayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516A9BF92A00A626006C9125 /* WebKitSwiftOverlayAdditions.swift */; };
 		7D20070C22F4EB72008DF640 /* libswiftWebKit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D20067522F2652E008DF640 /* libswiftWebKit.dylib */; };
 		7D20071B22F4ECCA008DF640 /* libswiftWebKit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D20068722F26721008DF640 /* libswiftWebKit.dylib */; };
 		B3A5D38F23F78F5400B17727 /* WebKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A5D38823F78F5400B17727 /* WebKitTests.swift */; };
@@ -39,7 +37,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		516A9BF92A00A626006C9125 /* WebKitSwiftOverlayAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebKitSwiftOverlayAdditions.swift; path = usr/local/include/WebKitAdditions/WebKitSwiftOverlayAdditions.swift; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D20067522F2652E008DF640 /* libswiftWebKit.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libswiftWebKit.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D20068722F26721008DF640 /* libswiftWebKit.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libswiftWebKit.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D20070722F4EB72008DF640 /* WebKitSwiftOverlayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WebKitSwiftOverlayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -97,7 +94,6 @@
 				B3A5D39923F790E100B17727 /* install-swiftmodules.sh */,
 				B3B8FEEE2502BAA0006172CA /* ObjectiveCBlockConversions.swift */,
 				B3A5D39123F790DB00B17727 /* WebKitSwiftOverlay.swift */,
-				516A9BF92A00A626006C9125 /* WebKitSwiftOverlayAdditions.swift */,
 			);
 			name = "Swift Overlay";
 			path = SwiftOverlay;
@@ -400,7 +396,6 @@
 			files = (
 				B3B8FEEF2502BAA0006172CA /* ObjectiveCBlockConversions.swift in Sources */,
 				B3A5D39223F790DB00B17727 /* WebKitSwiftOverlay.swift in Sources */,
-				5172437C2A1BF3DB00F0F6D8 /* WebKitSwiftOverlayAdditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -410,7 +405,6 @@
 			files = (
 				B3B8FEF02502BAA0006172CA /* ObjectiveCBlockConversions.swift in Sources */,
 				B3A5D39323F790DB00B17727 /* WebKitSwiftOverlay.swift in Sources */,
-				516A9BFB2A00A626006C9125 /* WebKitSwiftOverlayAdditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -24,6 +24,7 @@
  */
 
 @_exported import WebKit
+@_spi(CTypeConversion) import Network
 
 @available(iOS 14.0, macOS 10.16, *)
 extension WKPDFConfiguration {
@@ -106,3 +107,13 @@ extension WKWebExtensionContext {
         __didMove(movedTab, from: index, in: oldWindow)
     }
 }
+
+#if canImport(Network, _version: "3623.0.0.0")
+@available(iOS 17.0, macOS 14.0, *)
+extension WKWebsiteDataStore {
+    public var proxyConfigurations: [ProxyConfiguration] {
+        get { __proxyConfigurations?.map(ProxyConfiguration.init(_:)) ?? [] }
+        set { __proxyConfigurations = newValue.map(\.nw) }
+    }
+}
+#endif


### PR DESCRIPTION
#### 07a610a729e3aef47b09f92fa218a80938730363
<pre>
Upstream proxy config additions to WebKit&apos;s Swift overlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=280376">https://bugs.webkit.org/show_bug.cgi?id=280376</a>
<a href="https://rdar.apple.com/136717514">rdar://136717514</a>

Reviewed by Brady Eidson.

WKWebsiteDataStore.proxyConfigurations shipped in iOS 17 / macOS 14.
Move the API out of WebKitAdditions, and remove the
`WebKitSwiftOverlayAdditions.swift` file reference.

In the future, private additions to WebKit&apos;s Swift overlay can be copied
from WKA using the *.swift.in rule in Derived Sources, like we do for
other Swift code.

* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
(WKWebsiteDataStore.proxyConfigurations):

Canonical link: <a href="https://commits.webkit.org/284290@main">https://commits.webkit.org/284290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74475c24072d8ae13178eac2f2ebec7508120a6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20049 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54889 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13332 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40776 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17264 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74681 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16520 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/74681 "Failed to compile WebKit") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59572 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/74681 "Failed to compile WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4004 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10532 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44103 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45173 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->