### PR TITLE
Implement CSS Values 5 progress()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-interpolation-math-functions-tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-interpolation-math-functions-tentative-expected.txt
@@ -23,28 +23,28 @@ PASS Web Animations: property <rotate> from [100deg] to [calc(sign(20rem - 20px)
 PASS Web Animations: property <rotate> from [100deg] to [calc(sign(20rem - 20px) * 180deg)] at (0.875) should be [170deg]
 PASS Web Animations: property <rotate> from [100deg] to [calc(sign(20rem - 20px) * 180deg)] at (1) should be [180deg]
 PASS Web Animations: property <rotate> from [100deg] to [calc(sign(20rem - 20px) * 180deg)] at (2) should be [260deg]
-FAIL CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg] assert_true: 'to' value should be supported expected true got false
+PASS CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg]
+PASS CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg]
+PASS CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg]
+PASS CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg]
+PASS CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg]
+PASS CSS Transitions: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg]
+PASS CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg]
+PASS CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg]
+PASS CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg]
+PASS CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg]
+PASS CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg]
+PASS CSS Transitions with transition: all: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg]
+PASS CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg]
+PASS CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg]
+PASS CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg]
+PASS CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg]
+PASS CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg]
+PASS CSS Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg]
+PASS Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (-1) should be [20deg]
+PASS Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0) should be [100deg]
+PASS Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.125) should be [110deg]
+PASS Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (0.875) should be [170deg]
+PASS Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (1) should be [180deg]
+PASS Web Animations: property <rotate> from [calc(sign(20rem - 20px) * 100deg)] to [calc(progress(10rem from 20px to 100px) * 180deg)] at (2) should be [260deg]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-math-functions-tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-math-functions-tentative-expected.txt
@@ -23,28 +23,28 @@ PASS Web Animations: property <scale> from [100] to [calc(sign(20rem - 20px) * 1
 PASS Web Animations: property <scale> from [100] to [calc(sign(20rem - 20px) * 180)] at (0.875) should be [170]
 PASS Web Animations: property <scale> from [100] to [calc(sign(20rem - 20px) * 180)] at (1) should be [180]
 PASS Web Animations: property <scale> from [100] to [calc(sign(20rem - 20px) * 180)] at (2) should be [260]
-FAIL CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260] assert_true: 'to' value should be supported expected true got false
+PASS CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20]
+PASS CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100]
+PASS CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110]
+PASS CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170]
+PASS CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180]
+PASS CSS Transitions: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260]
+PASS CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20]
+PASS CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100]
+PASS CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110]
+PASS CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170]
+PASS CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180]
+PASS CSS Transitions with transition: all: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260]
+PASS CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20]
+PASS CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100]
+PASS CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110]
+PASS CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170]
+PASS CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180]
+PASS CSS Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260]
+PASS Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (-1) should be [20]
+PASS Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0) should be [100]
+PASS Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.125) should be [110]
+PASS Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (0.875) should be [170]
+PASS Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (1) should be [180]
+PASS Web Animations: property <scale> from [calc(sign(20rem - 20px) * 100)] to [calc(progress(10rem from 20px to 100px) * 180)] at (2) should be [260]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed.tentative-expected.txt
@@ -1,22 +1,22 @@
 
