### PR TITLE
REGRESSION(283632@main): WKWebExtensionController API tests assert

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -132,7 +132,16 @@ void AuxiliaryProcess::initializeConnection(IPC::Connection*)
 
 bool AuxiliaryProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    return m_messageReceiverMap.dispatchMessage(connection, decoder);
+    if (m_messageReceiverMap.dispatchMessage(connection, decoder))
+        return true;
+    // Note: because WebProcess receives messages to non-existing IDs, we have to filter the messages there to avoid asserts.
+    // Once these stop, this should be removed.
+    return filterUnhandledMessage(connection, decoder);
+}
+
+bool AuxiliaryProcess::filterUnhandledMessage(IPC::Connection&, IPC::Decoder&)
+{
+    return false;
 }
 
 bool AuxiliaryProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -127,6 +127,7 @@ protected:
     virtual void terminate();
 
     virtual void stopRunLoop();
+    virtual bool filterUnhandledMessage(IPC::Connection&, IPC::Decoder&);
 
 #if USE(OS_STATE)
     void registerWithStateDumper(ASCIILiteral title);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -982,6 +982,14 @@ bool WebProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& deco
     return false;
 }
 
+bool WebProcess::filterUnhandledMessage(IPC::Connection&, IPC::Decoder& decoder)
+{
+    // Note: due to receiving messages to non-existing IDs, we have to filter the messages.
+    // This should be removed once these messages are fixed.
+    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()).characters(), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
+    return true;
+}
+
 void WebProcess::didClose(IPC::Connection& connection)
 {
 #if ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -570,6 +570,8 @@ private:
     void stopRunLoop() override;
 #endif
 
+    bool filterUnhandledMessage(IPC::Connection&, IPC::Decoder&) override;
+
 #if ENABLE(MEDIA_STREAM)
     void addMockMediaDevice(const WebCore::MockMediaDevice&);
     void clearMockMediaDevices();


### PR DESCRIPTION
#### 39fbf6d920eece9486860681112bd29f3900134b
<pre>
REGRESSION(283632@main): WKWebExtensionController API tests assert
<a href="https://bugs.webkit.org/show_bug.cgi?id=280421">https://bugs.webkit.org/show_bug.cgi?id=280421</a>
<a href="https://rdar.apple.com/136770150">rdar://136770150</a>

Reviewed by Chris Dumez and Timothy Hatcher.

Before 283632@main, WebProcess would have manual IPC message handlers
which would log error and drop unhandled messages.

283632@main would use the normal generated IPC message handlers, where
unhandled messages cause asserts.

Add the log + drop logic back to WebProcess.
dispatchMessage is the last step of the normal IPC message handling
process, so AuxiliaryProcess will filter out unhandled messages
for WebProcess, just before the assertions.

* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::dispatchMessage):
(WebKit::AuxiliaryProcess::filterUnhandledMessage):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::dispatchMessage):
(WebKit::WebProcess::filterUnhandledMessage):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/284360@main">https://commits.webkit.org/284360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf199ed405f8e483d83c3c8841164725a5cc728f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20169 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54955 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40864 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12996 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16604 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62599 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4089 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44218 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->