### PR TITLE
[css-values] Implement attr() fallback support

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4152,7 +4152,6 @@ webkit.org/b/203331 imported/w3c/web-platform-tests/css/css-values/attr-px-valid
 webkit.org/b/259025 imported/w3c/web-platform-tests/css/css-values/ic-unit-015.html [ ImageOnlyFailure ]
 webkit.org/b/214466 imported/w3c/web-platform-tests/css/css-values/ex-unit-004.html [ ImageOnlyFailure ]
 webkit.org/b/242467 imported/w3c/web-platform-tests/css/css-values/calc-text-indent-intrinsic-1.html [ ImageOnlyFailure ]
-webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/attr-notype-fallback.html [ ImageOnlyFailure ]
 webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-aspect-ratio-001.html [ ImageOnlyFailure ]
 webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-aspect-ratio-002.html [ ImageOnlyFailure ]
 webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-aspect-ratio-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
@@ -326,10 +326,10 @@ PASS content: attr(foo-bar)
 PASS content: attr(foo_bar)
 FAIL content: attr(|bar) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
 FAIL content: attr( |bar ) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
-FAIL content: attr(foo-bar, "fallback") assert_equals: content raw inline style declaration expected "attr(foo-bar, \"fallback\")" but got ""
-FAIL content: attr(foo_bar, "fallback") assert_equals: content raw inline style declaration expected "attr(foo_bar, \"fallback\")" but got ""
+PASS content: attr(foo-bar, "fallback")
+PASS content: attr(foo_bar, "fallback")
 FAIL content: attr(|bar, "fallback") assert_equals: content raw inline style declaration expected "attr(bar, \"fallback\")" but got ""
-FAIL content: attr(foo, "") assert_equals: content raw inline style declaration expected "attr(foo)" but got ""
+PASS content: attr(foo, "")
 FAIL content: attr( |foo ,  "" ) assert_equals: content raw inline style declaration expected "attr(foo)" but got ""
 PASS content: inherit
 PASS cursor: auto

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -847,6 +847,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/SerializedCryptoKeyWrap.h
     crypto/WrappedCryptoKey.h
 
+    css/CSSAttrValue.h
     css/CSSConditionRule.h
     css/CSSCounterStyle.h
     css/CSSCounterStyleDescriptors.h

--- a/Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
@@ -1,6 +1,7 @@
 Modules/webtransport/WebTransportReceiveStream.h
 Modules/webtransport/WebTransportSendStream.h
 css/CSSAspectRatioValue.h
+css/CSSAttrValue.h
 css/CSSBackgroundRepeatValue.h
 css/CSSBasicShapes.h
 css/CSSBorderImageSliceValue.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -849,6 +849,7 @@ crypto/keys/CryptoKeyRaw.cpp
 css/BasicShapeConversion.cpp
 css/BasicShapesShapeSegmentConversion.cpp
 css/CSSAspectRatioValue.cpp
+css/CSSAttrValue.cpp
 css/CSSBackgroundRepeatValue.cpp
 css/CSSShapeSegmentValue.cpp
 css/CSSBasicShapes.cpp

