### PR TITLE
[CSS] Fix nested setSelectorText() to prepend implicit selector

### DIFF
--- a/LayoutTests/fast/css/cssom-insertrule-crash-expected.html
+++ b/LayoutTests/fast/css/cssom-insertrule-crash-expected.html
@@ -3,4 +3,4 @@
    color: green;
   }
 </style>
-<div id=om>div { color: green; baz { } bar { } foo { } }</div>
+<div id=om>div { color: green; & baz { } & bar { } & foo { } }</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt
@@ -11,5 +11,5 @@ PASS Bare declartaion in nested grouping rule can match pseudo-element
 PASS Nested group rules have top-level specificity behavior
 FAIL Nested @scope rules behave like :where(:scope) assert_equals: expected "PASS" but got "FAIL"
 FAIL Nested @scope rules behave like :where(:scope) (trailing) assert_equals: expected "PASS" but got "FAIL"
-FAIL Nested declarations rule responds to parent selector text change assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Nested declarations rule responds to parent selector text change
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html
@@ -213,6 +213,7 @@
     let a_rule = rules[0].cssRules[1];
     assert_equals(a_rule.selectorText, '& .a1');
     a_rule.selectorText = '.a2';
+    assert_equals(a_rule.selectorText, '& .a2');
 
     assert_equals(getComputedStyle(a1).color, 'rgb(255, 0, 0)');
     assert_equals(getComputedStyle(a2).color, 'rgb(0, 128, 0)');

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -67,8 +67,7 @@ ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsi
     }
 
     CSSStyleSheet* styleSheet = parentStyleSheet();
-    auto isNestedContext = hasStyleRuleAncestor() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No;
-    RefPtr<StyleRuleBase> newRule = CSSParser::parseRule(parserContext(), styleSheet ? &styleSheet->contents() : nullptr, ruleString, isNestedContext);
+    RefPtr newRule = CSSParser::parseRule(parserContext(), styleSheet ? &styleSheet->contents() : nullptr, ruleString, nestedContext());
     if (!newRule) {
         if (!hasStyleRuleAncestor())
             return Exception { ExceptionCode::SyntaxError };

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "CSSParserEnum.h"
 #include "ExceptionOr.h"
 #include "StyleRuleType.h"
 #include <wtf/TypeCasts.h>
@@ -52,6 +53,7 @@ public:
     CSSStyleSheet* parentStyleSheet() const;
     CSSRule* parentRule() const { return m_parentIsRule ? m_parentRule : nullptr; }
     bool hasStyleRuleAncestor() const;
+    CSSParserEnum::NestedContext nestedContext() const;
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
     virtual void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) { }
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -24,6 +24,7 @@
 
 #include "CSSGroupingRule.h"
 #include "CSSParser.h"
+#include "CSSParserEnum.h"
 #include "CSSParserImpl.h"
 #include "CSSRuleList.h"
 #include "CSSStyleSheet.h"
@@ -114,9 +115,8 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
         return;
 
     CSSParser p(parserContext());
-    auto isNestedContext = hasStyleRuleAncestor() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No;
     RefPtr sheet = parentStyleSheet();
-    auto selectorList = p.parseSelectorList(selectorText, sheet ? &sheet->contents() : nullptr, isNestedContext);
+    auto selectorList = p.parseSelectorList(selectorText, sheet ? &sheet->contents() : nullptr, nestedContext());
     if (!selectorList)
         return;
 
