### PR TITLE
Reduce use of LegacyNullableAtomicObjectIdentifier

### DIFF
--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -80,7 +80,7 @@ private:
     }
 
     RefPtr<Image> m_image;
-    RenderingResourceIdentifier m_renderingResourceIdentifier;
+    Markable<RenderingResourceIdentifier> m_renderingResourceIdentifier;
     FloatSize m_imageSize;
 };
 

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -86,7 +86,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ARKitBadgeSystemImage);
 
 RenderingResourceIdentifier ARKitBadgeSystemImage::imageIdentifier() const
 {
-    return m_image ? m_image->nativeImage()->renderingResourceIdentifier() : m_renderingResourceIdentifier;
+    return m_image ? m_image->nativeImage()->renderingResourceIdentifier() : *m_renderingResourceIdentifier;
 }
 
 void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRect& rect) const

--- a/Source/WebCore/platform/graphics/RenderingResourceIdentifier.h
+++ b/Source/WebCore/platform/graphics/RenderingResourceIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class RenderingResourceIdentifierType { };
-using RenderingResourceIdentifier = LegacyNullableAtomicObjectIdentifier<RenderingResourceIdentifierType>;
+using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -394,22 +394,22 @@ class ClipToImageBuffer {
 public:
     static constexpr char name[] = "clip-to-image-buffer";
 
-    ClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect)
+    ClipToImageBuffer(std::optional<RenderingResourceIdentifier> imageBufferIdentifier, const FloatRect& destinationRect)
         : m_imageBufferIdentifier(imageBufferIdentifier)
         , m_destinationRect(destinationRect)
     {
     }
 
-    RenderingResourceIdentifier imageBufferIdentifier() const { return m_imageBufferIdentifier; }
+    RenderingResourceIdentifier imageBufferIdentifier() const { return *m_imageBufferIdentifier; }
     FloatRect destinationRect() const { return m_destinationRect; }
 
-    bool isValid() const { return m_imageBufferIdentifier.isValid(); }
+    bool isValid() const { return !!m_imageBufferIdentifier; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    RenderingResourceIdentifier m_imageBufferIdentifier;
+    Markable<RenderingResourceIdentifier> m_imageBufferIdentifier;
     FloatRect m_destinationRect;
 };
 
@@ -569,19 +569,19 @@ public:
     {
     }
 
-    RenderingResourceIdentifier imageBufferIdentifier() const { return m_imageBufferIdentifier; }
+    RenderingResourceIdentifier imageBufferIdentifier() const { return *m_imageBufferIdentifier; }
     FloatRect source() const { return m_srcRect; }
     FloatRect destinationRect() const { return m_destinationRect; }
     ImagePaintingOptions options() const { return m_options; }
 
     // FIXME: We might want to validate ImagePaintingOptions.