--- a/Source/WebCore/css/CSSAttrValue.cpp
+++ b/Source/WebCore/css/CSSAttrValue.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Alexsander Borges Damaceno <alexbdamac@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "config.h"
+#include "CSSAttrValue.h"
+
+#include "CSSPrimitiveValue.h"
+
+namespace WebCore {
+
+Ref<CSSAttrValue> CSSAttrValue::create(String attributeName, RefPtr<CSSValue>&& fallback)
+{
+    return adoptRef(*new CSSAttrValue(WTFMove(attributeName), WTFMove(fallback)));
+}
+
+bool CSSAttrValue::equals(const CSSAttrValue& other) const
+{
+    RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
+    RefPtr otherFallback = dynamicDowncast<CSSPrimitiveValue>(other.m_fallback);
+
+    if (fallback && otherFallback)
+        return m_attributeName == other.m_attributeName && fallback->stringValue() == otherFallback->stringValue();
+    return m_attributeName == other.m_attributeName;
+}
+
+String CSSAttrValue::customCSSText() const
+{
+    RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
+    return makeString(
+        "attr("_s,
+        m_attributeName.impl(),
+        fallback && !fallback->stringValue().isEmpty() ? ", "_s : ""_s,
+        fallback && !fallback->stringValue().isEmpty() ? fallback->cssText() : ""_s,
+        ')'
+    );
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSAttrValue.h
+++ b/Source/WebCore/css/CSSAttrValue.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Alexsander Borges Damaceno <alexbdamac@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValue.h"
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class Element;
+
+class CSSAttrValue final : public CSSValue {
+public:
+    static Ref<CSSAttrValue> create(String attributeName, RefPtr<CSSValue>&& fallback = nullptr);
+    const String attributeName() const { return m_attributeName; }
+    const CSSValue* fallback() const { return m_fallback.get(); }
+    bool equals(const CSSAttrValue& other) const;
+    String customCSSText() const;
+
+private:
+    explicit CSSAttrValue(String&& attributeName, RefPtr<CSSValue>&& fallback)
+        : CSSValue(ClassType::Attr)
+        , m_attributeName(WTFMove(attributeName))
+        , m_fallback(WTFMove(fallback))
+    {
+    }
+
+    String m_attributeName;
+    RefPtr<CSSValue> m_fallback;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSAttrValue, isAttrValue())

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -351,6 +351,13 @@ CSSPrimitiveValue::CSSPrimitiveValue(CSSUnresolvedColor unresolvedColor)
     m_value.unresolvedColor = new CSSUnresolvedColor(WTFMove(unresolvedColor));
 }
 
+CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSAttrValue> value)
+    : CSSValue(ClassType::Primitive)
+{
+    setPrimitiveUnitType(CSSUnitType::CSS_ATTR);
+    m_value.attr = &value.leakRef();
+}
+
 CSSPrimitiveValue::~CSSPrimitiveValue()
 {
     auto type = primitiveUnitType();
@@ -358,10 +365,12 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_URI:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
         if (m_value.string)
             m_value.string->deref();
+        break;
+    case CSSUnitType::CSS_ATTR:
+        m_value.attr->deref();
         break;
     case CSSUnitType::CSS_CALC:
         m_value.calc->deref();
@@ -574,9 +583,9 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(CSSUnresolvedColor value)
     return adoptRef(*new CSSPrimitiveValue(WTFMove(value)));
 }
 
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::createAttr(String value)
+Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSAttrValue> value)
 {
-    return adoptRef(*new CSSPrimitiveValue(WTFMove(value), CSSUnitType::CSS_ATTR));
+    return adoptRef(*new CSSPrimitiveValue(WTFMove(value)));
 }
 
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::createCustomIdent(String value)
@@ -1278,7 +1287,6 @@ String CSSPrimitiveValue::stringValue() const
     switch (primitiveUnitType()) {
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CustomIdent:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
     case CSSUnitType::CSS_URI:
         return m_value.string;
@@ -1286,6 +1294,8 @@ String CSSPrimitiveValue::stringValue() const
         return nameString(m_value.valueID);
     case CSSUnitType::CSS_PROPERTY_ID:
         return nameString(m_value.propertyID);
+    case CSSUnitType::CSS_ATTR:
+        return m_value.attr->cssText();
     default:
         return String();
     }
@@ -1497,9 +1507,8 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_X:
         return formatNumberValue(unitTypeString(type));
-
     case CSSUnitType::CSS_ATTR:
-        return makeString("attr("_s, m_value.string, ')');
+        return m_value.attr->cssText();
     case CSSUnitType::CSS_CALC:
         return m_value.calc->cssText();
     case CSSUnitType::CSS_DIMENSION:
@@ -1641,9 +1650,10 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_URI:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
         return equal(m_value.string, other.m_value.string);
+    case CSSUnitType::CSS_ATTR:
+        return m_value.attr->equals(*other.m_value.attr);
     case CSSUnitType::CSS_RGBCOLOR:
         return color() == other.color();
     case CSSUnitType::CSS_CALC:
@@ -1745,9 +1755,11 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CustomIdent:
     case CSSUnitType::CSS_URI:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_FONT_FAMILY:
         add(hasher, String { m_value.string });
+        break;
+    case CSSUnitType::CSS_ATTR:
+        add(hasher, m_value.attr);
         break;
     case CSSUnitType::CSS_RGBCOLOR:
         add(hasher, color());

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "CSSAttrValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSUnits.h"
 #include "CSSValue.h"
@@ -86,6 +87,7 @@ public:
 
     // FIXME: Some of these use primitiveUnitType() and some use primitiveType(). Many that use primitiveUnitType() are likely broken with calc().
     bool isAngle() const { return unitCategory(primitiveType()) == CSSUnitCategory::Angle; }
