### PR TITLE
[WGSL] Override evaluation fails when one variables depends on another

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_280423-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_280423-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_280423.html
+++ b/LayoutTests/fast/webgpu/regression/repro_280423.html
@@ -1,0 +1,39 @@
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+onload = async () => {
+    try {
+        let adapter = await navigator.gpu.requestAdapter();
+        let device = await adapter.requestDevice();
+        let shaderModule = device.createShaderModule({
+            code: `
+            override override78 : f16;
+            @id(27126) override override83 : f16 = override78;
+            override override88 : f16 = -46067.8;
+            @compute @workgroup_size(3, 1, 1)
+            fn compute0() {
+                _ = override88;
+                _ = override83;
+            }`,
+            sourceMap: {},
+        });
+
+        let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: []});
+        await device.createComputePipelineAsync({
+            layout: pipelineLayout,
+            compute: {
+                module: shaderModule,
+                constants: { /*override78: -1*/ }
+            }
+        });
+        log('the end')
+    } catch (e) {
+        log('error');
+        log(e);
+        log(e[Symbol.toStringTag]);
+        log(e.stack);
+    }
+    globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -151,9 +151,11 @@ std::optional<ConstantValue> evaluate(const AST::Expression& expression, const H
     auto* maybeIdentifierExpression = dynamicDowncast<const AST::IdentifierExpression>(expression);
     if (!maybeIdentifierExpression)
         return std::nullopt;
-    auto constantValue = constants.get(maybeIdentifierExpression->identifier());
-    const_cast<AST::Expression&>(expression).setConstantValue(constantValue);
-    return constantValue;
+    auto it = constants.find(maybeIdentifierExpression->identifier());
+    if (it == constants.end())
+        return std::nullopt;
+    const_cast<AST::Expression&>(expression).setConstantValue(it->value);
+    return it->value;
 }
 
 }

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -67,21 +67,6 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
 
     const auto& entryPointInformation = iterator->value;
 
-    for (auto& kvp : entryPointInformation.specializationConstants) {
-        auto& specializationConstant = kvp.value;
-        if (!specializationConstant.defaultValue)
-            continue;
-
-        auto constantValue = WGSL::evaluate(*kvp.value.defaultValue, wgslConstantValues);
-        if (!constantValue) {
-            if (error)
-                *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed to evaluate override value" }];
-            return std::nullopt;
-        }
-        auto addResult = wgslConstantValues.add(kvp.key, *constantValue);
-        ASSERT_UNUSED(addResult, addResult.isNewEntry);
-    }
-
     for (uint32_t i = 0; i < constantCount; ++i) {
         const auto& entry = constants[i];
         auto keyEntry = fromAPI(entry.key);
@@ -90,6 +75,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
             return { };
 
         const auto& specializationConstant = indexIterator->value;
+        keyEntry = specializationConstant.mangledName;
         switch (specializationConstant.type) {
         case WGSL::Reflection::SpecializationConstantType::Boolean: {
             bool value = entry.value;
@@ -127,6 +113,21 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
             break;
         }
         }
+    }
+
+    for (auto& kvp : entryPointInformation.specializationConstants) {
+        auto& specializationConstant = kvp.value;
+        if (!specializationConstant.defaultValue || wgslConstantValues.contains(kvp.value.mangledName))
+            continue;
+
+        auto constantValue = WGSL::evaluate(*kvp.value.defaultValue, wgslConstantValues);
+        if (!constantValue) {
+            if (error)
+                *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed to evaluate override value" }];
+            return std::nullopt;
+        }
+        auto addResult = wgslConstantValues.add(kvp.value.mangledName, *constantValue);
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
 
     if (pipelineLayout) {


### PR DESCRIPTION
#### b2e093e2b9e12e09385ffcc3ce269cbc279b530b
<pre>
[WGSL] Override evaluation fails when one variables depends on another
<a href="https://bugs.webkit.org/show_bug.cgi?id=280423">https://bugs.webkit.org/show_bug.cgi?id=280423</a>
<a href="https://rdar.apple.com/135707429">rdar://135707429</a>

Reviewed by Mike Wyrzykowski.

There were 3 issues when one override variable referred to another:
- Default initializers were evaluated before user-provided values, but that fails
  the default initializer refers to a variable that has a user-provided value
- Override values were stored in the hash map with their original name as key
  (instead of the mangled name), so even if a default initializer referred to
  another variable that had a value, it wouldn&apos;t find it in the hash map.
- The case were the default initializer referred to a variable that didn&apos;t have
  a value wasn&apos;t handled. That happened when the referred variable didn&apos;t have
  a default initializer and a value wasn&apos;t provided through the API.

Additionally, the implementation was somewhat duplicated between the API and
the code generator, both created a similar dictionary of replacement values,
which was redundant. The logic is now completely removed from the code generator,
and to keep `wgslc` working, it now contains a simpler version of the logic that
exists in the API.

* LayoutTests/fast/webgpu/regression/repro_136222279-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_136222279.html: Added.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::visitGlobal): Deleted.
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::evaluate):
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):

Canonical link: <a href="https://commits.webkit.org/284345@main">https://commits.webkit.org/284345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1695970d6ae4671f476468676d9f2226f51ac4d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20171 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54960 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13406 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35434 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74804 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4087 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44219 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->