### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make WebProcess/WebCoreSupport classes ref counted

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -69,9 +69,9 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
         m_speechSynthesisClient = document->frame()->page()->speechSynthesisClient();
     }
 
-    if (m_speechSynthesisClient) {
-        m_speechSynthesisClient->setObserver(*this);
-        m_speechSynthesisClient->resetState();
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get()) {
+        speechSynthesisClient->setObserver(*this);
+        speechSynthesisClient->resetState();
     }
 }
 
@@ -117,7 +117,8 @@ const Vector<Ref<SpeechSynthesisVoice>>& SpeechSynthesis::getVoices()
         return *m_voiceList;
 
     // If the voiceList is empty, that's the cue to get the voices from the platform again.
-    auto& voiceList = m_speechSynthesisClient ? m_speechSynthesisClient->voiceList() : ensurePlatformSpeechSynthesizer().voiceList();
+    RefPtr speechSynthesisClient = m_speechSynthesisClient.get();
+    auto& voiceList = speechSynthesisClient ? speechSynthesisClient->voiceList() : ensurePlatformSpeechSynthesizer().voiceList();
     m_voiceList = voiceList.map([](auto& voice) {
         return SpeechSynthesisVoice::create(*voice);
     });
@@ -150,8 +151,8 @@ void SpeechSynthesis::startSpeakingImmediately(SpeechSynthesisUtterance& utteran
     m_currentSpeechUtterance = makeUnique<SpeechSynthesisUtteranceActivity>(Ref { utterance });
     m_isPaused = false;
 
-    if (m_speechSynthesisClient)
-        m_speechSynthesisClient->speak(utterance.platformUtterance());
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
+        speechSynthesisClient->speak(utterance.platformUtterance());
     else
         ensurePlatformSpeechSynthesizer().speak(utterance.platformUtterance());
 }
@@ -178,8 +179,8 @@ void SpeechSynthesis::cancel()
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
     RefPtr current = protectedCurrentSpeechUtterance();
     m_utteranceQueue.clear();
-    if (m_speechSynthesisClient) {
-        m_speechSynthesisClient->cancel();
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get()) {
+        speechSynthesisClient->cancel();
         // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
         // and the event won't be processed. Instead we process the error immediately.
         speakingErrorOccurred();
@@ -193,8 +194,8 @@ void SpeechSynthesis::cancel()
 void SpeechSynthesis::pause()
 {
     if (!m_isPaused) {
-        if (m_speechSynthesisClient)
-            m_speechSynthesisClient->pause();
+        if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
+            speechSynthesisClient->pause();
         else if (m_platformSpeechSynthesizer)
             m_platformSpeechSynthesizer->pause();
     }
@@ -203,8 +204,8 @@ void SpeechSynthesis::pause()
 void SpeechSynthesis::resumeSynthesis()
 {
     if (m_currentSpeechUtterance) {
-        if (m_speechSynthesisClient)
-            m_speechSynthesisClient->resume();
+        if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
+            speechSynthesisClient->resume();
         else if (m_platformSpeechSynthesizer)
             m_platformSpeechSynthesizer->resume();
     }

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -45,10 +45,11 @@ class SpeechSynthesisVoice;
 class SpeechSynthesis : public PlatformSpeechSynthesizerClient, public SpeechSynthesisClientObserver, public RefCounted<SpeechSynthesis>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SpeechSynthesis);
 public:
-    DEFINE_VIRTUAL_REFCOUNTED;
-
     static Ref<SpeechSynthesis> create(ScriptExecutionContext&);
     virtual ~SpeechSynthesis();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool pending() const;
     bool speaking() const;
@@ -109,9 +110,9 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;
-    
+
     PlatformSpeechSynthesizer& ensurePlatformSpeechSynthesizer();
-    
+
     RefPtr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
     std::optional<Vector<Ref<SpeechSynthesisVoice>>> m_voiceList;
     std::unique_ptr<SpeechSynthesisUtteranceActivity> m_currentSpeechUtterance;

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -346,8 +346,8 @@ void BaseDateAndTimeInputType::showPicker()
 
     if (auto* chrome = this->chrome()) {
         m_dateTimeChooser = chrome->createDateTimeChooser(*this);
-        if (m_dateTimeChooser)
-            m_dateTimeChooser->showChooser(parameters);
+        if (RefPtr dateTimeChooser = m_dateTimeChooser)
+            dateTimeChooser->showChooser(parameters);
     }
 }
 
@@ -549,8 +549,8 @@ void BaseDateAndTimeInputType::didChangeValueFromControl()
     if (!setupDateTimeChooserParameters(parameters))
         return;
 
-    if (m_dateTimeChooser)
-        m_dateTimeChooser->showChooser(parameters);
+    if (RefPtr dateTimeChooser = m_dateTimeChooser)
+        dateTimeChooser->showChooser(parameters);
 }
 
 bool BaseDateAndTimeInputType::isEditControlOwnerDisabled() const
