### PR TITLE
[UnifiedPDF][iOS] Update WKFoundTextRange to support found text ranges in PDFs

### DIFF
--- a/Source/WebKit/Shared/WebFoundTextRange.cpp
+++ b/Source/WebKit/Shared/WebFoundTextRange.cpp
@@ -26,9 +26,21 @@
 #include "config.h"
 #include "WebFoundTextRange.h"
 
-#include "WebCoreArgumentCoders.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebKit {
+
+unsigned WebFoundTextRange::hash() const
+{
+    return WTF::switchOn(data,
+        [] (const WebFoundTextRange::DOMData& domData) {
+            return pairIntHash(domData.location, domData.length);
+        },
+        [] (const WebFoundTextRange::PDFData& pdfData) {
+            return pairIntHash(pairIntHash(pairIntHash(pdfData.startPage, pdfData.endPage), pdfData.startOffset), pdfData.endOffset);
+        }
+    );
+}
 
 bool WebFoundTextRange::operator==(const WebFoundTextRange& other) const
 {
@@ -37,8 +49,7 @@ bool WebFoundTextRange::operator==(const WebFoundTextRange& other) const
     if (other.frameIdentifier.isHashTableDeletedValue())
         return false;
 
-    return location == other.location
-        && length == other.length
+    return data == other.data
         && frameIdentifier == other.frameIdentifier
         && order == other.order;
 }

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -26,16 +26,34 @@
 #pragma once
 
 #include "ArgumentCoders.h"
+#include <variant>
 #include <wtf/HashTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 struct WebFoundTextRange {
-    uint64_t location { 0 };
-    uint64_t length { 0 };
+    struct DOMData {
+        uint64_t location { 0 };
+        uint64_t length { 0 };
+
+        bool operator==(const DOMData& other) const = default;
+    };
+
+    struct PDFData {
+        uint64_t startPage { 0 };
+        uint64_t startOffset { 0 };
+        uint64_t endPage { 0 };
+        uint64_t endOffset { 0 };
+
+        bool operator==(const PDFData& other) const = default;
+    };
+
+    std::variant<DOMData, PDFData> data { DOMData { } };
     AtomString frameIdentifier;
     uint64_t order { 0 };
+
+    unsigned hash() const;
 
     bool operator==(const WebFoundTextRange& other) const;
 };
@@ -45,7 +63,7 @@ struct WebFoundTextRange {
 namespace WTF {
 
 struct WebFoundTextRangeHash {
-    static unsigned hash(const WebKit::WebFoundTextRange& range) { return pairIntHash(range.location, range.length); }
+    static unsigned hash(const WebKit::WebFoundTextRange& range) { return range.hash(); }
     static bool equal(const WebKit::WebFoundTextRange& a, const WebKit::WebFoundTextRange& b) { return a == b; }
     static const bool safeToCompareToEmptyOrDeleted = true;
 };

--- a/Source/WebKit/Shared/WebFoundTextRange.serialization.in
+++ b/Source/WebKit/Shared/WebFoundTextRange.serialization.in
@@ -20,9 +20,20 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-struct WebKit::WebFoundTextRange {
+[Nested] struct WebKit::WebFoundTextRange::DOMData {
     uint64_t location;
     uint64_t length;
+};
+
+[Nested] struct WebKit::WebFoundTextRange::PDFData {
+    uint64_t startPage;
+    uint64_t startOffset;
+    uint64_t endPage;
+    uint64_t endOffset;
+};
+
+struct WebKit::WebFoundTextRange {
+    std::variant<WebKit::WebFoundTextRange::DOMData, WebKit::WebFoundTextRange::PDFData> data;
     AtomString frameIdentifier;
     uint64_t order;
 }


### PR DESCRIPTION
#### dd76ffdd18b08ca780a84e401e7a5eeefb065e5b
<pre>
[UnifiedPDF][iOS] Update WKFoundTextRange to support found text ranges in PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=280431">https://bugs.webkit.org/show_bug.cgi?id=280431</a>
<a href="https://rdar.apple.com/136778579">rdar://136778579</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

`WKFoundTextRange` currently only works when searching for DOM text ranges. In
order to support searching PDFs using `UIFindInteraction` / `UITextSearching`,
it should also support retrieving and restoring PDF selections.

To achieve this goal, `WKFoundTextRange` is split into `WKFoundDOMTextRange`
and `WKFoundPDFTextRange`. A PDF selection can be encoded in terms of its
start and end pages, and their respective offsets. `WebFoundTextRange` encodes
the necessary data using a variant.

The PDF ranges still encode frame information, to enable an eventual future
where PDFs in subframes are supported.

Note that `WebFoundTextRangeController` still only knows how to return
and handle DOM text ranges. Subsequent patches will add support for PDF
ranges.

* Source/WebKit/Shared/WebFoundTextRange.cpp:
(WebKit::WebFoundTextRange::hash const):
(WebKit::WebFoundTextRange::operator== const):
* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::WebFoundTextRangeHash::hash):
* Source/WebKit/Shared/WebFoundTextRange.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView offsetFromPosition:toPosition:]):
(+[WKFoundTextRange foundTextRangeWithWebFoundTextRange:]):
(-[WKFoundTextRange isEmpty]):
(-[WKFoundTextRange webFoundTextRange]):
(-[WKFoundDOMTextRange start]):
(-[WKFoundDOMTextRange end]):
(-[WKFoundDOMTextRange webFoundTextRange]):
(+[WKFoundDOMTextPosition textPositionWithOffset:order:]):
(-[WKFoundPDFTextRange start]):
(-[WKFoundPDFTextRange end]):
(-[WKFoundPDFTextRange webFoundTextRange]):
(+[WKFoundPDFTextPosition textPositionWithPage:offset:]):
(-[WKFoundTextRange start]): Deleted.
(-[WKFoundTextRange end]): Deleted.
(+[WKFoundTextPosition textPositionWithOffset:order:]): Deleted.
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::redraw):
(WebKit::WebFoundTextRangeController::simpleRangeFromFoundTextRange):

Canonical link: <a href="https://commits.webkit.org/284370@main">https://commits.webkit.org/284370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc2878737f7f60f2dfd83303c71b10123d25b4d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20283 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40959 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13107 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16687 "Found 1 new test failure: media/video-webkit-playsinline.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62667 "Found 2 new test failures: imported/blink/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html webanimations/accelerated-animation-tiled-while-running.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62566 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4175 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10565 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44329 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->