### PR TITLE
testharness.js tests with complex urls do not work when loaded in cross-origin iframes

### DIFF
--- a/LayoutTests/resources/testharnessreport.js
+++ b/LayoutTests/resources/testharnessreport.js
@@ -61,7 +61,7 @@ if (self.testRunner) {
 
     // window.opener is a configurable property, so store it before we run anything.
     const orig_opener = window.opener;
-    const isInCrossOriginFrame = window.location.href.indexOf("inCrossOriginFrame=true") >= 0;
+    const isRunInCrossOriginFrame = new URLSearchParams(window.location.search).has("runInCrossOriginFrame", "true");
 
     /*  Using a callback function, test results will be added to the page in a
     *   manner that allows dumpAsText to produce readable test results
@@ -70,7 +70,7 @@ if (self.testRunner) {
         // Only pay attention to results at the top-level window.
         // Ideally testharness.js would allow us to only attach a completion handler in this case:
         // https://github.com/web-platform-tests/rfcs/pull/168
-        if (!isInCrossOriginFrame && (window !== window.top || (orig_opener !== null && orig_opener !== window))) {
+        if (!isRunInCrossOriginFrame && (window !== window.top || (orig_opener !== null && orig_opener !== window))) {
             return;
         }
 


### PR DESCRIPTION
#### d6da6bd550b372becfc251090ff73f3f99449d90
<pre>
testharness.js tests with complex urls do not work when loaded in cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=280404">https://bugs.webkit.org/show_bug.cgi?id=280404</a>
<a href="https://rdar.apple.com/136749450">rdar://136749450</a>

Reviewed by Charlie Wolfe and Alex Christensen.

Improve the logic to insert the runInCrossOriginFrame parameter to
the URL in case RWT sends a URL that contains search parameters or
fragments.

* LayoutTests/resources/testharnessreport.js:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::addQueryParameter):
(WTR::TestInvocation::loadTestInCrossOriginIframe):
(WTR::TestInvocation::dumpWebProcessUnresponsiveness):
(WTR::TestInvocation::dumpResults):
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
(WTR::TestInvocation::runUISideScript):
(WTR::TestInvocation::waitToDumpWatchdogTimerFired):

Canonical link: <a href="https://commits.webkit.org/284307@main">https://commits.webkit.org/284307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2c57b919ff19e0bcc06c229afa3e6afb49a26ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54923 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13381 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62571 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4050 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44165 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->