### PR TITLE
Implement browser.storageArea.getKeys() for Web Extension Storage API.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -55,7 +55,7 @@ void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifi
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".get()"_s);
 
-    auto storage = storageForType(dataType);
+    auto *storage = storageForType(dataType);
     [storage getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *values, NSString *errorMessage) mutable {
         if (errorMessage)
             completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
@@ -64,11 +64,24 @@ void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifi
     }).get()];
 }
 
+void WebExtensionContext::storageGetKeys(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, CompletionHandler<void(Expected<Vector<String>, WebExtensionError>&&)>&& completionHandler)
+{
+    auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".getKeys()"_s);
+
+    auto *storage = storageForType(dataType);
+    [storage getAllKeys:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](NSArray<NSString *> *keys, NSString *errorMessage) mutable {
+        if (errorMessage)
+            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+        else
+            completionHandler(makeVector<String>(keys));
+    }).get()];
+}
+
 void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&& completionHandler)
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".getBytesInUse()"_s);
 
-    auto storage = storageForType(dataType);
+    auto *storage = storageForType(dataType);
     [storage getStorageSizeForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](size_t size, NSString *errorMessage) mutable {
         if (errorMessage)
             completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h
@@ -40,6 +40,7 @@ enum class WebExtensionDataType : uint8_t;
 
 - (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier storageType:(WebKit::WebExtensionDataType)storageType directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase;
 
+- (void)getAllKeys:(void (^)(NSArray<NSString *> *keys, NSString * _Nullable errorMessage))completionHandler;
 - (void)getValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSDictionary<NSString *, NSString *> *results, NSString * _Nullable errorMessage))completionHandler;
 - (void)getStorageSizeForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(size_t storageSize, NSString * _Nullable errorMessage))completionHandler;
 - (void)getStorageSizeForAllKeysIncludingKeyedData:(NSDictionary<NSString *, NSString *> *)additionalKeyedData withCompletionHandler:(void (^)(size_t storageSize, NSUInteger numberOfKeysIncludingAdditionalKeyedData, NSDictionary<NSString *, NSString *> *existingKeysAndValues, NSString * _Nullable errorMessage))completionHandler;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
@@ -71,14 +71,34 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
     return self;
 }
 