-FAIL progress(1 from 0 to 1) should be used-value-equivalent to 1 assert_not_equals: progress(1 from 0 to 1) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL progress(progress(1 from 0 to 1) from progress(0px from 0px to 1px) to progress(1deg from 0deg to 1deg)) should be used-value-equivalent to 1 assert_not_equals: progress(progress(1 from 0 to 1) from progress(0px from 0px to 1px) to progress(1deg from 0deg to 1deg)) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL progress(sign(-10px) * 10px from (10px - 10px) to 10px * progress(1deg from 0deg to 1deg)) should be used-value-equivalent to -1 assert_not_equals: progress(sign(-10px) * 10px from (10px - 10px) to 10px * progress(1deg from 0deg to 1deg)) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL calc(progress(100px from 0px to 50px) * 10px + 100px) should be used-value-equivalent to 120px assert_not_equals: calc(progress(100px from 0px to 50px) * 10px + 100px) isn't valid in 'margin-left'; got the default value instead. got disallowed value "0px"
-FAIL calc(progress(100 from 0 to sign(50px))) should be used-value-equivalent to 100 assert_not_equals: calc(progress(100 from 0 to sign(50px))) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL calc(progress(abs(5%) from hypot(3%, 4%) to 10%)) should be used-value-equivalent to 0 assert_not_equals: calc(progress(abs(5%) from hypot(3%, 4%) to 10%)) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL progress(1000em from 10em to 110em) should be used-value-equivalent to 9.9 assert_not_equals: progress(1000em from 10em to 110em) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL scale(progress(1000em from 10rem to 110em)) should be used-value-equivalent to scale(9.9) assert_not_equals: scale(progress(1000em from 10rem to 110em)) isn't valid in 'transform'; got the default value instead. got disallowed value "none"
-FAIL scale(progress(0em from 0rem to 0em)) should be used-value-equivalent to scale(0) assert_not_equals: scale(progress(0em from 0rem to 0em)) isn't valid in 'transform'; got the default value instead. got disallowed value "none"
-FAIL scale(progress(sign(1em - 1rem) * 1ex from 0rem to 0em)) should be used-value-equivalent to scale(0) assert_not_equals: scale(progress(sign(1em - 1rem) * 1ex from 0rem to 0em)) isn't valid in 'transform'; got the default value instead. got disallowed value "none"
-FAIL calc(progress(1 from 0 to 1) * 10px) should be used-value-equivalent to 10px assert_not_equals: calc(progress(1 from 0 to 1) * 10px) isn't valid in 'margin-left'; got the default value instead. got disallowed value "0px"
-FAIL calc(progress(1 from 0 to 1) * 1s) should be used-value-equivalent to 1s assert_not_equals: calc(progress(1 from 0 to 1) * 1s) isn't valid in 'transition-delay'; got the default value instead. got disallowed value "0s"
-FAIL calc(progress(1 from 0 to 1) * 1deg) should be used-value-equivalent to 1deg assert_not_equals: calc(progress(1 from 0 to 1) * 1deg) isn't valid in 'rotate'; got the default value instead. got disallowed value "none"
-FAIL calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 10em from 2rem to 12em) / 2) should be used-value-equivalent to 0.4 assert_not_equals: calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 10em from 2rem to 12em) / 2) isn't valid in 'opacity'; got the default value instead. got disallowed value "1"
-FAIL calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 10) should be used-value-equivalent to 18 assert_not_equals: calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 10) isn't valid in 'order'; got the default value instead. got disallowed value "0"
-FAIL calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 30) should be used-value-equivalent to 54 assert_not_equals: calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 30) isn't valid in 'flex-grow'; got the default value instead. got disallowed value "0"
-FAIL calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) / 4) should be used-value-equivalent to 0.45 assert_not_equals: calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) / 4) isn't valid in 'flex-grow'; got the default value instead. got disallowed value "0"
-FAIL calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 4) should be used-value-equivalent to 7 assert_not_equals: calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 4) isn't valid in 'column-count'; got the default value instead. got disallowed value "auto"
-FAIL calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 2) should be used-value-equivalent to 3.6 assert_not_equals: calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 2) isn't valid in 'scale'; got the default value instead. got disallowed value "none"
-FAIL rotate3d(progress(21em from 1rem to 11em), progress(21em from 1rem to 11em), progress(21em from 1rem to 11em), calc(progress(11em from 1rem to 11em) * 2deg)) should be used-value-equivalent to rotate3d(2, 2, 2, 2deg) assert_not_equals: rotate3d(progress(21em from 1rem to 11em), progress(21em from 1rem to 11em), progress(21em from 1rem to 11em), calc(progress(11em from 1rem to 11em) * 2deg)) isn't valid in 'transform'; got the default value instead. got disallowed value "none"
+PASS progress(1 from 0 to 1) should be used-value-equivalent to 1
+PASS progress(progress(1 from 0 to 1) from progress(0px from 0px to 1px) to progress(1deg from 0deg to 1deg)) should be used-value-equivalent to 1
+PASS progress(sign(-10px) * 10px from (10px - 10px) to 10px * progress(1deg from 0deg to 1deg)) should be used-value-equivalent to -1
+PASS calc(progress(100px from 0px to 50px) * 10px + 100px) should be used-value-equivalent to 120px
+PASS calc(progress(100 from 0 to sign(50px))) should be used-value-equivalent to 100
+PASS calc(progress(abs(5%) from hypot(3%, 4%) to 10%)) should be used-value-equivalent to 0
+PASS progress(1000em from 10em to 110em) should be used-value-equivalent to 9.9
+PASS scale(progress(1000em from 10rem to 110em)) should be used-value-equivalent to scale(9.9)
+PASS scale(progress(0em from 0rem to 0em)) should be used-value-equivalent to scale(0)
+PASS scale(progress(sign(1em - 1rem) * 1ex from 0rem to 0em)) should be used-value-equivalent to scale(0)
+PASS calc(progress(1 from 0 to 1) * 10px) should be used-value-equivalent to 10px
+PASS calc(progress(1 from 0 to 1) * 1s) should be used-value-equivalent to 1s
+PASS calc(progress(1 from 0 to 1) * 1deg) should be used-value-equivalent to 1deg
+PASS calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 10em from 2rem to 12em) / 2) should be used-value-equivalent to 0.4
+PASS calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 10) should be used-value-equivalent to 18
+PASS calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 30) should be used-value-equivalent to 54
+PASS calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) / 4) should be used-value-equivalent to 0.45
+PASS calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 4) should be used-value-equivalent to 7
+PASS calc(progress(sign(1001em - 10lh * progress(100px from 2rex to 10ex)) * 20em from 2rem to 12em) * 2) should be used-value-equivalent to 3.6
+PASS rotate3d(progress(21em from 1rem to 11em), progress(21em from 1rem to 11em), progress(21em from 1rem to 11em), calc(progress(11em from 1rem to 11em) * 2deg)) should be used-value-equivalent to rotate3d(2, 2, 2, 2deg)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize.tentative-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL 'progress(100px from 0px to 100px)' as a specified value should serialize as 'calc(1)'. assert_not_equals: 'progress(100px from 0px to 100px)' should be valid in opacity. got disallowed value ""
-FAIL 'scale(progress(100px from 0px to 100px))' as a specified value should serialize as 'scale(calc(1))'. assert_not_equals: 'scale(progress(100px from 0px to 100px))' should be valid in transform. got disallowed value ""
+PASS 'progress(100px from 0px to 100px)' as a specified value should serialize as 'calc(1)'.
+PASS 'scale(progress(100px from 0px to 100px))' as a specified value should serialize as 'scale(calc(1))'.
 PASS 'progress(100px from 0px to 100px)' as a computed value should serialize as '1'.