@@ -645,8 +645,8 @@ bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserPar
 
 void BaseDateAndTimeInputType::closeDateTimeChooser()
 {
-    if (m_dateTimeChooser)
-        m_dateTimeChooser->endChooser();
+    if (RefPtr dateTimeChooser = m_dateTimeChooser)
+        dateTimeChooser->endChooser();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -151,7 +151,7 @@ private:
 
     void showPicker() override;
 
-    std::unique_ptr<DateTimeChooser> m_dateTimeChooser;
+    RefPtr<DateTimeChooser> m_dateTimeChooser;
     RefPtr<DateTimeEditElement> m_dateTimeEditElement;
 };
 

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -170,8 +170,8 @@ void ColorInputType::setValue(const String& value, bool valueChanged, TextFieldE
         return;
 
     updateColorSwatch();
-    if (m_chooser)
-        m_chooser->setSelectedColor(valueAsColor());
+    if (RefPtr chooser = m_chooser)
+        chooser->setSelectedColor(valueAsColor());
 }
 
 void ColorInputType::attributeChanged(const QualifiedName& name)
@@ -205,7 +205,7 @@ void ColorInputType::showPicker()
         if (!m_chooser)
             m_chooser = chrome->createColorChooser(*this, valueAsColor());
         else
-            m_chooser->reattachColorChooser(valueAsColor());
+            RefPtr { m_chooser }->reattachColorChooser(valueAsColor());
     }
 }
 
@@ -269,8 +269,8 @@ void ColorInputType::didEndChooser()
 
 void ColorInputType::endColorChooser()
 {
-    if (m_chooser)
-        m_chooser->endChooser();
+    if (RefPtr chooser = m_chooser)
+        chooser->endChooser();
 }
 
 void ColorInputType::updateColorSwatch()

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -89,7 +89,7 @@ private:
     void updateColorSwatch();
     HTMLElement* shadowColorSwatch() const;
 
-    std::unique_ptr<ColorChooser> m_chooser;
+    RefPtr<ColorChooser> m_chooser;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -207,8 +207,10 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
         return ShouldCallBaseEventHandler::Yes;
 #if ENABLE(DATALIST_ELEMENT)
     const String& key = event.keyIdentifier();
