### PR TITLE
Update Logger's logIdentifier to use a uint64_t instead of a void*

### DIFF
--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -38,8 +38,8 @@ Lock loggerObserverLock;
 String Logger::LogSiteIdentifier::toString() const
 {
     if (className)
-        return makeString(className, "::"_s, span(methodName), '(', hex(objectPtr), ") "_s);
-    return makeString(span(methodName), '(', hex(objectPtr), ") "_s);
+        return makeString(className, "::"_s, span(methodName), '(', hex(objectIdentifier), ") "_s);
+    return makeString(span(methodName), '(', hex(objectIdentifier), ") "_s);
 }
 
 String LogArgument<const void*>::toString(const void* argument)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -274,16 +274,16 @@ public:
     }
 
     struct LogSiteIdentifier {
-        LogSiteIdentifier(const char* methodName, const void* objectPtr)
+        LogSiteIdentifier(const char* methodName, uint64_t objectIdentifier)
             : methodName { methodName }
-            , objectPtr { reinterpret_cast<uintptr_t>(objectPtr) }
+            , objectIdentifier { objectIdentifier }
         {
         }
 
-        LogSiteIdentifier(ASCIILiteral className, const char* methodName, const void* objectPtr)
+        LogSiteIdentifier(ASCIILiteral className, const char* methodName, uint64_t objectIdentifier)
             : className { className }
             , methodName { methodName }
-            , objectPtr { reinterpret_cast<uintptr_t>(objectPtr) }
+            , objectIdentifier { objectIdentifier }
         {
         }
 
@@ -291,7 +291,7 @@ public:
 
         ASCIILiteral className;
         const char* methodName { nullptr };
-        const uintptr_t objectPtr { 0 };
+        const uint64_t objectIdentifier { 0 };
     };
 
     static inline void addObserver(Observer& observer)

--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -37,7 +37,7 @@ public:
     virtual const Logger& logger() const = 0;
     virtual ASCIILiteral logClassName() const = 0;
     virtual WTFLogChannel& logChannel() const = 0;
-    virtual const void* logIdentifier() const = 0;
+    virtual uint64_t logIdentifier() const = 0;
 
 #if !RELEASE_LOG_DISABLED
 
@@ -81,16 +81,16 @@ public:
 #define OBJC_DEBUG_LOG(...)      if (self.loggerPtr && self.logChannel) self.loggerPtr->debug(*self.logChannel, __VA_ARGS__)
 #endif
 
-    static const void* childLogIdentifier(const void* parentIdentifier, uint64_t childIdentifier)
+    static uint64_t childLogIdentifier(uint64_t parentIdentifier, uint64_t childIdentifier)
     {
         static constexpr uint64_t parentMask = 0xffffffffffff0000ull;
         static constexpr uint64_t maskLowerWord = 0xffffull;
-        return reinterpret_cast<const void*>((bitwise_cast<uintptr_t>(parentIdentifier) & parentMask) | (childIdentifier & maskLowerWord));
+        return reinterpret_cast<uint64_t>((parentIdentifier & parentMask) | (childIdentifier & maskLowerWord));
     }
 
-    static const void* uniqueLogIdentifier()
+    static uint64_t uniqueLogIdentifier()
     {
-        return reinterpret_cast<const void*>(cryptographicallyRandomNumber<uint64_t>());
+        return cryptographicallyRandomNumber<uint64_t>();
     }
 
 #else // RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/encryptedmedia/CDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.h
@@ -84,7 +84,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
 #endif
 
 private:
@@ -92,7 +92,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
     String m_keySystem;
     std::unique_ptr<CDMPrivate> m_private;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -70,7 +70,7 @@ MediaKeySession::MediaKeySession(Document& document, WeakPtr<MediaKeys>&& keys, 
     : ActiveDOMObject(&document)
 #if !RELEASE_LOG_DISABLED
     , m_logger(document.logger())
-    , m_logIdentifier(keys ? keys->nextChildIdentifier() : nullptr)
+    , m_logIdentifier(keys ? keys->nextChildIdentifier() : 0)
 #endif
     , m_keys(WTFMove(keys))
     , m_expiration(std::numeric_limits<double>::quiet_NaN())

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -123,10 +123,10 @@ private:
     const Logger& logger() const { return m_logger; }
     ASCIILiteral logClassName() const { return "MediaKeySession"_s; }
     WTFLogChannel& logChannel() const;
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
 
     Ref<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     WeakPtr<MediaKeys> m_keys;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -192,7 +192,7 @@ Ref<CDMInstance> MediaKeys::protectedCDMInstance() const
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* MediaKeys::nextChildIdentifier() const
+uint64_t MediaKeys::nextChildIdentifier() const
 {
     return LoggerHelper::childLogIdentifier(m_logIdentifier, ++m_childIdentifierSeed);
 }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -78,7 +78,7 @@ public:
     Ref<CDMInstance> protectedCDMInstance() const;
 
 #if !RELEASE_LOG_DISABLED
-    const void* nextChildIdentifier() const;
+    uint64_t nextChildIdentifier() const;
 #endif
 
     unsigned internalInstanceObjectRefCount() const { return m_instance->refCount(); }
@@ -91,7 +91,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
 #endif
 
     bool m_useDistinctiveIdentifier;
@@ -105,7 +105,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     Ref<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     mutable uint64_t m_childIdentifierSeed { 0 };
 #endif
 };

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -89,7 +89,7 @@ void NavigatorEME::requestMediaKeySystemAccess(Navigator& navigator, Document& d
 {
     // https://w3c.github.io/encrypted-media/#dom-navigator-requestmediakeysystemaccess
     // W3C Editor's Draft 09 November 2016
-    auto identifier = Logger::LogSiteIdentifier("NavigatorEME"_s, __func__, &navigator);
+    auto identifier = Logger::LogSiteIdentifier("NavigatorEME"_s, __func__, reinterpret_cast<uint64_t>(&navigator));
     Ref<Logger> logger = document.logger();
 
     infoLog(logger, identifier, "keySystem(", keySystem, "), supportedConfigurations(", supportedConfigurations, ")");

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -83,12 +83,12 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "WebKitMediaKeySession"_s; }
     WTFLogChannel& logChannel() const;
 
     Ref<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     WebKitMediaKeys* m_keys;

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -52,10 +52,10 @@
 
 namespace WebCore {
 
-static const void* nextLogIdentifier()
+static uint64_t nextLogIdentifier()
 {
     static uint64_t logIdentifier = cryptographicallyRandomNumber<uint32_t>();
-    return reinterpret_cast<const void*>(++logIdentifier);
+    return ++logIdentifier;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -147,7 +147,7 @@ public:
 private:
     explicit MediaSession(Navigator&);
 
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
 
     void updateReportedPosition();
 
@@ -176,7 +176,7 @@ private:
     MonotonicTime m_timeAtLastPositionUpdate;
     HashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers WTF_GUARDED_BY_LOCK(m_actionHandlersLock);
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 
     WeakHashSet<MediaSessionObserver> m_observers;
 

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
@@ -49,10 +49,10 @@ static const Seconds CommandTimeTolerance = 50_ms;
 
 namespace WebCore {
 
-static const void* nextCoordinatorLogIdentifier()
+static uint64_t nextCoordinatorLogIdentifier()
 {
     static uint64_t logIdentifier = cryptographicallyRandomNumber<uint32_t>();
-    return reinterpret_cast<const void*>(++logIdentifier);
+    return ++logIdentifier;
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionCoordinator);

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -105,7 +105,7 @@ private:
     bool currentPositionApproximatelyEqualTo(double) const;
 
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     static WTFLogChannel& logChannel();
     static ASCIILiteral logClassName() { return "MediaSessionCoordinator"_s; }
     bool shouldFireEvents() const;
@@ -113,7 +113,7 @@ private:
     WeakPtr<MediaSession> m_session;
     RefPtr<MediaSessionCoordinatorPrivate> m_privateCoordinator;
     const Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     MediaSessionCoordinatorState m_state { MediaSessionCoordinatorState::Closed };
     bool m_hasCoordinatorsStateChangeEventListener { false };
     std::optional<PlaySessionCommand> m_currentPlaySessionCommand;

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-void MediaSessionCoordinatorPrivate::setLogger(const Logger& logger, const void* logIdentifier)
+void MediaSessionCoordinatorPrivate::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     m_logger = &logger;
     m_logIdentifier = logIdentifier;

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.h
@@ -80,20 +80,20 @@ public:
     virtual void playbackStateChanged(MediaSessionPlaybackState) = 0;
     virtual void trackIdentifierChanged(const String&) = 0;
 
-    void setLogger(const Logger&, const void*);
+    void setLogger(const Logger&, uint64_t);
     virtual void setClient(WeakPtr<MediaSessionCoordinatorClient> client) { m_client = client;}
 
 protected:
     explicit MediaSessionCoordinatorPrivate() = default;
 
     const Logger* loggerPtr() const { return m_logger.get(); }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
 
     WeakPtr<MediaSessionCoordinatorClient> client() const { return m_client; }
 
 private:
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
     WeakPtr<MediaSessionCoordinatorClient> m_client;
 };
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -187,7 +187,7 @@ private:
     }
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void* identifier)
+    void setLogIdentifier(uint64_t identifier)
     {
         ensureWeakOnDispatcher([identifier](MediaSource& parent) {
             parent.setLogIdentifier(identifier);
@@ -1552,7 +1552,7 @@ void MediaSource::updateBufferedIfNeeded(bool force)
 }
 
 #if !RELEASE_LOG_DISABLED
-void MediaSource::setLogIdentifier(const void* identifier)
+void MediaSource::setLogIdentifier(uint64_t identifier)
 {
     m_logIdentifier = identifier;
     ALWAYS_LOG(LOGIDENTIFIER);

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -140,10 +140,10 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "MediaSource"_s; }
     WTFLogChannel& logChannel() const final;
-    void setLogIdentifier(const void*);
+    void setLogIdentifier(uint64_t);
 
     Ref<Logger> logger(ScriptExecutionContext&);
     void didLogMessage(const WTFLogChannel&, WTFLogLevel, Vector<JSONLogValue>&&) final;
@@ -244,7 +244,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
     std::atomic<uint64_t> m_associatedRegistryCount { 0 };
     Ref<MediaSourceClientImpl> m_client;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -138,7 +138,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "SourceBuffer"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -271,7 +271,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -61,7 +61,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "ImageCapture"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -69,7 +69,7 @@ private:
     Ref<MediaStreamTrack> m_track;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -100,7 +100,7 @@ public:
     void addTrackFromPlatform(Ref<MediaStreamTrack>&&);
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const final { return m_private->logIdentifier(); }
+    uint64_t logIdentifier() const final { return m_private->logIdentifier(); }
 #endif
 
 protected:

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -164,7 +164,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_private->logger(); }
-    const void* logIdentifier() const final { return m_private->logIdentifier(); }
+    uint64_t logIdentifier() const final { return m_private->logIdentifier(); }
 #endif
 
     void setShouldFireMuteEventImmediately(bool value) { m_shouldFireMuteEventImmediately = value; }

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -169,7 +169,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const override { return "PeerConnectionBackend"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -260,7 +260,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
     bool m_finishedGatheringCandidates { false };
     bool m_isProcessingLocalDescriptionAnswer { false };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -202,7 +202,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "RTCPeerConnection"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -262,7 +262,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     RtpTransceiverSet m_transceiverSet;

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -86,7 +86,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "RTCRtpReceiver"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -99,7 +99,7 @@ private:
     Vector<WeakPtr<MediaStream>> m_associatedStreams;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -101,7 +101,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "RTCRtpSender"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -116,7 +116,7 @@ private:
     std::unique_ptr<RTCRtpTransform> m_transform;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -171,7 +171,7 @@ private:
     void stopLoggingStats();
 
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "GStreamerMediaEndpoint"_s; }
     WTFLogChannel& logChannel() const final;
 
@@ -196,7 +196,7 @@ private:
     Timer m_statsLogTimer;
     Seconds m_statsFirstDeliveredTimestamp;
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     UniqueRef<GStreamerDataChannelHandler> findOrCreateIncomingChannelHandler(GRefPtr<GstWebRTCDataChannel>&&);

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -173,7 +173,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "LibWebRTCMediaEndpoint"_s; }
     WTFLogChannel& logChannel() const final;
 
@@ -204,7 +204,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     int64_t m_statsFirstDeliveredTimestamp { 0 };
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
     bool m_isGatheringRTCLogs { false };
     bool m_shouldIgnoreNegotiationNeededSignal { false };

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -68,7 +68,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "HTMLVideoElementPictureInPicture"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -86,7 +86,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -95,12 +95,12 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     WTFLogChannel& logChannel() const;
     ASCIILiteral logClassName() const { return "RemotePlayback"_s; }
 
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 
     WeakPtr<HTMLMediaElement> m_mediaElement;

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.cpp
@@ -40,10 +40,10 @@
 namespace WebCore {
 
 #if !RELEASE_LOG_DISABLED
-static const void* nextLogIdentifier()
+static uint64_t nextLogIdentifier()
 {
     static uint64_t logIdentifier = cryptographicallyRandomNumber<uint32_t>();
-    return reinterpret_cast<const void*>(++logIdentifier);
+    return ++logIdentifier;
 }
 
 static RefPtr<Logger>& nullLogger()

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -104,7 +104,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
-    const void* logIdentifier() const final { return BaseAudioContext::logIdentifier(); }
+    uint64_t logIdentifier() const final { return BaseAudioContext::logIdentifier(); }
 #endif
 
     void constructCommon();

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -227,7 +227,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "AudioNode"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -275,7 +275,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     mutable Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     unsigned m_channelCount { 2 };

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -125,7 +125,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "AudioParam"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -146,7 +146,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     mutable Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -215,10 +215,10 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const override { return m_logger.get(); }
-    const void* logIdentifier() const override { return m_logIdentifier; }
+    uint64_t logIdentifier() const override { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
-    const void* nextAudioNodeLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextAudioNodeIdentifier); }
-    const void* nextAudioParameterLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextAudioParameterIdentifier); }
+    uint64_t nextAudioNodeLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextAudioNodeIdentifier); }
+    uint64_t nextAudioParameterLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextAudioParameterIdentifier); }
 #endif
 
     void postTask(Function<void()>&&);
