### PR TITLE
Add Compression Streams Brotli

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt
@@ -1,22 +1,29 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.js
@@ -43,6 +43,16 @@ const badChunks = [
 
 for (const chunk of badChunks) {
   promise_test(async t => {
+    const cs = new CompressionStream('brotli');
+    const reader = cs.readable.getReader();
+    const writer = cs.writable.getWriter();
+    const writePromise = writer.write(chunk.value);
+    const readPromise = reader.read();
+    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
+    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
+  }, `chunk of type ${chunk.name} should error the stream for brotli`);
+
+  promise_test(async t => {
     const cs = new CompressionStream('gzip');
     const reader = cs.readable.getReader();
     const writer = cs.writable.getWriter();

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt
@@ -1,22 +1,29 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt
@@ -1,22 +1,29 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt
@@ -1,22 +1,29 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt
@@ -1,4 +1,5 @@
 
+PASS the length of brotli data should be shorter than that of the original data
 PASS the length of deflated data should be shorter than that of the original data
 PASS the length of gzipped data should be shorter than that of the original data
 PASS the length of deflated (with -raw) data should be shorter than that of the original data

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.js
@@ -38,6 +38,16 @@ promise_test(async () => {
   const buffer = await response.arrayBuffer();
   const bufferView = new Uint8Array(buffer);
   const originalLength = bufferView.length;
+  const compressedData = await compressArrayBuffer(bufferView, 'brotli');
+  const compressedLength = compressedData.length;
+  assert_less_than(compressedLength, originalLength, 'output should be smaller');
+}, 'the length of brotli data should be shorter than that of the original data');
+
+promise_test(async () => {
+  const response = await fetch(LARGE_FILE);
+  const buffer = await response.arrayBuffer();
+  const bufferView = new Uint8Array(buffer);
+  const originalLength = bufferView.length;
   const compressedData = await compressArrayBuffer(bufferView, 'deflate');
   const compressedLength = compressedData.length;
   assert_less_than(compressedLength, originalLength, 'output should be smaller');

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt
@@ -1,4 +1,5 @@
 
+PASS the length of brotli data should be shorter than that of the original data
 PASS the length of deflated data should be shorter than that of the original data
 PASS the length of gzipped data should be shorter than that of the original data
 PASS the length of deflated (with -raw) data should be shorter than that of the original data

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt
@@ -1,4 +1,5 @@
 
+PASS the length of brotli data should be shorter than that of the original data
 PASS the length of deflated data should be shorter than that of the original data
 PASS the length of gzipped data should be shorter than that of the original data
 PASS the length of deflated (with -raw) data should be shorter than that of the original data

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt
@@ -1,4 +1,5 @@
 
+PASS the length of brotli data should be shorter than that of the original data
 PASS the length of deflated data should be shorter than that of the original data
 PASS the length of gzipped data should be shorter than that of the original data
 PASS the length of deflated (with -raw) data should be shorter than that of the original data

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt
@@ -1,28 +1,37 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+PASS chunk of type invalid deflate bytes should error the stream for brotli
 PASS chunk of type invalid deflate bytes should error the stream for gzip
 PASS chunk of type invalid deflate bytes should error the stream for deflate
 PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+PASS chunk of type invalid gzip bytes should error the stream for brotli
 PASS chunk of type invalid gzip bytes should error the stream for gzip
 PASS chunk of type invalid gzip bytes should error the stream for deflate
 PASS chunk of type invalid gzip bytes should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.js
@@ -72,6 +72,10 @@ async function decompress(chunk, format, t)
 
 for (const chunk of badChunks) {
   promise_test(async t => {
+    await decompress(chunk, 'brotli', t);
+  }, `chunk of type ${chunk.name} should error the stream for brotli`);
+
+  promise_test(async t => {
     await decompress(chunk, 'gzip', t);
   }, `chunk of type ${chunk.name} should error the stream for gzip`);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt
@@ -1,28 +1,37 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+PASS chunk of type invalid deflate bytes should error the stream for brotli
 PASS chunk of type invalid deflate bytes should error the stream for gzip
 PASS chunk of type invalid deflate bytes should error the stream for deflate
 PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+PASS chunk of type invalid gzip bytes should error the stream for brotli
 PASS chunk of type invalid gzip bytes should error the stream for gzip
 PASS chunk of type invalid gzip bytes should error the stream for deflate
 PASS chunk of type invalid gzip bytes should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt
@@ -1,28 +1,37 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+PASS chunk of type invalid deflate bytes should error the stream for brotli
 PASS chunk of type invalid deflate bytes should error the stream for gzip
 PASS chunk of type invalid deflate bytes should error the stream for deflate
 PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+PASS chunk of type invalid gzip bytes should error the stream for brotli
 PASS chunk of type invalid gzip bytes should error the stream for gzip
 PASS chunk of type invalid gzip bytes should error the stream for deflate
 PASS chunk of type invalid gzip bytes should error the stream for deflate-raw

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt
@@ -1,28 +1,37 @@
 
+PASS chunk of type undefined should error the stream for brotli
 PASS chunk of type undefined should error the stream for gzip
 PASS chunk of type undefined should error the stream for deflate
 PASS chunk of type undefined should error the stream for deflate-raw
+PASS chunk of type null should error the stream for brotli
 PASS chunk of type null should error the stream for gzip
 PASS chunk of type null should error the stream for deflate
 PASS chunk of type null should error the stream for deflate-raw
+PASS chunk of type numeric should error the stream for brotli
 PASS chunk of type numeric should error the stream for gzip
 PASS chunk of type numeric should error the stream for deflate
 PASS chunk of type numeric should error the stream for deflate-raw
+PASS chunk of type object, not BufferSource should error the stream for brotli
 PASS chunk of type object, not BufferSource should error the stream for gzip
 PASS chunk of type object, not BufferSource should error the stream for deflate
 PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+PASS chunk of type array should error the stream for brotli
 PASS chunk of type array should error the stream for gzip
 PASS chunk of type array should error the stream for deflate
 PASS chunk of type array should error the stream for deflate-raw
+PASS chunk of type SharedArrayBuffer should error the stream for brotli
 PASS chunk of type SharedArrayBuffer should error the stream for gzip
 PASS chunk of type SharedArrayBuffer should error the stream for deflate
 PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+PASS chunk of type shared Uint8Array should error the stream for brotli
 PASS chunk of type shared Uint8Array should error the stream for gzip
 PASS chunk of type shared Uint8Array should error the stream for deflate
 PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+PASS chunk of type invalid deflate bytes should error the stream for brotli
 PASS chunk of type invalid deflate bytes should error the stream for gzip
 PASS chunk of type invalid deflate bytes should error the stream for deflate
 PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+PASS chunk of type invalid gzip bytes should error the stream for brotli
 PASS chunk of type invalid gzip bytes should error the stream for gzip
 PASS chunk of type invalid gzip bytes should error the stream for deflate
 PASS chunk of type invalid gzip bytes should error the stream for deflate-raw

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt
@@ -1,0 +1,30 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt
@@ -1,0 +1,30 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt
@@ -1,0 +1,30 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt
@@ -1,0 +1,30 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL the length of brotli data should be shorter than that of the original data promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS the length of deflated data should be shorter than that of the original data
+PASS the length of gzipped data should be shorter than that of the original data
+PASS the length of deflated (with -raw) data should be shorter than that of the original data
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL the length of brotli data should be shorter than that of the original data promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS the length of deflated data should be shorter than that of the original data
+PASS the length of gzipped data should be shorter than that of the original data
+PASS the length of deflated (with -raw) data should be shorter than that of the original data
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL the length of brotli data should be shorter than that of the original data promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS the length of deflated data should be shorter than that of the original data
+PASS the length of gzipped data should be shorter than that of the original data
+PASS the length of deflated (with -raw) data should be shorter than that of the original data
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL the length of brotli data should be shorter than that of the original data promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS the length of deflated data should be shorter than that of the original data
+PASS the length of gzipped data should be shorter than that of the original data
+PASS the length of deflated (with -raw) data should be shorter than that of the original data
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt
@@ -1,0 +1,38 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+FAIL chunk of type invalid deflate bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid deflate bytes should error the stream for gzip
+PASS chunk of type invalid deflate bytes should error the stream for deflate
+PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+FAIL chunk of type invalid gzip bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid gzip bytes should error the stream for gzip
+PASS chunk of type invalid gzip bytes should error the stream for deflate
+PASS chunk of type invalid gzip bytes should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt
@@ -1,0 +1,38 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+FAIL chunk of type invalid deflate bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid deflate bytes should error the stream for gzip
+PASS chunk of type invalid deflate bytes should error the stream for deflate
+PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+FAIL chunk of type invalid gzip bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid gzip bytes should error the stream for gzip
+PASS chunk of type invalid gzip bytes should error the stream for deflate
+PASS chunk of type invalid gzip bytes should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt
@@ -1,0 +1,38 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+FAIL chunk of type invalid deflate bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid deflate bytes should error the stream for gzip
+PASS chunk of type invalid deflate bytes should error the stream for deflate
+PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+FAIL chunk of type invalid gzip bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid gzip bytes should error the stream for gzip
+PASS chunk of type invalid gzip bytes should error the stream for deflate
+PASS chunk of type invalid gzip bytes should error the stream for deflate-raw
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt
@@ -1,0 +1,38 @@
+
+FAIL chunk of type undefined should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type undefined should error the stream for gzip
+PASS chunk of type undefined should error the stream for deflate
+PASS chunk of type undefined should error the stream for deflate-raw
+FAIL chunk of type null should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type null should error the stream for gzip
+PASS chunk of type null should error the stream for deflate
+PASS chunk of type null should error the stream for deflate-raw
+FAIL chunk of type numeric should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type numeric should error the stream for gzip
+PASS chunk of type numeric should error the stream for deflate
+PASS chunk of type numeric should error the stream for deflate-raw
+FAIL chunk of type object, not BufferSource should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type object, not BufferSource should error the stream for gzip
+PASS chunk of type object, not BufferSource should error the stream for deflate
+PASS chunk of type object, not BufferSource should error the stream for deflate-raw
+FAIL chunk of type array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type array should error the stream for gzip
+PASS chunk of type array should error the stream for deflate
+PASS chunk of type array should error the stream for deflate-raw
+FAIL chunk of type SharedArrayBuffer should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type SharedArrayBuffer should error the stream for gzip
+PASS chunk of type SharedArrayBuffer should error the stream for deflate
+PASS chunk of type SharedArrayBuffer should error the stream for deflate-raw
+FAIL chunk of type shared Uint8Array should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type shared Uint8Array should error the stream for gzip
+PASS chunk of type shared Uint8Array should error the stream for deflate
+PASS chunk of type shared Uint8Array should error the stream for deflate-raw
+FAIL chunk of type invalid deflate bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid deflate bytes should error the stream for gzip
+PASS chunk of type invalid deflate bytes should error the stream for deflate
+PASS chunk of type invalid deflate bytes should error the stream for deflate-raw
+FAIL chunk of type invalid gzip bytes should error the stream for brotli promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
+PASS chunk of type invalid gzip bytes should error the stream for gzip
+PASS chunk of type invalid gzip bytes should error the stream for deflate
+PASS chunk of type invalid gzip bytes should error the stream for deflate-raw
+

--- a/Source/WebCore/Modules/compression/CompressionStream.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStream.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CompressionStream.h"
+
+namespace WebCore {
+
+CompressionStream::CompressionStream()
+{
+#if PLATFORM(COCOA)
+    std::memset(&m_stream, 0, sizeof(m_stream));
+#endif
+}
+
+CompressionStream::~CompressionStream()
+{
+#if PLATFORM(COCOA)
+    if (m_isInitialized)
+        compression_stream_destroy(&m_stream);
+#endif
+}
+
+bool CompressionStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
+{
+    if (m_isInitialized)
+        return true;
+#if PLATFORM(COCOA)
+    switch (algorithm) {
+    case Algorithm::Brotli:
+        auto result = compression_stream_init(&m_stream, operation == Operation::Compression ? COMPRESSION_STREAM_ENCODE : COMPRESSION_STREAM_DECODE, COMPRESSION_BROTLI);
+        if (result != COMPRESSION_STATUS_OK)
+            return false;
+        break;
+    }
+#else
+    UNUSED_PARAM(algorithm);
+    UNUSED_PARAM(operation);
+#endif
+    m_isInitialized = true;
+    return true;
+}
+
+}

--- a/Source/WebCore/Modules/compression/CompressionStream.h
+++ b/Source/WebCore/Modules/compression/CompressionStream.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+#include <compression.h>
+#endif
+
+namespace WebCore {
+
+class CompressionStream {
+public:
+    enum class Algorithm : uint8_t { Brotli };
+    enum class Operation : bool { Compression, Decompression };
+
+    bool initializeIfNecessary(Algorithm, Operation);
+
+    CompressionStream();
+    ~CompressionStream();
+
+#if PLATFORM(COCOA)
+    compression_stream& getPlatformStream()
+    {
+        ASSERT(m_isInitialized);
+        return m_stream;
+    }
+#endif
+
+private:
+#if PLATFORM(COCOA)
+    compression_stream m_stream;
+#endif
+    bool m_isInitialized { false };
+};
+
+}

--- a/Source/WebCore/Modules/compression/CompressionStream.js
+++ b/Source/WebCore/Modules/compression/CompressionStream.js
@@ -27,12 +27,12 @@ function initializeCompressionStream(format)
 {
     "use strict";
 
-    const errorMessage = "CompressionStream requires a single argument with the value 'deflate', 'deflate-raw', or 'gzip'.";
+    const errorMessage = "CompressionStream requires a single argument with the value 'brotli', 'deflate', 'deflate-raw', or 'gzip'.";
 
     if (arguments.length < 1)
         @throwTypeError(errorMessage);
 
-    const algorithms = ['gzip', 'deflate', 'deflate-raw'];
+    const algorithms = ['brotli', 'gzip', 'deflate', 'deflate-raw'];
     const lowercaseFormat = @toString(arguments[0]).toLowerCase();
     const findAlgorithm = (element) => element === lowercaseFormat;
 

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
@@ -62,35 +62,6 @@ ExceptionOr<RefPtr<Uint8Array>> CompressionStreamEncoder::flush()
     return RefPtr { Uint8Array::create(WTFMove(compressedData)) };
 }
 
-ExceptionOr<bool> CompressionStreamEncoder::initialize() 
-{
-    int result = Z_OK;
-
-    m_initialized = true;
-
-    switch (m_format) {
-    // Values chosen here are based off
-    // https://developer.apple.com/documentation/compression/compression_algorithm/compression_zlib?language=objc
-    case Formats::CompressionFormat::Deflate:
-        result = deflateInit2(&m_zstream, 5, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
-        break;
-    case Formats::CompressionFormat::Zlib:
-        result = deflateInit2(&m_zstream, 5, Z_DEFLATED, 15, 8, Z_DEFAULT_STRATEGY);
-        break;
-    case Formats::CompressionFormat::Gzip:
-        result = deflateInit2(&m_zstream, 5, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
-        break;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        break;
-    }
-
-    if (result != Z_OK)
-        return Exception { ExceptionCode::TypeError, "Initialization Failed."_s };
-
-    return true;
-}
-
 // The compression algorithm is broken up into 2 steps.
 // 1. Compression of Data
 // 2. Flush Remaining Data
@@ -99,7 +70,7 @@ ExceptionOr<bool> CompressionStreamEncoder::initialize()
 // step we may have data buffered and will need to continue to keep flushing out the rest.
 bool CompressionStreamEncoder::didDeflateFinish(int result) const
 {
-    return !m_zstream.avail_in && (!m_didFinish || (m_didFinish && result == Z_STREAM_END));
+    return !m_zstream.getPlatformStream().avail_in && (!m_didFinish || (m_didFinish && result == Z_STREAM_END));
 }
 
 // See https://www.zlib.net/manual.html#Constants
@@ -110,20 +81,41 @@ static bool didDeflateFail(int result)
 
 ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(std::span<const uint8_t> input)
 {
+#if PLATFORM(COCOA)
+    if (m_format == Formats::CompressionFormat::Brotli)
+        return compressAppleCompressionFramework(input);
+#endif
+    return compressZlib(input);
+}
+
+static ZStream::Algorithm compressionAlgorithm(Formats::CompressionFormat format)
+{
+    switch (format) {
+    case Formats::CompressionFormat::Brotli:
+        RELEASE_ASSERT_NOT_REACHED();
+    case Formats::CompressionFormat::Gzip:
+        return ZStream::Algorithm::Gzip;
+    case Formats::CompressionFormat::Zlib:
+        return ZStream::Algorithm::Zlib;
+    case Formats::CompressionFormat::Deflate:
+        return ZStream::Algorithm::Deflate;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressZlib(std::span<const uint8_t> input)
+{
     size_t allocateSize = std::max(input.size(), startingAllocationSize);
     auto storage = SharedBufferBuilder();
 
     int result;    
     bool shouldCompress = true;
 
-    m_zstream.next_in = const_cast<z_const Bytef*>(input.data());
-    m_zstream.avail_in = input.size();
+    if (!m_zstream.initializeIfNecessary(compressionAlgorithm(m_format), ZStream::Operation::Compression))
+        return Exception { ExceptionCode::TypeError, "Initialization Failed."_s };
 
-    if (!m_initialized) {
-        auto initializeResult = initialize();
-        if (initializeResult.hasException())
-            return initializeResult.releaseException();
-    }
+    m_zstream.getPlatformStream().next_in = const_cast<z_const Bytef*>(input.data());
+    m_zstream.getPlatformStream().avail_in = input.size();
 
     while (shouldCompress) {
         Vector<uint8_t> output;
@@ -138,17 +130,17 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(std::span<
 
         output.grow(allocateSize);
 
-        m_zstream.next_out = output.data();
-        m_zstream.avail_out = output.size();
+        m_zstream.getPlatformStream().next_out = output.data();
+        m_zstream.getPlatformStream().avail_out = output.size();
 
-        result = deflate(&m_zstream, m_didFinish ? Z_FINISH : Z_NO_FLUSH);
+        result = deflate(&m_zstream.getPlatformStream(), m_didFinish ? Z_FINISH : Z_NO_FLUSH);
 
         if (didDeflateFail(result))
             return Exception { ExceptionCode::TypeError, "Failed to compress data."_s };
 
         if (didDeflateFinish(result)) {
             shouldCompress = false;
-            output.shrink(allocateSize - m_zstream.avail_out);
+            output.shrink(allocateSize - m_zstream.getPlatformStream().avail_out);
         }
         else {
             if (allocateSize < maxAllocationSize)
@@ -164,4 +156,5 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(std::span<
 
     return compressedData.releaseNonNull();
 }
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/compression/DecompressionStream.js
+++ b/Source/WebCore/Modules/compression/DecompressionStream.js
@@ -27,12 +27,12 @@ function initializeDecompressionStream(format)
 {
     "use strict";
 
-    const errorMessage = "DecompressionStream requires a single argument with the value 'deflate', 'deflate-raw', or 'gzip'.";
+    const errorMessage = "DecompressionStream requires a single argument with the value 'brotli', 'deflate', 'deflate-raw', or 'gzip'.";
 
     if (arguments.length < 1)
         @throwTypeError(errorMessage);
 
-    const algorithms = ['gzip', 'deflate', 'deflate-raw'];
+    const algorithms = ['brotli', 'gzip', 'deflate', 'deflate-raw'];
     const lowercaseFormat = @toString(arguments[0]).toLowerCase();
     const findAlgorithm = (element) => element === lowercaseFormat;
 

--- a/Source/WebCore/Modules/compression/Formats.h
+++ b/Source/WebCore/Modules/compression/Formats.h
@@ -28,9 +28,8 @@
 namespace WebCore {
 
 class Formats {
-
 public:
-    enum CompressionFormat : uint8_t { Gzip, Zlib, Deflate };
+    enum class CompressionFormat : uint8_t { Brotli, Gzip, Zlib, Deflate };
 };
 
 }

--- a/Source/WebCore/Modules/compression/ZStream.cpp
+++ b/Source/WebCore/Modules/compression/ZStream.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ZStream.h"
+
+namespace WebCore {
+
+bool ZStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
+{
+    if (m_isInitialized)
+        return true;
+
+    int result = Z_OK;
+
+    switch (operation) {
+    case Operation::Compression:
+        switch (algorithm) {
+        // Values chosen here are based off
+        // https://developer.apple.com/documentation/compression/compression_algorithm/compression_zlib?language=objc
+        case Algorithm::Deflate:
+            result = deflateInit2(&m_stream, 5, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+            break;
+        case Algorithm::Zlib:
+            result = deflateInit2(&m_stream, 5, Z_DEFLATED, 15, 8, Z_DEFAULT_STRATEGY);
+            break;
+        case Algorithm::Gzip:
+            result = deflateInit2(&m_stream, 5, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+            break;
+        }
+        break;
+    case Operation::Decompression:
+        switch (algorithm) {
+        case Algorithm::Deflate:
+            result = inflateInit2(&m_stream, -15);
+            break;
+        case Algorithm::Zlib:
+            result = inflateInit2(&m_stream, 15);
+            break;
+        case Algorithm::Gzip:
+            result = inflateInit2(&m_stream, 15 + 16);
+            break;
+        }
+        break;
+    }
+    if (result != Z_OK)
+        return false;
+    m_isInitialized = true;
+    return true;
+}
+
+ZStream::ZStream()
+{
+    std::memset(&m_stream, 0, sizeof(m_stream));
+}
+
+ZStream::~ZStream()
+{
+    if (m_isInitialized)
+        deflateEnd(&m_stream);
+}
+
+}

--- a/Source/WebCore/Modules/compression/ZStream.h
+++ b/Source/WebCore/Modules/compression/ZStream.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <zlib.h>
+
+namespace WebCore {
+
+class ZStream {
+public:
+    enum class Algorithm : uint8_t { Deflate, Zlib, Gzip };
+    enum class Operation : bool { Compression, Decompression };
+
+    ZStream();
+    ~ZStream();
+
+    bool initializeIfNecessary(Algorithm, Operation);
+
+    z_stream& getPlatformStream() { return m_stream; }
+    const z_stream& getPlatformStream() const { return m_stream; }
+
+private:
+    z_stream m_stream;
+    bool m_isInitialized { false };
+};
+
+}

--- a/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CompressionStreamEncoder.h"
+
+namespace WebCore {
+
+ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressAppleCompressionFramework(std::span<const uint8_t> input)
+{
+    size_t allocateSize = std::max(input.size(), startingAllocationSize);
+    auto storage = SharedBufferBuilder();
+
+    compression_status result;
+    bool shouldDecompress = true;
+
+    if (!m_compressionStream.initializeIfNecessary(CompressionStream::Algorithm::Brotli, CompressionStream::Operation::Compression))
+        return Exception { ExceptionCode::TypeError, "Initialization Failed."_s };
+
+    m_compressionStream.getPlatformStream().src_ptr = input.data();
+    m_compressionStream.getPlatformStream().src_size = input.size();
+
+    while (shouldDecompress) {
+        Vector<uint8_t> output;
+        if (!output.tryReserveInitialCapacity(allocateSize)) {
+            allocateSize /= 4;
+
+            if (allocateSize < startingAllocationSize)
+                return Exception { ExceptionCode::OutOfMemoryError };
+
+            continue;
+        }
+
+        output.grow(allocateSize);
+
+        m_compressionStream.getPlatformStream().dst_ptr = output.data();
+        m_compressionStream.getPlatformStream().dst_size = output.size();
+
+        result = compression_stream_process(&m_compressionStream.getPlatformStream(), m_didFinish ? COMPRESSION_STREAM_FINALIZE : 0);
+
+        if (result == COMPRESSION_STATUS_ERROR)
+            return Exception { ExceptionCode::TypeError, "Failed to Encode Data."_s };
+
+        if ((result == COMPRESSION_STATUS_END && m_compressionStream.getPlatformStream().src_size)
+            || (m_didFinish && m_compressionStream.getPlatformStream().src_size))
+            return Exception { ExceptionCode::TypeError, "Extra bytes past the end."_s };
+
+        if (!m_compressionStream.getPlatformStream().src_size) {
+            shouldDecompress = false;
+            output.shrink(allocateSize - m_compressionStream.getPlatformStream().dst_size);
+        } else {
+            if (allocateSize < maxAllocationSize)
+                allocateSize *= 2;
+        }
+
+        storage.append(output);
+    }
+
+    RefPtr decompressedData = storage.takeAsArrayBuffer();
+    if (!decompressedData)
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    return decompressedData.releaseNonNull();
+}
+
+}

--- a/Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DecompressionStreamDecoder.h"
+
+namespace WebCore {
+
+ExceptionOr<Ref<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppleCompressionFramework(std::span<const uint8_t> input)
+{
+    size_t allocateSize = startingAllocationSize;
+    auto storage = SharedBufferBuilder();
+
+    compression_status result;
+    bool shouldDecompress = true;
+
+    if (!m_compressionStream.initializeIfNecessary(CompressionStream::Algorithm::Brotli, CompressionStream::Operation::Decompression))
+        return Exception { ExceptionCode::TypeError, "Initialization Failed."_s };
+
+    m_compressionStream.getPlatformStream().src_ptr = input.data();
+    m_compressionStream.getPlatformStream().src_size = input.size();
+
+    while (shouldDecompress) {
+        Vector<uint8_t> output;
+        if (!output.tryReserveInitialCapacity(allocateSize)) {
+            allocateSize /= 4;
+
+            if (allocateSize < startingAllocationSize)
+                return Exception { ExceptionCode::OutOfMemoryError };
+
+            continue;
+        }
+
+        output.grow(allocateSize);
+
+        m_compressionStream.getPlatformStream().dst_ptr = output.data();
+        m_compressionStream.getPlatformStream().dst_size = output.size();
+
+        result = compression_stream_process(&m_compressionStream.getPlatformStream(), m_didFinish ? COMPRESSION_STREAM_FINALIZE : 0);
+
+        if (result == COMPRESSION_STATUS_ERROR)
+            return Exception { ExceptionCode::TypeError, "Failed to Decode Data."_s };
+
+        if ((result == COMPRESSION_STATUS_END && m_compressionStream.getPlatformStream().src_size)
+            || (m_didFinish && m_compressionStream.getPlatformStream().src_size))
+            return Exception { ExceptionCode::TypeError, "Extra bytes past the end."_s };
+
+        if (!m_compressionStream.getPlatformStream().src_size) {
+            shouldDecompress = false;
+            output.shrink(allocateSize - m_compressionStream.getPlatformStream().dst_size);
+        } else {
+            if (allocateSize < maxAllocationSize)
+                allocateSize *= 2;
+        }
+
+        storage.append(output);
+    }
+
+    RefPtr decompressedData = storage.takeAsArrayBuffer();
+    if (!decompressedData)
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    return decompressedData.releaseNonNull();
+}
+
+}

--- a/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
@@ -29,7 +29,6 @@
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
 static NSString * const WebNotificationDefaultActionKey = @"WebNotificationDefaultActionKey";
-static NSString * const WebNotificationTitleKey = @"WebNotificationTitleKey";
 static NSString * const WebNotificationAppBadgeKey = @"WebNotificationAppBadgeKey";
 static NSString * const WebNotificationOptionsKey = @"WebNotificationOptionsKey";
 static NSString * const WebNotificationMutableKey = @"WebNotificationMutableKey";

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -105,8 +105,10 @@ Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheEngine.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
+Modules/compression/CompressionStream.cpp
 Modules/compression/CompressionStreamEncoder.cpp
 Modules/compression/DecompressionStreamDecoder.cpp
+Modules/compression/ZStream.cpp
 Modules/contact-picker/ContactsManager.cpp
 Modules/contact-picker/NavigatorContacts.cpp
 Modules/cookie-consent/NavigatorCookieConsent.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -118,6 +118,8 @@ Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
 Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
 Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
 Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
+Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
+Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
 Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
 Modules/model-element/scenekit/SceneKitModel.mm
 Modules/model-element/scenekit/SceneKitModelLoader.mm


### PR DESCRIPTION
#### 0d3451c531c810977123d2b9503ed968381d2004
<pre>
Add Compression Streams Brotli
<a href="https://bugs.webkit.org/show_bug.cgi?id=280445">https://bugs.webkit.org/show_bug.cgi?id=280445</a>
<a href="https://rdar.apple.com/99159497">rdar://99159497</a>

Reviewed by Alex Christensen and Ryosuke Niwa.

Add Brotli support to Compression Streams by using Apple&apos;s Compression Framework.

Co-authored-by: Alex Christensen &lt;achristensen@apple.com&gt;

Initial implementation and tests written by Brandon Stewart.
Alex implemented a substantial refactor to improve upon the implementation.

* LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.js:
(const.chunk.of.badChunks.promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.js:
(const.chunk.of.badChunks.promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.serviceworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.sharedworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.worker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.sharedworker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.worker-expected.txt.
* Source/WebCore/Modules/compression/CompressionStream.cpp: Added.
(WebCore::CompressionStream::CompressionStream):
(WebCore::CompressionStream::~CompressionStream):
(WebCore::CompressionStream::initializeIfNecessary):
* Source/WebCore/Modules/compression/CompressionStream.h: Added.
(WebCore::CompressionStream::get):
* Source/WebCore/Modules/compression/CompressionStream.js:
(initializeCompressionStream):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::didDeflateFinish const):
(WebCore::CompressionStreamEncoder::compress):
(WebCore::compressionAlgorithm):
(WebCore::CompressionStreamEncoder::compressZlib):
(WebCore::CompressionStreamEncoder::initialize): Deleted.
* Source/WebCore/Modules/compression/CompressionStreamEncoder.h:
(WebCore::CompressionStreamEncoder::create):
(WebCore::CompressionStreamEncoder::CompressionStreamEncoder):
(WebCore::CompressionStreamEncoder::~CompressionStreamEncoder): Deleted.
* Source/WebCore/Modules/compression/DecompressionStream.js:
(initializeDecompressionStream):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decompress):
(WebCore::DecompressionStreamDecoder::didInflateFinish const):
(WebCore::DecompressionStreamDecoder::didInflateContainExtraBytes const):
(WebCore::decompressionAlgorithm):
(WebCore::DecompressionStreamDecoder::decompressZlib):
(WebCore::DecompressionStreamDecoder::initialize): Deleted.
(WebCore::DecompressionStreamDecoder::initializeAppleCompressionFramework): Deleted.
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework): Deleted.
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
(WebCore::DecompressionStreamDecoder::create):
(WebCore::DecompressionStreamDecoder::DecompressionStreamDecoder):
(WebCore::DecompressionStreamDecoder::~DecompressionStreamDecoder): Deleted.
* Source/WebCore/Modules/compression/Formats.h:
(): Deleted.
* Source/WebCore/Modules/compression/ZStream.cpp: Added.
(WebCore::ZStream::initializeIfNecessary):
(WebCore::ZStream::ZStream):
(WebCore::ZStream::~ZStream):
* Source/WebCore/Modules/compression/ZStream.h: Added.
(WebCore::ZStream::get):
(WebCore::ZStream::get const):
* Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm: Added.
(WebCore::CompressionStreamEncoder::compressAppleCompressionFramework):
* Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm: Added.
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/285391@main">https://commits.webkit.org/285391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1535f2672269646376efbaf0586dabf5964c95b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19856 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22002 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78292 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64774 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6680 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47662 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2447 "Found 1 new failure in Modules/webaudio/AudioNodeOutput.h and found 1 fixed file: Modules/screen-wake-lock/WakeLockManager.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->