### PR TITLE
[iOS] Selection UI should be clipped in overflow scrolling containers

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller-expected.txt
@@ -1,0 +1,17 @@
+Verifies that the selection highlight is clipped to overflow scrolling container. Select the first word in the container below and scroll down
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.
+
+You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.
+
+Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.
+
+PASS getSelection().toString() became 'Here’s'
+PASS selectionRects[0]?.width || 0 is 0
+PASS selectionRects[0]?.height || 0 is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller.html
+++ b/LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+#target {
+    border: 1px solid tomato;
+    padding: 3px;
+    font-size: 24px;
+}
+
+.container {
+    width: 300px;
+    height: 350px;
+    border: solid 1px black;
+    border-radius: 4px;
+    box-sizing: border-box;
+    overflow-y: scroll;
+    line-height: 1.5em;
+    outline: none;
+    padding: 1em;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection highlight is clipped to overflow scrolling container. Select the first word in the container below and scroll down");
+
+    let scroller = document.querySelector(".container");
+    await UIHelper.longPressElement(document.getElementById("target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Here’s'");
+    await UIHelper.waitForSelectionToAppear();
+
+    let {x, y} = UIHelper.midPointOfRect(scroller.getBoundingClientRect());
+    while (scroller.scrollTop < 80) {
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(x, y + 60)
+            .move(x, y - 60, 0.25)
+            .end()
+            .takeResult());
+    }
+
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+
+    selectionRects = await UIHelper.getUISelectionViewRects();
+    shouldBe("selectionRects[0]?.width || 0", "0");
+    shouldBe("selectionRects[0]?.height || 0", "0");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="description"></div>
+    <div class="container">
+        <p><span id="target">Here’s</span> to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+        <p>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.</p>
+        <p>Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/selection-handle-clamping-in-iframe.html
+++ b/LayoutTests/editing/selection/ios/selection-handle-clamping-in-iframe.html
@@ -52,12 +52,18 @@ async function runTest() {
     }
 
     const [startX, startY] = midPointOfRect(startRect);
-    await touchAndDragFromPointToPoint(startX, startY, startX, startY + 100);
-    await liftUpAtPoint(startX, startY + 100);
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(startX, startY)
+        .move(startX, startY + 150, 0.5)
+        .end()
+        .takeResult());
 
     const [endX, endY] = midPointOfRect(endRect);
-    await touchAndDragFromPointToPoint(endX, endY, endX, endY - 100);
-    await liftUpAtPoint(endX, endY - 100);
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(endX, endY)
+        .move(endX, endY - 150, 0.5)
+        .end()
+        .takeResult());
 
     result.textContent = target.contentWindow.getSelection().toString();
     testRunner.notifyDone();

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -250,7 +250,7 @@ Position lastPositionInNode(Node* anchorNode);
 
 bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode);
 
-Node* commonInclusiveAncestor(const Position&, const Position&);
+WEBCORE_EXPORT Node* commonInclusiveAncestor(const Position&, const Position&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const Position&);
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -734,7 +734,7 @@ public:
     inline bool preservesNewline() const;
 
     RenderView& view() const { return *document().renderView(); }
-    CheckedRef<RenderView> checkedView() const;
+    WEBCORE_EXPORT CheckedRef<RenderView> checkedView() const;
 
     HostWindow* hostWindow() const;
 
@@ -767,7 +767,7 @@ public:
     // Returns the object containing this one. Can be different from parent for positioned elements.
     // If repaintContainer and repaintContainerSkipped are not null, on return *repaintContainerSkipped
     // is true if the renderer returned is an ancestor of repaintContainer.
-    RenderElement* container() const;
+    WEBCORE_EXPORT RenderElement* container() const;
     RenderElement* container(const RenderLayerModelObject* repaintContainer, bool& repaintContainerSkipped) const;
 
     RenderBoxModelObject* offsetParent() const;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -665,13 +665,13 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
         }();
     }
 
-    if (RefPtr editableRootOrFormControl = enclosingTextFormControl(selection.start()) ?: selection.rootEditableElement()) {
-#if PLATFORM(IOS_FAMILY)
-        auto& visualData = *result.visualData;
-        visualData.selectionClipRect = rootViewInteractionBounds(*editableRootOrFormControl);
-#endif
+    RefPtr editableRootOrFormControl = enclosingTextFormControl(selection.start()) ?: selection.rootEditableElement();
+    if (editableRootOrFormControl)
         postLayoutData.editableRootIsTransparentOrFullyClipped = result.isContentEditable && isTransparentOrFullyClipped(*editableRootOrFormControl);
-    }
+
+#if PLATFORM(IOS_FAMILY)
+    computeSelectionClipRect(result, selection, editableRootOrFormControl.get());
+#endif
 }
 
 void WebPage::getPDFFirstPageSize(WebCore::FrameIdentifier frameID, CompletionHandler<void(WebCore::FloatSize)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1868,6 +1868,7 @@ private:
     void clearSelectionAfterTapIfNeeded();
     void scheduleLayoutViewportHeightExpansionUpdate();
     void scheduleEditorStateUpdateAfterAnimationIfNeeded(const WebCore::Element&);
+    void computeSelectionClipRect(EditorState&, const WebCore::VisibleSelection&, const WebCore::Element* editableRootOrFormControl) const;
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)


### PR DESCRIPTION
#### 952deaf8f19d5f78cafe8218cdb965bf88a912f8
<pre>
[iOS] Selection UI should be clipped in overflow scrolling containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=280440">https://bugs.webkit.org/show_bug.cgi?id=280440</a>
<a href="https://rdar.apple.com/9906345">rdar://9906345</a>

Reviewed by Aditya Keerthi.

Currently, we plumb `selectionClipRect` to the UI process only in the case where the selection is
inside of an editable root or form control. This means we fail to clip UIKit&apos;s native selection UI
in cases where the selection is non-editable, but inside of a subscrollable region. To fix this, we
compute and send the `selectionClipRect` over to the UI process through `EditorState`&apos;s visual data
struct in the case where the selection is both:

1. User-visible (i.e. not a collapsed selection caret in non-editable content)
2. Inside of a scrollable area.

See below for more details.

* LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller.html: Added.

Add a layout test to verify that the selection highlight disappears when scrolling the selection
range outside of an overflow sroller&apos;s clip rect.

* LayoutTests/editing/selection/ios/selection-handle-clamping-in-iframe.html:

Adjust an existing test to work around an existing issue where the selection briefly collapses to
the first visible character in the subframe when moving selection handles upwards. Using the event
stream builder to synthesize the pan gesture sends higher resolution events that better simulates
real user interaction.

* Source/WebCore/dom/Position.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::enclosingScroller):

Walk up the render tree in search of an enclosing renderer that `canBeScrolledAndHasScrollableArea`,
starting from the selection&apos;s common ancestor node.

(WebKit::WebPage::computeSelectionClipRect const):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(isZoomingOrScrolling):
(-[TestRunnerWKWebView isZoomingOrScrolling]):

Adjust this test harness method to also return `YES` in the case where any child scroller underneath
the web view is being scrolled.

Canonical link: <a href="https://commits.webkit.org/284387@main">https://commits.webkit.org/284387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a419b55d001c37a644d5283886bf14a48668dabb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20192 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59731 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17161 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18717 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13167 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4229 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->