@@ -287,7 +287,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     uint64_t m_nextAudioNodeIdentifier { 0 };
     uint64_t m_nextAudioParameterIdentifier { 0 };
 #endif

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -110,7 +110,7 @@ protected:
 private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return document().logger(); }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "FullscreenManager"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -137,7 +137,7 @@ private:
     bool m_isAnimatingFullscreen { false };
 
 #if !RELEASE_LOG_DISABLED
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -611,7 +611,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return *m_logger.get(); }
     Ref<Logger> protectedLogger() const;
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "HTMLMediaElement"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -1101,7 +1101,7 @@ private:
     bool videoUsesElementFullscreen() const;
 
 #if !RELEASE_LOG_DISABLED
-    const void* mediaPlayerLogIdentifier() final { return logIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() final { return logIdentifier(); }
     const Logger& mediaPlayerLogger() final { return logger(); }
 #endif
 
@@ -1406,7 +1406,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -242,7 +242,7 @@ private:
     Timer m_clientDataBufferingTimer;
 
 #if !RELEASE_LOG_DISABLED
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 #endif
 
 #if ENABLE(MEDIA_USAGE)

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -492,7 +492,7 @@ const Logger& MediaControlTextTrackContainerElement::logger() const
     return *m_logger;
 }
 
-const void* MediaControlTextTrackContainerElement::logIdentifier() const
+uint64_t MediaControlTextTrackContainerElement::logIdentifier() const
 {
     if (!m_logIdentifier && m_mediaElement)
         m_logIdentifier = m_mediaElement->logIdentifier();

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -90,11 +90,11 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
-    const void* logIdentifier() const final;
+    uint64_t logIdentifier() const final;
     WTFLogChannel& logChannel() const final;
     ASCIILiteral logClassName() const final { return "MediaControlTextTrackContainerElement"_s; }
     mutable RefPtr<Logger> m_logger;
-    mutable const void* m_logIdentifier { nullptr };
+    mutable uint64_t m_logIdentifier { 0 };
 #endif
 
     std::unique_ptr<TextTrackRepresentation> m_textTrackRepresentation;

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -229,7 +229,7 @@ void AudioTrack::updateConfigurationFromPrivate()
 }
 
 #if !RELEASE_LOG_DISABLED
-void AudioTrack::setLogger(const Logger& logger, const void* logIdentifier)
+void AudioTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TrackBase::setLogger(logger, logIdentifier);
     m_private->setLogger(logger, this->logIdentifier());

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -68,7 +68,7 @@ public:
     AudioTrackConfiguration& configuration() const { return m_configuration; }
 
 #if !RELEASE_LOG_DISABLED
-    void setLogger(const Logger&, const void*) final;
+    void setLogger(const Logger&, uint64_t) final;
 #endif
 
 private:

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -203,7 +203,7 @@ MediaTime InbandTextTrack::startTimeVariance() const
 }
 
 #if !RELEASE_LOG_DISABLED
-void InbandTextTrack::setLogger(const Logger& logger, const void* logIdentifier)
+void InbandTextTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TextTrack::setLogger(logger, logIdentifier);
     m_private->setLogger(logger, this->logIdentifier());

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -51,7 +51,7 @@ public:
 
     void setPrivate(InbandTextTrackPrivate&);
 #if !RELEASE_LOG_DISABLED
-    void setLogger(const Logger&, const void*) final;
+    void setLogger(const Logger&, uint64_t) final;
 #endif
 
 protected:

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -185,7 +185,7 @@ void TrackBase::setLanguage(const AtomString& language)
 }
 
 #if !RELEASE_LOG_DISABLED
-void TrackBase::setLogger(const Logger& logger, const void* logIdentifier)
+void TrackBase::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     m_logger = &logger;
     m_logIdentifier = childLogIdentifier(logIdentifier, m_uniqueId);

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -79,9 +79,9 @@ public:
     virtual bool enabled() const = 0;
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogger(const Logger&, const void*);
+    virtual void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 #endif
 
@@ -113,7 +113,7 @@ private:
     AtomString m_validBCP47Language;
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
     WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
     size_t m_clientRegistrationId;

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1464,7 +1464,7 @@ void VTTCue::prepareToSpeak(SpeechSynthesis& speechSynthesis, double rate, doubl
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* VTTCue::logIdentifier() const
+uint64_t VTTCue::logIdentifier() const
 {
     if (!m_logIdentifier && track())
         m_logIdentifier = childLogIdentifier(track()->logIdentifier(), cryptographicallyRandomNumber<uint64_t>());

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -261,7 +261,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return *m_logger; }
-    const void* logIdentifier() const final;
+    uint64_t logIdentifier() const final;
     WTFLogChannel& logChannel() const final;
     ASCIILiteral logClassName() const final { return "VTTCue"_s; }
 #endif
@@ -311,7 +311,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     mutable RefPtr<Logger> m_logger;
-    mutable const void* m_logIdentifier { nullptr };
+    mutable uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -246,7 +246,7 @@ void VideoTrack::updateConfigurationFromPrivate()
 }
 
 #if !RELEASE_LOG_DISABLED
