### PR TITLE
Fix infinite loops when parsing invalid CSP header fields after 273894@main

### DIFF
--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -615,8 +615,10 @@ void ContentSecurityPolicyDirectiveList::parseRequireTrustedTypesFor(ParsedDirec
             auto begin = buffer.position();
             if (skipExactlyIgnoringASCIICase(buffer, "'script'"_s))
                 m_requireTrustedTypesForScript = true;
-            else
+            else {
                 policy().reportInvalidTrustedTypesSinkGroup(String({ begin, buffer.position() }));
+                return;
+            }
 
             ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
         }

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -126,6 +126,7 @@ void ContentSecurityPolicyTrustedTypesDirective::parse(const String& value)
             } else {
                 auto policy = String({ beginPolicy, buffer.position() });
                 directiveList().policy().reportInvalidTrustedTypesPolicy(policy);
+                return;
             }
 
             ASSERT(buffer.atEnd() || isASCIIWhitespace(*buffer));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm
@@ -25,6 +25,8 @@
 
 #import "config.h"
 
+#import "HTTPServer.h"
+#import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -117,4 +119,15 @@ TEST(WKWebView, CheckViolationReportDocumentURIForAboutProtocol)
         [webView loadHTMLString:content baseURL:nil];
         [webView waitForMessage:@"document-uri: about"];
     }
+}
+
+TEST(ContentSecurityPolicy, InvalidRequireTrustedTypesFor)
+{
+    using namespace TestWebKitAPI;
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "content-security-policy"_s, "require-trusted-types-for 'script html'"_s } }, "hi"_s } }
+    });
+    auto webView = adoptNS([WKWebView new]);
+    [webView loadRequest:server.request()];
+    [webView _test_waitForDidFinishNavigation];
 }


### PR DESCRIPTION
#### 1db982b7c00fb561e1028e9d460a3425848c30e8
<pre>
Fix infinite loops when parsing invalid CSP header fields after 273894@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=280442">https://bugs.webkit.org/show_bug.cgi?id=280442</a>
<a href="https://rdar.apple.com/136779806">rdar://136779806</a>

Reviewed by Brent Fulgham.

If we find an invalid value, report it and return instead of reporting it over and over
again in an infinite loop until we run out of memory from too many reports.

* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parseRequireTrustedTypesFor):
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::parse):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentSecurityPolicy.mm:
(TEST(ContentSecurityPolicy, InvalidRequireTrustedTypesFor)):

Canonical link: <a href="https://commits.webkit.org/284334@main">https://commits.webkit.org/284334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f4172648e0ab16fde35a00ec486947393844fd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54983 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13430 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17060 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16647 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59713 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62535 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/15331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4134 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44276 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->