### PR TITLE
[GTK][WPE] Add more composition related signposts

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -172,10 +172,12 @@ enum TracePointCode {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     GTKWPEPortRange = 20000,
 
+    FlushPendingLayerChangesStart,
+    FlushPendingLayerChangesEnd,
     WaitForCompositionCompletionStart,
     WaitForCompositionCompletionEnd,
-    FrameCompositionStart,
-    FrameCompositionEnd,
+    RenderLayerTreeStart,
+    RenderLayerTreeEnd,
     LayerFlushStart,
     LayerFlushEnd,
     UpdateLayerContentBuffersStart,

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -136,7 +136,8 @@ public:
         case BackingStoreFlushStart:
         case BuildTransactionStart:
         case WaitForCompositionCompletionStart:
-        case FrameCompositionStart:
+        case RenderLayerTreeStart:
+        case FlushPendingLayerChangesStart:
         case LayerFlushStart:
         case SyncMessageStart:
         case SyncTouchEventStart:
@@ -194,7 +195,8 @@ public:
         case WebHTMLViewPaintEnd:
         case BackingStoreFlushEnd:
         case WaitForCompositionCompletionEnd:
-        case FrameCompositionEnd:
+        case RenderLayerTreeEnd:
+        case FlushPendingLayerChangesEnd:
         case LayerFlushEnd:
         case BuildTransactionEnd:
         case SyncMessageEnd:
@@ -438,12 +440,15 @@ private:
         case WakeUpAndApplyDisplayListEnd:
             return "WakeUpAndApplyDisplayList"_s;
 
+        case FlushPendingLayerChangesStart:
+        case FlushPendingLayerChangesEnd:
+            return "FlushPendingLayerChanges"_s;
         case WaitForCompositionCompletionStart:
         case WaitForCompositionCompletionEnd:
             return "WaitForCompositionCompletion"_s;
-        case FrameCompositionStart:
-        case FrameCompositionEnd:
-            return "FrameComposition"_s;
+        case RenderLayerTreeStart:
+        case RenderLayerTreeEnd:
+            return "RenderLayerTree"_s;
         case LayerFlushStart:
         case LayerFlushEnd:
             return "LayerFlush"_s;

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -225,7 +225,7 @@ void ThreadedCompositor::forceRepaint()
 void ThreadedCompositor::renderLayerTree()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    TraceScope traceScope(FrameCompositionStart, FrameCompositionEnd);
+    TraceScope traceScope(RenderLayerTreeStart, RenderLayerTreeEnd);
 #endif
 
     if (!m_scene || !m_scene->isActive())
@@ -375,6 +375,8 @@ WebCore::DisplayRefreshMonitor& ThreadedCompositor::displayRefreshMonitor() cons
 
 void ThreadedCompositor::frameComplete()
 {
+    WTFEmitSignpost(this, FrameComplete);
+
     ASSERT(m_compositingRunLoop->isCurrent());
 #if !HAVE(DISPLAY_LINK)
     displayUpdateFired();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -160,7 +160,7 @@ void CompositingCoordinator::sizeDidChange(const IntSize& newSize)
 
 bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderingUpdateFlags> flags)
 {
-    TraceScope traceScope(BackingStoreFlushStart, BackingStoreFlushEnd);
+    TraceScope traceScope(FlushPendingLayerChangesStart, FlushPendingLayerChangesEnd);
     SetForScope protector(m_isFlushingLayerChanges, true);
 
     bool shouldSyncFrame = initializeRootCompositingLayerIfNeeded();


### PR DESCRIPTION
#### d90b9267a7df7c311bf59d976af2d865369c2ee9
<pre>
[GTK][WPE] Add more composition related signposts
<a href="https://bugs.webkit.org/show_bug.cgi?id=280410">https://bugs.webkit.org/show_bug.cgi?id=280410</a>

Reviewed by Alejandro G. Castro.

Add more signposts to better understand the composition pipeline.

No need for new tests.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::frameComplete):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::scheduleLayerFlush):
(WebKit::LayerTreeHost::layerFlushTimerFired):
(WebKit::LayerTreeHost::commitSceneState):
(WebKit::LayerTreeHost::didRenderFrame):
(WebKit::LayerTreeHost::renderNextFrame):

Canonical link: <a href="https://commits.webkit.org/284347@main">https://commits.webkit.org/284347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba2da74c810605a1bc7c0fa010c8fe0facbfcf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20288 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20137 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40964 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18662 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62246 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74922 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68376 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13112 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59760 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15339 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4179 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90157 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44334 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15987 "Found 26 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/es5/TypeConversions.js.default, ChakraCore.yaml/ChakraCore/test/es6/regex-set.js.default, ChakraCore.yaml/ChakraCore/test/es6/weakmap_basic.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck3.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-other-then-exit-on-object.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-not-string.js.layout, stress/big-int-prototype-value-of.js.bytecode-cache, stress/big-int-right-shift-type-error.js.default, stress/big-int-white-space-trailing-leading.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->