### PR TITLE
Fix PlayStation build following 284305@main

### DIFF
--- a/Source/WebCore/css/color/CSSColorConversion+Normalize.h
+++ b/Source/WebCore/css/color/CSSColorConversion+Normalize.h
@@ -105,7 +105,7 @@ auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const std::va
 template<typename Descriptor, unsigned Index>
 auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const std::optional<GetCSSColorParseTypeWithCalcComponentResult<Descriptor, Index>>& optional) -> std::optional<GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index>>
 {
-    return optional.transform([&](auto&& v) { return normalizeAndClampNumericComponentsIntoCanonicalRepresentation<Descriptor, Index>(v); });
+    return optional ? std::make_optional(normalizeAndClampNumericComponentsIntoCanonicalRepresentation<Descriptor, Index>(*optional)) : std::nullopt;
 }
 
 // MARK: - normalizeNumericComponents
@@ -166,7 +166,7 @@ auto normalizeNumericComponentsIntoCanonicalRepresentation(const std::variant<Ts
 template<typename Descriptor, unsigned Index>
 auto normalizeNumericComponentsIntoCanonicalRepresentation(const std::optional<GetCSSColorParseTypeWithCalcComponentResult<Descriptor, Index>>& optional) -> std::optional<GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index>>
 {
-    return optional.transform([&](auto&& v) { return normalizeNumericComponentsIntoCanonicalRepresentation<Descriptor, Index>(v); });
+    return optional ? std::make_optional(normalizeNumericComponentsIntoCanonicalRepresentation<Descriptor, Index>(*optional)) : std::nullopt;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -74,7 +74,7 @@ template<typename T> static CSSUnresolvedColor makeCSSUnresolvedColor(T&& unreso
 
 template<typename T> static std::optional<CSSUnresolvedColor> makeCSSUnresolvedColor(std::optional<T>&& unresolvedColorKind)
 {
-    return unresolvedColorKind.transform([](auto&& v) { return makeCSSUnresolvedColor(std::forward<T>(v)); });
+    return unresolvedColorKind ? std::make_optional(makeCSSUnresolvedColor(std::forward<T>(*unresolvedColorKind))) : std::nullopt;
 }
 
 // State passed to internal color consumer functions. Used to pass information

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+EvaluateCalc.h
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+EvaluateCalc.h
@@ -60,7 +60,7 @@ template<typename T> auto evaluateCalcIfNoConversionDataRequired(const Primitive
 
 template<typename T> decltype(auto) evaluateCalcIfNoConversionDataRequired(const std::optional<T>& component, const CSSCalcSymbolTable& symbolTable)
 {
-    return component.transform([&](auto&& v) { return evaluateCalcIfNoConversionDataRequired(v, symbolTable); });
+    return component ? std::make_optional(evaluateCalcIfNoConversionDataRequired(*component, symbolTable)) : std::nullopt;
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+SymbolReplacement.h
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+SymbolReplacement.h
@@ -50,7 +50,7 @@ template<typename... Ts> constexpr auto replaceSymbol(const std::variant<Ts...>&
 
 template<typename T> constexpr decltype(auto) replaceSymbol(const std::optional<T>& component, const CSSCalcSymbolTable& symbolTable)
 {
-    return component.transform([&](auto&& v) { return replaceSymbol(v, symbolTable); });
+    return component ? std::make_optional(replaceSymbol(*component, symbolTable)) : std::nullopt;
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/CSSUnevaluatedCalc.h
@@ -150,7 +150,7 @@ template<typename... Ts> auto simplifyUnevaluatedCalc(const std::variant<Ts...>&
 
 template<typename T> decltype(auto) simplifyUnevaluatedCalc(const std::optional<T>& component, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
 {
-    return component.transform([&](auto&& v) { return simplifyUnevaluatedCalc(v, conversionData, symbolTable); });
+    return component ? std::make_optional(simplifyUnevaluatedCalc(*component, conversionData, symbolTable)) : std::nullopt;
 }
 
 // MARK: - Serialization

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -65,7 +65,7 @@ template<typename... Ts> struct SpaceSeparatedTuple {
 
 template<typename StyleType> decltype(auto) toCSS(const std::optional<StyleType>& value, const RenderStyle& style)
 {
-    return value.transform([&](auto&& v) { return toCSS(v, style); });
+    return value ? std::make_optional(toCSS(*value, style)) : std::nullopt;
 }
 
 template<typename... StyleTypes> decltype(auto) toCSS(const SpaceSeparatedTuple<StyleTypes...>& value, const RenderStyle& style)
@@ -101,12 +101,12 @@ template<typename... CSSTypes> decltype(auto) toStyle(const std::variant<CSSType
 
 template<typename CSSType> decltype(auto) toStyle(const std::optional<CSSType>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
 {
-    return value.transform([&](auto&& v) { return toStyle(v, conversionData, symbolTable); });
+    return value ? std::make_optional(toStyle(*value, conversionData, symbolTable)) : std::nullopt;
 }
 
 template<typename CSSType> decltype(auto) toStyle(const std::optional<CSSType>& value, Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
 {
-    return value.transform([&](auto&& v) { return toStyle(v, state, symbolTable); });
+    return value ? std::make_optional(toStyle(*value, state, symbolTable)) : std::nullopt;
 }
 
 template<typename... CSSTypes> decltype(auto) toStyle(const SpaceSeparatedTuple<CSSTypes...>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
@@ -143,7 +143,7 @@ template<typename... CSSTypes> decltype(auto) toStyleNoConversionDataRequired(co
 
 template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(const std::optional<CSSType>& value, const CSSCalcSymbolTable& symbolTable)
 {
-    return value.transform([&](auto&& v) { return toStyleNoConversionDataRequired(v, symbolTable); });
+    return value ? std::make_optional(toStyleNoConversionDataRequired(*value, symbolTable)) : std::nullopt;
 }
 
 template<typename... CSSTypes> decltype(auto) toStyleNoConversionDataRequired(const SpaceSeparatedTuple<CSSTypes...>& value, const CSSCalcSymbolTable& symbolTable)


### PR DESCRIPTION
#### 0377f91692999c5269879f68daf25ccdb393b77e
<pre>
Fix PlayStation build following 284305@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=280491">https://bugs.webkit.org/show_bug.cgi?id=280491</a>

Unreviewed build fix.

As I stated in 282722@main, my fix for Sam&apos;s earlier patch 282670@main:
std::optional::transform is a C++23 feature and, at least in the context of this patch,
is not pulling its own weight; it suffices to write an explicit early-out for nullopt.

The better solution here would probably be to add a WTF::mapOptional alongside switchOn.

* Source/WebCore/css/color/CSSColorConversion+Normalize.h:
(WebCore::normalizeAndClampNumericComponentsIntoCanonicalRepresentation):
(WebCore::normalizeNumericComponentsIntoCanonicalRepresentation):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::makeCSSUnresolvedColor):
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+EvaluateCalc.h:
(WebCore::CSS::evaluateCalcIfNoConversionDataRequired):
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+SymbolReplacement.h:
(WebCore::CSS::replaceSymbol):
* Source/WebCore/css/values/CSSUnevaluatedCalc.h:
(WebCore::CSS::simplifyUnevaluatedCalc):
* Source/WebCore/style/values/StyleValueTypes.h:
(WebCore::Style::toCSS):
(WebCore::CSS::toStyle):
(WebCore::CSS::toStyleNoConversionDataRequired):

Canonical link: <a href="https://commits.webkit.org/284337@main">https://commits.webkit.org/284337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/997c8c957de824251a157132e77d6c7be389d632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21780 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20115 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72174 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59660 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40944 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62887 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16672 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59743 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/62552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10552 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44312 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->