-    if (m_suggestionPicker && (key == "Enter"_s || key == "Up"_s || key == "Down"_s)) {
-        m_suggestionPicker->handleKeydownWithIdentifier(key);
+    RefPtr suggestionPicker = m_suggestionPicker;
+
+    if (suggestionPicker && (key == "Enter"_s || key == "Up"_s || key == "Down"_s)) {
+        suggestionPicker->handleKeydownWithIdentifier(key);
         event.setDefaultHandled();
     }
 #endif
@@ -1016,16 +1018,14 @@ void TextFieldInputType::displaySuggestions(DataListSuggestionActivationType typ
     if (!m_suggestionPicker && suggestions().size() > 0)
         m_suggestionPicker = chrome()->createDataListSuggestionPicker(*this);
 
-    if (!m_suggestionPicker)
-        return;
-
-    m_suggestionPicker->displayWithActivationType(type);
+    if (RefPtr suggestionPicker = m_suggestionPicker)
+        suggestionPicker->displayWithActivationType(type);
 }
 
 void TextFieldInputType::closeSuggestions()
 {
-    if (m_suggestionPicker)
-        m_suggestionPicker->close();
+    if (RefPtr suggestionPicker = m_suggestionPicker)
+        suggestionPicker->close();
 }
 
 bool TextFieldInputType::isPresentingAttachedView() const

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -147,7 +147,7 @@ private:
     RefPtr<DataListButtonElement> m_dataListDropdownIndicator;
 
     std::pair<String, Vector<DataListSuggestion>> m_cachedSuggestions;
-    std::unique_ptr<DataListSuggestionPicker> m_suggestionPicker;
+    RefPtr<DataListSuggestionPicker> m_suggestionPicker;
 #endif
 
     RefPtr<HTMLElement> m_container;

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -544,7 +544,7 @@ RefPtr<SearchPopupMenu> EmptyChromeClient::createSearchPopupMenu(PopupMenuClient
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
-std::unique_ptr<ColorChooser> EmptyChromeClient::createColorChooser(ColorChooserClient&, const Color&)
+RefPtr<ColorChooser> EmptyChromeClient::createColorChooser(ColorChooserClient&, const Color&)
 {
     return nullptr;
 }
@@ -553,7 +553,7 @@ std::unique_ptr<ColorChooser> EmptyChromeClient::createColorChooser(ColorChooser
 
 #if ENABLE(DATALIST_ELEMENT)
 
-std::unique_ptr<DataListSuggestionPicker> EmptyChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient&)
+RefPtr<DataListSuggestionPicker> EmptyChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient&)
 {
     return nullptr;
 }
@@ -562,7 +562,7 @@ std::unique_ptr<DataListSuggestionPicker> EmptyChromeClient::createDataListSugge
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
-std::unique_ptr<DateTimeChooser> EmptyChromeClient::createDateTimeChooser(DateTimeChooserClient&)
+RefPtr<DateTimeChooser> EmptyChromeClient::createDateTimeChooser(DateTimeChooserClient&)
 {
     return nullptr;
 }

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -140,16 +140,16 @@ class EmptyChromeClient : public ChromeClient {
     void reachedApplicationCacheOriginQuota(SecurityOrigin&, int64_t) final { }
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    std::unique_ptr<ColorChooser> createColorChooser(ColorChooserClient&, const Color&) final;
+    RefPtr<ColorChooser> createColorChooser(ColorChooserClient&, const Color&) final;
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-    std::unique_ptr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&) final;
+    RefPtr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&) final;
     bool canShowDataListSuggestionLabels() const final { return false; }
 #endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-    std::unique_ptr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&) final;
+    RefPtr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&) final;
 #endif
 
     void setTextIndicator(const TextIndicatorData&) const final;

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -443,7 +443,7 @@ void Chrome::disableSuddenTermination()
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
-std::unique_ptr<ColorChooser> Chrome::createColorChooser(ColorChooserClient& client, const Color& initialColor)
+RefPtr<ColorChooser> Chrome::createColorChooser(ColorChooserClient& client, const Color& initialColor)
 {
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(client);
@@ -459,7 +459,7 @@ std::unique_ptr<ColorChooser> Chrome::createColorChooser(ColorChooserClient& cli
 
 #if ENABLE(DATALIST_ELEMENT)
 
-std::unique_ptr<DataListSuggestionPicker> Chrome::createDataListSuggestionPicker(DataListSuggestionsClient& client)
+RefPtr<DataListSuggestionPicker> Chrome::createDataListSuggestionPicker(DataListSuggestionsClient& client)
 {
     notifyPopupOpeningObservers();
     return m_client->createDataListSuggestionPicker(client);
@@ -469,7 +469,7 @@ std::unique_ptr<DataListSuggestionPicker> Chrome::createDataListSuggestionPicker
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
-std::unique_ptr<DateTimeChooser> Chrome::createDateTimeChooser(DateTimeChooserClient& client)
+RefPtr<DateTimeChooser> Chrome::createDateTimeChooser(DateTimeChooserClient& client)
 {
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(client);

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -193,15 +193,15 @@ public:
     WEBCORE_EXPORT void disableSuddenTermination();
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    std::unique_ptr<ColorChooser> createColorChooser(ColorChooserClient&, const Color& initialColor);
+    RefPtr<ColorChooser> createColorChooser(ColorChooserClient&, const Color& initialColor);
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-    std::unique_ptr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&);
+    RefPtr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&);
 #endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-    std::unique_ptr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&);
+    RefPtr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&);
 #endif
 
     std::unique_ptr<WorkerClient> createWorkerClient(SerialFunctionDispatcher&);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -345,16 +345,16 @@ public:
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    virtual std::unique_ptr<ColorChooser> createColorChooser(ColorChooserClient&, const Color&) = 0;
+    virtual RefPtr<ColorChooser> createColorChooser(ColorChooserClient&, const Color&) = 0;
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-    virtual std::unique_ptr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&) = 0;
+    virtual RefPtr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&) = 0;
     virtual bool canShowDataListSuggestionLabels() const = 0;
 #endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-    virtual std::unique_ptr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&) = 0;