@@ -236,7 +236,7 @@ ExceptionOr<unsigned> CSSStyleRule::insertRule(const String& ruleString, unsigne
         return Exception { ExceptionCode::IndexSizeError };
 
     RefPtr styleSheet = parentStyleSheet();
-    RefPtr<StyleRuleBase> newRule = CSSParser::parseRule(parserContext(), styleSheet ? &styleSheet->contents() : nullptr, ruleString, CSSParserEnum::IsNestedContext::Yes);
+    RefPtr newRule = CSSParser::parseRule(parserContext(), styleSheet ? &styleSheet->contents() : nullptr, ruleString, CSSParserEnum::NestedContextType::Style);
     if (!newRule) {
         newRule = CSSParserImpl::parseNestedDeclarations(parserContext(), ruleString);
         if (!newRule)

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -71,9 +71,9 @@ void CSSParser::parseSheetForInspector(const CSSParserContext& context, StyleShe
     return CSSParserImpl::parseStyleSheetForInspector(string, context, sheet, observer);
 }
 
-RefPtr<StyleRuleBase> CSSParser::parseRule(const CSSParserContext& context, StyleSheetContents* sheet, const String& string, CSSParserEnum::IsNestedContext isNestedContext)
+RefPtr<StyleRuleBase> CSSParser::parseRule(const CSSParserContext& context, StyleSheetContents* sheet, const String& string, CSSParserEnum::NestedContext nestedContext)
 {
-    return CSSParserImpl::parseRule(string, context, sheet, CSSParserImpl::AllowedRules::ImportRules, isNestedContext);
+    return CSSParserImpl::parseRule(string, context, sheet, CSSParserImpl::AllowedRules::ImportRules, nestedContext);
 }
 
 RefPtr<StyleRuleKeyframe> CSSParser::parseKeyframeRule(const String& string)
@@ -87,7 +87,7 @@ bool CSSParser::parseSupportsCondition(const String& condition)
     CSSParserImpl parser(m_context, condition);
     if (!parser.tokenizer())
         return false;
-    return CSSSupportsParser::supportsCondition(parser.tokenizer()->tokenRange(), parser, CSSSupportsParser::ParsingMode::AllowBareDeclarationAndGeneralEnclosed, CSSParserEnum::IsNestedContext::No) == CSSSupportsParser::Supported;
+    return CSSSupportsParser::supportsCondition(parser.tokenizer()->tokenRange(), parser, CSSSupportsParser::ParsingMode::AllowBareDeclarationAndGeneralEnclosed) == CSSSupportsParser::Supported;
 }
 
 static Color color(RefPtr<CSSValue>&& value)
@@ -160,9 +160,9 @@ CSSParser::ParseResult CSSParser::parseValue(MutableStyleProperties& declaration
     return CSSParserImpl::parseValue(declaration, propertyID, string, important, m_context);
 }
 
-std::optional<CSSSelectorList> CSSParser::parseSelectorList(const String& string, StyleSheetContents* styleSheet, CSSParserEnum::IsNestedContext isNestedContext)
+std::optional<CSSSelectorList> CSSParser::parseSelectorList(const String& string, StyleSheetContents* styleSheet, CSSParserEnum::NestedContext nestedContext)
 {
-    return parseCSSSelectorList(CSSTokenizer(string).tokenRange(), m_context, styleSheet, isNestedContext);
+    return parseCSSSelectorList(CSSTokenizer(string).tokenRange(), m_context, styleSheet, nestedContext);
 }
 
 Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(const String& string, const Element& element)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -57,7 +57,7 @@ public:
 
     void parseSheet(StyleSheetContents&, const String&);
     
-    static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
+    static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserEnum::NestedContext = { });
     
     RefPtr<StyleRuleKeyframe> parseKeyframeRule(const String&);
     static Vector<double> parseKeyframeKeyList(const String&);
@@ -75,7 +75,7 @@ public:
     WEBCORE_EXPORT bool parseDeclaration(MutableStyleProperties&, const String&);
     static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element&);
 