+    bool isAttr() const { return primitiveUnitType() == CSSUnitType::CSS_ATTR; }
     bool isFontIndependentLength() const { return isFontIndependentLength(primitiveUnitType()); }
     bool isFontRelativeLength() const { return isFontRelativeLength(primitiveUnitType()); }
     bool isParentFontRelativeLength() const { return isPercentage() || (isFontRelativeLength() && !isRootFontRelativeLength()); }
@@ -118,6 +120,7 @@ public:
     static Ref<CSSPrimitiveValue> create(const Length&);
     static Ref<CSSPrimitiveValue> create(const Length&, const RenderStyle&);
     static Ref<CSSPrimitiveValue> create(Ref<CSSCalcValue>);
+    static Ref<CSSPrimitiveValue> create(Ref<CSSAttrValue>);
 
     static inline Ref<CSSPrimitiveValue> create(CSSValueID);
     bool isValueID() const { return primitiveUnitType() == CSSUnitType::CSS_VALUE_ID; }
@@ -133,9 +136,6 @@ public:
     static Ref<CSSPrimitiveValue> create(CSSUnresolvedColor);
     bool isUnresolvedColor() const { return primitiveUnitType() == CSSUnitType::CSS_UNRESOLVED_COLOR; }
     const CSSUnresolvedColor& unresolvedColor() const { ASSERT(isUnresolvedColor()); return *m_value.unresolvedColor; }
-
-    static Ref<CSSPrimitiveValue> createAttr(String);
-    bool isAttr() const { return primitiveUnitType() == CSSUnitType::CSS_ATTR; }
 
     bool isColor() const { return primitiveUnitType() == CSSUnitType::CSS_RGBCOLOR; }
     const Color& color() const { ASSERT(isColor()); return *reinterpret_cast<const Color*>(&m_value.colorAsInteger); }
@@ -223,6 +223,7 @@ public:
 
     WEBCORE_EXPORT String stringValue() const;
     const CSSCalcValue* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
+    const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
 
     String customCSSText() const;
 
@@ -254,6 +255,7 @@ private:
     CSSPrimitiveValue(double, CSSUnitType);
     explicit CSSPrimitiveValue(Ref<CSSCalcValue>);
     explicit CSSPrimitiveValue(CSSUnresolvedColor);
+    explicit CSSPrimitiveValue(Ref<CSSAttrValue>);
 
     CSSPrimitiveValue(StaticCSSValueTag, CSSValueID);
     CSSPrimitiveValue(StaticCSSValueTag, Color);
@@ -307,6 +309,7 @@ private:
         uint64_t colorAsInteger;
         const CSSUnresolvedColor* unresolvedColor;
         const CSSCalcValue* calc;
+        const CSSAttrValue* attr;
     } m_value;
 };
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3298,7 +3298,7 @@
                 "custom": "All",
                 "separator": ",",
                 "parser-function": "consumeContent",
-                "parser-grammar-unused": "none | normal | [ <image> | open-quote | close-quote | no-open-quote | no-close-quote | attr(<custom-ident>) | counter(<counter-name>, <counter-style>?) | counters(<counter-name>, <string>, <counter-style>?) ]+",
+                "parser-grammar-unused": "none | normal | [ <image> | open-quote | close-quote | no-open-quote | no-close-quote | attr(<custom-ident>,<declaration-value>?) | counter(<counter-name>, <counter-style>?) | counters(<counter-name>, <string>, <counter-style>?) ]+",
                 "parser-grammar-unused-reason": "consumeContent is quite different than current spec"
             },
             "specification": {

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -30,6 +30,7 @@
 #include "CSSValue.h"
 
 #include "CSSAspectRatioValue.h"
+#include "CSSAttrValue.h"
 #include "CSSBackgroundRepeatValue.h"
 #include "CSSBasicShapes.h"
 #include "CSSBorderImageSliceValue.h"
@@ -104,6 +105,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
 {
     using enum CSSValue::ClassType;
     switch (m_classType) {
+    case Attr:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAttrValue>(*this));
     case AspectRatio:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAspectRatioValue>(*this));
     case BackgroundRepeat:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -64,6 +64,7 @@ public:
 
     WEBCORE_EXPORT String cssText() const;
 
+    bool isAttrValue() const { return m_classType == ClassType::Attr; }
     bool isAspectRatioValue() const { return m_classType == ClassType::AspectRatio; }
     bool isBackgroundRepeatValue() const { return m_classType == ClassType::BackgroundRepeat; }
     bool isBorderImageSliceValue() const { return m_classType == ClassType::BorderImageSlice; }
@@ -225,6 +226,7 @@ protected:
 
         // Other non-list classes.
         AspectRatio,
+        Attr,
         BackgroundRepeat,
         BorderImageSlice,
         BorderImageWidth,

--- a/Source/WebCore/css/calc/CSSCalcTree+Copy.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Copy.cpp
@@ -78,7 +78,7 @@ template<typename Op> Child copy(const IndirectNode<Op>& root)
     return makeChild(WTF::apply([](const auto& ...x) { return Op { copy(x)... }; } , *root), root.type);
 }
 