+- (void)getAllKeys:(void (^)(NSArray<NSString *> *keys, NSString *errorMessage))completionHandler
+{
+    auto weakSelf = WeakObjCPtr { self };
+    dispatch_async(_databaseQueue, ^{
+        auto *strongSelf = weakSelf.get().get();
+        if (!strongSelf) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to retrieve all keys for extension %{private}@.", self->_uniqueIdentifier);
+            completionHandler(nil, @"Failed to retrieve all keys");
+            return;
+        }
+
+        NSString *errorMessage;
+        auto *keysArray = [self _getAllKeysReturningErrorMessage:&errorMessage].allObjects;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler(keysArray, errorMessage);
+        });
+    });
+}
+
 - (void)getValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSDictionary<NSString *, NSString *> *results, NSString *errorMessage))completionHandler
 {
-    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    auto weakSelf = WeakObjCPtr { self };
     dispatch_async(_databaseQueue, ^{
-        auto strongSelf = weakSelf.get();
+        auto *strongSelf = weakSelf.get().get();
         if (!strongSelf) {
-            RELEASE_LOG_ERROR(Extensions, "Failed to retrieve keys: %{private}@ for extension %{private}@.", keys, self->_uniqueIdentifier);
-            completionHandler(nil, [NSString stringWithFormat:@"Failed to retrieve keys %@", keys]);
+            RELEASE_LOG_ERROR(Extensions, "Failed to retrieve values for keys: %{private}@ for extension %{private}@.", keys, self->_uniqueIdentifier);
+            completionHandler(nil, [NSString stringWithFormat:@"Failed to retrieve values for keys %@", keys]);
             return;
         }
 
@@ -93,9 +113,9 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
 
 - (void)getStorageSizeForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(size_t storageSize, NSString *errorMessage))completionHandler
 {
-    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    auto weakSelf = WeakObjCPtr { self };
     dispatch_async(_databaseQueue, ^{
-        auto strongSelf = weakSelf.get();
+        auto *strongSelf = weakSelf.get().get();
         if (!strongSelf) {
             RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for keys: %{private}@ for extension %{private}@.", keys, self->_uniqueIdentifier);
             completionHandler(0, [NSString stringWithFormat:@"Failed to caluclate storage size for keys: %@", keys]);
@@ -144,9 +164,9 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
             return;
         }
 
-        auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+        auto weakSelf = WeakObjCPtr { self };
         dispatch_async(self->_databaseQueue, ^{
-            auto strongSelf = weakSelf.get();
+            auto *strongSelf = weakSelf.get().get();
             if (!strongSelf) {
                 RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for extension %{private}@.", self->_uniqueIdentifier);
                 completionHandler(0.0, 0, @{ }, @"Failed to calculate storage size");
@@ -171,9 +191,9 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
 
 - (void)setKeyedData:(NSDictionary<NSString *, NSString *> *)keyedData completionHandler:(void (^)(NSArray<NSString *> *keysSuccessfullySet, NSString *errorMessage))completionHandler
 {
-    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    auto weakSelf = WeakObjCPtr { self };
     dispatch_async(_databaseQueue, ^{
-        auto strongSelf = weakSelf.get();
+        auto *strongSelf = weakSelf.get().get();
         if (!strongSelf) {
             completionHandler(nil, [NSString stringWithFormat:@"Failed to set keys %@", keyedData.allKeys]);
             return;
@@ -207,9 +227,9 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
 
 - (void)deleteValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSString *errorMessage))completionHandler
 {
-    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    auto weakSelf = WeakObjCPtr { self };
     dispatch_async(_databaseQueue, ^{
-        auto strongSelf = weakSelf.get();
+        auto *strongSelf = weakSelf.get().get();
         if (!strongSelf) {
             completionHandler([NSString stringWithFormat:@"Failed to delete keys %@", keys]);
             return;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -857,6 +857,7 @@ private:
     // Storage APIs
     bool isStorageMessageAllowed();
     void storageGet(WebPageProxyIdentifier, WebExtensionDataType, const Vector<String>& keys, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
+    void storageGetKeys(WebPageProxyIdentifier, WebExtensionDataType, CompletionHandler<void(Expected<Vector<String>, WebExtensionError>&&)>&&);
     void storageGetBytesInUse(WebPageProxyIdentifier, WebExtensionDataType, const Vector<String>& keys, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&&);
     void storageSet(WebPageProxyIdentifier, WebExtensionDataType, const String& dataJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void storageRemove(WebPageProxyIdentifier, WebExtensionDataType, const Vector<String>& keys, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -133,6 +133,7 @@ messages -> WebExtensionContext {
 
     // Storage APIs
     [EnabledIf='isStorageMessageAllowed()'] StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<String, WebKit::WebExtensionError> result)
+    [EnabledIf='isStorageMessageAllowed()'] StorageGetKeys(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType) -> (Expected<Vector<String>, WebKit::WebExtensionError> result)
     [EnabledIf='isStorageMessageAllowed()'] StorageGetBytesInUse(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<size_t, WebKit::WebExtensionError> result)
     [EnabledIf='isStorageMessageAllowed()'] StorageSet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, String dataJSON) -> (Expected<void, WebKit::WebExtensionError> result)
     [EnabledIf='isStorageMessageAllowed()'] StorageRemove(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<void, WebKit::WebExtensionError> result)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -116,6 +116,18 @@ void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCa
     }, extensionContext().identifier());
 }
 
+void WebExtensionAPIStorageArea::getKeys(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetKeys(page.webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<String>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call(createNSArray(result.value()).get());
+    }, extensionContext().identifier());
+}
+
 void WebExtensionAPIStorageArea::getBytesInUse(WebPage& page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -43,6 +43,7 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     void get(WebPage&, id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getKeys(WebPage&, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getBytesInUse(WebPage&, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void set(WebPage&, NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void remove(WebPage&, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
@@ -30,6 +30,7 @@
 ] interface WebExtensionAPIStorageArea {
 
     [RaisesException] void get([Optional, NSObject=StopAtTopLevel, DOMString] any items, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getKeys([Optional, CallbackHandler] function callback);
     [RaisesException] void getBytesInUse([Optional, NSObject, DOMString] any keys, [Optional, CallbackHandler] function callback);
     [RaisesException] void set([NSDictionary=StopAtTopLevel] any items, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any keys, [Optional, CallbackHandler] function callback);


### PR DESCRIPTION
#### 972a6ce2e9ed3c6b75eedc37b7d53112c036fef1
<pre>
Implement browser.storageArea.getKeys() for Web Extension Storage API.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280275">https://bugs.webkit.org/show_bug.cgi?id=280275</a>

Reviewed by Timothy Hatcher.

This patch implements a web extension API to retrieve all keys for a given storage area in the
browser.storage API.

WECG Proposal: <a href="https://github.com/w3c/webextensions/blob/main/proposals/storage-get-keys.md">https://github.com/w3c/webextensions/blob/main/proposals/storage-get-keys.md</a>
WECG Original Issue: w3c/webextensions#601

This patch also includes the following clean-ups:
- Change &apos;auto&apos; to &apos;auto *&apos; when assigning the result of WebExtensionContext::storageForType()
 to explicitly denote pointer type.
- Update strongSelf retrieval to in _WKWebExtensionStorageSQLiteStore.mm methods to leverage
 ARC in extension code, allowing the use of Objective-C pointers instead of RetainPtr, which
is only necessary in other parts of WebKit that do not utilize ARC.
- Remove unnecessary explicit template types from WeakObjCPtr in _WKWebExtensionStorageSQLiteStore.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageGet):
(WebKit::WebExtensionContext::storageGetKeys):
(WebKit::WebExtensionContext::storageGetBytesInUse):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm:
(-[_WKWebExtensionStorageSQLiteStore getAllKeys:]):
(-[_WKWebExtensionStorageSQLiteStore getValuesForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForAllKeysIncludingKeyedData:withCompletionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore setKeyedData:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore deleteValuesForKeys:completionHandler:]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::getKeys):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, Errors)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, GetKeys)):

Canonical link: <a href="https://commits.webkit.org/284602@main">https://commits.webkit.org/284602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4568afafb22b89dc59d7412757d64c79470628c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55502 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60321 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35982 "Found 1 new API test failure: /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75739 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14164 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17329 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 17 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63197 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63132 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4759 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10681 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->