-void VideoTrack::setLogger(const Logger& logger, const void* logIdentifier)
+void VideoTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TrackBase::setLogger(logger, logIdentifier);
     m_private->setLogger(logger, this->logIdentifier());

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -70,7 +70,7 @@ public:
 
     void setPrivate(VideoTrackPrivate&);
 #if !RELEASE_LOG_DISABLED
-    void setLogger(const Logger&, const void*) final;
+    void setLogger(const Logger&, uint64_t) final;
 #endif
 
 private:

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -187,7 +187,7 @@ protected:
     Logger& logger();
     ASCIILiteral logClassName() const { return "AudioSession"_s; }
     WTFLogChannel& logChannel() const;
-    const void* logIdentifier() const { return nullptr; }
+    uint64_t logIdentifier() const { return 0; }
 
     mutable RefPtr<Logger> m_logger;
 
@@ -226,7 +226,7 @@ public:
     virtual void beginRoutingArbitrationWithCategory(AudioSession::CategoryType, ArbitrationCallback&&) = 0;
     virtual void leaveRoutingAbritration() = 0;
 
-    virtual const void* logIdentifier() const = 0;
+    virtual uint64_t logIdentifier() const = 0;
     virtual bool canLog() const = 0;
 };
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -499,7 +499,7 @@ const Logger& PlatformMediaSession::logger() const
     return client().logger();
 }
 
-const void* PlatformMediaSession::logIdentifier() const
+uint64_t PlatformMediaSession::logIdentifier() const
 {
     return client().logIdentifier();
 }

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -230,7 +230,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
-    const void* logIdentifier() const final;
+    uint64_t logIdentifier() const final;
     ASCIILiteral logClassName() const override { return "PlatformMediaSession"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -333,7 +333,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
-    virtual const void* logIdentifier() const = 0;
+    virtual uint64_t logIdentifier() const = 0;
 #endif
 
 protected:

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -917,7 +917,7 @@ void PlatformMediaSessionManager::dumpSessionStates()
     StringBuilder builder;
 
     forEachSession([&](auto& session) {
-        builder.append('(', hex(reinterpret_cast<uintptr_t>(session.logIdentifier())), "): "_s, session.description(), "\n"_s);
+        builder.append('(', hex(session.logIdentifier()), "): "_s, session.description(), "\n"_s);
     });
 
     ALWAYS_LOG(LOGIDENTIFIER, " Sessions:\n", builder.toString());

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -216,7 +216,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return nullptr; }
+    uint64_t logIdentifier() const final { return 0; }
     ASCIILiteral logClassName() const override { return "PlatformMediaSessionManager"_s; }
     WTFLogChannel& logChannel() const final;
 #endif

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -64,7 +64,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     ASCIILiteral logClassName() const final { return "AudioFileReaderCocoa"_s; }
 #endif
@@ -91,7 +91,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Ref<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
 };

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -78,8 +78,8 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
-    void setLogger(Ref<const Logger>&&, const void*);
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
+    void setLogger(Ref<const Logger>&&, uint64_t);
 #endif
 
     static constexpr float EquivalentToMaxVolume = 0.95;
@@ -125,7 +125,7 @@ private:
     bool m_isInNeedOfMoreData { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -329,7 +329,7 @@ bool AudioSampleDataSource::pullAvailableSamplesAsChunks(AudioBufferList& buffer
 }
 
 #if !RELEASE_LOG_DISABLED
-void AudioSampleDataSource::setLogger(Ref<const Logger>&& logger, const void* logIdentifier)
+void AudioSampleDataSource::setLogger(Ref<const Logger>&& logger, uint64_t logIdentifier)
 {
     m_logger = WTFMove(logger);
     m_logIdentifier = logIdentifier;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -84,7 +84,7 @@ private:
     void removeConfigurationChangeObserver(AudioSessionConfigurationChangeObserver&) final;
 
     WTFLogChannel& logChannel() const;
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
 
     std::optional<bool> m_lastMutedState;
     mutable WeakHashSet<AudioSessionConfigurationChangeObserver> m_configurationChangeObservers;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -549,14 +549,14 @@ WTFLogChannel& AudioSessionMac::logChannel() const
     return LogMedia;
 }
 
-const void* AudioSessionMac::logIdentifier() const
+uint64_t AudioSessionMac::logIdentifier() const
 {
 #if ENABLE(ROUTING_ARBITRATION)
     if (m_routingArbitrationClient)
         return m_routingArbitrationClient->logIdentifier();
 #endif
 
-    return nullptr;
+    return 0;
 }
 
 }

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
@@ -50,11 +50,11 @@ class WEBCORE_EXPORT SharedRoutingArbitratorToken : public CanMakeWeakPtr<Shared
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SharedRoutingArbitratorToken, WEBCORE_EXPORT);
 public:
     static UniqueRef<SharedRoutingArbitratorToken> create();
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
 private:
     friend UniqueRef<SharedRoutingArbitratorToken> WTF::makeUniqueRefWithoutFastMallocCheck<SharedRoutingArbitratorToken>();
     SharedRoutingArbitratorToken() = default;
-    mutable const void* m_logIdentifier;
+    mutable uint64_t m_logIdentifier { 0 };
 };
 
 class WEBCORE_EXPORT SharedRoutingArbitrator {

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
@@ -46,7 +46,7 @@ UniqueRef<SharedRoutingArbitratorToken> SharedRoutingArbitratorToken::create()
     return makeUniqueRef<SharedRoutingArbitratorToken>();
 }
 
-const void* SharedRoutingArbitratorToken::logIdentifier() const
+uint64_t SharedRoutingArbitratorToken::logIdentifier() const
 {
     if (!m_logIdentifier)
         m_logIdentifier = LoggerHelper::uniqueLogIdentifier();

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -145,7 +145,7 @@ public:
 #endif
 
 #if !RELEASE_LOG_DISABLED
-    virtual const void* logIdentifier() const { return nullptr; }
+    virtual uint64_t logIdentifier() const { return 0; }
     virtual const Logger* loggerPtr() const { return nullptr; }
 #endif
 };

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -140,7 +140,7 @@ private:
     const AtomString& eventNameAll();
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const final;
+    uint64_t logIdentifier() const final;
     const Logger* loggerPtr() const final;
 #endif
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -778,11 +778,11 @@ bool PlaybackSessionModelMediaElement::isInWindowFullscreenActive() const
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* PlaybackSessionModelMediaElement::logIdentifier() const
+uint64_t PlaybackSessionModelMediaElement::logIdentifier() const
 {
     if (RefPtr mediaElement = m_mediaElement)
         return mediaElement->logIdentifier();
-    return nullptr;
+    return 0;
 }
 
 const Logger* PlaybackSessionModelMediaElement::loggerPtr() const

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -104,8 +104,8 @@ public:
 #endif
 
 #if !RELEASE_LOG_DISABLED
-    virtual const void* logIdentifier() const { return nullptr; }
-    virtual const void* nextChildIdentifier() const { return logIdentifier(); }
+    virtual uint64_t logIdentifier() const { return 0; }
+    virtual uint64_t nextChildIdentifier() const { return logIdentifier(); }
     virtual const Logger* loggerPtr() const { return nullptr; }
 #endif
 };

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -80,8 +80,8 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger* loggerPtr() const final;
-    WEBCORE_EXPORT const void* logIdentifier() const final;
-    WEBCORE_EXPORT const void* nextChildIdentifier() const final;
+    WEBCORE_EXPORT uint64_t logIdentifier() const final;
+    WEBCORE_EXPORT uint64_t nextChildIdentifier() const final;
     ASCIILiteral logClassName() const { return "VideoPresentationModelVideoElement"_s; }
     WTFLogChannel& logChannel() const;
 #endif

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -410,12 +410,12 @@ const Logger* VideoPresentationModelVideoElement::loggerPtr() const
     return m_videoElement ? &m_videoElement->logger() : nullptr;
 }
 
-const void* VideoPresentationModelVideoElement::logIdentifier() const
+uint64_t VideoPresentationModelVideoElement::logIdentifier() const
 {
-    return m_videoElement ? m_videoElement->logIdentifier() : nullptr;
+    return m_videoElement ? m_videoElement->logIdentifier() : 0;
 }
 
-const void* VideoPresentationModelVideoElement::nextChildIdentifier() const
+uint64_t VideoPresentationModelVideoElement::nextChildIdentifier() const
 {
     return LoggerHelper::childLogIdentifier(logIdentifier(), ++m_childIdentifierSeed);
 }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -50,7 +50,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
 
 #if !RELEASE_LOG_DISABLED
 @interface WebAVPlayerLayer (Logging)
-@property (readonly, nonatomic) const void* logIdentifier;
+@property (readonly, nonatomic) uint64_t logIdentifier;
 @property (readonly, nonatomic) const Logger* loggerPtr;
 @property (readonly, nonatomic) WTFLogChannel* logChannel;
 @end
@@ -93,7 +93,7 @@ private:
     std::unique_ptr<WebAVPlayerLayerPresentationModelClient> _presentationModelClient;
     NSEdgeInsets _legibleContentInsets;
 #if !RELEASE_LOG_DISABLED
-    const void* _logIdentifier;
+    uint64_t _logIdentifier;
 #endif
 }
 
@@ -136,7 +136,7 @@ private:
 
     _presentationModel = presentationModel;
 #if !RELEASE_LOG_DISABLED
-    _logIdentifier = presentationModel ? presentationModel->nextChildIdentifier() : nullptr;
+    _logIdentifier = presentationModel ? presentationModel->nextChildIdentifier() : 0;
 #endif
 
     if (presentationModel)
@@ -423,7 +423,7 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
 
 #if !RELEASE_LOG_DISABLED
 @implementation WebAVPlayerLayer (Logging)
-- (const void*)logIdentifier
+- (uint64_t)logIdentifier
 {
     return _logIdentifier;
 }