+    virtual RefPtr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&) = 0;
 #endif
 
     virtual void setTextIndicator(const TextIndicatorData&) const = 0;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1322,7 +1322,7 @@ private:
     std::unique_ptr<PerformanceLoggingClient> m_performanceLoggingClient;
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    std::unique_ptr<SpeechSynthesisClient> m_speechSynthesisClient;
+    RefPtr<SpeechSynthesisClient> m_speechSynthesisClient;
 #endif
 
     UniqueRef<SpeechRecognitionProvider> m_speechRecognitionProvider;

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -180,7 +180,7 @@ public:
     std::unique_ptr<DiagnosticLoggingClient> diagnosticLoggingClient;
     std::unique_ptr<PerformanceLoggingClient> performanceLoggingClient;
 #if ENABLE(SPEECH_SYNTHESIS)
-    std::unique_ptr<SpeechSynthesisClient> speechSynthesisClient;
+    RefPtr<SpeechSynthesisClient> speechSynthesisClient;
 #endif
 
     RefPtr<ApplicationCacheStorage> applicationCacheStorage;

--- a/Source/WebCore/page/SpeechSynthesisClient.h
+++ b/Source/WebCore/page/SpeechSynthesisClient.h
@@ -27,32 +27,24 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class SpeechSynthesisClientObserver;
-class SpeechSynthesisClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechSynthesisClientObserver> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechSynthesisClient> : std::true_type { };
-}
+#include <wtf/CanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class PlatformSpeechSynthesisUtterance;
 class SpeechSynthesisClientObserver;
 class PlatformSpeechSynthesisVoice;
