### PR TITLE
[WPE][cross-toolchain-helper] Default to disable SPEECH_SYNTHESIS after 284276@main due to missing libspiel on the build environment

### DIFF
--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -39,7 +39,7 @@ conf_local_path = rpi/local-rpi3-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi3-32bits-userland]
 repo_manifest_path = rpi/manifest.xml
@@ -49,7 +49,7 @@ image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
 # WTR and MiniBrowser require wpbackend-fdo, with wpbackend-rdk we can only build cog
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-32bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -58,7 +58,7 @@ conf_local_path = rpi/local-rpi4-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 # ARM 64-bits targets (AArch64)
 
@@ -69,7 +69,7 @@ conf_local_path = rpi/local-rpi3-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-64bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -78,7 +78,7 @@ conf_local_path = rpi/local-rpi4-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [qemu-riscv64]
 repo_manifest_path = riscv/manifest.xml
@@ -87,4 +87,4 @@ conf_local_path = riscv/local-qemu-riscv64.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF -DENABLE_SPEECH_SYNTHESIS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"


### PR DESCRIPTION
#### 7cffa8c4ee0c1431d8bf5bb2c23743226ceb1c66
<pre>
[WPE][cross-toolchain-helper] Default to disable SPEECH_SYNTHESIS after 284276@main due to missing libspiel on the build environment
<a href="https://bugs.webkit.org/show_bug.cgi?id=280414">https://bugs.webkit.org/show_bug.cgi?id=280414</a>

Reviewed by Philippe Normand.

Feature SPEECH_SYNTHESIS requires library libspiel since 284276@main but
that library is still not available on the Yocto-based environment used
for the cross-toolchain-helper builds.
I tried to add the library but found issues building it that were reported
at: <a href="https://github.com/project-spiel/libspiel/issues/68">https://github.com/project-spiel/libspiel/issues/68</a>
So, default to disable SPEECH_SYNTHESIS on this builds until we can provide
libspiel there.

* Tools/yocto/targets.conf:

Canonical link: <a href="https://commits.webkit.org/284298@main">https://commits.webkit.org/284298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91665ca5387310d124fd497dd0eed5c3f64cee6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21668 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20002 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72062 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/16998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13016 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/10466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10536 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44200 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->