--- a/Source/WebCore/platform/encryptedmedia/CDMInstance.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstance.h
@@ -67,7 +67,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
-    virtual const void* logIdentifier() const = 0;
+    virtual uint64_t logIdentifier() const = 0;
 #endif
 };
 
@@ -81,7 +81,7 @@ public:
     virtual void clearClient() { }
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogIdentifier(const void*) { }
+    virtual void setLogIdentifier(uint64_t) { }
 #endif
 
     enum class ImplementationType {

--- a/Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h
@@ -87,7 +87,7 @@ public:
     using MessageType = CDMMessageType;
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogIdentifier(const void*) { }
+    virtual void setLogIdentifier(uint64_t) { }
 #endif
 
     virtual void setClient(WeakPtr<CDMInstanceSessionClient>&&) { }

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
@@ -69,7 +69,7 @@ public:
     WEBCORE_EXPORT virtual ~CDMPrivate();
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogIdentifier(const void*) { };
+    virtual void setLogIdentifier(uint64_t) { };
 #endif
 
     enum class LocalStorageAccess : bool {

--- a/Source/WebCore/platform/graphics/LegacyCDMSession.h
+++ b/Source/WebCore/platform/graphics/LegacyCDMSession.h
@@ -64,7 +64,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
-    virtual const void* logIdentifier() const = 0;
+    virtual uint64_t logIdentifier() const = 0;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -341,7 +341,7 @@ public:
     virtual MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const { return { }; }
 
 #if !RELEASE_LOG_DISABLED
-    virtual const void* mediaPlayerLogIdentifier() { return nullptr; }
+    virtual uint64_t mediaPlayerLogIdentifier() { return 0; }
     virtual const Logger& mediaPlayerLogger() = 0;
 #endif
 
@@ -703,7 +703,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger();
-    const void* mediaPlayerLogIdentifier() { return client().mediaPlayerLogIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() { return client().mediaPlayerLogIdentifier(); }
 #endif
 
     void applicationWillResignActive();

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -49,7 +49,7 @@ public:
     virtual RefPtr<MediaSourcePrivate> mediaSourcePrivate() const = 0;
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogIdentifier(const void*) = 0;
+    virtual void setLogIdentifier(uint64_t) = 0;
     virtual const Logger* logger() const { return nullptr; }
 #endif
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -157,7 +157,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& sourceBufferLogger() const = 0;
-    virtual const void* sourceBufferLogIdentifier() = 0;
+    virtual uint64_t sourceBufferLogIdentifier() = 0;
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -398,7 +398,7 @@ void TrackBuffer::setRoundedTimestampOffset(const MediaTime& time, uint32_t time
 }
 
 #if !RELEASE_LOG_DISABLED
-void TrackBuffer::setLogger(const Logger& newLogger, const void* newLogIdentifier)
+void TrackBuffer::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
     m_logger = &newLogger;
     m_logIdentifier = childLogIdentifier(newLogIdentifier, cryptographicallyRandomNumber<uint32_t>());

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -111,9 +111,9 @@ public:
     PlatformTimeRanges& buffered() { return m_buffered; }
     
 #if !RELEASE_LOG_DISABLED
-    void setLogger(const Logger&, const void*);
+    void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "TrackBuffer"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -146,7 +146,7 @@ private:
     
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 #endif
     
     uint32_t m_lastFrameTimescale { 0 };

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -131,7 +131,7 @@ bool TrackPrivateBase::hasOneClient() const
 
 static uint64_t s_uniqueId = 0;
 
-void TrackPrivateBase::setLogger(const Logger& logger, const void* logIdentifier)
+void TrackPrivateBase::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     m_logger = &logger;
     m_logIdentifier = childLogIdentifier(logIdentifier, ++s_uniqueId);

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -80,9 +80,9 @@ public:
     virtual Type type() const = 0;
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogger(const Logger&, const void*);
+    virtual void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 #endif
 
@@ -116,7 +116,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -59,9 +59,9 @@ public:
     virtual ~CDMPrivateFairPlayStreaming();
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
+    void setLogIdentifier(uint64_t logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "CDMPrivateFairPlayStreaming"_s; }
 #endif
 
@@ -105,7 +105,7 @@ public:
 private:
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
@@ -54,7 +54,7 @@ public:
 
     virtual Vector<RetainPtr<AVContentKey>> contentKeyGroupDataSourceKeys() const = 0;
 #if !RELEASE_LOG_DISABLED
-    virtual const void* contentKeyGroupDataSourceLogIdentifier() const = 0;
+    virtual uint64_t contentKeyGroupDataSourceLogIdentifier() const = 0;
     virtual const Logger& contentKeyGroupDataSourceLogger() const = 0;
     virtual WTFLogChannel& contentKeyGroupDataSourceLogChannel() const = 0;
 #endif // !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -154,7 +154,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateAVFoundation"_s; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 #endif
 
@@ -353,7 +353,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     FloatSize m_cachedNaturalSize;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -86,7 +86,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
-    virtual const void* logIdentifier() const = 0;
+    virtual uint64_t logIdentifier() const = 0;
 #endif
 };
 
@@ -151,9 +151,9 @@ public:
     void attachContentKeyToSample(const MediaSampleAVFObjC&);
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
+    void setLogIdentifier(uint64_t logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "CDMInstanceFairPlayStreamingAVFObjC"_s; }
 #endif
 
@@ -171,7 +171,7 @@ private:
     WeakHashSet<KeyStatusesChangedObserver> m_keyStatusChangedObservers;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 
@@ -249,16 +249,16 @@ private:
     bool requestMatchesRenewingRequest(AVContentKeyRequest *);
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
+    void setLogIdentifier(uint64_t logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "CDMInstanceSessionFairPlayStreamingAVFObjC"_s; }
 #endif
 
     // ContentKeyGroupDataSource
     Vector<RetainPtr<AVContentKey>> contentKeyGroupDataSourceKeys() const final;
 #if !RELEASE_LOG_DISABLED
-    const void* contentKeyGroupDataSourceLogIdentifier() const final;
+    uint64_t contentKeyGroupDataSourceLogIdentifier() const final;
     const Logger& contentKeyGroupDataSourceLogger() const final;
     WTFLogChannel& contentKeyGroupDataSourceLogChannel() const final;
 #endif // !RELEASE_LOG_DISABLED
@@ -288,7 +288,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1797,7 +1797,7 @@ Vector<RetainPtr<AVContentKey>> CDMInstanceSessionFairPlayStreamingAVFObjC::cont
 
 #if !RELEASE_LOG_DISABLED
 
-const void* CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceLogIdentifier() const
+uint64_t CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceLogIdentifier() const
 {
     return logIdentifier();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -97,7 +97,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
@@ -67,7 +67,7 @@ public:
 private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "CDMSessionAVFoundationObjC"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -79,7 +79,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
@@ -83,7 +83,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     WTFLogChannel& logChannel() const;
 #endif
 
@@ -96,7 +96,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -168,10 +168,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateMediaSourceAVFObjC"_s; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
-    const void* mediaPlayerLogIdentifier() { return logIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() { return logIdentifier(); }
     const Logger& mediaPlayerLogger() { return logger(); }
 #endif
 
@@ -397,7 +397,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool m_shouldPlayToTarget { false };
 #endif
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     std::unique_ptr<VideoLayerManagerObjC> m_videoLayerManager;
     Ref<EffectiveRateChangedListener> m_effectiveRateChangedListener;
     uint64_t m_sampleCount { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -88,7 +88,7 @@ public:
 
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateMediaStreamAVFObjC"_s; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
     USING_CAN_MAKE_WEAKPTR(MediaStreamTrackPrivateObserver);
@@ -283,7 +283,7 @@ private:
     bool m_videoMirrored { false };
 
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     std::unique_ptr<VideoLayerManagerObjC> m_videoLayerManager;
 
     // SampleBufferDisplayLayerClient

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -433,7 +433,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
 
     scheduleRenderingModeChanged();
 
-    m_sampleBufferDisplayLayer->setLogIdentifier(makeString(hex(reinterpret_cast<uintptr_t>(logIdentifier()))));
+    m_sampleBufferDisplayLayer->setLogIdentifier(makeString(hex(logIdentifier())));
     if (m_storedBounds)
         m_sampleBufferDisplayLayer->updateBoundsAndPosition(*m_storedBounds);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -102,10 +102,10 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const final { return "MediaSourcePrivateAVFObjC"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
-    const void* nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
+    uint64_t nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
 #endif
 
     using RendererType = MediaSourcePrivateClient::RendererType;
@@ -139,7 +139,7 @@ private:
 #endif
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     uint64_t m_nextSourceBufferID { 0 };
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -63,7 +63,7 @@ public:
     void resetParserState() final;
     void invalidate() final;
 #if !RELEASE_LOG_DISABLED
-    void setLogger(const Logger&, const void* identifier) final;
+    void setLogger(const Logger&, uint64_t identifier) final;
 #endif
 
     void didParseStreamDataAsAsset(AVAsset*);
@@ -77,7 +77,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "SourceBufferParserAVFObjC"_s; }
     WTFLogChannel& logChannel() const final { return LogMedia; }
 #endif
@@ -89,7 +89,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -275,7 +275,7 @@ void SourceBufferParserAVFObjC::invalidate()
 }
 
 #if !RELEASE_LOG_DISABLED
-void SourceBufferParserAVFObjC::setLogger(const Logger& newLogger, const void* newLogIdentifier)
+void SourceBufferParserAVFObjC::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
     m_logger = &newLogger;
     m_logIdentifier = newLogIdentifier;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -140,10 +140,10 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "SourceBufferPrivateAVFObjC"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger.get(); }
-    const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
+    uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
@@ -272,7 +272,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     ProcessIdentity m_resourceOwner;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
@@ -51,7 +51,7 @@ class VideoLayerManagerObjC final
 
 public:
 #if !RELEASE_LOG_DISABLED
-    WEBCORE_EXPORT VideoLayerManagerObjC(const Logger&, const void*);
+    WEBCORE_EXPORT VideoLayerManagerObjC(const Logger&, uint64_t);
 #else
     VideoLayerManagerObjC() = default;
 #endif
@@ -78,12 +78,12 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "VideoLayerManagerObjC"_s; }
     WTFLogChannel& logChannel() const final;
 
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     RetainPtr<WebVideoContainerLayer> m_videoInlineLayer;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -48,7 +48,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoLayerManagerObjC);
 
 #if !RELEASE_LOG_DISABLED
-VideoLayerManagerObjC::VideoLayerManagerObjC(const Logger& logger, const void* logIdentifier)
+VideoLayerManagerObjC::VideoLayerManagerObjC(const Logger& logger, uint64_t logIdentifier)
     : m_logger(logger)
     , m_logIdentifier(logIdentifier)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if !RELEASE_LOG_DISABLED
 @interface WebAVContentKeyGroup (Logging)
-@property (nonatomic, readonly) const void* logIdentifier;
+@property (nonatomic, readonly) uint64_t logIdentifier;
 @property (nonatomic, readonly) const Logger* loggerPtr;
 @property (nonatomic, readonly) WTFLogChannel* logChannel;
 @end
@@ -129,9 +129,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation WebAVContentKeyGroup (Logging)
 
-- (const void*)logIdentifier
+- (uint64_t)logIdentifier
 {
-    return _dataSource ? _dataSource->contentKeyGroupDataSourceLogIdentifier() : nullptr;
+    return _dataSource ? _dataSource->contentKeyGroupDataSourceLogIdentifier() : 0;
 }
 
 - (const Logger*)loggerPtr

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -308,7 +308,7 @@ private:
 
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const final { return "MediaPlayerPrivateWebM"_s; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
     friend class MediaPlayerFactoryWebM;
@@ -356,7 +356,7 @@ private:
     bool m_shouldPlayToTarget { false };
 #endif
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     std::unique_ptr<VideoLayerManagerObjC> m_videoLayerManager;
     RetainPtr<id> m_videoFrameMetadataGatheringObserver;
     bool m_isGatheringVideoFrameMetadata { false };

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -93,7 +93,7 @@ public:
     virtual void invalidate() = 0;
     virtual void setMinimumAudioSampleDuration(float);
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogger(const Logger&, const void* logIdentifier) = 0;
+    virtual void setLogger(const Logger&, uint64_t logIdentifier) = 0;
 #endif
 
     // Will be called on the main thread.

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -577,7 +577,7 @@ ExceptionOr<int> WebMParser::parse(SourceBufferParser::Segment&& segment)
     return m_status.code;
 }
 
-void WebMParser::setLogger(const Logger& newLogger, const void* newLogIdentifier)
+void WebMParser::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
     m_logger = &newLogger;
     m_logIdentifier = newLogIdentifier;
@@ -1584,7 +1584,7 @@ void SourceBufferParserWebM::invalidate()
     m_parser.invalidate();
 }
 
