### PR TITLE
Adopt more smart pointers in WebExtensionContext and WebGeolocationManagerProxy

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -602,20 +602,6 @@ WebExtensionContext* WebExtensionAction::extensionContext() const
     return m_extensionContext.get();
 }
 
-RefPtr<WebExtensionTab> WebExtensionAction::tab() const
-{
-    return m_tab.and_then([](auto const& maybeTab) {
-        return std::optional(RefPtr(maybeTab.get()));
-    }).value_or(nullptr);
-}
-
-RefPtr<WebExtensionWindow> WebExtensionAction::window() const
-{
-    return m_window.and_then([](auto const& maybeWindow) {
-        return std::optional(RefPtr(maybeWindow.get()));
-    }).value_or(nullptr);
-}
-
 void WebExtensionAction::clearCustomizations()
 {
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -29,6 +29,8 @@
 
 #include "APIObject.h"
 #include "CocoaImage.h"
+#include "WebExtensionTab.h"
+#include "WebExtensionWindow.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -51,8 +53,6 @@ OBJC_CLASS _WKWebExtensionActionPopover;
 
 namespace WebKit {
 
-class WebExtensionContext;
-class WebExtensionTab;
 class WebExtensionWindow;
 
 class WebExtensionAction : public API::ObjectImpl<API::Object::Type::WebExtensionAction>, public CanMakeWeakPtr<WebExtensionAction> {
@@ -78,8 +78,8 @@ public:
     bool operator==(const WebExtensionAction&) const;
 
     WebExtensionContext* extensionContext() const;
-    RefPtr<WebExtensionTab> tab() const;
-    RefPtr<WebExtensionWindow> window() const;
+    RefPtr<WebExtensionTab> tab() const { return m_tab.value_or(nullptr).get(); }
+    RefPtr<WebExtensionWindow> window() const { return m_window.value_or(nullptr).get(); }
 
     void clearCustomizations();
     void clearBlockedResourceCount();

--- a/Source/WebKit/UIProcess/WebContextSupplement.h
+++ b/Source/WebKit/UIProcess/WebContextSupplement.h
@@ -49,6 +49,7 @@ public:
     }
 
     WebProcessPool* processPool() { return m_processPool.get(); }
+    RefPtr<WebProcessPool> protectedProcessPool() { return processPool(); }
 
     void clearProcessPool() { m_processPool = nullptr; }
 

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -59,7 +59,7 @@ Ref<WebGeolocationManagerProxy> WebGeolocationManagerProxy::create(WebProcessPoo
 WebGeolocationManagerProxy::WebGeolocationManagerProxy(WebProcessPool* processPool)
     : WebContextSupplement(processPool)
 {
-    WebContextSupplement::processPool()->addMessageReceiver(Messages::WebGeolocationManagerProxy::messageReceiverName(), *this);
+    WebContextSupplement::protectedProcessPool()->addMessageReceiver(Messages::WebGeolocationManagerProxy::messageReceiverName(), *this);
 }
 
 WebGeolocationManagerProxy::~WebGeolocationManagerProxy() = default;
@@ -137,7 +137,7 @@ void WebGeolocationManagerProxy::startUpdating(IPC::Connection& connection, cons
 
 void WebGeolocationManagerProxy::startUpdatingWithProxy(WebProcessProxy& proxy, const WebCore::RegistrableDomain& registrableDomain, WebPageProxyIdentifier pageProxyID, const String& authorizationToken, bool enableHighAccuracy)
 {
-    auto page = WebProcessProxy::webPage(pageProxyID);
+    RefPtr page = WebProcessProxy::webPage(pageProxyID);
     MESSAGE_CHECK(proxy.connection(), !!page);
 
     auto isValidAuthorizationToken = page->geolocationPermissionRequestManager().isValidAuthorizationToken(authorizationToken);

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -97,6 +97,16 @@ void GeolocationPermissionRequestManager::didReceiveGeolocationPermissionDecisio
     geolocation->setIsAllowed(!authorizationToken.isNull(), authorizationToken);
 }
 
+void GeolocationPermissionRequestManager::ref() const
+{
+    m_page.ref();
+}
+
+void GeolocationPermissionRequestManager::deref() const
+{
+    m_page.deref();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GEOLOCATION)

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -51,6 +51,9 @@ public:
 
     void didReceiveGeolocationPermissionDecision(GeolocationIdentifier, const String& authorizationToken);
 
+    void ref() const;
+    void deref() const;
+
 private:
     using IDToGeolocationMap = HashMap<GeolocationIdentifier, WeakRef<WebCore::Geolocation>>;
     using GeolocationToIDMap = HashMap<WeakRef<WebCore::Geolocation>, GeolocationIdentifier>;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5837,6 +5837,11 @@ void WebPage::didReceiveGeolocationPermissionDecision(GeolocationIdentifier geol
 {
     geolocationPermissionRequestManager().didReceiveGeolocationPermissionDecision(geolocationID, authorizationToken);
 }
+
+Ref<GeolocationPermissionRequestManager> WebPage::protectedGeolocationPermissionRequestManager()
+{
+    return m_geolocationPermissionRequestManager.get();
+}
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -852,6 +852,7 @@ public:
 
 #if ENABLE(GEOLOCATION)
     GeolocationPermissionRequestManager& geolocationPermissionRequestManager() { return m_geolocationPermissionRequestManager.get(); }
+    Ref<GeolocationPermissionRequestManager> protectedGeolocationPermissionRequestManager();
 #endif
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 8864e650bf5ab2a2e90de8324002db7ba71c6f67
<pre>
Adopt more smart pointers in WebExtensionContext and WebGeolocationManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=280420">https://bugs.webkit.org/show_bug.cgi?id=280420</a>
<a href="https://rdar.apple.com/136769688">rdar://136769688</a>

Reviewed by Chris Dumez, Geoffrey Garen, and Timothy Hatcher.

Smart pointer adoption as per the static analyzer.

We are now able to use WebContextSupplement::protectedProcessPool() in
WebGeolocationManagerProxy::WebGeolocationManagerProxy since 284304@main
makes it safe to ref an API object in it&apos;s constructor.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::tab const): Deleted.
(WebKit::WebExtensionAction::window const): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::getAction):
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::addExtensionTabPage):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::tab const):
(WebKit::WebExtensionAction::window const):
* Source/WebKit/UIProcess/WebContextSupplement.h:
(WebKit::WebContextSupplement::protectedProcessPool):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::WebGeolocationManagerProxy):
(WebKit::WebGeolocationManagerProxy::startUpdatingWithProxy):
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
(WebKit::GeolocationPermissionRequestManager::ref const):
(WebKit::GeolocationPermissionRequestManager::deref const):
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::protectedGeolocationPermissionRequestManager):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/284338@main">https://commits.webkit.org/284338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/390feedb5f180859ec9452a89c4dabf72e90b3d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20220 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54981 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40902 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62632 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62531 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15332 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10514 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4126 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44266 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->