### PR TITLE
[css-anchor-position-1] Collect anchor dependencies

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-custom-property-registration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-custom-property-registration-expected.txt
@@ -1,10 +1,5 @@
 
-FAIL anchor() cannot be used as <length> initial value assert_throws_dom: function "() => CSS.registerProperty({
-    name: '--x',
-    syntax: '<length>',
-    inherits: false,
-    initialValue: 'anchor(--foo top)',
-  })" did not throw
+PASS anchor() cannot be used as <length> initial value
 PASS anchor-size() cannot be used as <length> initial value
 PASS anchor() cannot be used as <length-percentage> initial value
 PASS anchor-size() cannot be used as <length-percentage> initial value

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -53,8 +53,9 @@ struct ComputedStyleDependencies {
     Vector<CSSPropertyID> rootProperties;
     bool containerDimensions { false };
     bool viewportDimensions { false };
+    bool anchors { false };
 
-    bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions; }
+    bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions && !anchors; }
 };
 
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);

--- a/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
@@ -155,6 +155,7 @@ static void collectComputedStyleDependencies(const Child& root, ComputedStyleDep
             collectComputedStyleDependencies(root.unit, dependencies);
         },
         [&](const IndirectNode<Anchor>& anchor) {
+            dependencies.anchors = true;
             if (anchor->fallback)
                 collectComputedStyleDependencies(*anchor->fallback, dependencies);
         },

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1308,7 +1308,7 @@ RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange
 
     auto initialValueIsValid = [&] {
         auto tokenRange = descriptor.initialValue->tokenRange();
-        auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, tokenRange, strictCSSParserContext());
+        auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, tokenRange, m_context);
         if (!dependencies.isComputationallyIndependent())
             return false;
         auto containsVariable = CSSVariableParser::containsValidVariableReferences(descriptor.initialValue->tokenRange(), m_context);

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -191,7 +191,7 @@ void CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration(const 
 auto CustomPropertyRegistry::parseInitialValue(const Document& document, const AtomString& propertyName, const CSSCustomPropertySyntax& syntax, CSSParserTokenRange tokenRange) -> Expected<std::pair<RefPtr<CSSCustomPropertyValue>, ViewportUnitDependency>, ParseInitialValueError>
 {
     // FIXME: This parses twice.
-    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(syntax, tokenRange, strictCSSParserContext());
+    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(syntax, tokenRange, document.cssParserContext());
     if (!dependencies.isComputationallyIndependent())
         return makeUnexpected(ParseInitialValueError::NotComputationallyIndependent);
 


### PR DESCRIPTION
#### 3e101866bc4be83d6de43e4b37b20c3d2141eeef
<pre>
[css-anchor-position-1] Collect anchor dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=280396">https://bugs.webkit.org/show_bug.cgi?id=280396</a>
<a href="https://rdar.apple.com/136737352">rdar://136737352</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-query-custom-property-registration-expected.txt:
* Source/WebCore/css/CSSValue.h:
(WebCore::ComputedStyleDependencies::isComputationallyIndependent const):

Anchor functions are not computationally indepependent.

* Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp:
(WebCore::CSSCalc::collectComputedStyleDependencies):
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::parseInitialValue):

Pass real parser context.

Canonical link: <a href="https://commits.webkit.org/284280@main">https://commits.webkit.org/284280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce76663ebd9ee898051ef2e6929ee993e88cfa5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19956 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16959 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16552 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62554 "Found 3 new test failures: webanimations/accelerated-animation-easing-update-after-pause.html webanimations/accelerated-animation-slot-invalidation.html webanimations/marker-opacity-animation-no-effect.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15299 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4038 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->