-void SourceBufferParserWebM::setLogger(const Logger& newLogger, const void* newLogIdentifier)
+void SourceBufferParserWebM::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
     m_logger = &newLogger;
     m_logIdentifier = newLogIdentifier;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -86,7 +86,7 @@ public:
 
     void provideMediaData(MediaSamplesBlock&&);
 
-    WEBCORE_EXPORT void setLogger(const Logger&, const void* identifier);
+    WEBCORE_EXPORT void setLogger(const Logger&, uint64_t identifier);
     WTFLogChannel& logChannel() const final;
 
     enum class ErrorCode : int32_t {
@@ -289,7 +289,7 @@ private:
 
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "WebMParser"_s; }
 
     std::unique_ptr<SourceBufferParser::InitializationSegment> m_initializationSegment;
@@ -312,7 +312,7 @@ private:
     std::optional<uint64_t> m_rewindToPosition;
 
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
     uint64_t m_nextChildIdentifier { 0 };
     Callback& m_callback;
     bool m_createByteRangeSamples { false };
@@ -347,7 +347,7 @@ public:
     void flushPendingAudioSamples();
     void setMinimumAudioSampleDuration(float);
 
-    WEBCORE_EXPORT void setLogger(const Logger&, const void* identifier) final;
+    WEBCORE_EXPORT void setLogger(const Logger&, uint64_t identifier) final;
 
 private:
     SourceBufferParserWebM();
@@ -363,7 +363,7 @@ private:
 
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "SourceBufferParserWebM"_s; }
     WTFLogChannel& logChannel() const final;
 
@@ -378,7 +378,7 @@ private:
     MediaTime m_queuedAudioDuration;
     bool m_audioDiscontinuity { true };
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -210,10 +210,10 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateGStreamer"_s; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const override;
 
-    const void* mediaPlayerLogIdentifier() { return logIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() { return logIdentifier(); }
     const Logger& mediaPlayerLogger() { return logger(); }
 #endif
 
@@ -610,7 +610,7 @@ private:
     mutable PlatformTimeRanges m_buffered;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     String m_errorMessage;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -80,10 +80,10 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
-    const void* nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
+    uint64_t nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
 #endif
 
 private:
@@ -94,7 +94,7 @@ private:
     bool m_hasAllTracks { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     uint64_t m_nextSourceBufferID { 0 };
 #endif
 };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -84,10 +84,10 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "SourceBufferPrivateGStreamer"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger; }
-    const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
+    uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
 
     size_t platformMaximumBufferSize() const override;
@@ -111,7 +111,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -86,7 +86,7 @@ public:
     virtual void stopObservingNowPlayingMetadata();
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;
     virtual ASCIILiteral logClassName() const = 0;
     WTFLogChannel& logChannel() const;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -117,9 +117,9 @@ void PlaybackSessionInterfaceIOS::stopObservingNowPlayingMetadata()
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* PlaybackSessionInterfaceIOS::logIdentifier() const
+uint64_t PlaybackSessionInterfaceIOS::logIdentifier() const
 {
-    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : nullptr;
+    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : 0;
 }
 
 const Logger* PlaybackSessionInterfaceIOS::loggerPtr() const

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -361,7 +361,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 - (void)setWebKitOverrideRouteSharingPolicy:(NSUInteger)routeSharingPolicy routingContextUID:(NSString *)routingContextUID;
 #if !RELEASE_LOG_DISABLED
-@property (readonly, nonatomic) const void* logIdentifier;
+@property (readonly, nonatomic) uint64_t logIdentifier;
 @property (readonly, nonatomic) const Logger* loggerPtr;
 @property (readonly, nonatomic) WTFLogChannel* logChannel;
 #endif
@@ -739,11 +739,11 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 }
 
 #if !RELEASE_LOG_DISABLED
-- (const void*)logIdentifier
+- (uint64_t)logIdentifier
 {
     if (auto fullscreenInterface = _fullscreenInterface.get())
         return fullscreenInterface->logIdentifier();
-    return nullptr;
+    return 0;
 }
 
 - (const Logger*)loggerPtr

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -171,7 +171,7 @@ public:
 #endif
 
 #if !RELEASE_LOG_DISABLED
-    WEBCORE_EXPORT const void* logIdentifier() const;
+    WEBCORE_EXPORT uint64_t logIdentifier() const;
     WEBCORE_EXPORT const Logger* loggerPtr() const;
     ASCIILiteral logClassName() const { return "VideoPresentationInterfaceIOS"_s; };
     WEBCORE_EXPORT WTFLogChannel& logChannel() const;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -910,7 +910,7 @@ void VideoPresentationInterfaceIOS::clearMode(HTMLMediaElementEnums::VideoFullsc
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* VideoPresentationInterfaceIOS::logIdentifier() const
+uint64_t VideoPresentationInterfaceIOS::logIdentifier() const
 {
     return m_playbackSessionInterface->logIdentifier();
 }

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -83,7 +83,7 @@ public:
     void invalidate();
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;
     ASCIILiteral logClassName() const { return "PlaybackSessionInterfaceMac"_s; };
     WTFLogChannel& logChannel() const;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -326,9 +326,9 @@ void PlaybackSessionInterfaceMac::decrementPtrCount() const
 #endif // ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 
 #if !RELEASE_LOG_DISABLED
-const void* PlaybackSessionInterfaceMac::logIdentifier() const
+uint64_t PlaybackSessionInterfaceMac::logIdentifier() const
 {
-    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : nullptr;
+    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : 0;
 }
 
 const Logger* PlaybackSessionInterfaceMac::loggerPtr() const

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -108,7 +108,7 @@ public:
     WEBCORE_EXPORT void documentVisibilityChanged(bool) final;
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;
     ASCIILiteral logClassName() const { return "VideoPresentationInterfaceMac"_s; };
     WTFLogChannel& logChannel() const;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -628,7 +628,7 @@ bool VideoPresentationInterfaceMac::isPlayingVideoInEnhancedFullscreen() const
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* VideoPresentationInterfaceMac::logIdentifier() const
+uint64_t VideoPresentationInterfaceMac::logIdentifier() const
 {
     return m_playbackSessionInterface->logIdentifier();
 }

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
@@ -81,7 +81,7 @@ const Logger& AudioMediaStreamTrackRenderer::logger() const
 
 }
 
-const void* AudioMediaStreamTrackRenderer::logIdentifier() const
+uint64_t AudioMediaStreamTrackRenderer::logIdentifier() const
 {
     return m_logIdentifier;
 }

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
@@ -51,7 +51,7 @@ public:
 #endif
 #if !RELEASE_LOG_DISABLED
         const Logger& logger;