-FAIL 'scale(progress(100px from 0px to 100px))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'. assert_equals: 'scale(progress(100px from 0px to 100px))' and 'matrix(1, 0, 0, 1, 0, 0)' should serialize the same in computed values. expected "matrix(1, 0, 0, 1, 0, 0)" but got "none"
-FAIL 'progress(10em from 0px to 10em)' as a specified value should serialize as 'progress(10em from 0px to 10em)'. assert_not_equals: 'progress(10em from 0px to 10em)' should be valid in opacity. got disallowed value ""
-FAIL 'scale(progress(10em from 0px to 10em))' as a specified value should serialize as 'scale(progress(10em from 0px to 10em))'. assert_not_equals: 'scale(progress(10em from 0px to 10em))' should be valid in transform. got disallowed value ""
+PASS 'scale(progress(100px from 0px to 100px))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
+PASS 'progress(10em from 0px to 10em)' as a specified value should serialize as 'progress(10em from 0px to 10em)'.
+PASS 'scale(progress(10em from 0px to 10em))' as a specified value should serialize as 'scale(progress(10em from 0px to 10em))'.
 PASS 'progress(10em from 0px to 10em)' as a computed value should serialize as '1'.
-FAIL 'scale(progress(10em from 0px to 10em))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'. assert_equals: 'scale(progress(10em from 0px to 10em))' and 'matrix(1, 0, 0, 1, 0, 0)' should serialize the same in computed values. expected "matrix(1, 0, 0, 1, 0, 0)" but got "none"
-FAIL 'progress(10em from 0px to 10rem)' as a specified value should serialize as 'progress(10em from 0px to 10rem)'. assert_not_equals: 'progress(10em from 0px to 10rem)' should be valid in opacity. got disallowed value ""
-FAIL 'scale(progress(10em from 0px to 10rem))' as a specified value should serialize as 'scale(progress(10em from 0px to 10rem))'. assert_not_equals: 'scale(progress(10em from 0px to 10rem))' should be valid in transform. got disallowed value ""
+PASS 'scale(progress(10em from 0px to 10em))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
+PASS 'progress(10em from 0px to 10rem)' as a specified value should serialize as 'progress(10em from 0px to 10rem)'.
+PASS 'scale(progress(10em from 0px to 10rem))' as a specified value should serialize as 'scale(progress(10em from 0px to 10rem))'.
 PASS 'progress(10em from 0px to 10rem)' as a computed value should serialize as '1'.
