### PR TITLE
[GTK] Unreviewed non-unified build fix

### DIFF
--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.h
@@ -36,6 +36,7 @@
 #include "ProfilerOriginStack.h"
 #include "ProfilerProfiledBytecodes.h"
 #include "ProfilerUID.h"
+#include <wtf/ObjectIdentifier.h>
 #include <wtf/RefCounted.h>
 #include <wtf/SegmentedVector.h>
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -45,11 +45,6 @@ unsigned FunctionIPIntMetadataGenerator::addSignature(const TypeDefinition& sign
     return index;
 }
 
-void FunctionIPIntMetadataGenerator::addBlankSpace(size_t size)
-{
-    m_metadata.grow(m_metadata.size() + size);
-}
-
 void FunctionIPIntMetadataGenerator::addLength(size_t length)
 {
     IPInt::InstructionLengthMetadata instructionLength {

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -127,6 +127,11 @@ private:
     Vector<UnlinkedHandlerInfo> m_exceptionHandlers;
 };
 
+void FunctionIPIntMetadataGenerator::addBlankSpace(size_t size)
+{
+    m_metadata.grow(m_metadata.size() + size);
+}
+
 } } // namespace JSC::Wasm
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <span>
+#include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -29,6 +29,7 @@
 #include "CSSPropertyParser.h"
 #include "CSSStyleSheet.h"
 #include "CSSTokenizer.h"
+#include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"

--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -29,6 +29,7 @@
 #include "StylePropertiesInlines.h"
 #include <wtf/HashMap.h>
 #include <wtf/Hasher.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -35,6 +35,7 @@
 #include "CSSPropertyParserConsumer+Grid.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSValueKeywords.h"
+#include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include "CSSVariableReferenceValue.h"
 #include "ComputedStyleExtractor.h"

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -30,6 +30,8 @@
 #include "CSSCalcTree+Simplification.h"
 #include "CSSCalcTree.h"
 #include "CalculationExecutor.h"
+#include "RenderStyle.h"
+#include "RenderStyleInlines.h"
 
 namespace WebCore {
 namespace CSSCalc {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCalcSymbolTable.h"
 #include "CSSCalcValue.h"
+#include "CSSParserContext.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+PercentageDefinitions.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class CSSCalcSymbolTable;
 class CSSPrimitiveValue;
 class CSSParserTokenRange;
+struct CSSParserContext;
 
 namespace CSSPropertyParserHelpers {
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -62,6 +62,7 @@
 #include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include "CSSValue.h"
 #include "CSSValueList.h"
+#include "CSSValuePool.h"
 #include "StyleImage.h"
 #include <wtf/SortedArrayMap.h>
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
@@ -29,6 +29,7 @@
 #include "CSSCalcSymbolTable.h"
 #include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
+#include "CSSParserContext.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CalculationCategory.h"

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -28,7 +28,7 @@
 
 #include "LayoutIntegrationBoxGeometryUpdater.h"
 #include "RenderBlock.h"
-#include "RenderBox.h"
+#include "RenderBoxInlines.h"
 
 namespace WebCore {
 namespace LayoutIntegration {

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -31,6 +31,7 @@
 
 #include "Adwaita.h"
 #include "Color.h"
+#include "FontCascade.h"
 #include "LengthSize.h"
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -41,6 +41,7 @@
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include "CSSPropertyParserHelpers.h"
+#include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include "Document.h"
 #include "DocumentInlines.h"


### PR DESCRIPTION
#### fd2f10a39d3834be6c9383b82ca741ed89e3513e
<pre>
[GTK] Unreviewed non-unified build fix

* Source/JavaScriptCore/profiler/ProfilerCompilation.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace): Deleted.
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace):
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
* Source/WebCore/css/ImmutableStyleProperties.cpp:
* Source/WebCore/css/ShorthandSerializer.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInterpolationMethod.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp:
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
* Source/WebCore/style/StyleResolveForFont.cpp:

Canonical link: <a href="https://commits.webkit.org/284296@main">https://commits.webkit.org/284296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7abbc894944158d76a3239bef3bc64eaca50d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54925 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18495 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62079 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74751 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16565 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62565 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62463 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4052 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89991 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44167 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/89991 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->