### PR TITLE
[UnifiedPDF] Switching from two page continuous to discrete two up causes jump to last page of PDF.

### DIFF
--- a/LayoutTests/pdf/two-pages-continuous-to-discrete-expected.html
+++ b/LayoutTests/pdf/two-pages-continuous-to-discrete-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<embed id="plugin" src="../http/tests/pdf/resources/non-linearized.pdf" style="width: 100%; height: 100vh;">
+</body>
+<script>
+    window.addEventListener('load', async () => {
+        if (!window.internals || !window.testRunner)
+            return;
+
+        let pluginElement = document.getElementById("plugin");
+        testRunner.waitUntilDone();
+        window.internals.registerPDFTest(async () => {
+            internals.setPDFDisplayModeForTesting(pluginElement, "TwoUpDiscrete");
+            await UIHelper.renderingUpdate();
+            testRunner.notifyDone();
+        }, pluginElement);
+    });
+</script>
+</head>
+</html>

--- a/LayoutTests/pdf/two-pages-continuous-to-discrete.html
+++ b/LayoutTests/pdf/two-pages-continuous-to-discrete.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<embed id="plugin" src="../http/tests/pdf/resources/non-linearized.pdf" style="width: 100%; height: 100vh;">
+</body>
+<script>
+    window.addEventListener('load', async () => {
+        if (!window.internals || !window.testRunner)
+            return;
+
+        let pluginElement = document.getElementById("plugin");
+        testRunner.waitUntilDone();
+        window.internals.registerPDFTest(async () => {
+            internals.setPDFDisplayModeForTesting(pluginElement, "TwoUpContinuous");
+            internals.setPDFDisplayModeForTesting(pluginElement, "TwoUpDiscrete");
+            await UIHelper.renderingUpdate();
+            testRunner.notifyDone();
+        }, pluginElement);
+    });
+</script>
+</head>
+</html>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -275,6 +275,7 @@ auto PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset(float documentYO
             // Handle side by side pages with different sizes.
             std::optional<PageIndex> targetPageIndex = [&](PageIndex index) -> std::optional<PageIndex> {
                 auto leftPageBounds = layoutBoundsForPageAtIndex(index);
+                leftPageBounds.inflate(PDFDocumentLayout::documentMargin);
                 if (documentYOffset >= leftPageBounds.y() && documentYOffset < leftPageBounds.maxY())
                     return index;
 
@@ -283,6 +284,7 @@ auto PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset(float documentYO
                     return { };
 
                 auto rightPageBounds = layoutBoundsForPageAtIndex(rightPageIndex);
+                rightPageBounds.inflate(PDFDocumentLayout::documentMargin);
                 if (documentYOffset >= rightPageBounds.y() && documentYOffset < rightPageBounds.maxY())
                     return rightPageIndex;
 


### PR DESCRIPTION
#### aee3f60e1e0a10a4caf0c7ce2a32e210b0422f5c
<pre>
[UnifiedPDF] Switching from two page continuous to discrete two up causes jump to last page of PDF.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280383">https://bugs.webkit.org/show_bug.cgi?id=280383</a>
<a href="https://rdar.apple.com/136653611">rdar://136653611</a>

Reviewed by Abrar Rahman Protyasha.

When switching the display mode the presentation control attempts to get the current point
of the page(s) in document space by converting the top left point of the plugin to
document coordinates. We then attempt to map that point to the corresponding page point
and index. However, during this mapping we fail to take into consideration the margins
imposed by the document so we end up computing a point and index of the last page. We
can fix this by simply inflating the bounds of each page by the document margins.

* LayoutTests/pdf/two-pages-continuous-to-discrete-expected.html: Added.
* LayoutTests/pdf/two-pages-continuous-to-discrete.html: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset const):

Canonical link: <a href="https://commits.webkit.org/284375@main">https://commits.webkit.org/284375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d362282595884aa0104cbd1d788977df4ecb7341

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20176 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13499 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35529 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17149 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16728 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62608 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4218 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44373 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46642 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->