-static Anchor::Side copy(const Anchor::Side& side)
+Anchor::Side copy(const Anchor::Side& side)
 {
     return WTF::switchOn(side,
         [](CSSValueID value) -> Anchor::Side {

--- a/Source/WebCore/css/calc/CSSCalcTree+Copy.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Copy.h
@@ -31,6 +31,7 @@ struct Tree;
 
 // Makes a copy of the tree.
 Tree copy(const Tree&);
+Anchor::Side copy(const Anchor::Side&);
 
 } // namespace CSSCalc
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -27,6 +27,7 @@
 
 #include "AnchorPositionEvaluator.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSCalcTree+Copy.h"
 #include "CSSCalcTree+Evaluation.h"
 #include "CSSCalcTree+NumericIdentity.h"
 #include "CSSCalcTree+Traversal.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimingFunction.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimingFunction.cpp
@@ -32,6 +32,7 @@
 #include "CSSPropertyParserConsumer+Integer.h"
 #include "CSSPropertyParserConsumer+Number.h"
 #include "CSSPropertyParserConsumer+Percentage.h"
+#include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSTimingFunctionValue.h"
 #include "CSSValueKeywords.h"
 #include "TimingFunction.h"

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes.cpp
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes.cpp
@@ -26,6 +26,8 @@
 #include "CSSPrimitiveNumericTypes.h"
 
 #include "CSSPrimitiveValue.h"
+#include "CSSToLengthConversionData.h"
+#include "FloatConversion.h"
 
 namespace WebCore {
 namespace CSS {

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1258,13 +1258,19 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
             builderState.style().setHasAttrContent();
         else
             const_cast<RenderStyle&>(builderState.parentStyle()).setHasAttrContent();
-        QualifiedName attr(nullAtom(), primitiveValue.stringValue().impl(), nullAtom());
+
+        auto value = primitiveValue.cssAttrValue();
+        QualifiedName attr(nullAtom(), value->attributeName().impl(), nullAtom());
         const AtomString& attributeValue = builderState.element() ? builderState.element()->getAttribute(attr) : nullAtom();
 
         // Register the fact that the attribute value affects the style.
         builderState.registerContentAttribute(attr.localName());
 
-        return attributeValue.isNull() ? emptyAtom() : attributeValue.impl();
+        if (attributeValue.isNull()) {
+            auto fallback = dynamicDowncast<CSSPrimitiveValue>(value->fallback());
+            return fallback && fallback->isString() ? fallback->stringValue().impl() : emptyAtom();
+        }
+        return attributeValue.impl();
     };
 
     bool didSet = false;


### PR DESCRIPTION
#### fe663b06e8da7388f053104ca13de9ca48730212
<pre>
[css-values] Implement attr() fallback support
<a href="https://bugs.webkit.org/show_bug.cgi?id=280406">https://bugs.webkit.org/show_bug.cgi?id=280406</a>

Reviewed by Tim Nguyen.

Implement initial fallback support for attr(), refactor attr into a class to facilitate easier extension for additional features.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SmartPointerExpectations/RefCntblBaseVirtualDtorExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/css/CSSAttrValue.cpp: Added.
(WebCore::CSSAttrValue::create):
(WebCore::CSSAttrValue::equals const):
(WebCore::CSSAttrValue::customCSSText const):
* Source/WebCore/css/CSSAttrValue.h: Added.
* Source/WebCore/css/CSSFontFeatureValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::create):
(WebCore::CSSPrimitiveValue::stringValue const):
(WebCore::CSSPrimitiveValue::serializeInternal const):
(WebCore::CSSPrimitiveValue::createAttr): Deleted.
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isAttrValue const):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeAttr):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueContent):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Copy.cpp:
(WebCore::CSSCalc::copy):
* Source/WebCore/css/calc/CSSCalcTree+Copy.h:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::isSyntaxValueString const):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::stringValue const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/values/CSSPrimitiveNumericTypes.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimingFunction.cpp:

Canonical link: <a href="https://commits.webkit.org/285849@main">https://commits.webkit.org/285849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eff3cf1e845fca8dcaab979c06a98b35859ce08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58135 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21051 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66413 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7768 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3907 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1192 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->