-FAIL 'scale(progress(10em from 0px to 10rem))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'. assert_equals: 'scale(progress(10em from 0px to 10rem))' and 'matrix(1, 0, 0, 1, 0, 0)' should serialize the same in computed values. expected "matrix(1, 0, 0, 1, 0, 0)" but got "none"
-FAIL 'progress(100px from (10px - 10px) to 100px)' as a specified value should serialize as 'calc(1)'. assert_not_equals: 'progress(100px from (10px - 10px) to 100px)' should be valid in opacity. got disallowed value ""
-FAIL 'scale(progress(100px from (10px - 10px) to 100px))' as a specified value should serialize as 'scale(calc(1))'. assert_not_equals: 'scale(progress(100px from (10px - 10px) to 100px))' should be valid in transform. got disallowed value ""
+PASS 'scale(progress(10em from 0px to 10rem))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
+PASS 'progress(100px from (10px - 10px) to 100px)' as a specified value should serialize as 'calc(1)'.
+PASS 'scale(progress(100px from (10px - 10px) to 100px))' as a specified value should serialize as 'scale(calc(1))'.
 PASS 'progress(100px from (10px - 10px) to 100px)' as a computed value should serialize as '1'.
-FAIL 'scale(progress(100px from (10px - 10px) to 100px))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'. assert_equals: 'scale(progress(100px from (10px - 10px) to 100px))' and 'matrix(1, 0, 0, 1, 0, 0)' should serialize the same in computed values. expected "matrix(1, 0, 0, 1, 0, 0)" but got "none"
-FAIL 'progress(1% from (10% - 10%) to 100%)' as a specified value should serialize as 'calc(0.01)'. assert_not_equals: 'progress(1% from (10% - 10%) to 100%)' should be valid in opacity. got disallowed value ""
-FAIL 'scale(progress(1% from (10% - 10%) to 100%))' as a specified value should serialize as 'scale(calc(0.01))'. assert_not_equals: 'scale(progress(1% from (10% - 10%) to 100%))' should be valid in transform. got disallowed value ""
-FAIL 'progress(1% from (10% - 10%) to 100%)' as a computed value should serialize as '0.01'. assert_equals: 'progress(1% from (10% - 10%) to 100%)' and '0.01' should serialize the same in computed values. expected "0.01" but got "1"
-FAIL 'scale(progress(1% from (10% - 10%) to 100%))' as a computed value should serialize as 'matrix(0.01, 0, 0, 0.01, 0, 0)'. assert_equals: 'scale(progress(1% from (10% - 10%) to 100%))' and 'matrix(0.01, 0, 0, 0.01, 0, 0)' should serialize the same in computed values. expected "matrix(0.01, 0, 0, 0.01, 0, 0)" but got "none"
-FAIL 'calc(0.5 * progress(100px from 0px to 100px))' as a specified value should serialize as 'calc(0.5)'. assert_not_equals: 'calc(0.5 * progress(100px from 0px to 100px))' should be valid in opacity. got disallowed value ""
-FAIL 'scale(calc(0.5 * progress(100px from 0px to 100px)))' as a specified value should serialize as 'scale(calc(0.5))'. assert_not_equals: 'scale(calc(0.5 * progress(100px from 0px to 100px)))' should be valid in transform. got disallowed value ""
-FAIL 'calc(0.5 * progress(100px from 0px to 100px))' as a computed value should serialize as '0.5'. assert_equals: 'calc(0.5 * progress(100px from 0px to 100px))' and '0.5' should serialize the same in computed values. expected "0.5" but got "1"
-FAIL 'scale(calc(0.5 * progress(100px from 0px to 100px)))' as a computed value should serialize as 'matrix(0.5, 0, 0, 0.5, 0, 0)'. assert_equals: 'scale(calc(0.5 * progress(100px from 0px to 100px)))' and 'matrix(0.5, 0, 0, 0.5, 0, 0)' should serialize the same in computed values. expected "matrix(0.5, 0, 0, 0.5, 0, 0)" but got "none"
-FAIL 'calc(50px * progress(100px from 0px to 100px))' as a specified value should serialize as 'calc(50px)'. assert_not_equals: 'calc(50px * progress(100px from 0px to 100px))' should be valid in width. got disallowed value ""
-FAIL 'calc(1px * progress(abs(10%) from (10% - 10%) to 100% / 10))' as a computed value should serialize as '1px'. assert_equals: 'calc(1px * progress(abs(10%) from (10% - 10%) to 100% / 10))' and '1px' should serialize the same in computed values. expected "1px" but got "784px"
+PASS 'scale(progress(100px from (10px - 10px) to 100px))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
+PASS 'progress(1% from (10% - 10%) to 100%)' as a specified value should serialize as 'calc(0.01)'.
+PASS 'scale(progress(1% from (10% - 10%) to 100%))' as a specified value should serialize as 'scale(calc(0.01))'.
+PASS 'progress(1% from (10% - 10%) to 100%)' as a computed value should serialize as '0.01'.
+PASS 'scale(progress(1% from (10% - 10%) to 100%))' as a computed value should serialize as 'matrix(0.01, 0, 0, 0.01, 0, 0)'.
+PASS 'calc(0.5 * progress(100px from 0px to 100px))' as a specified value should serialize as 'calc(0.5)'.
+PASS 'scale(calc(0.5 * progress(100px from 0px to 100px)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'calc(0.5 * progress(100px from 0px to 100px))' as a computed value should serialize as '0.5'.
+PASS 'scale(calc(0.5 * progress(100px from 0px to 100px)))' as a computed value should serialize as 'matrix(0.5, 0, 0, 0.5, 0, 0)'.
+PASS 'calc(50px * progress(100px from 0px to 100px))' as a specified value should serialize as 'calc(50px)'.
+PASS 'calc(1px * progress(abs(10%) from (10% - 10%) to 100% / 10))' as a computed value should serialize as '1px'.
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1315,6 +1315,20 @@ CSSPaintingAPIEnabled:
     WebCore:
       default: false
 
