### PR TITLE
Re-landing 284236@main (966da8693f4b)

### DIFF
--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -35,6 +35,7 @@
 #include "WKObject.h"
 #include <wtf/RetainPtr.h>
 #endif
+#include <wtf/HashMap.h>
 #endif
 
 #define DELEGATE_REF_COUNTING_TO_COCOA PLATFORM(COCOA)
@@ -241,8 +242,11 @@ public:
     template<typename T, typename... Args>
     static void constructInWrapper(id <WKObject> wrapper, Args&&... args)
     {
-        Object* object = new (&wrapper._apiObject) T(std::forward<Args>(args)...);
-        object->m_wrapper = (__bridge CFTypeRef)wrapper;
+        Object& object = wrapper._apiObject;
+
+        apiObjectsUnderConstruction().add(&object, (__bridge CFTypeRef)wrapper);
+
+        new (&object) T(std::forward<Args>(args)...);
     }
 
     id <WKObject> wrapper() const { return (__bridge id <WKObject>)m_wrapper; }
@@ -269,6 +273,8 @@ protected:
     static void* newObject(size_t, Type);
 
 private:
+    static HashMap<Object*, CFTypeRef>& apiObjectsUnderConstruction();
+
     // Derived classes must override operator new and call newObject().
     void* operator new(size_t) = delete;
 

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -520,7 +520,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     Object& object = wrapper._apiObject;
-    object.m_wrapper = (__bridge CFTypeRef)wrapper;
+
+    apiObjectsUnderConstruction().add(&object, (__bridge CFTypeRef)wrapper);
 
     return &object;
 }


### PR DESCRIPTION
#### f697d3cc179183bdd37a7e2b96a882a142cdcd4f
<pre>
Re-landing 284236@main (966da8693f4b)

Reviewed by Chris Dumez.

284253@main fixes the test failures we saw on bots.

API objects should be safe to ref() inside their constructors
    <a href="https://bugs.webkit.org/show_bug.cgi?id=280278">https://bugs.webkit.org/show_bug.cgi?id=280278</a>
    <a href="https://rdar.apple.com/136599625">rdar://136599625</a>
    284236@main (966da8693f4b)

Canonical link: <a href="https://commits.webkit.org/284304@main">https://commits.webkit.org/284304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef49404d31795bcc2e60339cbbbfc20afc075eba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69019 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/48419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21691 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20025 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72085 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/74808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/13039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10541 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/44223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/45038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->