-    bool isValid() const { return m_imageBufferIdentifier.isValid(); }
+    bool isValid() const { return !!m_imageBufferIdentifier; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    RenderingResourceIdentifier m_imageBufferIdentifier;
+    Markable<RenderingResourceIdentifier> m_imageBufferIdentifier;
     FloatRect m_destinationRect;
     FloatRect m_srcRect;
     ImagePaintingOptions m_options;
@@ -599,19 +599,19 @@ public:
     {
     }
 
-    RenderingResourceIdentifier imageIdentifier() const { return m_imageIdentifier; }
+    RenderingResourceIdentifier imageIdentifier() const { return *m_imageIdentifier; }
     const FloatRect& destinationRect() const { return m_destinationRect; }
     const FloatRect& source() const { return m_srcRect; }
     ImagePaintingOptions options() const { return m_options; }
 
     // FIXME: We might want to validate ImagePaintingOptions.
-    bool isValid() const { return m_imageIdentifier.isValid(); }
+    bool isValid() const { return !!m_imageIdentifier; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&, NativeImage&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    RenderingResourceIdentifier m_imageIdentifier;
+    Markable<RenderingResourceIdentifier> m_imageIdentifier;
     FloatRect m_destinationRect;
     FloatRect m_srcRect;
     ImagePaintingOptions m_options;
@@ -644,7 +644,7 @@ public:
 
     WEBCORE_EXPORT DrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { });
 
-    RenderingResourceIdentifier imageIdentifier() const { return m_imageIdentifier; }
+    RenderingResourceIdentifier imageIdentifier() const { return *m_imageIdentifier; }
     FloatRect destRect() const { return m_destination; }
     FloatRect tileRect() const { return m_tileRect; }
     const AffineTransform& patternTransform() const { return m_patternTransform; }
@@ -653,13 +653,13 @@ public:
     ImagePaintingOptions options() const { return m_options; }
 
     // FIXME: We might want to validate ImagePaintingOptions.
-    bool isValid() const { return m_imageIdentifier.isValid(); }
+    bool isValid() const { return !!m_imageIdentifier; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&, SourceImage&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    RenderingResourceIdentifier m_imageIdentifier;
+    Markable<RenderingResourceIdentifier> m_imageIdentifier;
     FloatRect m_destination;
     FloatRect m_tileRect;
     AffineTransform m_patternTransform;

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -232,7 +232,7 @@ void setMockGamepadButtonValue(unsigned gamepadIndex, unsigned buttonIndex, doub
 
 void setupNewlyCreatedServiceWorker(uint64_t serviceWorkerIdentifier)
 {
-    auto identifier = LegacyNullableAtomicObjectIdentifier<ServiceWorkerIdentifierType>(serviceWorkerIdentifier);
+    auto identifier = AtomicObjectIdentifier<ServiceWorkerIdentifierType>(serviceWorkerIdentifier);
     SWContextManager::singleton().postTaskToServiceWorker(identifier, [identifier] (ServiceWorkerGlobalScope& globalScope) {
         auto* script = globalScope.script();
         if (!script)

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -116,11 +116,11 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
 
     auto& context = *scriptExecutionContext();
     // FIXME: Maybe we could use a ScriptExecutionContextIdentifier for service workers too.
-    ServiceWorkerOrClientIdentifier sourceIdentifier;
-    if (auto* serviceWorker = dynamicDowncast<ServiceWorkerGlobalScope>(context))
-        sourceIdentifier = serviceWorker->thread().identifier();
-    else
-        sourceIdentifier = context.identifier();
+    ServiceWorkerOrClientIdentifier sourceIdentifier = [&]() -> ServiceWorkerOrClientIdentifier {
+        if (auto* serviceWorker = dynamicDowncast<ServiceWorkerGlobalScope>(context))
+            return serviceWorker->thread().identifier();
+        return context.identifier();
+    }();
 
     MessageWithMessagePorts message { messageData.releaseReturnValue(), portsOrException.releaseReturnValue() };
     swConnection().postMessageToServiceWorker(identifier(), WTFMove(message), sourceIdentifier);

--- a/Source/WebCore/workers/service/ServiceWorkerIdentifier.h
+++ b/Source/WebCore/workers/service/ServiceWorkerIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class ServiceWorkerIdentifierType { };
-using ServiceWorkerIdentifier = LegacyNullableAtomicObjectIdentifier<ServiceWorkerIdentifierType>;
+using ServiceWorkerIdentifier = AtomicObjectIdentifier<ServiceWorkerIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerTypes.h
+++ b/Source/WebCore/workers/service/ServiceWorkerTypes.h
@@ -80,7 +80,7 @@ using SWServerConnectionIdentifier = LegacyNullableObjectIdentifier<SWServerConn
 using ServiceWorkerOrClientData = std::variant<ServiceWorkerData, ServiceWorkerClientData>;
 
 // FIXME: It should be possible to replace ServiceWorkerOrClientIdentifier with ScriptExecutionContextIdentifier entirely.
-using ServiceWorkerOrClientIdentifier = std::variant<ServiceWorkerIdentifier, ScriptExecutionContextIdentifier>;
+using ServiceWorkerOrClientIdentifier = std::variant<ScriptExecutionContextIdentifier, ServiceWorkerIdentifier>;
 
 struct ServiceWorkerScripts {
     ServiceWorkerScripts isolatedCopy() const

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -102,7 +102,7 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
     , m_serviceWorkerRegistrationIdentifier(registration.identifier())
     , m_shouldSoftUpdate(registration.shouldSoftUpdate(loader.parameters().options))
 {
-    SWFETCH_RELEASE_LOG("ServiceWorkerFetchTask: (serverConnectionIdentifier=%" PRIu64 ", serviceWorkerRegistrationIdentifier=%" PRIu64 ", serviceWorkerIdentifier=%" PRIu64 ", %d)", m_serverConnectionIdentifier.toUInt64(), m_serviceWorkerRegistrationIdentifier->toUInt64(), m_serviceWorkerIdentifier.toUInt64(), isWorkerReady);
+    SWFETCH_RELEASE_LOG("ServiceWorkerFetchTask: (serverConnectionIdentifier=%" PRIu64 ", serviceWorkerRegistrationIdentifier=%" PRIu64 ", serviceWorkerIdentifier=%" PRIu64 ", %d)", m_serverConnectionIdentifier.toUInt64(), m_serviceWorkerRegistrationIdentifier->toUInt64(), m_serviceWorkerIdentifier->toUInt64(), isWorkerReady);
 
     // We only do the timeout logic for main document navigations because it is not Web-compatible to do so for subresources.
     if (loader.parameters().request.requester() == WebCore::ResourceRequestRequester::Main) {
@@ -201,7 +201,7 @@ void ServiceWorkerFetchTask::startFetch()
     if (auto& identifier = loader->parameters().options.resultingClientIdentifier)
         resultingClientIdentifier = identifier->toString();
 
-    bool isSent = sendToServiceWorker(Messages::WebSWContextManagerConnection::StartFetch { m_serverConnectionIdentifier, m_serviceWorkerIdentifier, m_fetchIdentifier, request, options, IPC::FormDataReference { m_currentRequest.httpBody() }, referrer, m_preloader && m_preloader->isServiceWorkerNavigationPreloadEnabled(), clientIdentifier, resultingClientIdentifier });
+    bool isSent = sendToServiceWorker(Messages::WebSWContextManagerConnection::StartFetch { m_serverConnectionIdentifier, *m_serviceWorkerIdentifier, m_fetchIdentifier, request, options, IPC::FormDataReference { m_currentRequest.httpBody() }, referrer, m_preloader && m_preloader->isServiceWorkerNavigationPreloadEnabled(), clientIdentifier, resultingClientIdentifier });
     ASSERT_UNUSED(isSent, isSent);
 
     if (m_preloader && m_preloader->didReceiveResponseOrError())
@@ -410,7 +410,7 @@ void ServiceWorkerFetchTask::cancelFromClient()
     if (m_isDone)
         return;
 
-    sendToServiceWorker(Messages::WebSWContextManagerConnection::CancelFetch { m_serverConnectionIdentifier, m_serviceWorkerIdentifier, m_fetchIdentifier });
+    sendToServiceWorker(Messages::WebSWContextManagerConnection::CancelFetch { m_serverConnectionIdentifier, *m_serviceWorkerIdentifier, m_fetchIdentifier });
 }
 
 void ServiceWorkerFetchTask::continueDidReceiveFetchResponse()
@@ -420,7 +420,7 @@ void ServiceWorkerFetchTask::continueDidReceiveFetchResponse()
         loadBodyFromPreloader();
         return;
     }
-    sendToServiceWorker(Messages::WebSWContextManagerConnection::ContinueDidReceiveFetchResponse { m_serverConnectionIdentifier, m_serviceWorkerIdentifier, m_fetchIdentifier });
+    sendToServiceWorker(Messages::WebSWContextManagerConnection::ContinueDidReceiveFetchResponse { m_serverConnectionIdentifier, *m_serviceWorkerIdentifier, m_fetchIdentifier });
 }
 
 void ServiceWorkerFetchTask::continueFetchTaskWith(ResourceRequest&& request)
@@ -448,7 +448,7 @@ void ServiceWorkerFetchTask::timeoutTimerFired()
     cannotHandle();
 
     if (CheckedPtr swServerConnection = m_swServerConnection.get())
-        swServerConnection->fetchTaskTimedOut(serviceWorkerIdentifier());
+        swServerConnection->fetchTaskTimedOut(*serviceWorkerIdentifier());
 }
 
 void ServiceWorkerFetchTask::softUpdateIfNeeded()
@@ -507,9 +507,9 @@ void ServiceWorkerFetchTask::sendNavigationPreloadUpdate()
     ASSERT(!!m_serviceWorkerConnection);
 
     if (!m_preloader->error().isNull())
-        sendToServiceWorker(Messages::WebSWContextManagerConnection::NavigationPreloadFailed { m_serverConnectionIdentifier, m_serviceWorkerIdentifier, m_fetchIdentifier, m_preloader->error() });
+        sendToServiceWorker(Messages::WebSWContextManagerConnection::NavigationPreloadFailed { m_serverConnectionIdentifier, *m_serviceWorkerIdentifier, m_fetchIdentifier, m_preloader->error() });
     else
-        sendToServiceWorker(Messages::WebSWContextManagerConnection::NavigationPreloadIsReady { m_serverConnectionIdentifier, m_serviceWorkerIdentifier, m_fetchIdentifier, m_preloader->response() });
+        sendToServiceWorker(Messages::WebSWContextManagerConnection::NavigationPreloadIsReady { m_serverConnectionIdentifier, *m_serviceWorkerIdentifier, m_fetchIdentifier, m_preloader->response() });
 }
 
 void ServiceWorkerFetchTask::loadBodyFromPreloader()
@@ -571,7 +571,7 @@ bool ServiceWorkerFetchTask::convertToDownload(DownloadManager& manager, Downloa
     // FIXME: We might want to keep the service worker alive until the download ends.
     RefPtr<ServiceWorkerDownloadTask> serviceWorkerDownloadTask;
     auto serviceWorkerDownloadLoad = NetworkLoad::create(*protectedLoader(), *session, [&](auto& client) {
-        serviceWorkerDownloadTask =  ServiceWorkerDownloadTask::create(*session, client, *m_serviceWorkerConnection, m_serviceWorkerIdentifier, m_serverConnectionIdentifier, m_fetchIdentifier, request, response, downloadID);
+        serviceWorkerDownloadTask =  ServiceWorkerDownloadTask::create(*session, client, *m_serviceWorkerConnection, *m_serviceWorkerIdentifier, m_serverConnectionIdentifier, m_fetchIdentifier, request, response, downloadID);
         return serviceWorkerDownloadTask.copyRef();
     });
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -79,7 +79,7 @@ public:
     void continueFetchTaskWith(WebCore::ResourceRequest&&);
 
     WebCore::FetchIdentifier fetchIdentifier() const { return m_fetchIdentifier; }
-    WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier() const { return m_serviceWorkerIdentifier; }
+    std::optional<WebCore::ServiceWorkerIdentifier> serviceWorkerIdentifier() const { return m_serviceWorkerIdentifier; }
 
     WebCore::ResourceRequest takeRequest() { return WTFMove(m_currentRequest); }
 
@@ -131,7 +131,7 @@ private:
     WeakPtr<WebSWServerToContextConnection> m_serviceWorkerConnection;
     WebCore::FetchIdentifier m_fetchIdentifier;
     WebCore::SWServerConnectionIdentifier m_serverConnectionIdentifier;
-    WebCore::ServiceWorkerIdentifier m_serviceWorkerIdentifier;
+    Markable<WebCore::ServiceWorkerIdentifier> m_serviceWorkerIdentifier;
     WebCore::ResourceRequest m_currentRequest;
     std::unique_ptr<WebCore::Timer> m_timeoutTimer;
     Markable<WebCore::ServiceWorkerRegistrationIdentifier> m_serviceWorkerRegistrationIdentifier;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -293,7 +293,7 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
         }
 
         RefPtr server = protectedServer();
-        RefPtr worker = server->workerByID(task->serviceWorkerIdentifier());
+        RefPtr worker = server->workerByID(*task->serviceWorkerIdentifier());
         if (!worker || worker->hasTimedOutAnyFetchTasks()) {
             task->cannotHandle();
             return;
@@ -302,7 +302,7 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
         if (!worker->contextConnection())
             server->createContextConnection(worker->topRegistrableDomain(), worker->serviceWorkerPageIdentifier());
 
-        auto identifier = task->serviceWorkerIdentifier();
+        auto identifier = *task->serviceWorkerIdentifier();
         server->runServiceWorkerIfNecessary(identifier, [weakThis = WTFMove(weakThis), this, task = WTFMove(task)](auto* contextConnection) mutable {
 #if RELEASE_LOG_DISABLED
             UNUSED_PARAM(this);
@@ -321,7 +321,7 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
                 task->cannotHandle();
                 return;
             }
-            SWSERVERCONNECTION_RELEASE_LOG("startFetch: Starting fetch %" PRIu64 " via service worker %" PRIu64, task->fetchIdentifier().toUInt64(), task->serviceWorkerIdentifier().toUInt64());
+            SWSERVERCONNECTION_RELEASE_LOG("startFetch: Starting fetch %" PRIu64 " via service worker %" PRIu64, task->fetchIdentifier().toUInt64(), task->serviceWorkerIdentifier()->toUInt64());
             static_cast<WebSWServerToContextConnection&>(*contextConnection).startFetch(*task);
         });
     };

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
@@ -24,7 +24,7 @@
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierReference; }
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierWriteReference; }
 additional_forward_declaration: namespace IPC { template<typename> struct ObjectIdentifierReadReference; }
-additional_forward_declaration: namespace WebCore { using RenderingResourceIdentifier = LegacyNullableAtomicObjectIdentifier<RenderingResourceIdentifierType>; }
+additional_forward_declaration: namespace WebCore { using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>; }
 additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = LegacyNullableAtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
 additional_forward_declaration: namespace WebKit { using RemoteSerializedImageBufferIdentifier = WebCore::RenderingResourceIdentifier; }
 

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
@@ -178,6 +178,7 @@ namespace WTF {
 
 template<typename T> struct HashTraits<IPC::ObjectIdentifierReference<T>> : SimpleClassHashTraits<IPC::ObjectIdentifierReference<T>> {
     static constexpr bool emptyValueIsZero = HashTraits<T>::emptyValueIsZero;
+    static IPC::ObjectIdentifierReference<T> emptyValue() { return { HashTraits<T>::emptyValue(), 0 }; }
 };
 
 template<typename T> struct DefaultHash<IPC::ObjectIdentifierReference<T>> {

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -166,8 +166,6 @@ template: struct WebKit::WebExtensionWindowIdentifierType
 }
 
 header: <wtf/ObjectIdentifier.h>
-template: enum class WebCore::RenderingResourceIdentifierType
-template: enum class WebCore::ServiceWorkerIdentifierType
 template: enum class WebCore::IDBDatabaseConnectionIdentifierType
 template: enum class WebCore::WorkerFileSystemStorageConnectionCallbackIdentifierType
 template: enum class WebKit::GraphicsContextGLIdentifierType
@@ -188,7 +186,6 @@ template: class WebCore::WebSocketChannel
 template: enum class IPC::ConnectionSyncRequestIDType
 template: enum class JSC::MicrotaskIdentifierType
 template: enum class WebCore::DOMCacheIdentifierType
-template: enum class WebCore::WebSocketIdentifierType
 template: enum class WebCore::BroadcastChannelIdentifierType
 template: enum class WebCore::FileSystemHandleIdentifierType
 template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
@@ -199,9 +196,12 @@ template: enum class WebCore::OpaqueOriginIdentifierType
 template: enum class WebCore::PortIdentifierType
 template: enum class WebCore::RTCDataChannelLocalIdentifierType
 template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
+template: enum class WebCore::RenderingResourceIdentifierType
+template: enum class WebCore::ServiceWorkerIdentifierType
 template: enum class WebCore::ServiceWorkerJobIdentifierType
 template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
 template: enum class WebCore::WebLockIdentifierType
+template: enum class WebCore::WebSocketIdentifierType
 template: enum class WebKit::GPUProcessConnectionIdentifierType
 template: enum class WebKit::LegacyCustomProtocolIDType
 template: enum class WebKit::LibWebRTCResolverIdentifierType

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8252,7 +8252,7 @@ using WebCore::TrackID = uint64_t
 #endif
 using WebCore::EpochTimeStamp = uint64_t
 using WebCore::SharedMemory::Handle = WebCore::SharedMemoryHandle
-using WebCore::ServiceWorkerOrClientIdentifier = std::variant<WebCore::ServiceWorkerIdentifier, WebCore::ScriptExecutionContextIdentifier>
+using WebCore::ServiceWorkerOrClientIdentifier = std::variant<WebCore::ScriptExecutionContextIdentifier, WebCore::ServiceWorkerIdentifier>
 
 [Nested] enum class WebCore::GraphicsContext::RequiresClipToRect : bool
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -182,7 +182,7 @@ private:
     Markable<WebCore::PlatformLayerIdentifier> m_layerID;
     Lock m_surfaceLock;
     std::optional<ImageBufferBackendHandle> m_surfaceBackendHandle WTF_GUARDED_BY_LOCK(m_surfaceLock);
-    WebCore::RenderingResourceIdentifier m_surfaceIdentifier WTF_GUARDED_BY_LOCK(m_surfaceLock);
+    Markable<WebCore::RenderingResourceIdentifier> m_surfaceIdentifier WTF_GUARDED_BY_LOCK(m_surfaceLock);
 };
 
 RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCARemote::createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -88,8 +88,8 @@ TEST(DisplayListTests, ItemValidationFailure)
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.get(), kCGImageAlphaPremultipliedLast));
     GraphicsContextCG context { cgContext.get() };
 
