### PR TITLE
[scroll-animations] Fix computeViewTimelineData calculation

### DIFF
--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -64,9 +64,8 @@ public:
 
 private:
     struct Data {
-        float scrollContainerSize { 0 };
-        float subjectOffset { 0 };
         float currentScrollOffset { 0 };
+        float coverRangeStart { 0 };
         float coverRangeEnd { 0 };
     };
     Data computeViewTimelineData() const;

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -66,12 +66,11 @@ public:
 
     Element* anchorElement() const { return m_anchorElement.get(); }
 
-    enum class ShouldIncludeFrameViewLocation { Yes, No };
-    static FloatPoint computeOffsetFromScrollableArea(RenderObject&, ScrollableArea&, ShouldIncludeFrameViewLocation = ShouldIncludeFrameViewLocation::Yes);
 
 private:
     Element* findAnchorElementRecursive(Element*);
     bool didFindPriorityCandidate(Document&);
+    FloatPoint computeOffsetFromOwningScroller(RenderObject&);
     LocalFrameView& frameView();
 
     ScrollableArea& m_owningScrollableArea;


### PR DESCRIPTION
#### 9ed7eb275fc90b1b3ff4a2878aa6d77eb475ced7
<pre>
[scroll-animations] Fix computeViewTimelineData calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=280444">https://bugs.webkit.org/show_bug.cgi?id=280444</a>
<a href="https://rdar.apple.com/136789447">rdar://136789447</a>

Reviewed by Antoine Quint.

Previously this calculation had coverRangeEnd take into account the current scroll offset
which was incorrect. Update the progress calculation to be more in line with the spec. Also
update subjectOffset to use offsetTop/Left since we need an offset that is not affected by
scroll position. This is not correct for situations where offsetParent is different than the
source scroller, so we may need a solution that walks up the tree and adds scrollTop/Left. Also
update the comment and filed an issue (<a href="https://github.com/w3c/csswg-drafts/issues/10960)">https://github.com/w3c/csswg-drafts/issues/10960)</a> due
to a small issue in the spec.

To help visualize this calculation, there is a tool: <a href="https://scroll-driven-animations.style/tools/view-timeline/ranges/.">https://scroll-driven-animations.style/tools/view-timeline/ranges/.</a>
coverRangeStart is equivalent to the scroll offset necessary to have the top edge of the subject touch
the bottom edge of the scroller. Conversly, coverRangeEnd is equivalent to the scroll offset necessary
to have the bottom edge of the subject touch the top edge of the scroller. Note that this calculation is
only correct for the cover named timeline range. This will be further complicated when we start
doing calculations for other timeline ranges, which correspond to different start and end positions for
the subject.

* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::computeViewTimelineData const):
(WebCore::ViewTimeline::startOffset const):
(WebCore::ViewTimeline::endOffset const):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/284398@main">https://commits.webkit.org/284398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14ee6e4a9fd3351405a121ac786170da387b4236

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20230 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16769 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59844 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4256 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10580 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45501 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->