### PR TITLE
[WGSL] Attribute validator should not access Type::alignment

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -394,6 +394,13 @@ void AttributeValidator::visit(AST::StructureMember& member)
                 error(attribute.span(), "@align value must be positive"_s);
             else if (!isPowerOf2)
                 error(attribute.span(), "@align value must be a power of two"_s);
+
+            if (UNLIKELY(!m_errors.isEmpty())) {
+                // It's not safe to access Type::alignment below if errors have
+                // already occurred
+                continue;
+            }
+
             // FIXME: validate that alignment is a multiple of RequiredAlignOf(T,C)
             auto* type = member.type().inferredType();
             update(attribute.span(), member.m_alignment, std::max<unsigned>(alignmentValue, type ? type->alignment() : 1u));

--- a/Source/WebGPU/WGSL/tests/invalid/fuzz-136222279.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/fuzz-136222279.wgsl
@@ -1,0 +1,11 @@
+// RUN: %not %wgslc | %check
+
+struct S {
+    // CHECK-L: @size value must be at least the byte-size of the type of the member
+    @size(2) x: i32,
+}
+
+struct T {
+    // Test that we don't crash when referring to a struct that contains errors
+    @align(32) x: S,
+}


### PR DESCRIPTION
#### be0e71ac63cf08348ea4cdcdbc55cc67892dff00
<pre>
[WGSL] Attribute validator should not access Type::alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=280405">https://bugs.webkit.org/show_bug.cgi?id=280405</a>
<a href="https://rdar.apple.com/136222279">rdar://136222279</a>

Reviewed by Mike Wyrzykowski.

Type::alignment can access AST::Structure::m_alignment, which is populated by the
AttributeValidator itself, so it&apos;s only safe to access it when no validation errors
have occurred so far. Otherwise, there&apos;s a chance we might be accessing the alignment
(or size) of a struct that contained an error, and therefore its alignment/size
wouldn&apos;t have been computed.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/tests/invalid/fuzz-136222279.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/284346@main">https://commits.webkit.org/284346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdb322443b6420bc0d17da98b864783034c4c688

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20125 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54931 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13383 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40832 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15337 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4058 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44178 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->