-    auto runTestWithInvalidIdentifier = [&](RenderingResourceIdentifier identifier) {
-        EXPECT_FALSE(identifier.isValid());
+    auto runTestWithInvalidIdentifier = [&](std::optional<RenderingResourceIdentifier> identifier) {
+        EXPECT_TRUE(!identifier);
 
         DisplayList list;
         list.append(ClipToImageBuffer(identifier, FloatRect { }));
@@ -100,8 +100,7 @@ TEST(DisplayListTests, ItemValidationFailure)
         EXPECT_EQ(result.reasonForStopping, StopReplayReason::InvalidItemOrExtent);
     };
 
-    runTestWithInvalidIdentifier(RenderingResourceIdentifier { });
-    runTestWithInvalidIdentifier(RenderingResourceIdentifier { WTF::HashTableDeletedValue });
+    runTestWithInvalidIdentifier(std::nullopt);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 970ab24e4030f3049eac52f83fb5946e88cbf831
<pre>
Reduce use of LegacyNullableAtomicObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=280407">https://bugs.webkit.org/show_bug.cgi?id=280407</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/graphics/RenderingResourceIdentifier.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::ClipToImageBuffer::ClipToImageBuffer):
(WebCore::DisplayList::ClipToImageBuffer::imageBufferIdentifier const):
(WebCore::DisplayList::ClipToImageBuffer::isValid const):
(WebCore::DisplayList::DrawImageBuffer::imageBufferIdentifier const):
(WebCore::DisplayList::DrawImageBuffer::isValid const):
(WebCore::DisplayList::DrawNativeImage::imageIdentifier const):
(WebCore::DisplayList::DrawNativeImage::isValid const):
(WebCore::DisplayList::DrawPattern::imageIdentifier const):
(WebCore::DisplayList::DrawPattern::isValid const):
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::setupNewlyCreatedServiceWorker):
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::postMessage):
* Source/WebCore/workers/service/ServiceWorkerIdentifier.h:
* Source/WebCore/workers/service/ServiceWorkerTypes.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::startFetch):
(WebKit::ServiceWorkerFetchTask::cancelFromClient):
(WebKit::ServiceWorkerFetchTask::continueDidReceiveFetchResponse):
(WebKit::ServiceWorkerFetchTask::timeoutTimerFired):
(WebKit::ServiceWorkerFetchTask::sendNavigationPreloadUpdate):
(WebKit::ServiceWorkerFetchTask::convertToDownload):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
(WebKit::ServiceWorkerFetchTask::serviceWorkerIdentifier const):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::startFetch):
* Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in:
* Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h:
(WTF::HashTraits&lt;IPC::ObjectIdentifierReference&lt;T&gt;&gt;::emptyValue):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST(DisplayListTests, ItemValidationFailure)):

Canonical link: <a href="https://commits.webkit.org/284324@main">https://commits.webkit.org/284324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d64ac96fe1bb5ff8e5de5c3497d2398a1f76186d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20074 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13426 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72133 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44242 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59629 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16643 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62529 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4133 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10549 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44271 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->