+CSSProgressFunctionEnabled:
+  type: bool
+  category: css
+  status: preview
+  humanReadableName: "CSS progress()"
+  humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 progress()"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSRhythmicSizingEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1497,6 +1497,9 @@ mod
 rem
 to-zero
 // nearest
+// progress
+// from
+// to
 infinity
 -infinity id=NegativeInfinity
 NaN

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -85,6 +85,7 @@ template<typename Op> static void serializeMathFunctionPrefix(StringBuilder&, co
 
 static void serializeMathFunctionArguments(StringBuilder&, const IndirectNode<Sum>&, SerializationState&);
 static void serializeMathFunctionArguments(StringBuilder&, const IndirectNode<Product>&, SerializationState&);
+static void serializeMathFunctionArguments(StringBuilder&, const IndirectNode<Progress>&, SerializationState&);
 static void serializeMathFunctionArguments(StringBuilder&, const IndirectNode<Anchor>&, SerializationState&);
 template<typename Op> static void serializeMathFunctionArguments(StringBuilder&, const IndirectNode<Op>&, SerializationState&);
 
@@ -364,6 +365,15 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<S
 void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Product>& fn, SerializationState& state)
 {
     serializeCalculationTree(builder, fn, state);
+}
+
+void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Progress>& fn, SerializationState& state)
+{
+    serializeCalculationTree(builder, fn->progress, state);
+    builder.append(" from "_s);
+    serializeCalculationTree(builder, fn->from, state);
+    builder.append(" to "_s);
+    serializeCalculationTree(builder, fn->to, state);
 }
 
 void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Anchor>& anchor, SerializationState&)

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -97,6 +97,7 @@ std::optional<Child> simplify(Log&, const SimplificationOptions&);
 std::optional<Child> simplify(Exp&, const SimplificationOptions&);
 std::optional<Child> simplify(Abs&, const SimplificationOptions&);
 std::optional<Child> simplify(Sign&, const SimplificationOptions&);
