### PR TITLE
Log activity that caused process wakeup

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -156,7 +156,7 @@ private:
     friend WTF::TextStream& operator<<(WTF::TextStream&, const ProcessThrottler&);
 
     ProcessThrottleState expectedThrottleState();
-    void updateThrottleStateIfNeeded();
+    void updateThrottleStateIfNeeded(ASCIILiteral);
     void updateThrottleStateNow();
     void setAssertionType(ProcessAssertionType);
     void setThrottleState(ProcessThrottleState);


### PR DESCRIPTION
#### 6672b29c5e0d93567efd0ed1a9530baaa5b668a3
<pre>
Log activity that caused process wakeup
<a href="https://bugs.webkit.org/show_bug.cgi?id=280417">https://bugs.webkit.org/show_bug.cgi?id=280417</a>
<a href="https://rdar.apple.com/136766275">rdar://136766275</a>

Reviewed by Chris Dumez.

Generally speaking, an auxiliary process wakes up because a new activity was added to its activity
set. Instead of just logging that we are resuming the process, we should also log the activity
name. This helps us debug whether or not the process wakeup is reasonable or spurious.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::addActivity):
(WebKit::ProcessThrottler::removeActivity):
(WebKit::ProcessThrottler::updateThrottleStateIfNeeded):
* Source/WebKit/UIProcess/ProcessThrottler.h:

Canonical link: <a href="https://commits.webkit.org/284303@main">https://commits.webkit.org/284303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f97c7913e2cfed5d9e0ca0e085d0cbb3e93d211e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73084 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20155 "Hash f97c7913 for PR 34310 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20010 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/20155 "Hash f97c7913 for PR 34310 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59572 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40855 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74793 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16594 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59655 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4080 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44208 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->