### PR TITLE
[SVG2] Sync `getTotalLength()` with web specification to throw exception when non-renderable and path is empty

### DIFF
--- a/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached-expected.txt
+++ b/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached-expected.txt
@@ -1,0 +1,5 @@
+
+PASS SVGGeometryElement.getTotalLength method (element detached) with SVGPathElement
+PASS SVGGeometryElement.getTotalLength method (element detached) with SVGRectElement
+PASS SVGGeometryElement.getTotalLength method (element detached) with SVGCircleElement
+

--- a/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached.html
+++ b/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>SVGGeometryElement.getTotalLength method (element detached)</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  var pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
+
+  function getTotalLength(string) {
+      pathElement.setAttribute("d", string);
+      return pathElement.getTotalLength();
+  }
+
+  assert_equals(getTotalLength('M0,20 L400,20 L640,20'), 640);
+  assert_equals(getTotalLength('M0,20 L400,20 L640,20 z'), 1280);
+  assert_equals(getTotalLength('M0,20 L400,20 z M 320,20 L640,20'), 1120);
+  assert_throws_dom("InvalidStateError", function() { getTotalLength('') });
+}, document.title + " with SVGPathElement");
+
+test(function() {
+  var rectElement = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+
+  function getTotalLength(rx, ry, width, height) {
+    rectElement.setAttribute("rx", rx);
+    rectElement.setAttribute("ry", ry);
+    rectElement.setAttribute("width", width);
+    rectElement.setAttribute("height", height);
+
+    return rectElement.getTotalLength();
+  }
+
+  assert_throws_dom("InvalidStateError", function() { getTotalLength(0, 0, 200, 300) });
+  assert_throws_dom("InvalidStateError", function() { getTotalLength(50, 50, 200, 300)});
+}, document.title + " with SVGRectElement");
+
+test(function() {
+  var circleElement = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+
+  circleElement.setAttribute("r", 10);
+  assert_throws_dom("InvalidStateError", function() { circleElement.getTotalLength() });
+  circleElement.setAttribute("r", 20);
+  assert_throws_dom("InvalidStateError", function() { circleElement.getTotalLength() });
+}, document.title + " with SVGCircleElement");
+</script>

--- a/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-exception-expected.txt
+++ b/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-exception-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVGGeometryElement.getTotalLength Exception with SVGRectElement
+PASS SVGGeometryElement.getTotalLength Exception with SVGCircleElement
+

--- a/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-exception.html
+++ b/LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-exception.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>SVGGeometryElement.getTotalLength Exception</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength"/>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <rect id="rectTest" style="display:none" x="30" y="30" width="10" height="10"></rect>
+  <circle id="circleTest" style="display:none" cx="50" cy="50" r="5" />
+</svg>
+<script>
+  test(function() {
+    assert_throws_dom("InvalidStateError", function() { rectTest.getTotalLength(); });
+  }, document.title + " with SVGRectElement");
+  
+  test(function() {
+    assert_throws_dom("InvalidStateError", function() { circleTest.getTotalLength(); });
+  }, document.title + " with SVGCircleElement");
+</script>

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2018 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,7 +36,7 @@ class SVGGeometryElement : public SVGGraphicsElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGGeometryElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGeometryElement);
 public:
-    virtual float getTotalLength() const;
+    virtual ExceptionOr<float> getTotalLength() const;
     virtual ExceptionOr<Ref<SVGPoint>> getPointAtLength(float distance) const;
 
     bool isPointInFill(DOMPointInit&&);

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -89,7 +89,7 @@ public:
         return SVGPathSegCurvetoQuadraticSmoothRel::create(x, y);
     }
 
-    float getTotalLength() const final;
+    ExceptionOr<float> getTotalLength() const final;
     ExceptionOr<Ref<SVGPoint>> getPointAtLength(float distance) const final;
     unsigned getPathSegAtLength(float distance) const;
 


### PR DESCRIPTION
#### 48ed528d4e27ad7f8424955add1d503ed28f0ee6
<pre>
[SVG2] Sync `getTotalLength()` with web specification to throw exception when non-renderable and path is empty

<a href="https://bugs.webkit.org/show_bug.cgi?id=280350">https://bugs.webkit.org/show_bug.cgi?id=280350</a>
<a href="https://rdar.apple.com/136719548">rdar://136719548</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength">https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength</a>

&quot;If current element is a non-rendered element, and the UA is not able to
compute the total length of the path, then throw an InvalidStateError.&quot;

In following patch, we update to throw exception when there is no `renderer`
and also when path is empty similar to `getPointAtLength`.

It merges tests from following Chromium commit [2]:

[2] <a href="https://source.chromium.org/chromium/chromium/src/+/5ad2c261332caaad06a0827addccb575215e87b7">https://source.chromium.org/chromium/chromium/src/+/5ad2c261332caaad06a0827addccb575215e87b7</a>

* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
* Source/WebCore/svg/SVGGeometryElement.h:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::getTotalLength const):
(WebCore::SVGPathElement::getPointAtLength const):
* Source/WebCore/svg/SVGPathElement.h:
* LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-exception.html:
* LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-exception-expected.txt:
* LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached.html:
* LayoutTests/svg/dom/SVGGeometryElement-getTotalLength-detached-expected.txt:

Canonical link: <a href="https://commits.webkit.org/284311@main">https://commits.webkit.org/284311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ba82449b70cfab093b6d12b02603c241ee5141e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73093 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20019 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17009 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18545 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4088 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44217 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->