-        const void* logIdentifier;
+        uint64_t logIdentifier;
 #endif
     };
     static std::unique_ptr<AudioMediaStreamTrackRenderer> create(Init&&);
@@ -73,7 +73,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
-    const void* logIdentifier() const final;
+    uint64_t logIdentifier() const final;
 
     ASCIILiteral logClassName() const final;
     WTFLogChannel& logChannel() const final;
@@ -96,7 +96,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
@@ -115,7 +115,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
 #endif
 
 private:
@@ -146,7 +146,7 @@ private:
     bool m_isActive { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -151,7 +151,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
 #endif
 
     friend class MediaStreamTrackPrivateSourceObserver;
@@ -206,7 +206,7 @@ private:
     MediaStreamTrackHintValue m_contentHint { MediaStreamTrackHintValue::Empty };
     Ref<const Logger> m_logger;
 #if !RELEASE_LOG_DISABLED
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
     bool m_isProducingData { false };
     bool m_isMuted { false };

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
@@ -94,7 +94,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     mutable RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -98,7 +98,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     bool m_enableFrameRatedMonitoringLogging { false };
     mutable RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1485,7 +1485,7 @@ auto RealtimeMediaSource::getPhotoSettings() -> Ref<PhotoSettingsNativePromise>
 }
 
 #if !RELEASE_LOG_DISABLED
-void RealtimeMediaSource::setLogger(const Logger& newLogger, const void* newLogIdentifier)
+void RealtimeMediaSource::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
     m_logger = &newLogger;
     m_logIdentifier = newLogIdentifier;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -276,10 +276,10 @@ public:
     virtual bool isIncomingVideoSource() const { return false; }
 
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogger(const Logger&, const void*);
+    virtual void setLogger(const Logger&, uint64_t);
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const override { return "RealtimeMediaSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -368,7 +368,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
     MonotonicTime m_lastFrameLogTime;
     unsigned m_frameCount { 0 };
 #endif

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
@@ -84,7 +84,7 @@ protected:
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper API
     const Logger& logger() const final { return m_audioSource->logger(); }
-    const void* logIdentifier() const final { return m_audioSource->logIdentifier(); }
+    uint64_t logIdentifier() const final { return m_audioSource->logIdentifier(); }
     ASCIILiteral logClassName() const final { return "RealtimeOutgoingAudioSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -90,7 +90,7 @@ protected:
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper API
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "RealtimeOutgoingVideoSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -162,7 +162,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     MonotonicTime m_lastFrameLogTime;
     unsigned m_frameCount { 0 };
 #endif

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -343,13 +343,13 @@ void DisplayCaptureSourceCocoa::capturerConfigurationChanged()
     });
 }
 
-void DisplayCaptureSourceCocoa::setLogger(const Logger& logger, const void* identifier)
+void DisplayCaptureSourceCocoa::setLogger(const Logger& logger, uint64_t identifier)
 {
     RealtimeMediaSource::setLogger(logger, identifier);
     m_capturer->setLogger(logger, identifier);
 }
 
-void DisplayCaptureSourceCocoa::Capturer::setLogger(const Logger& newLogger, const void* newLogIdentifier)
+void DisplayCaptureSourceCocoa::Capturer::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
     m_logger = &newLogger;
     m_logIdentifier = newLogIdentifier;

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -96,10 +96,10 @@ public:
         virtual IntSize intrinsicSize() const = 0;
         virtual void whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback) { callback({ }); }
 
-        virtual void setLogger(const Logger&, const void*);
+        virtual void setLogger(const Logger&, uint64_t);
         const Logger* loggerPtr() const { return m_logger.get(); }
         const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-        const void* logIdentifier() const final { return m_logIdentifier; }
+        uint64_t logIdentifier() const final { return m_logIdentifier; }
         WTFLogChannel& logChannel() const final;
 
         void setObserver(CapturerObserver&);
@@ -125,7 +125,7 @@ public:
     private:
         WeakPtr<CapturerObserver> m_observer;
         RefPtr<const Logger> m_logger;
-        const void* m_logIdentifier;
+        uint64_t m_logIdentifier { 0 };
     };
 
     static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
@@ -157,7 +157,7 @@ private:
     void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
 
     ASCIILiteral logClassName() const final { return "DisplayCaptureSourceCocoa"_s; }
-    void setLogger(const Logger&, const void*) final;
+    void setLogger(const Logger&, uint64_t) final;
 
     // CapturerObserver
     void capturerIsRunningChanged(bool isRunning) final { notifyMutedChange(!isRunning); }

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
@@ -195,7 +195,7 @@ WTFLogChannel& IncomingAudioMediaStreamTrackRendererUnit::logChannel() const
     return LogWebRTC;
 }
 
-const void* IncomingAudioMediaStreamTrackRendererUnit::logIdentifier() const
+uint64_t IncomingAudioMediaStreamTrackRendererUnit::logIdentifier() const
 {
     return m_logIdentifier;
 }

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -77,7 +77,7 @@ private:
     const Logger& logger() const final;
     ASCIILiteral logClassName() const final { return "IncomingAudioMediaStreamTrackRendererUnit"_s; }
     WTFLogChannel& logChannel() const final;
-    const void* logIdentifier() const final;
+    uint64_t logIdentifier() const final;
 #endif
 
     // Main thread variables.
@@ -96,7 +96,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -68,7 +68,7 @@ public:
     void setNetworkState(MediaPlayer::NetworkState);
 
 #if !RELEASE_LOG_DISABLED
-    const void* mediaPlayerLogIdentifier() { return m_player.get()->mediaPlayerLogIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() { return m_player.get()->mediaPlayerLogIdentifier(); }
     const Logger& mediaPlayerLogger() { return m_player.get()->mediaPlayerLogger(); }
 #endif
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -61,10 +61,10 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "MockMediaSourcePrivate"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
-    const void* nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
+    uint64_t nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
 #endif
 
 private:
@@ -90,7 +90,7 @@ private:
     MediaTime m_totalFrameDelay;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     uint64_t m_nextSourceBufferID { 0 };
 #endif
 };

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -71,11 +71,11 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "MockSourceBufferPrivate"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
     const Logger& sourceBufferLogger() const final { return m_logger.get(); }
-    const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
+    uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
 
     MediaTime m_minimumUpcomingPresentationTime;
@@ -85,7 +85,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -63,11 +63,11 @@ private:
     Logger& logger();
     ASCIILiteral logClassName() const { return "LocalAudioSessionRoutingArbitrator"_s; }
     WTFLogChannel& logChannel() const;
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -163,14 +163,14 @@ private:
 #endif
 
     Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "RemoteAudioDestination"_s; }
     WTFLogChannel& logChannel() const { return WebKit2LogMedia; }
 
     IPC::Semaphore m_renderSemaphore;
     bool m_isPlaying { false };
     Ref<Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 
 #if PLATFORM(COCOA)
     WebCore::AudioOutputUnitAdaptor m_audioOutputUnitAdaptor;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -70,7 +70,7 @@ private:
     void unrequestedInitializationDataReceived(const String&, Ref<WebCore::SharedBuffer>&&) final;
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
 #endif
 
     // IPC::MessageReceiver
