### PR TITLE
[Shrink-To-Fit] shrink-to-fit sizing should consider max-inline-size: min-content.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/shrink-to-fit-sizing-max-width-min-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/shrink-to-fit-sizing-max-width-min-content-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/shrink-to-fit-sizing-max-width-min-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/shrink-to-fit-sizing-max-width-min-content.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="help" href="https://drafts.csswg.org/css2/#float-width">
+<meta name="assert" content="shrink-to-fit sizing should respect max-width: min-content">
+<style>
+.container {
+  font: 100px/1 Ahem;
+  color: green;
+  width: 100px;
+}
+.float {
+  float: right;
+}
+.max-content {
+  max-width: min-content;
+  width: 600px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class=float>
+      <div class=max-content>x</div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -716,7 +716,7 @@ protected:
         return LayoutUnit((inlineSize - borderPaddingInlineSum) / aspectRatio) + borderPaddingBlockSum;
     }
 
-    void computePreferredLogicalWidths(const Length& logicalMinWidth, const Length& logicalMaxWidth, LayoutUnit borderAndPaddingLogicalWidth);
+    void computePreferredLogicalWidths(const Length& minLogicalWidth, const Length& maxLogicalWidth, LayoutUnit borderAndPaddingLogicalWidth);
     
     bool isAspectRatioDegenerate(double aspectRatio) const { return !aspectRatio || isnan(aspectRatio); }
     
@@ -763,6 +763,7 @@ private:
     // These values are used in shrink-to-fit layout systems.
     // These include tables, positioned objects, floats and flexible boxes.
     virtual void computePreferredLogicalWidths();
+    bool shouldComputePreferredLogicalWidthsFromStyle() const;
 
     LayoutRect frameRectForStickyPositioning() const override { return frameRect(); }
 


### PR DESCRIPTION
#### 93eee6b40662353c53e00e0403410071dcf86e01
<pre>
[Shrink-To-Fit] shrink-to-fit sizing should consider max-inline-size: min-content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280549">https://bugs.webkit.org/show_bug.cgi?id=280549</a>
<a href="https://rdar.apple.com/136520853">rdar://136520853</a>

Reviewed by Alan Baradlay.

Currently, when we compute the preferred logical widths of a renderer, we will consider
the min/max logical width properties if they are fixed values. We should, however, be
able to handle any other values for these properties, and in this patch, we extend support
for min-content of the max logical width.

To accomplish this, I shuffled around some of the logic that was trying to compute the used
min/max logical widths at the top of the method. This should not be a functional change since
these computations don&apos;t rely on the values we have so far computed for m_min/maxPreferredLogicalWidth.

In the logic for computing the used max logical width, we now consider max-width: min-content:

- If the m_min/maxPreferredLogicalWidths computed from the style&apos;s logical width value, then
we compute the intrinsic logical widths of the renderer. This appears to happen when the
computed logical width is a fixed and positive value in most cases. RenderBlock has some
additional constraints in order to determine this, but I factored out this logic into a
separate method.

- Otherwise, m_min/maxPreferredLogicalWidths should hold the intrinsic values, so we can just
use the already computed value in m_minPreferredLogicalWidth.

(Also, a quick change of argument names in computePreferredLogicalWidths in the declaration
to match the ones used in the definition.)

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/shrink-to-fit-sizing-max-width-min-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/shrink-to-fit-sizing-max-width-min-content.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::shouldComputePreferredLogicalWidthsFromStyle const):
(WebCore::RenderBox::computePreferredLogicalWidths):
* Source/WebCore/rendering/RenderBox.h:

Canonical link: <a href="https://commits.webkit.org/286051@main">https://commits.webkit.org/286051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/369aaee225036665ef0e70b72c98b78c4413c273

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1840 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16915 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21635 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66887 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8271 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1908 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4695 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1936 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/2857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->