-    WEBCORE_EXPORT std::optional<CSSSelectorList> parseSelectorList(const String&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
+    WEBCORE_EXPORT std::optional<CSSSelectorList> parseSelectorList(const String&, StyleSheetContents* = nullptr, CSSParserEnum::NestedContext = { });
 
     WEBCORE_EXPORT static Color parseColor(const String&, const CSSParserContext&);
     // FIXME: All callers are not getting the right Settings for parsing due to lack of CSSParserContext and should switch to the parseColor function above.

--- a/Source/WebCore/css/parser/CSSParserEnum.h
+++ b/Source/WebCore/css/parser/CSSParserEnum.h
@@ -28,11 +28,17 @@
 
 #pragma once
 
+#include <cstdint>
 namespace WebCore {
 
 namespace CSSParserEnum {
 
-enum class IsNestedContext : bool { No, Yes };
+enum class NestedContextType : bool {
+    Style,
+    Scope,
+};
+
+using NestedContext = std::optional<NestedContextType>;
 
 enum class IsForgiving : bool { No, Yes };
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -78,40 +78,7 @@
 
 namespace WebCore {
 
-static void appendImplicitSelectorPseudoClassScopeIfNeeded(MutableCSSSelector& selector)
-{
-    if ((!selector.hasExplicitNestingParent() && !selector.hasExplicitPseudoClassScope()) || selector.startsWithExplicitCombinator()) {
-        auto scopeSelector = makeUnique<MutableCSSSelector>();
-        scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
-        scopeSelector->setPseudoClass(CSSSelector::PseudoClass::Scope);
-        scopeSelector->setImplicit();
-        selector.appendTagHistoryAsRelative(WTFMove(scopeSelector));
-    }
-}
-
-static void appendImplicitSelectorNestingParentIfNeeded(MutableCSSSelector& selector)
-{
-    if (!selector.hasExplicitNestingParent() || selector.startsWithExplicitCombinator()) {
-        auto nestingParentSelector = makeUnique<MutableCSSSelector>();
-        nestingParentSelector->setMatch(CSSSelector::Match::NestingParent);
-        // https://drafts.csswg.org/css-nesting/#nesting
-        // Spec: nested rules with relative selectors include the specificity of their implied nesting selector.
-        selector.appendTagHistoryAsRelative(WTFMove(nestingParentSelector));
-    }
-}
-
 CSSParserImpl::~CSSParserImpl() = default;
-
-void CSSParserImpl::appendImplicitSelectorIfNeeded(MutableCSSSelector& selector, AncestorRuleType last)
-{
-    if (last == AncestorRuleType::Style) {
-        // For a rule inside a style rule, we had the implicit & if it's not there already or if it starts with a combinator > ~ +
-        appendImplicitSelectorNestingParentIfNeeded(selector);
-    } else if (last == AncestorRuleType::Scope) {
-        // For a rule inside a scope rule, we had the implicit ":scope" if there is no explicit & or :scope already
-        appendImplicitSelectorPseudoClassScopeIfNeeded(selector);
-    }
-}
 
 CSSParserImpl::CSSParserImpl(const CSSParserContext& context, StyleSheetContents* styleSheet)
     : m_context(context)
@@ -119,13 +86,19 @@ CSSParserImpl::CSSParserImpl(const CSSParserContext& context, StyleSheetContents
 {
 }
 
-CSSParserImpl::CSSParserImpl(const CSSParserContext& context, const String& string, StyleSheetContents* styleSheet, CSSParserObserverWrapper* wrapper, CSSParserEnum::IsNestedContext isNestedContext)
-    : m_isAlwaysNestedContext(isNestedContext)
-    , m_context(context)
+CSSParserImpl::CSSParserImpl(const CSSParserContext& context, const String& string, StyleSheetContents* styleSheet, CSSParserObserverWrapper* wrapper, CSSParserEnum::NestedContext nestedContext)
+    : m_context(context)
     , m_styleSheet(styleSheet)
     , m_tokenizer(wrapper ? CSSTokenizer::tryCreate(string, *wrapper) : CSSTokenizer::tryCreate(string))
     , m_observerWrapper(wrapper)
 {
+    // With CSSOM, we might want the parser to start in an already nested state.
+    if (nestedContext) {
+        if (*nestedContext== CSSParserEnum::NestedContextType::Style)
+            m_styleRuleNestingLevel++;
+
+        m_ancestorRuleTypeStack.append(*nestedContext);
+    }
 }
 
 CSSParser::ParseResult CSSParserImpl::parseValue(MutableStyleProperties& declaration, CSSPropertyID propertyID, const String& string, IsImportant important, const CSSParserContext& context)
@@ -222,9 +195,9 @@ bool CSSParserImpl::parseDeclarationList(MutableStyleProperties* declaration, co
     return declaration->addParsedProperties(results);
 }
 
-RefPtr<StyleRuleBase> CSSParserImpl::parseRule(const String& string, const CSSParserContext& context, StyleSheetContents* styleSheet, AllowedRules allowedRules, CSSParserEnum::IsNestedContext isNestedContext)
+RefPtr<StyleRuleBase> CSSParserImpl::parseRule(const String& string, const CSSParserContext& context, StyleSheetContents* styleSheet, AllowedRules allowedRules, CSSParserEnum::NestedContext nestedContext)
 {
-    CSSParserImpl parser(context, string, styleSheet, nullptr, isNestedContext);
+    CSSParserImpl parser(context, string, styleSheet, nullptr, nestedContext);
     CSSParserTokenRange range = parser.tokenizer()->tokenRange();
     range.consumeWhitespace();
     if (range.atEnd())
@@ -496,7 +469,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& r
     const auto initialRange = range;
 
     auto isNestedStyleRule = [&] {
-        return isNestedContext() && allowedRules <= AllowedRules::RegularRules;
+        return isStyleNestedContext() && allowedRules <= AllowedRules::RegularRules;
     };
 
     const CSSParserToken* preludeStart = &range.peek();
@@ -522,7 +495,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& r
         auto customProperty = CSSPropertyParserHelpers::consumeDashedIdent(rangeCopyForDashedIdent);
         // This rule is ambigous with a custom property because it looks like "--ident: ...."
         if (customProperty && rangeCopyForDashedIdent.peek().type() == ColonToken) {
-            if (isNestedContext()) {
+            if (isStyleNestedContext()) {
                 // Error, consume until semicolon or end of block.
                 while (!range.atEnd() && range.peek().type() != SemicolonToken)
                     range.consumeComponentValue();
@@ -639,7 +612,7 @@ RefPtr<StyleRuleImport> CSSParserImpl::consumeImportRule(CSSParserTokenRange pre
         auto& token = prelude.peek();
         if (token.type() == FunctionToken && equalLettersIgnoringASCIICase(token.value(), "supports"_s)) {
             auto arguments = CSSPropertyParserHelpers::consumeFunction(prelude);
-            auto supported = CSSSupportsParser::supportsCondition(arguments, *this, CSSSupportsParser::ParsingMode::AllowBareDeclarationAndGeneralEnclosed, isNestedContext() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No);
+            auto supported = CSSSupportsParser::supportsCondition(arguments, *this, CSSSupportsParser::ParsingMode::AllowBareDeclarationAndGeneralEnclosed);
             if (supported == CSSSupportsParser::Invalid)
                 return { }; // Discard import rule.
             return StyleRuleImport::SupportsCondition { arguments.serialize(), supported == CSSSupportsParser::Supported };
@@ -739,7 +712,7 @@ RefPtr<StyleRuleMedia> CSSParserImpl::consumeMediaRule(CSSParserTokenRange prelu
 
 RefPtr<StyleRuleSupports> CSSParserImpl::consumeSupportsRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    auto supported = CSSSupportsParser::supportsCondition(prelude, *this, CSSSupportsParser::ParsingMode::ForAtRuleSupports, isNestedContext() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No);
+    auto supported = CSSSupportsParser::supportsCondition(prelude, *this, CSSSupportsParser::ParsingMode::ForAtRuleSupports);
     if (supported == CSSSupportsParser::Invalid)
         return nullptr; // Parse error, invalid @supports condition
 
@@ -1078,7 +1051,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
 
     if (!prelude.atEnd()) {
         auto consumePrelude = [&] {
-            auto consumeScope = [&](auto& scope, std::optional<AncestorRuleType> last) {
+            auto consumeScope = [&](auto& scope, auto ancestorRuleType) {
                 // Consume the left parenthesis
                 if (prelude.peek().type() != LeftParenthesisToken)
                     return false;
@@ -1091,19 +1064,9 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
                 CSSParserTokenRange selectorListRange = prelude.makeSubRange(selectorListRangeStart, &prelude.peek());
 
                 // Parse the selector list range
-                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), last.has_value() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving::Yes);
+                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), ancestorRuleType, CSSParserEnum::IsForgiving::Yes);
                 if (mutableSelectorList.isEmpty())
                     return false;
-
-                // In nested context, add the implicit :scope or &
-                if (last) {
-                    for (auto& mutableSelector : mutableSelectorList) {
-                        if (*last == AncestorRuleType::Scope)
-                            appendImplicitSelectorPseudoClassScopeIfNeeded(*mutableSelector);
-                        else if (*last == AncestorRuleType::Style)
-                            appendImplicitSelectorNestingParentIfNeeded(*mutableSelector);
-                    }
-                }
 
                 // Consume the right parenthesis
                 if (prelude.peek().type() != RightParenthesisToken)
@@ -1114,10 +1077,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
                 scope = CSSSelectorList { WTFMove(mutableSelectorList) };
                 return true;
             };
-            std::optional<AncestorRuleType> last;
-            if (!m_ancestorRuleTypeStack.isEmpty())
-                last = m_ancestorRuleTypeStack.last();
-            auto successScopeStart = consumeScope(scopeStart, last);
+            auto successScopeStart = consumeScope(scopeStart, lastAncestorRuleType());
             if (successScopeStart && prelude.atEnd())
                 return true;
             if (prelude.peek().type() != IdentToken)
@@ -1125,7 +1085,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
             auto to = prelude.consumeIncludingWhitespace();
             if (!equalLettersIgnoringASCIICase(to.value(), "to"_s))
                 return false;
-            if (!consumeScope(scopeEnd, AncestorRuleType::Scope)) // scopeEnd is always considered nested, at least by the scopeStart
+            if (!consumeScope(scopeEnd, CSSParserEnum::NestedContextType::Scope)) // scopeEnd is always considered nested, at least by the scopeStart
                 return false;
             if (!prelude.atEnd())
                 return false;
@@ -1142,8 +1102,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
     }
 
-    NestingLevelIncrementer incrementer { m_scopeRuleNestingLevel };
-    m_ancestorRuleTypeStack.append(AncestorRuleType::Scope);
+    m_ancestorRuleTypeStack.append(CSSParserEnum::NestedContextType::Scope);
     auto rules = consumeNestedGroupRules(block);
     m_ancestorRuleTypeStack.removeLast();
     Ref rule = StyleRuleScope::create(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules));
@@ -1362,19 +1321,10 @@ static void observeSelectors(CSSParserObserverWrapper& wrapper, CSSParserTokenRa
 RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
     auto preludeCopyForInspector = prelude;
-    auto mutableSelectorList = parseMutableCSSSelectorList(prelude, m_context, protectedStyleSheet().get(), isNestedContext() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving::No);
+    auto mutableSelectorList = parseMutableCSSSelectorList(prelude, m_context, protectedStyleSheet().get(), lastAncestorRuleType(), CSSParserEnum::IsForgiving::No);
 
     if (mutableSelectorList.isEmpty())
         return nullptr; // Parse error, invalid selector list
-
-    // FIXME: We should pass the ancestor rule type also for CSSSOM.
-    if (!m_ancestorRuleTypeStack.isEmpty()) {
-        // https://drafts.csswg.org/css-nesting/#cssom
-        // Relative selector should be absolutized (only when not "nest-containing" for the descendant one),
-        // with the implied nesting selector inserted.
-        for (auto& mutableSelector : mutableSelectorList)
-            appendImplicitSelectorIfNeeded(*mutableSelector, m_ancestorRuleTypeStack.last());
-    }
 
     CSSSelectorList selectorList { WTFMove(mutableSelectorList) };
     ASSERT(!selectorList.isEmpty());
@@ -1387,7 +1337,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
     runInNewNestingContext([&] {
         {
             NestingLevelIncrementer incrementer { m_styleRuleNestingLevel };
-            m_ancestorRuleTypeStack.append(AncestorRuleType::Style);
+            m_ancestorRuleTypeStack.append(CSSParserEnum::NestedContextType::Style);
             consumeStyleBlock(block, StyleRuleType::Style);
             m_ancestorRuleTypeStack.removeLast();
         }
@@ -1396,7 +1346,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
         Ref properties = createStyleProperties(topContext().m_parsedProperties, m_context.mode);
 
         // We save memory by creating a simple StyleRule instead of a heavier StyleRuleWithNesting when we don't need the CSS Nesting features.
-        if (nestedRules.isEmpty() && !selectorList.hasExplicitNestingParent() && !isNestedContext())
+        if (nestedRules.isEmpty() && !selectorList.hasExplicitNestingParent() && !isStyleNestedContext())
             styleRule = StyleRule::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, WTFMove(selectorList));
         else
             styleRule = StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, WTFMove(selectorList), WTFMove(nestedRules));
@@ -1408,7 +1358,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
 void CSSParserImpl::consumeBlockContent(CSSParserTokenRange range, StyleRuleType ruleType, OnlyDeclarations onlyDeclarations, ParsingStyleDeclarationsInRuleList isParsingStyleDeclarationsInRuleList)
 {
     auto nestedRulesAllowed = [&] {
-        return isNestedContext() && onlyDeclarations == OnlyDeclarations::No;
+        return isStyleNestedContext() && onlyDeclarations == OnlyDeclarations::No;
     };
 
     ASSERT(topContext().m_parsedProperties.isEmpty());

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -52,7 +52,7 @@ struct PseudoElementIdentifier;
 
 class CSSSelectorParser {
 public:
-    CSSSelectorParser(const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
+    CSSSelectorParser(const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::NestedContext = { });
 
     MutableCSSSelectorList consumeComplexSelectorList(CSSParserTokenRange&);
     MutableCSSSelectorList consumeNestedSelectorList(CSSParserTokenRange&);
@@ -102,7 +102,7 @@ private:
 
     const CSSSelectorParserContext m_context;
     const RefPtr<StyleSheetContents> m_styleSheet;
-    CSSParserEnum::IsNestedContext m_isNestedContext { CSSParserEnum::IsNestedContext::No };
+    CSSParserEnum::NestedContext m_nestedContext;
 
     // FIXME: This m_failedParsing is ugly and confusing, we should look into removing it (the return value of each function already convey this information).
     bool m_failedParsing { false };
@@ -115,7 +115,8 @@ private:
     std::optional<CSSSelector::PseudoElement> m_precedingPseudoElement;
 };
 
-std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
-MutableCSSSelectorList parseMutableCSSSelectorList(CSSParserTokenRange&, const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext, CSSParserEnum::IsForgiving);
+std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::NestedContext = { });
+
+MutableCSSSelectorList parseMutableCSSSelectorList(CSSParserTokenRange&, const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::NestedContext, CSSParserEnum::IsForgiving);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -40,12 +40,12 @@
 
 namespace WebCore {
 
-CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(CSSParserTokenRange range, CSSParserImpl& parser, ParsingMode mode, CSSParserEnum::IsNestedContext isNestedContext)
+CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(CSSParserTokenRange range, CSSParserImpl& parser, ParsingMode mode)
 {
     // FIXME: The spec allows leading whitespace in @supports but not CSS.supports,
     // but major browser vendors allow it in CSS.supports also.
     range.consumeWhitespace();
-    CSSSupportsParser supportsParser(parser, isNestedContext);
+    CSSSupportsParser supportsParser(parser);
 
     auto result = supportsParser.consumeCondition(range);
     if (mode != ParsingMode::AllowBareDeclarationAndGeneralEnclosed || result != Invalid)

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -50,12 +50,11 @@ public:
         AllowBareDeclarationAndGeneralEnclosed,
     };
 
-    static SupportsResult supportsCondition(CSSParserTokenRange, CSSParserImpl&, ParsingMode, CSSParserEnum::IsNestedContext);
+    static SupportsResult supportsCondition(CSSParserTokenRange, CSSParserImpl&, ParsingMode);
 
 private:
-    CSSSupportsParser(CSSParserImpl& parser, CSSParserEnum::IsNestedContext isNestedContext = CSSParserEnum::IsNestedContext::No)
+    CSSSupportsParser(CSSParserImpl& parser)
         : m_parser(parser)
-        , m_isNestedContext(isNestedContext)
     { }
 
     SupportsResult consumeCondition(CSSParserTokenRange);
@@ -74,7 +73,6 @@ private:
     SupportsResult consumeConditionInParenthesis(CSSParserTokenRange&, CSSParserTokenType);
 
     CSSParserImpl& m_parser;
-    CSSParserEnum::IsNestedContext m_isNestedContext;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 85f439ac76ff4256c6a9e662e309e82b11da10f4
<pre>
[CSS] Fix nested setSelectorText() to prepend implicit selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=280446">https://bugs.webkit.org/show_bug.cgi?id=280446</a>
<a href="https://rdar.apple.com/136791222">rdar://136791222</a>

Reviewed by Antti Koivisto.

Previously, CSSParserImpl was doing the implicit selector prepend.
However when using the CSSOM setSelectorText(), we don&apos;t use CSSParserImpl at all.

This patch:
  * adds more information in the NestedContext structure (kind of the closest ancestor rule)
  * moves the implicit selector preprend from CSSParserImpl to CSSSelectorParser
  * passes the NestedContext to the selector parser on setSelectorText()
  * cleanups some unused parameter or redundant members

* LayoutTests/fast/css/cssom-insertrule-crash-expected.html:

Fix wrong expectations (the &amp; selector should always be serialized)

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::insertRule):
* Source/WebCore/css/CSSRule.cpp:
(WebCore::CSSRule::parserContext const):
(WebCore::CSSRule::nestedContext const):
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::setSelectorText):
(WebCore::CSSStyleRule::insertRule):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseSupportsCondition):
* Source/WebCore/css/parser/CSSParser.h:
(WebCore::CSSParser::parseRule):
(WebCore::CSSParser::parseSelectorList):
* Source/WebCore/css/parser/CSSParserEnum.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::CSSParserImpl):
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::CSSParserImpl::consumeImportRule):
(WebCore::CSSParserImpl::consumeSupportsRule):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
(WebCore::CSSParserImpl::consumeBlockContent):
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded): Deleted.
(WebCore::appendImplicitSelectorNestingParentIfNeeded): Deleted.
(WebCore::CSSParserImpl::appendImplicitSelectorIfNeeded): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::CSSParserImpl):
(WebCore::CSSParserImpl::parseRule):
(WebCore::CSSParserImpl::isStyleNestedContext):
(WebCore::CSSParserImpl::lastAncestorRuleType const):
(WebCore::CSSParserImpl::isNestedContext): Deleted.

Remove unused m_scopeRuleNestingLevel (we only need m_styleRuleNestingLevel)

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded):
(WebCore::appendImplicitSelectorNestingParentIfNeeded):
(WebCore::appendImplicitSelectorIfNeeded):
(WebCore::parseMutableCSSSelectorList):
* Source/WebCore/css/parser/CSSSelectorParser.h:
(WebCore::CSSSelectorParser::CSSSelectorParser):
(WebCore::parseCSSSelectorList):
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::supportsCondition):
* Source/WebCore/css/parser/CSSSupportsParser.h:
(WebCore::CSSSupportsParser::CSSSupportsParser):

Remove unused isNestedContext parameter

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::isValidRuleHeaderText):
(WebCore::InspectorStyleSheet::setRuleHeaderText):
(WebCore::isNestedContext): Deleted.

Canonical link: <a href="https://commits.webkit.org/284537@main">https://commits.webkit.org/284537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/862557891136aee5a5d33bafd37fcc3bf8478c1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20740 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17577 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75529 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/13867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17177 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/13903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62997 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15487 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4608 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44935 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->