### PR TITLE
[JSC] Check if the species watchpoint is valid before `array.concat()` fast path

### DIFF
--- a/JSTests/stress/array-prototype-concat-species.js
+++ b/JSTests/stress/array-prototype-concat-species.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+let constructorCallCount = 0;
+function Constructor() {
+    constructorCallCount++;
+    return {};
+}
+
+const array = [1, 2, 3];
+array.constructor = { [Symbol.species]: Constructor };
+
+const result = array.concat();
+
+shouldBe(constructorCallCount, 1);
+shouldBe(Object.getPrototypeOf(result) === Array.prototype, false);
+shouldBe(result[0], 1);
+shouldBe(result[1], 2);
+shouldBe(result[2], 3);

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -402,7 +402,8 @@ function concat(first)
 
     if (@argumentCount() === 0
         && @isJSArray(this)
-        && @tryGetByIdWithWellKnownSymbol(this, "isConcatSpreadable") === @undefined) {
+        && @tryGetByIdWithWellKnownSymbol(this, "isConcatSpreadable") === @undefined
+        && @arraySpeciesWatchpointIsValid(this)) {
 
         var result = @arrayFromFastFillWithEmpty(@Array, this);
         if (result)

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -204,6 +204,7 @@ namespace JSC {
     macro(isRemoteFunction) \
     macro(arrayFromFastFillWithUndefined) \
     macro(arrayFromFastFillWithEmpty) \
+    macro(arraySpeciesWatchpointIsValid) \
     macro(arraySort) \
     macro(jsonParse) \
     macro(jsonStringify) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -134,6 +134,7 @@ class JSGlobalObject;
     v(isRemoteFunction, nullptr) \
     v(arrayFromFastFillWithUndefined, nullptr) \
     v(arrayFromFastFillWithEmpty, nullptr) \
+    v(arraySpeciesWatchpointIsValid, nullptr) \
     v(arraySort, nullptr) \
     v(jsonParse, nullptr) \
     v(jsonStringify, nullptr) \

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1767,4 +1767,17 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithEmpty, (JSGlobalOb
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(arrayPrototPrivateFuncArraySpeciesWatchpointIsValid, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    ASSERT(callFrame->argumentCount() == 1);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    bool isValidSpecies = arraySpeciesWatchpointIsValid(vm, jsCast<JSArray*>(callFrame->uncheckedArgument(0)));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    return JSValue::encode(jsBoolean(isValidSpecies));
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.h
@@ -52,5 +52,6 @@ JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncConcatMemcpy);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncAppendMemcpy);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithUndefined);
 JSC_DECLARE_HOST_FUNCTION(arrayProtoPrivateFuncFromFastFillWithEmpty);
+JSC_DECLARE_HOST_FUNCTION(arrayPrototPrivateFuncArraySpeciesWatchpointIsValid);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1658,6 +1658,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFastFillWithEmpty)].initLater([] (const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFastFillWithEmpty"_s, arrayProtoPrivateFuncFromFastFillWithEmpty, ImplementationVisibility::Private));
     });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arraySpeciesWatchpointIsValid)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "arraySpeciesWatchpointIsValid"_s, arrayPrototPrivateFuncArraySpeciesWatchpointIsValid, ImplementationVisibility::Private));
+    });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isDetached)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsDetached"_s, typedArrayViewPrivateFuncIsDetached, ImplementationVisibility::Private));
         });


### PR DESCRIPTION
#### e7aeca7171e3be024a2efdc2eeddb55a9d9ba82b
<pre>
[JSC] Check if the species watchpoint is valid before `array.concat()` fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=280381">https://bugs.webkit.org/show_bug.cgi?id=280381</a>

Reviewed by Yusuke Suzuki.

The Array.prototype.concat test262 started failing due to <a href="https://commits.webkit.org/284060@main.">https://commits.webkit.org/284060@main.</a>
This was because the species check was not performed before entering the fast path.

This patch changes to check whether the Array&apos;s species watchpoint is valid before entering the fast
path.

According to microbenchmarks, there seems to be no performance regression caused by this patch:

                                                  TipOfTree                  Patched

array-prototype-concat-copy-obj                 1.2244+-0.2875     ?      1.2272+-0.2899        ?
array-prototype-concat-copy-double-and-int32
                                                1.2631+-0.1158     ?      1.3107+-0.0959        ? might be 1.0377x slower
array-prototype-concat-copy-double              1.2239+-0.2762            1.0875+-0.1126          might be 1.1254x faster
array-prototype-concat-copy-int32               1.1629+-0.2731            1.1406+-0.2677          might be 1.0196x faster

&lt;geometric&gt;                                     1.2119+-0.1094            1.1832+-0.0463          might be 1.0243x faster

* JSTests/stress/array-prototype-concat-species.js: Added.
(shouldBe):
(Constructor):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(concat):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayPrototype.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/284330@main">https://commits.webkit.org/284330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/020794f0c78f1d68efc74165531fa013898dbef0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20057 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54896 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13340 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35366 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16925 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18440 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62022 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74693 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68152 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62482 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62418 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15327 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4009 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89931 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44107 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15938 "Found 37 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck.js.default, ChakraCore.yaml/ChakraCore/test/strict/12.delete_sm.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-dead-unreachable-code-with-chain-of-dead-unchecked-nodes.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-not-string.js.layout, stress/big-int-division.js.bytecode-cache, stress/big-int-literals.js.bytecode-cache, stress/escaped-keyword-identifiers.js.dfg-eager, stress/iterator-from.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->