-    
+
 class SpeechSynthesisClient : public CanMakeWeakPtr<SpeechSynthesisClient> {
 public:
     virtual ~SpeechSynthesisClient() = default;
 
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
     virtual void setObserver(WeakPtr<SpeechSynthesisClientObserver>) = 0;
     virtual WeakPtr<SpeechSynthesisClientObserver> observer() const = 0;
-    
+
     virtual const Vector<RefPtr<PlatformSpeechSynthesisVoice>>& voiceList() = 0;
     virtual void speak(RefPtr<PlatformSpeechSynthesisUtterance>) = 0;
     virtual void cancel() = 0;
@@ -65,6 +57,9 @@ public:
 class SpeechSynthesisClientObserver : public CanMakeWeakPtr<SpeechSynthesisClientObserver>  {
 public:
     virtual ~SpeechSynthesisClientObserver() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void didStartSpeaking() = 0;
     virtual void didFinishSpeaking() = 0;

--- a/Source/WebCore/platform/ColorChooser.h
+++ b/Source/WebCore/platform/ColorChooser.h
@@ -6,13 +6,13 @@
  * are met:
  *
  * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer. 
+ *     notice, this list of conditions and the following disclaimer.
  * 2.  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution. 
+ *     documentation and/or other materials provided with the distribution.
  * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
  *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission. 
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -32,16 +32,18 @@
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
-#include <wtf/TZoneMallocInlines.h>
+#include <wtf/CanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class Color;
 
-class ColorChooser {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(ColorChooser);
+class ColorChooser : public CanMakeWeakPtr<ColorChooser> {
 public:
     virtual ~ColorChooser() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void reattachColorChooser(const Color&) { }
     virtual void setSelectedColor(const Color&) { }

--- a/Source/WebCore/platform/DataListSuggestionPicker.h
+++ b/Source/WebCore/platform/DataListSuggestionPicker.h
@@ -28,25 +28,17 @@
 #if ENABLE(DATALIST_ELEMENT)
 
 #include "DataListSuggestionInformation.h"
-#include <wtf/TZoneMallocInlines.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/text/WTFString.h>
-
-namespace WebCore {
-class DataListSuggestionPicker;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DataListSuggestionPicker> : std::true_type { };
-}
 
 namespace WebCore {
 
 class DataListSuggestionPicker : public CanMakeWeakPtr<DataListSuggestionPicker> {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(DataListSuggestionPicker);
 public:
     virtual ~DataListSuggestionPicker() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void close() { }
     virtual void handleKeydownWithIdentifier(const String&) { }

--- a/Source/WebCore/platform/DateTimeChooser.h
+++ b/Source/WebCore/platform/DateTimeChooser.h
@@ -31,26 +31,18 @@
 #pragma once
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-#include <wtf/TZoneMallocInlines.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class DateTimeChooser;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DateTimeChooser> : std::true_type { };
-}
+#include <wtf/CanMakeWeakPtr.h>
 
 namespace WebCore {
 
 struct DateTimeChooserParameters;
 
 class DateTimeChooser : public CanMakeWeakPtr<DateTimeChooser> {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(DateTimeChooser);
 public:
     virtual ~DateTimeChooser() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void endChooser() = 0;
     virtual void showChooser(const DateTimeChooserParameters&) = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -839,18 +839,18 @@ void WebChromeClient::print(LocalFrame& frame, const StringWithDirection& title)
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
-std::unique_ptr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient& client, const Color& initialColor)
+RefPtr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient& client, const Color& initialColor)
 {
-    return makeUnique<WebColorChooser>(protectedPage().ptr(), &client, initialColor);
+    return WebColorChooser::create(protectedPage().ptr(), &client, initialColor);
 }
 
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
 
-std::unique_ptr<DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient& client)
+RefPtr<DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient& client)
 {
-    return makeUnique<WebDataListSuggestionPicker>(protectedPage(), client);
+    return WebDataListSuggestionPicker::create(protectedPage(), client);
 }
 
 bool WebChromeClient::canShowDataListSuggestionLabels() const
@@ -866,9 +866,9 @@ bool WebChromeClient::canShowDataListSuggestionLabels() const
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
-std::unique_ptr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTimeChooserClient& client)
+RefPtr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTimeChooserClient& client)
 {
-    return makeUnique<WebDateTimeChooser>(protectedPage(), client);
+    return WebDateTimeChooser::create(protectedPage(), client);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -156,16 +156,16 @@ private:
     void exceededDatabaseQuota(WebCore::LocalFrame&, const String& databaseName, WebCore::DatabaseDetails) final { }
     
 #if ENABLE(INPUT_TYPE_COLOR)
-    std::unique_ptr<WebCore::ColorChooser> createColorChooser(WebCore::ColorChooserClient&, const WebCore::Color&) final;
+    RefPtr<WebCore::ColorChooser> createColorChooser(WebCore::ColorChooserClient&, const WebCore::Color&) final;
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-    std::unique_ptr<WebCore::DataListSuggestionPicker> createDataListSuggestionPicker(WebCore::DataListSuggestionsClient&) final;
+    RefPtr<WebCore::DataListSuggestionPicker> createDataListSuggestionPicker(WebCore::DataListSuggestionsClient&) final;
     bool canShowDataListSuggestionLabels() const final;
 #endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-    std::unique_ptr<WebCore::DateTimeChooser> createDateTimeChooser(WebCore::DateTimeChooserClient&) final;
+    RefPtr<WebCore::DateTimeChooser> createDateTimeChooser(WebCore::DateTimeChooserClient&) final;
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
@@ -29,17 +29,9 @@
 
 #include <WebCore/ColorChooser.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class WebColorChooser;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebColorChooser> : std::true_type { };
-}
-
 
 namespace WebCore {
 class Color;
@@ -50,10 +42,18 @@ namespace WebKit {
 
 class WebPage;
 
-class WebColorChooser : public WebCore::ColorChooser, public CanMakeWeakPtr<WebColorChooser> {
+class WebColorChooser : public RefCounted<WebColorChooser>, public WebCore::ColorChooser {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebColorChooser);
 public:
-    WebColorChooser(WebPage*, WebCore::ColorChooserClient*, const WebCore::Color&);
+    static Ref<WebColorChooser> create(WebPage* page, WebCore::ColorChooserClient* client, const WebCore::Color& initialColor)
+    {
+        return adoptRef(*new WebColorChooser(page, client, initialColor));
+    }
+
     virtual ~WebColorChooser();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void didChooseColor(const WebCore::Color&);
     void didEndChooser();
@@ -64,6 +64,8 @@ public:
     void endChooser() override;
 
 private:
+    WebColorChooser(WebPage*, WebCore::ColorChooserClient*, const WebCore::Color&);
+
     CheckedPtr<WebCore::ColorChooserClient> m_colorChooserClient;
     WeakPtr<WebPage> m_page;
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
@@ -28,16 +28,9 @@
 #if ENABLE(DATALIST_ELEMENT)
 
 #include <WebCore/DataListSuggestionPicker.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakRef.h>
-
-namespace WebKit {
-class WebDataListSuggestionPicker;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebDataListSuggestionPicker> : std::true_type { };
-}
 
 namespace WebCore {
 class DataListSuggestionsClient;
@@ -47,14 +40,23 @@ namespace WebKit {
 
 class WebPage;
 
-class WebDataListSuggestionPicker final : public WebCore::DataListSuggestionPicker {
+class WebDataListSuggestionPicker final : public RefCounted<WebDataListSuggestionPicker>, public WebCore::DataListSuggestionPicker {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebDataListSuggestionPicker);
 public:
-    WebDataListSuggestionPicker(WebPage&, WebCore::DataListSuggestionsClient&);
+    static Ref<WebDataListSuggestionPicker> create(WebPage& page, WebCore::DataListSuggestionsClient& client)
+    {
+        return adoptRef(*new WebDataListSuggestionPicker(page, client));
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void didSelectOption(const String&);
     void didCloseSuggestions();
 
 private:
+    WebDataListSuggestionPicker(WebPage&, WebCore::DataListSuggestionsClient&);
+
     void handleKeydownWithIdentifier(const String&) final;
     void displayWithActivationType(WebCore::DataListSuggestionActivationType) final;
     void close() final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
@@ -28,16 +28,9 @@
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
 #include <WebCore/DateTimeChooser.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakRef.h>
-
-namespace WebKit {
-class WebDateTimeChooser;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebDateTimeChooser> : std::true_type { };
-}
 
 namespace WebCore {
 class DateTimeChooserClient;
@@ -48,14 +41,23 @@ namespace WebKit {
 
 class WebPage;
 
-class WebDateTimeChooser final : public WebCore::DateTimeChooser {
+class WebDateTimeChooser final : public RefCounted<WebDateTimeChooser>, public WebCore::DateTimeChooser {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebDateTimeChooser);
 public:
-    WebDateTimeChooser(WebPage&, WebCore::DateTimeChooserClient&);
+    static Ref<WebDateTimeChooser> create(WebPage& page, WebCore::DateTimeChooserClient& client)
+    {
+        return adoptRef(*new WebDateTimeChooser(page, client));
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void didChooseDate(StringView);
     void didEndChooser();
 
 private:
+    WebDateTimeChooser(WebPage&, WebCore::DateTimeChooserClient&);
+
     void endChooser() final;
     void showChooser(const WebCore::DateTimeChooserParameters&) final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
@@ -30,27 +30,26 @@
 #include <WebCore/PlatformSpeechSynthesisUtterance.h>
 #include <WebCore/PlatformSpeechSynthesisVoice.h>
 #include <WebCore/SpeechSynthesisClient.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebKit {
-class WebSpeechSynthesisClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebSpeechSynthesisClient> : std::true_type { };
-}
 
 namespace WebKit {
 
 class WebPage;
-    
-class WebSpeechSynthesisClient : public WebCore::SpeechSynthesisClient {
+
+class WebSpeechSynthesisClient : public RefCounted<WebSpeechSynthesisClient>, public WebCore::SpeechSynthesisClient {
     WTF_MAKE_TZONE_ALLOCATED(WebSpeechSynthesisClient);
 public:
-    explicit WebSpeechSynthesisClient(WebPage&);
+    static Ref<WebSpeechSynthesisClient> create(WebPage& page)
+    {
+        return adoptRef(*new WebSpeechSynthesisClient(page));
+    }
+
     virtual ~WebSpeechSynthesisClient() { }
-    
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& voiceList() override;
     void speak(RefPtr<WebCore::PlatformSpeechSynthesisUtterance>) override;
     void cancel() override;
@@ -58,6 +57,8 @@ public:
     void resume() override;
 
 private:
+    explicit WebSpeechSynthesisClient(WebPage&);
+
     Ref<WebPage> protectedPage() const;
 
     void setObserver(WeakPtr<WebCore::SpeechSynthesisClientObserver> observer) override { m_observer = observer; }
@@ -65,7 +66,7 @@ private:
     void resetState() override;
 
     WebCore::SpeechSynthesisClientObserver* corePageObserver() const;
-    
+
     WeakRef<WebPage> m_page;
     WeakPtr<WebCore::SpeechSynthesisClientObserver> m_observer;
     Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>> m_voices;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -740,7 +740,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.screenOrientationManager = m_screenOrientationManager.get();
 
 #if ENABLE(SPEECH_SYNTHESIS) && !USE(GSTREAMER)
-    pageConfiguration.speechSynthesisClient = makeUnique<WebSpeechSynthesisClient>(*this);
+    pageConfiguration.speechSynthesisClient = WebSpeechSynthesisClient::create(*this);
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
@@ -1867,8 +1867,8 @@ void WebPage::close()
     }
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    if (m_activeColorChooser) {
-        m_activeColorChooser->disconnectFromPage();
+    if (RefPtr activeColorChooser = m_activeColorChooser.get()) {
+        activeColorChooser->disconnectFromPage();
         m_activeColorChooser = nullptr;
     }
 #endif
@@ -5584,14 +5584,14 @@ void WebPage::setActiveColorChooser(WebColorChooser* colorChooser)
 
 void WebPage::didEndColorPicker()
 {
-    if (m_activeColorChooser)
-        m_activeColorChooser->didEndChooser();
+    if (RefPtr activeColorChooser = m_activeColorChooser.get())
+        activeColorChooser->didEndChooser();
 }
 
 void WebPage::didChooseColor(const WebCore::Color& color)
 {
-    if (m_activeColorChooser)
-        m_activeColorChooser->didChooseColor(color);
+    if (RefPtr activeColorChooser = m_activeColorChooser.get())
+        activeColorChooser->didChooseColor(color);
 }
 
 #endif
@@ -5605,14 +5605,14 @@ void WebPage::setActiveDataListSuggestionPicker(WebDataListSuggestionPicker& dat
 
 void WebPage::didSelectDataListOption(const String& selectedOption)
 {
-    if (m_activeDataListSuggestionPicker)
-        m_activeDataListSuggestionPicker->didSelectOption(selectedOption);
+    if (RefPtr activeDataListSuggestionPicker = m_activeDataListSuggestionPicker.get())
+        activeDataListSuggestionPicker->didSelectOption(selectedOption);
 }
 
 void WebPage::didCloseSuggestions()
 {
     if (auto picker = std::exchange(m_activeDataListSuggestionPicker, nullptr))
-        picker->didCloseSuggestions();
+        RefPtr { picker.get() }->didCloseSuggestions();
 }
 
 #endif
@@ -5626,14 +5626,14 @@ void WebPage::setActiveDateTimeChooser(WebDateTimeChooser& dateTimeChooser)
 
 void WebPage::didChooseDate(const String& date)
 {
-    if (m_activeDateTimeChooser)
-        m_activeDateTimeChooser->didChooseDate(date);
+    if (RefPtr activeDateTimeChooser = m_activeDateTimeChooser.get())
+        activeDateTimeChooser->didChooseDate(date);
 }
 
 void WebPage::didEndDateTimePicker()
 {
     if (auto chooser = std::exchange(m_activeDateTimeChooser, nullptr))
-        chooser->didEndChooser();
+        RefPtr { chooser.get() }->didEndChooser();
 }
 
 #endif

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -139,16 +139,16 @@ private:
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    std::unique_ptr<WebCore::ColorChooser> createColorChooser(WebCore::ColorChooserClient&, const WebCore::Color&) final;
+    RefPtr<WebCore::ColorChooser> createColorChooser(WebCore::ColorChooserClient&, const WebCore::Color&) final;
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-    std::unique_ptr<WebCore::DataListSuggestionPicker> createDataListSuggestionPicker(WebCore::DataListSuggestionsClient&) final;
+    RefPtr<WebCore::DataListSuggestionPicker> createDataListSuggestionPicker(WebCore::DataListSuggestionsClient&) final;
     bool canShowDataListSuggestionLabels() const final { return false; }
 #endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-    std::unique_ptr<WebCore::DateTimeChooser> createDateTimeChooser(WebCore::DateTimeChooserClient&) final;
+    RefPtr<WebCore::DateTimeChooser> createDateTimeChooser(WebCore::DateTimeChooserClient&) final;
 #endif
 
     void setTextIndicator(const WebCore::TextIndicatorData&) const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -693,7 +693,7 @@ void WebChromeClient::exceededDatabaseQuota(LocalFrame& frame, const String& dat
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
-std::unique_ptr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient& client, const Color& initialColor)
+RefPtr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient& client, const Color& initialColor)
 {
     // FIXME: Implement <input type='color'> for WK1 (Bug 119094).
     ASSERT_NOT_REACHED();
@@ -703,7 +703,7 @@ std::unique_ptr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserCl
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-std::unique_ptr<DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient& client)
+RefPtr<DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient& client)
 {
     ASSERT_NOT_REACHED();
     return nullptr;
@@ -711,7 +711,7 @@ std::unique_ptr<DataListSuggestionPicker> WebChromeClient::createDataListSuggest
 #endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
-std::unique_ptr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTimeChooserClient&)
+RefPtr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTimeChooserClient&)
 {
     ASSERT_NOT_REACHED();
     return nullptr;


### PR DESCRIPTION
#### 59781b1175f4d8ec6f7fc1d69a66247487ac6b8e
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make WebProcess/WebCoreSupport classes ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280448">https://bugs.webkit.org/show_bug.cgi?id=280448</a>
<a href="https://rdar.apple.com/136792953">rdar://136792953</a>

Reviewed by NOBODY (OOPS!).

Remove IsDeprecatedWeakRefSmartPointerException by making the classes ref counted.

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::SpeechSynthesis):
(WebCore::SpeechSynthesis::getVoices):
(WebCore::SpeechSynthesis::startSpeakingImmediately):
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::pause):
(WebCore::SpeechSynthesis::resumeSynthesis):
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::showPicker):
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):
(WebCore::BaseDateAndTimeInputType::closeDateTimeChooser):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::setValue):
(WebCore::ColorInputType::showPicker):
(WebCore::ColorInputType::endColorChooser):
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::handleKeydownEvent):
(WebCore::TextFieldInputType::displaySuggestions):
(WebCore::TextFieldInputType::closeSuggestions):
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyChromeClient::createColorChooser):
(WebCore::EmptyChromeClient::createDataListSuggestionPicker):
(WebCore::EmptyChromeClient::createDateTimeChooser):
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createColorChooser):
(WebCore::Chrome::createDataListSuggestionPicker):
(WebCore::Chrome::createDateTimeChooser):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/SpeechSynthesisClient.h:
* Source/WebCore/platform/ColorChooser.h:
* Source/WebCore/platform/DataListSuggestionPicker.h:
* Source/WebCore/platform/DateTimeChooser.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createColorChooser):
(WebKit::WebChromeClient::createDataListSuggestionPicker):
(WebKit::WebChromeClient::createDateTimeChooser):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h:
(WebKit::WebColorChooser::create):
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h:
(WebKit::WebSpeechSynthesisClient::create):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::close):
(WebKit::WebPage::didEndColorPicker):
(WebKit::WebPage::didChooseColor):
(WebKit::WebPage::didSelectDataListOption):
(WebKit::WebPage::didCloseSuggestions):
(WebKit::WebPage::didChooseDate):
(WebKit::WebPage::didEndDateTimePicker):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createColorChooser):
(WebChromeClient::createDataListSuggestionPicker):
(WebChromeClient::createDateTimeChooser):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59781b1175f4d8ec6f7fc1d69a66247487ac6b8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55077 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17549 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75031 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16780 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/75031 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59857 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/75031 "") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4269 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44441 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->