### PR TITLE
REGRESSION(284214@main): [ GTK WPE Debug ] `ld.lld: error: undefined symbol: Inspector::InspectorTargetAgent::~InspectorTargetAgent()`

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
@@ -37,12 +37,12 @@ namespace Inspector {
 
 class InspectorTarget;
 
-class InspectorTargetAgent final : public InspectorAgentBase, public TargetBackendDispatcherHandler, public CanMakeCheckedPtr<InspectorTargetAgent> {
+class JS_EXPORT_PRIVATE InspectorTargetAgent final : public InspectorAgentBase, public TargetBackendDispatcherHandler, public CanMakeCheckedPtr<InspectorTargetAgent> {
     WTF_MAKE_NONCOPYABLE(InspectorTargetAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorTargetAgent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorTargetAgent);
 public:
-    JS_EXPORT_PRIVATE InspectorTargetAgent(FrontendRouter&, BackendDispatcher&);
+    InspectorTargetAgent(FrontendRouter&, BackendDispatcher&);
     ~InspectorTargetAgent() final;
 
     // InspectorAgentBase
@@ -55,12 +55,12 @@ public:
     Protocol::ErrorStringOr<void> sendMessageToTarget(const String& targetId, const String& message) final;
 
     // Target lifecycle.
-    JS_EXPORT_PRIVATE void targetCreated(InspectorTarget&);
-    JS_EXPORT_PRIVATE void targetDestroyed(InspectorTarget&);
-    JS_EXPORT_PRIVATE void didCommitProvisionalTarget(const String& oldTargetID, const String& committedTargetID);
+    void targetCreated(InspectorTarget&);
+    void targetDestroyed(InspectorTarget&);
+    void didCommitProvisionalTarget(const String& oldTargetID, const String& committedTargetID);
 
     // Target messages.
-    JS_EXPORT_PRIVATE void sendMessageFromTargetToFrontend(const String& targetId, const String& message);
+    void sendMessageFromTargetToFrontend(const String& targetId, const String& message);
 
 private:
     // FrontendChannel

--- a/Source/cmake/OptionsMSVC.cmake
+++ b/Source/cmake/OptionsMSVC.cmake
@@ -45,6 +45,9 @@ string(REGEX REPLACE "/W3" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 string(REGEX REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(/W4)
 
+# Not apply class-level dllexport and dllimport attributes to inline member functions
+WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(/Zc:dllexportInlines-)
+
 # Make sure incremental linking is turned off, as it creates unacceptably long link times.
 string(REPLACE "/INCREMENTAL[:A-Z]+" "" CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
 string(REPLACE "/INCREMENTAL[:A-Z]+" "" CMAKE_EXE_LINKER_FLAGS_DEBUG ${CMAKE_EXE_LINKER_FLAGS_DEBUG})


### PR DESCRIPTION
#### 5a61ed2c4b8ad01ceb71e250e894b40df402768f
<pre>
REGRESSION(284214@main): [ GTK WPE Debug ] `ld.lld: error: undefined symbol: Inspector::InspectorTargetAgent::~InspectorTargetAgent()`

Unreviewed build fix.

* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h:
* Source/cmake/OptionsMSVC.cmake

Canonical link: <a href="https://commits.webkit.org/284286@main">https://commits.webkit.org/284286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ac7acaecbf379de606e8e798eae28bdd8a1a74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13372 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16967 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18488 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62072 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74744 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68202 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62560 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62459 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4046 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89982 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44160 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15955 "Found 138 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/fastRegexCaptures.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/split.js.default, ChakraCore.yaml/ChakraCore/test/es6/ES6Function_bugs.js.default, ChakraCore.yaml/ChakraCore/test/es6/ProxySetPrototypeOf.js.default, ChakraCore.yaml/ChakraCore/test/es6/map_basic.js.default, ChakraCore.yaml/ChakraCore/test/es6/regex-set.js.default, ChakraCore.yaml/ChakraCore/test/es6/set_basic.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck6.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->