### PR TITLE
TestRunner.forceImmediateCompletion() hangs with site isolation

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -1,5 +1,11 @@
 # Test expectations for macOS with --site-isolation
 
+# wktr itself is broken for site isolation.
+webkit.org/b/280402 wktr/force-immediate-completion-moment-dump-as-text-onload-async.html [ Failure ]
+webkit.org/b/280402 wktr/force-immediate-completion-moment-dump-as-text-onload-sync.html [ Failure ]
+webkit.org/b/280402 wktr/force-immediate-completion-moment-dump-as-text-sync.html [ Failure ]
+webkit.org/b/280402 wktr/notify-done-moment-dump-as-text-onload-async.html [ Failure ]
+
 ##########################################################################
 # Root directories skipped until we can make test expectations for them: #
 ##########################################################################

--- a/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-async-expected.txt
+++ b/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-async-expected.txt
@@ -1,0 +1,1 @@
+Dumps immediately at call.

--- a/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-async.html
+++ b/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-async.html
@@ -1,0 +1,16 @@
+<html>
+<head><title>Tests testRunner.forceImmediateCompletion() dump moment, async after onload.</title></head>
+<body>
+<p id="log">Dumps immediately at call.</p>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+window.onload = () => {
+    setTimeout(() => {
+        testRunner.forceImmediateCompletion();
+        log.innerHTML = "Dumps after leaving call scope.";
+    }, 100);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-sync-expected.txt
+++ b/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-sync-expected.txt
@@ -1,0 +1,1 @@
+Dumps immediately at call.

--- a/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-sync.html
+++ b/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-sync.html
@@ -1,0 +1,14 @@
+<html>
+<head><title>Tests testRunner.forceImmediateCompletion() dump moment, sync after onload.</title></head>
+<body>
+<p id="log">Dumps immediately at call.</p>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+window.onload = () => {
+    testRunner.forceImmediateCompletion();
+    log.innerHTML = "Dumps after leaving call scope.";
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-sync-expected.txt
+++ b/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-sync-expected.txt
@@ -1,0 +1,1 @@
+Dumps immediately at call.

--- a/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-sync.html
+++ b/LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-sync.html
@@ -1,0 +1,15 @@
+<html>
+<head><title>Tests testRunner.forceImmediateCompletion() dump moment, sync during load.</title></head>
+<body>
+<p id="log">Dumps immediately at call.</p>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+testRunner.forceImmediateCompletion();
+log.innerHTML = "Dumps after leaving call scope.";
+window.onload = () => {
+    log.innerHTML = "Dumps after leaving onload scope.";
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-async-expected.txt
+++ b/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-async-expected.txt
@@ -1,0 +1,1 @@
+Dumps immediately at call.

--- a/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-async.html
+++ b/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-async.html
@@ -1,0 +1,16 @@
+<html>
+<head><title>Tests testRunner.notifyDone() dump moment, async after onload.</title></head>
+<body>
+<p id="log">Dumps immediately at call.</p>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+window.onload = () => {
+    setTimeout(() => {
+        testRunner.notifyDone();
+        log.innerHTML = "Dumps after leaving call scope.";
+    }, 100);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-sync-expected.txt
+++ b/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-sync-expected.txt
@@ -1,0 +1,1 @@
+Dumps after leaving call scope.

--- a/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-sync.html
+++ b/LayoutTests/wktr/notify-done-moment-dump-as-text-onload-sync.html
@@ -1,0 +1,14 @@
+<html>
+<head><title>Tests testRunner.notifyDone() dump moment, sync after onload.</title></head>
+<body>
+<p id="log">Dumps immediately at call.</p>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+window.onload = () => {
+    testRunner.notifyDone();
+    log.innerHTML = "Dumps after leaving call scope.";
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/wktr/notify-done-moment-dump-as-text-sync-expected.txt
+++ b/LayoutTests/wktr/notify-done-moment-dump-as-text-sync-expected.txt
@@ -1,0 +1,1 @@
+Dumps after leaving onload scope.

--- a/LayoutTests/wktr/notify-done-moment-dump-as-text-sync.html
+++ b/LayoutTests/wktr/notify-done-moment-dump-as-text-sync.html
@@ -1,0 +1,15 @@
+<html>
+<head><title>Tests testRunner.notifyDone() dump moment, sync during load.</title></head>
+<body>
+<p id="log">Dumps immediately at call.</p>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+testRunner.notifyDone();
+log.innerHTML = "Dumps after leaving call scope.";
+window.onload = () => {
+    log.innerHTML = "Dumps after leaving onload scope.";
+};
+</script>
+</body>
+</html>

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -292,14 +292,14 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "WorkQueueProcessedCallback")) {
-        if (!topLoadingFrame() && m_testRunner && m_testRunner && !m_testRunner->shouldWaitUntilDone())
+        if (!topLoadingFrame() && m_testRunner && !m_testRunner->shouldWaitUntilDone())
             InjectedBundle::page()->dump(m_testRunner->shouldForceRepaint());
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "ForceImmediateCompletion")) {
-        if (m_testRunner)
-            m_testRunner->forceImmediateCompletion();
+        if (m_testRunner && InjectedBundle::page())
+            InjectedBundle::page()->dump(m_testRunner->shouldForceRepaint());
         return;
     }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -1745,4 +1745,19 @@ void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
     dumpAfterWaitAttributeIsRemoved(page->page());
 }
 
+void InjectedBundlePage::notifyDone()
+{
+    if (InjectedBundle::singleton().topLoadingFrame())
+        return;
+    forceImmediateCompletion();
+}
+
+void InjectedBundlePage::forceImmediateCompletion()
+{
+    RefPtr testRunner = InjectedBundle::singleton().testRunner();
+    if (!testRunner)
+        return;
+    dump(testRunner->shouldForceRepaint());
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -41,6 +41,8 @@ public:
 
     WKBundlePageRef page() const { return m_page; }
 
+    void notifyDone();
+    void forceImmediateCompletion();
     void dump(bool forceRepaint);
 
     void prepare();

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -98,6 +98,12 @@ private:
     void done();
     void setWaitUntilDone(bool);
 
+    // Returns true if the caller bundle should proceed with dumping.
+    // Returns false if the WKTR invokes dumping through page, asynchronously.
+    // Resets waitUntilDone.
+    bool resolveNotifyDone();
+    bool resolveForceImmediateCompletion();
+
     void dumpResults();
     static void dump(const char* textToStdout, const char* textToStderr = 0, bool seenError = false);
     enum class SnapshotResultType { WebView, WebContents };

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -49,6 +49,7 @@ public:
     bool punchOutWhiteBackgroundsInDarkMode() const { return boolWebPreferenceFeatureValue("PunchOutWhiteBackgroundsInDarkMode", false); }
     bool useServiceWorkerShortTimeout() const { return boolWebPreferenceFeatureValue("ShouldUseServiceWorkerShortTimeout", false); }
     bool accessibilityIsolatedTreeMode() const { return boolWebPreferenceFeatureValue("IsAccessibilityIsolatedTreeEnabled", false); }
+    bool siteIsolationEnabled() const { return boolWebPreferenceFeatureValue("SiteIsolationEnabled", false); }
 
     bool allowsLinkPreview() const { return boolTestRunnerFeatureValue("allowsLinkPreview"); }
     bool appHighlightsEnabled() const { return boolTestRunnerFeatureValue("appHighlightsEnabled"); }


### PR DESCRIPTION
#### 34863c0ae258b67d0817a9cbde6086426e0602e7
<pre>
TestRunner.forceImmediateCompletion() hangs with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=280403">https://bugs.webkit.org/show_bug.cgi?id=280403</a>
<a href="https://rdar.apple.com/136748844">rdar://136748844</a>

Reviewed by Alex Christensen.

TestRunner.forceImmediateCompletion() would skip work because
it would try to run InjectedBundlePage::dump() in the calling WCP.
This would try to access main frame url, which is not available as
it is a remote frame.

Fix by resolving whether to dump or not by asking the WKTR process.

This is incorrect for forceImmediateCompletion(), as the semantics is
that the dump happens at that JS call stack immediately. This of
course is infeasible for site isolation, as the dump is global but
the processes cannot re-enter like that.

This is also incorrect for earlier notifyDone(). The notifyDone()
should dump immediately in case the load has happened.
(bug 268471 274211@main)

Add tests for WKTR to explain the semantics. These semantics should
likely change, as they&apos;re incompatible with how site isolation works.
The re-entrant semantics has been causing mismatches also
without site isolation, so it may be beneficial to rethink these.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-async-expected.txt: Added.
* LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-async.html: Added.
* LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-sync-expected.txt: Added.
* LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-onload-sync.html: Added.
* LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-sync-expected.txt: Added.
* LayoutTests/wktr/force-immediate-completion-moment-dump-as-text-sync.html: Added.
* LayoutTests/wktr/notify-done-moment-dump-as-text-onload-async-expected.txt: Added.
* LayoutTests/wktr/notify-done-moment-dump-as-text-onload-async.html: Added.
* LayoutTests/wktr/notify-done-moment-dump-as-text-onload-sync-expected.txt: Added.
* LayoutTests/wktr/notify-done-moment-dump-as-text-onload-sync.html: Added.
* LayoutTests/wktr/notify-done-moment-dump-as-text-sync-expected.txt: Added.
* LayoutTests/wktr/notify-done-moment-dump-as-text-sync.html: Added.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::notifyDone):
(WTR::TestRunner::forceImmediateCompletion):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
(WTR::TestInvocation::resolveNotifyDone):
(WTR::TestInvocation::resolveForceImmediateCompletion):
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::siteIsolationEnabled const):

Canonical link: <a href="https://commits.webkit.org/285592@main">https://commits.webkit.org/285592@main</a>
</pre>