+std::optional<Child> simplify(Progress&, const SimplificationOptions&);
 std::optional<Child> simplify(Anchor&, const SimplificationOptions&);
 
 // MARK: Unit Canonicalization

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -384,6 +384,14 @@ std::optional<Type> toType(const Sign& root)
     return transformTypeFor(root, getValidatedTypeFor(root, root.a));
 }
 
+std::optional<Type> toType(const Progress& root)
+{
+    auto type = getValidatedTypeFor(root, root.progress);
+    type = mergeTypesFor(root, type, getValidatedTypeFor(root, root.from));
+    type = mergeTypesFor(root, type, getValidatedTypeFor(root, root.to));
+    return transformTypeFor(root, type);
+}
+
 TextStream& operator<<(TextStream& ts, Tree tree)
 {
     return ts << "CSSCalc::Tree [ " << serializationForCSS(tree) << " ]";

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -71,6 +71,7 @@ struct Log;
 struct Exp;
 struct Abs;
 struct Sign;
+struct Progress;
 struct Anchor;
 
 template<typename Op>
@@ -189,6 +190,7 @@ using Node = std::variant<
     IndirectNode<Exp>,
     IndirectNode<Abs>,
     IndirectNode<Sign>,
+    IndirectNode<Progress>,
     IndirectNode<Anchor>
 >;
 
@@ -707,6 +709,26 @@ public:
     bool operator==(const Sign&) const = default;
 };
 
+// Progress-Related Functions - https://drafts.csswg.org/css-values-5/#progress
+struct Progress {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Progress);
+public:
+    using Base = Calculation::Progress;
+    static constexpr auto id = CSSValueProgress;
+
+    // <progress()> = progress( <calc-sum> from <calc-sum> to <calc-sum> )
+    //     - INPUT: "consistent" <number>, <dimension>, or <percentage>
+    //     - OUTPUT: <number> "made consistent"
+    static constexpr auto input = AllowedTypes::Any;
+    static constexpr auto merge = MergePolicy::Consistent;
+    static constexpr auto output = OutputTransform::NumberMadeConsistent;
+
+    Child progress;
+    Child from;
+    Child to;
+
+    bool operator==(const Progress&) const = default;
+};
 
 struct Anchor {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(Anchor);
@@ -758,6 +780,7 @@ template<> struct ReverseMapping<Calculation::Log> { using Op = Log; };
 template<> struct ReverseMapping<Calculation::Exp> { using Op = Exp; };
 template<> struct ReverseMapping<Calculation::Abs> { using Op = Abs; };
 template<> struct ReverseMapping<Calculation::Sign> { using Op = Sign; };
+template<> struct ReverseMapping<Calculation::Progress> { using Op = Progress; };
 
 // MARK: TextStream
 
@@ -859,6 +882,7 @@ std::optional<Type> toType(const Log&);
 std::optional<Type> toType(const Exp&);
 std::optional<Type> toType(const Abs&);
 std::optional<Type> toType(const Sign&);
+std::optional<Type> toType(const Progress&);
 
 // MARK: CSSUnitType Evaluation
 
@@ -1128,6 +1152,16 @@ template<size_t I> const auto& get(const Sign& root)
     return root.a;
 }
 
+template<size_t I> const auto& get(const Progress& root)
+{
+    if constexpr (!I)
+        return root.progress;
+    else if constexpr (I == 1)
+        return root.from;
+    else if constexpr (I == 2)
+        return root.to;
+}
+
 } // namespace CSSCalc
 } // namespace WebCore
 