@@ -97,7 +97,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -60,7 +60,7 @@ RemoteCDMInstanceSessionProxy::~RemoteCDMInstanceSessionProxy()
 void RemoteCDMInstanceSessionProxy::setLogIdentifier(uint64_t logIdentifier)
 {
 #if !RELEASE_LOG_DISABLED
-    m_session->setLogIdentifier(reinterpret_cast<const void*>(logIdentifier));
+    m_session->setLogIdentifier(logIdentifier);
 #else
     UNUSED_PARAM(logIdentifier);
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -108,7 +108,7 @@ void RemoteCDMProxy::loadAndInitialize()
 void RemoteCDMProxy::setLogIdentifier(uint64_t logIdentifier)
 {
 #if !RELEASE_LOG_DISABLED
-    m_logIdentifier = reinterpret_cast<const void*>(logIdentifier);
+    m_logIdentifier = logIdentifier;
     if (m_factory)
         m_private->setLogIdentifier(m_logIdentifier);
 #else

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -67,7 +67,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
 #endif
 
 private:
@@ -90,7 +90,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -51,7 +51,7 @@ RemoteLegacyCDMSessionProxy::RemoteLegacyCDMSessionProxy(RemoteLegacyCDMFactoryP
     : m_factory(factory)
 #if !RELEASE_LOG_DISABLED
     , m_logger(factory.logger())
-    , m_logIdentifier(reinterpret_cast<const void*>(parentLogIdentifier))
+    , m_logIdentifier(parentLogIdentifier)
 #endif
     , m_identifier(sessionIdentifier)
     , m_session(cdm.createSession(*this))

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -74,7 +74,7 @@ private:
     String mediaKeysStorageDirectory() const final;
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "RemoteLegacyCDMSessionProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -92,7 +92,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     RemoteLegacyCDMSessionIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -383,9 +383,9 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final { return m_logger; }
     Ref<const Logger> protectedMediaPlayerLogger() const { return m_logger; }
-    const void* mediaPlayerLogIdentifier() { return reinterpret_cast<const void*>(m_configuration.logIdentifier); }
+    uint64_t mediaPlayerLogIdentifier() { return m_configuration.logIdentifier; }
     const Logger& logger() { return mediaPlayerLogger(); }
-    const void* logIdentifier() { return mediaPlayerLogIdentifier(); }
+    uint64_t logIdentifier() { return mediaPlayerLogIdentifier(); }
     ASCIILiteral logClassName() const { return "RemoteMediaPlayerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -110,7 +110,7 @@ Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
 }
 
 #if !RELEASE_LOG_DISABLED
-void RemoteMediaSourceProxy::setLogIdentifier(const void*)
+void RemoteMediaSourceProxy::setLogIdentifier(uint64_t)
 {
     notImplemented();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -71,7 +71,7 @@ public:
     RefPtr<WebCore::MediaSourcePrivate> mediaSourcePrivate() const final { return m_private; }
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void*) final;
+    void setLogIdentifier(uint64_t) final;
 #endif
 
     void failedToCreateRenderer(RendererType) final;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -175,8 +175,8 @@ private:
     void setSoundStageSize(WebCore::AudioSessionSoundStageSize) final;
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void* identifier) { m_logIdentifier = identifier; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    void setLogIdentifier(uint64_t identifier) { m_logIdentifier = identifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     const Logger* loggerPtr() const;
 
     ASCIILiteral logClassName() const { return "PlaybackSessionModelContext"_s; };
@@ -220,7 +220,7 @@ private:
 #endif
 
 #if !RELEASE_LOG_DISABLED
-    const void* m_logIdentifier { nullptr };
+    uint64_t m_logIdentifier { 0 };
 #endif
 };
 
@@ -329,7 +329,7 @@ private:
     void setLogIdentifier(PlaybackSessionContextIdentifier, uint64_t);
 
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "VideoPresentationManagerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -342,7 +342,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -1048,7 +1048,7 @@ const SharedPreferencesForWebProcess& PlaybackSessionManagerProxy::sharedPrefere
 void PlaybackSessionManagerProxy::setLogIdentifier(PlaybackSessionContextIdentifier identifier, uint64_t logIdentifier)
 {
     Ref model = ensureModel(identifier);
-    model->setLogIdentifier(reinterpret_cast<const void*>(logIdentifier));
+    model->setLogIdentifier(logIdentifier);
 }
 
 WTFLogChannel& PlaybackSessionManagerProxy::logChannel() const

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -129,8 +129,8 @@ private:
     void setTextTrackRepresentationBounds(const WebCore::IntRect&) final;
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const final;
-    const void* nextChildIdentifier() const final;
+    uint64_t logIdentifier() const final;
+    uint64_t nextChildIdentifier() const final;
     const Logger* loggerPtr() const final;
 
     ASCIILiteral logClassName() const { return "VideoPresentationModelContext"_s; };
@@ -269,7 +269,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
     ASCIILiteral logClassName() const;
     WTFLogChannel& logChannel() const;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -481,12 +481,12 @@ void VideoPresentationModelContext::setTextTrackRepresentationBounds(const IntRe
 }
 
 #if !RELEASE_LOG_DISABLED
-const void* VideoPresentationModelContext::logIdentifier() const
+uint64_t VideoPresentationModelContext::logIdentifier() const
 {
     return m_playbackSessionModel->logIdentifier();
 }
 
-const void* VideoPresentationModelContext::nextChildIdentifier() const
+uint64_t VideoPresentationModelContext::nextChildIdentifier() const
 {
     return LoggerHelper::childLogIdentifier(m_playbackSessionModel->logIdentifier(), ++m_childIdentifierSeed);
 }
@@ -1430,7 +1430,7 @@ const Logger& VideoPresentationManagerProxy::logger() const
     return m_playbackSessionManagerProxy->logger();
 }
 
-const void* VideoPresentationManagerProxy::logIdentifier() const
+uint64_t VideoPresentationManagerProxy::logIdentifier() const
 {
     return m_playbackSessionManagerProxy->logIdentifier();
 }

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -78,7 +78,7 @@ public:
 
 protected:
     Logger& logger();
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "AudioSessionRoutingArbitrator"_s; }
     WTFLogChannel& logChannel() const;
 
@@ -96,7 +96,7 @@ private:
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };
     ArbitrationStatus m_arbitrationStatus { ArbitrationStatus::None };
     WallTime m_arbitrationUpdateTime;
-    const void* m_logIdentifier;
+    uint64_t m_logIdentifier { 0 };
 
 #if HAVE(AVAUDIO_ROUTING_ARBITER)
     UniqueRef<WebCore::SharedRoutingArbitratorToken> m_token;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -89,7 +89,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const WTF::Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinatorProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -98,7 +98,7 @@ private:
     Ref<MediaSessionCoordinatorProxyPrivate> m_privateCoordinator;
 #if !RELEASE_LOG_DISABLED
     Ref<const WTF::Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -69,7 +69,7 @@ public:
 private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
 #endif
 
     WeakRef<WebPageProxy> m_page;
@@ -78,7 +78,7 @@ private:
     HashSet<String> m_validAuthorizationTokens;
 
 #if !RELEASE_LOG_DISABLED
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -151,7 +151,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const override { return "UserMediaPermissionRequestManagerProxy"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -216,7 +216,7 @@ private:
     Seconds m_currentWatchdogInterval;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
     bool m_hasFilteredDeviceList { false };
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -136,7 +136,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "WebFullScreenManagerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -156,7 +156,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14016,9 +14016,9 @@ Logger& WebPageProxy::logger()
     return *m_logger;
 }
 
-const void* WebPageProxy::logIdentifier() const
+uint64_t WebPageProxy::logIdentifier() const
 {
-    return reinterpret_cast<const void*>(intHash(identifier().toUInt64()));
+    return intHash(identifier().toUInt64());
 }
 
 void WebPageProxy::configureLoggingChannel(const String& channelName, WTFLogChannelState state, WTFLogLevel level)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2086,7 +2086,7 @@ public:
 #endif
 
     Logger& logger();
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
 
     // IPC::MessageReceiver
     // Implemented in generated WebPageProxyMessageReceiver.cpp

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -740,7 +740,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 #if !RELEASE_LOG_DISABLED
 @interface WKFullScreenWindowController (Logging)
-@property (readonly, nonatomic) const void* logIdentifier;
+@property (readonly, nonatomic) uint64_t logIdentifier;
 @property (readonly, nonatomic) const Logger* loggerPtr;
 @property (readonly, nonatomic) WTFLogChannel* logChannel;
 @end
@@ -792,7 +792,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     RetainPtr<id> _notificationListener;
 #if !RELEASE_LOG_DISABLED
     RefPtr<Logger> _logger;
-    const void* _logIdentifier;
+    uint64_t _logIdentifier;
 #endif
 }
 
@@ -2064,7 +2064,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 #if !RELEASE_LOG_DISABLED
 @implementation WKFullScreenWindowController (Logging)
-- (const void*)logIdentifier
+- (uint64_t)logIdentifier
 {
     return _logIdentifier;
 }

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -144,7 +144,7 @@ void WebFullScreenManager::setPIPStandbyElement(WebCore::HTMLVideoElement* pipSt
         return;
 
 #if !RELEASE_LOG_DISABLED
-    auto logIdentifierForElement = [] (auto* element) { return element ? element->logIdentifier() : nullptr; };
+    auto logIdentifierForElement = [] (auto* element) { return element ? element->logIdentifier() : 0; };
 #endif
     ALWAYS_LOG(LOGIDENTIFIER, "old element ", logIdentifierForElement(m_pipStandbyElement.get()), ", new element ", logIdentifierForElement(pipStandbyElement));
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -114,7 +114,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "WebFullScreenManager"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -143,7 +143,7 @@ private:
     bool m_inWindowFullScreenMode { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -197,7 +197,7 @@ public:
     WebCore::FloatSize naturalSize() const final;
 
 #if !RELEASE_LOG_DISABLED
-    const void* mediaPlayerLogIdentifier() const { return logIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() const { return logIdentifier(); }
     const Logger& mediaPlayerLogger() const { return logger(); }
 #endif
 
@@ -237,11 +237,11 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateRemote"_s; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 
     void load(const URL&, const WebCore::ContentType&, const String&) final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -83,7 +83,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const void* nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
+    uint64_t nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
 #endif
 
     class MessageReceiver : public IPC::WorkQueueMessageReceiver {
@@ -122,11 +122,11 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateRemote"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
     uint64_t m_nextSourceBufferID { 0 };
 #endif
 };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
@@ -60,7 +60,7 @@ private:
 
     // WTF::LoggerHelper
     const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "RemoteAudioSourceProvider"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -69,7 +69,7 @@ private:
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -56,10 +56,10 @@ RemoteCDM::RemoteCDM(WeakPtr<RemoteCDMFactory>&& factory, RemoteCDMIdentifier&& 
 }
 
 #if !RELEASE_LOG_DISABLED
-void RemoteCDM::setLogIdentifier(const void* logIdentifier)
+void RemoteCDM::setLogIdentifier(uint64_t logIdentifier)
 {
     if (m_factory)
-        m_factory->gpuProcessConnection().connection().send(Messages::RemoteCDMProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
+        m_factory->gpuProcessConnection().connection().send(Messages::RemoteCDMProxy::SetLogIdentifier(logIdentifier), m_identifier);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
@@ -44,7 +44,7 @@ private:
     RemoteCDM(WeakPtr<RemoteCDMFactory>&&, RemoteCDMIdentifier&&, RemoteCDMConfiguration&&);
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void*) final;
+    void setLogIdentifier(uint64_t) final;
 #endif
 
     void getSupportedConfiguration(WebCore::CDMKeySystemConfiguration&& candidateConfiguration, LocalStorageAccess, SupportedConfigurationCallback&&) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
@@ -54,7 +54,7 @@ RemoteCDMInstanceSession::~RemoteCDMInstanceSession()
 }
 
 #if !RELEASE_LOG_DISABLED
-void RemoteCDMInstanceSession::setLogIdentifier(const void* logIdentifier)
+void RemoteCDMInstanceSession::setLogIdentifier(uint64_t logIdentifier)
 {
     m_factory->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -51,7 +51,7 @@ private:
     RemoteCDMInstanceSession(WeakPtr<RemoteCDMFactory>&&, RemoteCDMInstanceSessionIdentifier&&);
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(const void*) final;
+    void setLogIdentifier(uint64_t) final;
 #endif
 
     // IPC::MessageReceiver

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -175,13 +175,13 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "SourceBufferPrivateRemote"_s; }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger.get(); }
-    const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
+    uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
 
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9563,9 +9563,9 @@ const Logger& WebPage::logger() const
     return *m_logger;
 }
 
-const void* WebPage::logIdentifier() const
+uint64_t WebPage::logIdentifier() const
 {
-    return reinterpret_cast<const void*>(intHash(m_identifier.toUInt64()));
+    return intHash(m_identifier.toUInt64());
 }
 
 void WebPage::useRedirectionForCurrentNavigation(WebCore::ResourceResponse&& response)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1769,7 +1769,7 @@ public:
     WebCore::FloatSize screenSizeForFingerprintingProtections(const WebCore::LocalFrame&, WebCore::FloatSize defaultSize) const;
 
     const Logger& logger() const;
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #if USE(GBM)

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -53,11 +53,11 @@ public:
     void leaveRoutingAbritration() final;
 
 private:
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 
     WebCore::AudioSession::ChangedObserver m_observer;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 };
 
 }

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -203,7 +203,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "VideoPresentationManager"_s; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -216,7 +216,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
+    const uint64_t m_logIdentifier;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -209,7 +209,7 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;
-    const void* logIdentifier() const;
+    uint64_t logIdentifier() const;
     ASCIILiteral logClassName() const;
     WTFLogChannel& logChannel() const;
 #endif

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -867,7 +867,7 @@ const Logger& VideoPresentationManager::logger() const
     return m_playbackSessionManager->logger();
 }
 
