### PR TITLE
Pressing any modifier key causes many WebContent processes to briefly unsuspend

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -58,8 +58,7 @@
 @property (nonatomic, readonly) BOOL _secureEventInputEnabledForTesting;
 
 - (void)_createFlagsChangedEventMonitorForTesting;
-
-- (void)_removeFlagsChangedEventMonitorForTesting;
+- (BOOL)_hasFlagsChangedEventMonitorForTesting;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -143,9 +143,9 @@
     _impl->createFlagsChangedEventMonitor();
 }
 
-- (void)_removeFlagsChangedEventMonitorForTesting
+- (BOOL)_hasFlagsChangedEventMonitorForTesting
 {
-    _impl->removeFlagsChangedEventMonitor();
+    return _impl->hasFlagsChangedEventMonitor();
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -620,6 +620,7 @@ public:
 
     void createFlagsChangedEventMonitor();
     void removeFlagsChangedEventMonitor();
+    bool hasFlagsChangedEventMonitor();
 
     void mouseMoved(NSEvent *);
     void mouseDown(NSEvent *);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2291,6 +2291,8 @@ void WebViewImpl::viewDidMoveToWindow()
             cancelImmediateActionAnimation();
             [m_view removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
         }
+
+        removeFlagsChangedEventMonitor();
     }
 
     m_page->setIntrinsicDeviceScaleFactor(intrinsicDeviceScaleFactor());
@@ -5695,6 +5697,11 @@ void WebViewImpl::removeFlagsChangedEventMonitor()
 
     [NSEvent removeMonitor:m_flagsChangedEventMonitor];
     m_flagsChangedEventMonitor = nil;
+}
+
+bool WebViewImpl::hasFlagsChangedEventMonitor()
+{
+    return m_flagsChangedEventMonitor;
 }
 
 void WebViewImpl::mouseEntered(NSEvent *event)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1085,7 +1085,7 @@ TEST(WebKit, MouseMoveOverElementWithClosedWebView)
         gEventMonitorHandler([NSEvent mouseEventWithType:NSEventTypeMouseMoved location:linkLocation modifierFlags:0 timestamp:0 windowNumber:[[webView hostWindow] windowNumber] context:nil eventNumber:0 clickCount:0 pressure:0]);
         [webView removeFromSuperview];
 
-        [webView _removeFlagsChangedEventMonitorForTesting];
+        EXPECT_FALSE([webView _hasFlagsChangedEventMonitorForTesting]);
     }
 
     TestWebKitAPI::Util::runFor(10_ms);


### PR DESCRIPTION
#### 20bc8fb08d58bc9419c555d941a0ed5d8b152bd6
<pre>
Pressing any modifier key causes many WebContent processes to briefly unsuspend
<a href="https://bugs.webkit.org/show_bug.cgi?id=280435">https://bugs.webkit.org/show_bug.cgi?id=280435</a>
<a href="https://rdar.apple.com/136712547">rdar://136712547</a>

Reviewed by Richard Robinson.

The fix in 279557@main does not completely work. After that patch, the active tab in a background
window no longer gets modifier key events. However, background tabs in the background window now
unexpectedly get modifier key events. This can cause the associated WebContent processes to
spuriously unsuspend.

What is happening is that when you switch tabs, the view associated with that tab does not get a
-mouseExited: message (which is what removes the modifier flag event listener). Instead, it just
gets removed from the view hierarchy. So we have to remove the modifier flag event listener in
*both* -mouseExited: and when the view is removed from the view hierarchy.

This patch restores the behavior that we had pre-279557@main where we were removing the modifier
flag event listener after the view was removed from the view hierarchy.

* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _hasFlagsChangedEventMonitorForTesting]):
(-[WKWebView _removeFlagsChangedEventMonitorForTesting]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::viewDidMoveToWindow):
(WebKit::WebViewImpl::hasFlagsChangedEventMonitor):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((WebKit, MouseMoveOverElementWithClosedWebView)):

Canonical link: <a href="https://commits.webkit.org/284335@main">https://commits.webkit.org/284335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/661c44aa9c662ed810d01ea34cd89825e01c3a11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54977 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62627 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62526 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15330 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4128 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44264 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->