@@ -1168,6 +1202,7 @@ OP_TUPLE_LIKE_CONFORMANCE(Log, 2);
 OP_TUPLE_LIKE_CONFORMANCE(Exp, 1);
 OP_TUPLE_LIKE_CONFORMANCE(Abs, 1);
 OP_TUPLE_LIKE_CONFORMANCE(Sign, 1);
+OP_TUPLE_LIKE_CONFORMANCE(Progress, 3);
 OP_TUPLE_LIKE_CONFORMANCE(Anchor, 0);
 
 #undef OP_TUPLE_LIKE_CONFORMANCE

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -114,6 +114,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , contrastColorEnabled { document.settings().cssContrastColorEnabled() }
     , targetTextPseudoElementEnabled { document.settings().targetTextPseudoElementEnabled() }
     , viewTransitionTypesEnabled { document.settings().viewTransitionsEnabled() && document.settings().viewTransitionTypesEnabled() }
+    , cssProgressFunctionEnabled { document.settings().cssProgressFunctionEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -152,7 +153,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.contrastColorEnabled                      << 25
         | context.targetTextPseudoElementEnabled            << 26
         | context.viewTransitionTypesEnabled                << 27
-        | (uint32_t)context.mode                            << 28; // This is multiple bits, so keep it last.
+        | context.cssProgressFunctionEnabled                << 28
+        | (uint32_t)context.mode                            << 29; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -105,6 +105,7 @@ struct CSSParserContext {
     bool contrastColorEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
     bool viewTransitionTypesEnabled : 1 { false };
+    bool cssProgressFunctionEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/platform/calc/CalculationExecutor.h
+++ b/Source/WebCore/platform/calc/CalculationExecutor.h
@@ -477,5 +477,13 @@ template<> struct OperatorExecutor<Sign> {
     }
 };
 
+template<> struct OperatorExecutor<Progress> {
+    double operator()(double progress, double from, double to)
+    {
+        // (progress value - start value) / (end value - start value)
+        return (progress - from) / (to - from);
+    }
+};
+
 } // namespace Calculation
 } // namespace WebCore

--- a/Source/WebCore/platform/calc/CalculationOperator.cpp
+++ b/Source/WebCore/platform/calc/CalculationOperator.cpp
@@ -63,6 +63,7 @@ TextStream& operator<<(TextStream& ts, Operator op)
     case Operator::Down: ts << "down"; break;
     case Operator::ToZero: ts << "to-zero"; break;
     case Operator::Nearest: ts << "nearest"; break;
+    case Operator::Progress: ts << "progress"; break;
     case Operator::Blend: ts << "blend"; break;
     }
     return ts;

--- a/Source/WebCore/platform/calc/CalculationOperator.h
+++ b/Source/WebCore/platform/calc/CalculationOperator.h
@@ -62,6 +62,7 @@ enum class Operator : uint8_t {
     Up,
     Down,
     ToZero,
+    Progress,
     Blend,
 };
 

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -74,6 +74,7 @@ struct Sqrt;
 struct Hypot;
 struct Abs;
 struct Sign;
+struct Progress;
 
 // Non-standard
 struct Blend;
@@ -164,6 +165,7 @@ using Child = std::variant<
     IndirectNode<Exp>,
     IndirectNode<Abs>,
     IndirectNode<Sign>,
+    IndirectNode<Progress>,
     IndirectNode<Blend>
 >;
 
@@ -472,15 +474,28 @@ public:
     bool operator==(const Sign&) const = default;
 };
 
+// Progress-Related Functions - https://drafts.csswg.org/css-values-5/#progress
+struct Progress {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Progress);
+public:
+    static constexpr auto op = Operator::Progress;
+
+    Child progress;
+    Child from;
+    Child to;
+
+    bool operator==(const Progress&) const = default;
+};
+
 // Non-standard
 struct Blend {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(Blend);
 public:
     static constexpr auto op = Operator::Blend;
 
+    double progress;
     Child from;
     Child to;
-    double progress;
 
     bool operator==(const Blend&) const = default;
 };