-const void* VideoPresentationManager::logIdentifier() const
+uint64_t VideoPresentationManager::logIdentifier() const
 {
     return m_playbackSessionManager->logIdentifier();
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -157,7 +157,7 @@ static auto doFail()
     };
 }
 
-static auto doFailAndReject(Logger::LogSiteIdentifier location = Logger::LogSiteIdentifier(__builtin_FUNCTION(), nullptr))
+static auto doFailAndReject(Logger::LogSiteIdentifier location = Logger::LogSiteIdentifier(__builtin_FUNCTION(), 0))
 {
     return [location = WTFMove(location)] {
         EXPECT_TRUE(false);

--- a/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
@@ -104,7 +104,7 @@ public:
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const final { return "LoggingTest"_s; }
     WTFLogChannel& logChannel() const final { return TestChannel1; }
-    const void* logIdentifier() const final { return reinterpret_cast<const void*>(123456789); }
+    uint64_t logIdentifier() const final { return 123456789; }
 
 private:
 
@@ -290,7 +290,7 @@ TEST_F(LoggingTest, DISABLED_Logger)
     logger->debug(TestChannel1, "You're using coconuts!");
     EXPECT_EQ(0u, output().length());
 
-    logger->error(TestChannel1, Logger::LogSiteIdentifier("LoggingTest::Logger"_s, this) , ": test output");
+    logger->error(TestChannel1, Logger::LogSiteIdentifier("LoggingTest::Logger"_s, reinterpret_cast<uint64_t>(this)) , ": test output");
     EXPECT_TRUE(output().containsIgnoringASCIICase("LoggingTest::Logger("_s));
 
     logger->error(TestChannel1, "What is ", 1, " + " , 12.5F, "?");


### PR DESCRIPTION
#### dc36b5063145b9a0f225c671ec78c6e130d13fdb
<pre>
Update Logger&apos;s logIdentifier to use a uint64_t instead of a void*
<a href="https://bugs.webkit.org/show_bug.cgi?id=280437">https://bugs.webkit.org/show_bug.cgi?id=280437</a>

Reviewed by Eric Carlson.

Update Logger&apos;s logIdentifier to use a uint64_t instead of a void*. There is
no need to use a pointer here, this makes the code look unsafe unnecessarily.

* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::LogSiteIdentifier::toString const):
* Source/WTF/wtf/Logger.h:
(WTF::Logger::LogSiteIdentifier::LogSiteIdentifier):
* Source/WTF/wtf/LoggerHelper.h:
(WTF::LoggerHelper::childLogIdentifier):
(WTF::LoggerHelper::uniqueLogIdentifier):
* Source/WTF/wtf/NativePromise.h:
(WTF::invokeAsync):
* Source/WebCore/Modules/encryptedmedia/CDM.h:
(WebCore::CDM::logIdentifier const):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::MediaKeySession):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::MediaKeys::nextChildIdentifier const):
* Source/WebCore/Modules/encryptedmedia/MediaKeys.h:
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WebCore::NavigatorEME::requestMediaKeySystemAccess):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::nextLogIdentifier):
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::logIdentifier const):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp:
(WebCore::nextCoordinatorLogIdentifier):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
(WebCore::MediaSessionCoordinator::logIdentifier const):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.cpp:
(WebCore::MediaSessionCoordinatorPrivate::setLogger):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.h:
(WebCore::MediaSessionCoordinatorPrivate::logIdentifier const):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setLogIdentifier):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/ImageCapture.h:
(WebCore::ImageCapture::logIdentifier const):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpReceiver.h:
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.cpp:
(WebCore::nextLogIdentifier):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioParam.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::nextAudioNodeLogIdentifier):
(WebCore::BaseAudioContext::nextAudioParameterLogIdentifier):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::logIdentifier const):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::setLogger):
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::setLogger):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::setLogger):
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::logIdentifier const):
* Source/WebCore/html/track/VTTCue.h:
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::setLogger):
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::logIdentifier const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::dumpSessionStates):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::setLogger):
* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::logIdentifier const):
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h:
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
(WebCore::SharedRoutingArbitratorToken::logIdentifier const):
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModel::logIdentifier const):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::logIdentifier const):
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModel::logIdentifier const):
(WebCore::VideoPresentationModel::nextChildIdentifier const):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::logIdentifier const):
(WebCore::VideoPresentationModelVideoElement::nextChildIdentifier const):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setPresentationModel:]):
(-[WebAVPlayerLayer logIdentifier]):
* Source/WebCore/platform/encryptedmedia/CDMInstance.h:
(WebCore::CDMInstance::setLogIdentifier):
* Source/WebCore/platform/encryptedmedia/CDMInstanceSession.h:
(WebCore::CDMInstanceSession::setLogIdentifier):
* Source/WebCore/platform/encryptedmedia/CDMPrivate.h:
(WebCore::CDMPrivate::setLogIdentifier):
* Source/WebCore/platform/graphics/LegacyCDMSession.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerLogIdentifier):
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::setLogger):
* Source/WebCore/platform/graphics/TrackBuffer.h:
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::setLogger):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h:
* Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceLogIdentifier const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h:
(WebCore::CDMSessionMediaSourceAVFObjC::logIdentifier const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::mediaPlayerLogIdentifier):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::setLogger):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::VideoLayerManagerObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm:
(-[WebAVContentKeyGroup logIdentifier]):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::setLogger):
(WebCore::SourceBufferParserWebM::setLogger):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
(WebCore::MediaPlayerPrivateGStreamer::mediaPlayerLogIdentifier):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm:
(WebCore::PlaybackSessionInterfaceIOS::logIdentifier const):
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm:
(-[WebAVPlayerViewController logIdentifier]):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::logIdentifier const):
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::logIdentifier const):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::logIdentifier const):
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp:
(WebCore::AudioMediaStreamTrackRenderer::logIdentifier const):
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h:
* Source/WebCore/platform/mediastream/MediaStreamPrivate.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::setLogger):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::setLogger):
(WebCore::DisplayCaptureSourceCocoa::Capturer::setLogger):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::logIdentifier const):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::setLogIdentifier):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp:
(WebKit::RemoteCDMProxy::setLogIdentifier):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
(WebKit::RemoteCDMProxy::logIdentifier const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::RemoteLegacyCDMSessionProxy):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::setLogIdentifier):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::logIdentifier const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::setLogIdentifier):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::logIdentifier const):
(WebKit::VideoPresentationModelContext::nextChildIdentifier const):
(WebKit::VideoPresentationManagerProxy::logIdentifier const):
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
(WebKit::AudioSessionRoutingArbitratorProxy::logIdentifier const):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
(WebKit::RemoteMediaSessionCoordinatorProxy::logIdentifier const):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::logIdentifier const):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::logIdentifier const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::logIdentifier const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController logIdentifier]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::setPIPStandbyElement):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
(WebKit::RemoteCDM::setLogIdentifier):
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp:
(WebKit::RemoteCDMInstanceSession::setLogIdentifier):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::logIdentifier const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
(WebKit::PlaybackSessionManager::logIdentifier const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::logIdentifier const):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::doFailAndReject):
* Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp:
(TestWebKitAPI::TEST_F(LoggingTest, DISABLED_Logger)):

Canonical link: <a href="https://commits.webkit.org/284358@main">https://commits.webkit.org/284358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3ead32c3e19ea7d0e93f78bee3f6de4dbc0146

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69095 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13442 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18627 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62211 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74887 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68341 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16666 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62646 "Found 22 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-5.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-root-propagation-002.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-wildcard.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62563 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4153 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10561 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44299 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15981 "Found 87 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/es6/ES6Function_bugs.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck3.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-osr-exit-multiple-blocks-before-exit.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-get-by-id-unset-then-proto-less-warmup.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-get-by-id-unset-then-proto-more-warmup.js.layout, stress/array-length-cant-get-casted-to-unsigned.js.dfg-eager, stress/array-methods-should-not-modify-string.js.bytecode-cache, stress/array-methods-should-not-modify-string.js.dfg-eager, stress/array-prototype-splice-making-typed-array.js.bytecode-cache, stress/array-species-functions.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->