@@ -554,7 +569,7 @@ inline Child subtract(Child&& a, Child&& b)
 
 inline Child blend(Child&& from, Child&& to, double progress)
 {
-    return makeChild(Blend { .from = WTFMove(from), .to = WTFMove(to), .progress = progress });
+    return makeChild(Blend { .progress = progress, .from = WTFMove(from), .to = WTFMove(to) });
 }
 
 // MARK: Dumping
@@ -749,14 +764,24 @@ template<size_t I> const auto& get(const Sign& root)
     return root.a;
 }
 
+template<size_t I> const auto& get(const Progress& root)
+{
+    if constexpr (!I)
+        return root.progress;
+    else if constexpr (I == 1)
+        return root.from;
+    else if constexpr (I == 2)
+        return root.to;
+}
+
 template<size_t I> const auto& get(const Blend& root)
 {
     if constexpr (!I)
-        return root.from;
-    else if constexpr (I == 1)
-        return root.to;
-    else if constexpr (I == 2)
         return root.progress;
+    else if constexpr (I == 1)
+        return root.from;
+    else if constexpr (I == 2)
+        return root.to;
 }
 
 } // namespace Calculation
@@ -799,6 +824,7 @@ OP_TUPLE_LIKE_CONFORMANCE(Log, 2);
 OP_TUPLE_LIKE_CONFORMANCE(Exp, 1);
 OP_TUPLE_LIKE_CONFORMANCE(Abs, 1);
 OP_TUPLE_LIKE_CONFORMANCE(Sign, 1);
+OP_TUPLE_LIKE_CONFORMANCE(Progress, 3);
 OP_TUPLE_LIKE_CONFORMANCE(Blend, 3);
 
 #undef OP_TUPLE_LIKE_CONFORMANCE


### PR DESCRIPTION
#### 454d21c821f2def7667def083b3cc71afc3ecae1
<pre>
Implement CSS Values 5 progress()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280495">https://bugs.webkit.org/show_bug.cgi?id=280495</a>

Reviewed by Antti Koivisto.

Implements CSS Values 5 progress() math function behind a
new feature flag, CSSProgressFunctionEnabled.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-interpolation-math-functions-tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-math-functions-tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-computed.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/progress-serialize.tentative-expected.txt:
    - Update now passing results.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
    - Add feature flag.

* Source/WebCore/css/CSSValueKeywords.in:
    - Add comments for extending existing keyword usage.

* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::isCalcFunction):
(WebCore::CSSCalc::consumeProgress):
(WebCore::CSSCalc::parseCalcFunction):
    - Implement parsing and type validation for progress()/

* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::serializeMathFunctionArguments):
    - Implement serialization for progress().

* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
    - Implement simplification for progress().

* Source/WebCore/css/calc/CSSCalcTree.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
    - Define Progress type for the CSSCalcTree level.

* Source/WebCore/css/parser/CSSParserContext.cpp:
* Source/WebCore/css/parser/CSSParserContext.h:
    - Expose settings flag for progress().

* Source/WebCore/platform/calc/CalculationExecutor.h:
    - Implement progress() evaluation.

* Source/WebCore/platform/calc/CalculationOperator.cpp:
* Source/WebCore/platform/calc/CalculationOperator.h:
    - Define Progress operator.

* Source/WebCore/platform/calc/CalculationTree.h:
    - Define Progress type for the CalculationTree level.

Canonical link: <a href="https://commits.webkit.org/284368@main">https://commits.webkit.org/284368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9a2ea67871c3655d2c87fb431716e300276caa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69157 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20164 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13493 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40988 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18689 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74949 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68403 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16718 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62612 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15349 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4206 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44361 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15997 "Found 117 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Bugs/withnonativeApplyOptimizationBug3433559.js.default, ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/assertion.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/sets.js.default, ChakraCore.yaml/ChakraCore/test/es6/ES6Function_bugs.js.default, ChakraCore.yaml/ChakraCore/test/es6/superDotOSBug3930962.js.default, ChakraCore.yaml/ChakraCore/test/es6/weakset_basic.js.default, ChakraCore.yaml/ChakraCore/test/strict/09.ObjectLiteral_sm.js.default, ChakraCore.yaml/ChakraCore/test/strict/16.catch_sm.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45434 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->