### PR TITLE
Further reduce use of LegacyNullableAtomicObjectIdentifier

### DIFF
--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum class WorkerFileSystemStorageConnectionCallbackIdentifierType { };
-using WorkerFileSystemStorageConnectionCallbackIdentifier = LegacyNullableAtomicObjectIdentifier<WorkerFileSystemStorageConnectionCallbackIdentifierType>;
+using WorkerFileSystemStorageConnectionCallbackIdentifier = AtomicObjectIdentifier<WorkerFileSystemStorageConnectionCallbackIdentifierType>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseConnectionIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseConnectionIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class IDBDatabaseConnectionIdentifierType { };
-using IDBDatabaseConnectionIdentifier = LegacyNullableAtomicObjectIdentifier<IDBDatabaseConnectionIdentifierType>;
+using IDBDatabaseConnectionIdentifier = AtomicObjectIdentifier<IDBDatabaseConnectionIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
@@ -25,7 +25,7 @@ additional_forward_declaration: namespace IPC { template<typename> class ObjectI
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierWriteReference; }
 additional_forward_declaration: namespace IPC { template<typename> struct ObjectIdentifierReadReference; }
 additional_forward_declaration: namespace WebCore { using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>; }
-additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = LegacyNullableAtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
+additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
 additional_forward_declaration: namespace WebKit { using RemoteSerializedImageBufferIdentifier = WebCore::RenderingResourceIdentifier; }
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -166,29 +166,16 @@ template: struct WebKit::WebExtensionWindowIdentifierType
 }
 
 header: <wtf/ObjectIdentifier.h>
-template: enum class WebCore::IDBDatabaseConnectionIdentifierType
-template: enum class WebCore::WorkerFileSystemStorageConnectionCallbackIdentifierType
-template: enum class WebKit::GraphicsContextGLIdentifierType
-template: enum class WebKit::RemoteVideoFrameIdentifierType
-template: enum class WebKit::RenderingBackendIdentifierType
-template: enum class WebKit::VideoDecoderIdentifierType
-template: enum class WebKit::VideoEncoderIdentifierType
-template: enum class WebKit::WCContentBufferIdentifierType
-template: enum class WebKit::WebGPUIdentifierType
-template: enum class TestWebKitAPI::TestedObjectIdentifierType
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::LegacyNullableAtomicObjectIdentifier {
-    [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
-}
-
-header: <wtf/ObjectIdentifier.h>
 template: class WebCore::ResourceLoader
 template: class WebCore::WebSocketChannel
 template: enum class IPC::ConnectionSyncRequestIDType
 template: enum class JSC::MicrotaskIdentifierType
+template: enum class TestWebKitAPI::TestedObjectIdentifierType
 template: enum class WebCore::DOMCacheIdentifierType
 template: enum class WebCore::BroadcastChannelIdentifierType
 template: enum class WebCore::FileSystemHandleIdentifierType
 template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
+template: enum class WebCore::IDBDatabaseConnectionIdentifierType
 template: enum class WebCore::IDBObjectStoreIdentifierType
 template: enum class WebCore::LibWebRTCSocketIdentifierType
 template: enum class WebCore::MainThreadPermissionObserverIdentifierType
@@ -202,11 +189,19 @@ template: enum class WebCore::ServiceWorkerJobIdentifierType
 template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
 template: enum class WebCore::WebLockIdentifierType
 template: enum class WebCore::WebSocketIdentifierType
+template: enum class WebCore::WorkerFileSystemStorageConnectionCallbackIdentifierType
 template: enum class WebKit::GPUProcessConnectionIdentifierType
+template: enum class WebKit::GraphicsContextGLIdentifierType
 template: enum class WebKit::LegacyCustomProtocolIDType
 template: enum class WebKit::LibWebRTCResolverIdentifierType
 template: enum class WebKit::LogStreamIdentifierType
 template: enum class WebKit::QuotaIncreaseRequestIdentifierType
+template: enum class WebKit::RemoteVideoFrameIdentifierType
+template: enum class WebKit::RenderingBackendIdentifierType
+template: enum class WebKit::VideoDecoderIdentifierType
+template: enum class WebKit::VideoEncoderIdentifierType
+template: enum class WebKit::WCContentBufferIdentifierType
+template: enum class WebKit::WebGPUIdentifierType
 template: struct IPC::AsyncReplyIDType
 template: struct WebKit::StorageAreaIdentifierType
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::AtomicObjectIdentifier {

--- a/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
@@ -42,8 +42,6 @@ std::optional<BindGroupDescriptor> ConvertToBackingContext::convertToBacking(con
         return std::nullopt;
 
     auto identifier = convertToBacking(bindGroupDescriptor.layout);
-    if (!identifier)
-        return std::nullopt;
 
     Vector<BindGroupEntry> entries;
     entries.reserveInitialCapacity(bindGroupDescriptor.entries.size());

--- a/Source/WebKit/Shared/WebGPU/WebGPUBindGroupEntry.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBindGroupEntry.cpp
@@ -41,14 +41,10 @@ std::optional<BindGroupEntry> ConvertToBackingContext::convertToBacking(const We
 {
     return WTF::switchOn(bindGroupEntry.resource, [&] (std::reference_wrapper<WebCore::WebGPU::Sampler> sampler) -> std::optional<BindGroupEntry> {
         auto identifier = convertToBacking(sampler);
-        if (!identifier)
-            return std::nullopt;
 
         return { { bindGroupEntry.binding, { identifier }, identifier, BindingResourceType::Sampler } };
     }, [&] (std::reference_wrapper<WebCore::WebGPU::TextureView> textureView) -> std::optional<BindGroupEntry> {
         auto identifier = convertToBacking(textureView);
-        if (!identifier)
-            return std::nullopt;
 
         return { { bindGroupEntry.binding, { identifier }, identifier, BindingResourceType::TextureView } };
     }, [&] (const auto& bufferBinding) -> std::optional<BindGroupEntry> {
@@ -59,8 +55,6 @@ std::optional<BindGroupEntry> ConvertToBackingContext::convertToBacking(const We
         return { { bindGroupEntry.binding, WTFMove(*convertedBufferBinding), convertedBufferBinding->buffer, BindingResourceType::BufferBinding } };
     }, [&] (std::reference_wrapper<WebCore::WebGPU::ExternalTexture> externalTexture) -> std::optional<BindGroupEntry> {
         auto identifier = convertToBacking(externalTexture);
-        if (!identifier)
-            return std::nullopt;
 
         return { { bindGroupEntry.binding, { identifier }, identifier, BindingResourceType::ExternalTexture } };
     });

--- a/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<BufferBinding> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::BufferBinding& bufferBinding)
 {
     auto buffer = convertToBacking(bufferBinding.buffer);
-    if (!buffer)
-        return std::nullopt;
 
     return { { buffer, bufferBinding.offset, bufferBinding.size } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<CanvasConfiguration> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::CanvasConfiguration& canvasConfiguration)
 {
     auto device = convertToBacking(canvasConfiguration.device);
-    if (!device)
-        return std::nullopt;
 
     return { { device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.toneMappingMode, canvasConfiguration.compositingAlphaMode, canvasConfiguration.reportValidationErrors } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
@@ -42,8 +42,6 @@ std::optional<ComputePassTimestampWrites> ConvertToBackingContext::convertToBack
         return std::nullopt;
 
     auto querySet = convertToBacking(*computePassTimestampWrite.querySet);
-    if (!querySet)
-        return std::nullopt;
 
     return { { querySet, computePassTimestampWrite.beginningOfPassWriteIndex, computePassTimestampWrite.endOfPassWriteIndex } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class WebGPUIdentifierType { };
-using WebGPUIdentifier = LegacyNullableAtomicObjectIdentifier<WebGPUIdentifierType>;
+using WebGPUIdentifier = AtomicObjectIdentifier<WebGPUIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
@@ -38,12 +38,7 @@ namespace WebKit::WebGPU {
 std::optional<ImageCopyBuffer> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ImageCopyBuffer& imageCopyBuffer)
 {
     auto base = convertToBacking(static_cast<const WebCore::WebGPU::ImageDataLayout&>(imageCopyBuffer));
-    if (!base)
-        return std::nullopt;
-
     auto buffer = convertToBacking(imageCopyBuffer.buffer);
-    if (!buffer)
-        return std::nullopt;
 
     return { { WTFMove(*base), buffer } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<ImageCopyTexture> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ImageCopyTexture& imageCopyTexture)
 {
     auto texture = convertToBacking(imageCopyTexture.texture);
-    if (!texture)
-        return std::nullopt;
 
     std::optional<Origin3D> origin;
     if (imageCopyTexture.origin) {

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
@@ -41,7 +41,7 @@ std::optional<PipelineDescriptorBase> ConvertToBackingContext::convertToBacking(
     if (!base)
         return std::nullopt;
 
-    WebGPUIdentifier layout;
+    std::optional<WebGPUIdentifier> layout;
     if (pipelineDescriptorBase.layout) {
         layout = convertToBacking(*pipelineDescriptorBase.layout);
         if (!layout)
@@ -57,12 +57,12 @@ std::optional<WebCore::WebGPU::PipelineDescriptorBase> ConvertFromBackingContext
     if (!base)
         return std::nullopt;
 
-    WeakPtr<WebCore::WebGPU::PipelineLayout> layout;
-    if (pipelineDescriptorBase.layout) {
-        layout = convertPipelineLayoutFromBacking(pipelineDescriptorBase.layout);
-        if (!layout)
-            return std::nullopt;
-    }
+    if (!pipelineDescriptorBase.layout)
+        return std::nullopt;
+
+    auto layout = convertPipelineLayoutFromBacking(*pipelineDescriptorBase.layout);
+    if (!layout)
+        return std::nullopt;
 
     return { { WTFMove(*base), layout } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.h
@@ -34,7 +34,7 @@
 namespace WebKit::WebGPU {
 
 struct PipelineDescriptorBase : public ObjectDescriptorBase {
-    WebGPUIdentifier layout;
+    Markable<WebGPUIdentifier> layout;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.serialization.in
@@ -22,6 +22,6 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::PipelineDescriptorBase : WebKit::WebGPU::ObjectDescriptorBase {
-    WebKit::WebGPUIdentifier layout;
+    Markable<WebKit::WebGPUIdentifier> layout;
 };
 #endif

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
@@ -45,12 +45,8 @@ std::optional<PipelineLayoutDescriptor> ConvertToBackingContext::convertToBackin
     Vector<WebGPUIdentifier> bindGroupLayouts;
     if (pipelineLayoutDescriptor.bindGroupLayouts) {
         bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts->size());
-        for (auto backingBindGroupLayout : *pipelineLayoutDescriptor.bindGroupLayouts) {
-            auto entry = convertToBacking(backingBindGroupLayout);
-            if (!entry)
-                return std::nullopt;
-            bindGroupLayouts.append(entry);
-        }
+        for (auto backingBindGroupLayout : *pipelineLayoutDescriptor.bindGroupLayouts)
+            bindGroupLayouts.append(convertToBacking(backingBindGroupLayout));
 
         optionalBindGroupLayouts = bindGroupLayouts;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp
@@ -37,8 +37,6 @@ namespace WebKit::WebGPU {
 std::optional<PresentationContextDescriptor> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::PresentationContextDescriptor& presentationContextDescriptor)
 {
     auto identifier = convertToBacking(presentationContextDescriptor.compositorIntegration);
-    if (!identifier)
-        return std::nullopt;
 
     return { { identifier } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<ProgrammableStage> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ProgrammableStage& programmableStage)
 {
     auto module = convertToBacking(programmableStage.module);
-    if (!module)
-        return std::nullopt;
 
     return { { module, programmableStage.entryPoint, programmableStage.constants } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<RenderPassColorAttachment> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassColorAttachment& renderPassColorAttachment)
 {
     auto view = convertToBacking(renderPassColorAttachment.view);
-    if (!view)
-        return std::nullopt;
 
     std::optional<WebGPUIdentifier> resolveTarget;
     if (renderPassColorAttachment.resolveTarget) {

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<RenderPassDepthStencilAttachment> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassDepthStencilAttachment& renderPassDepthStencilAttachment)
 {
     auto view = convertToBacking(renderPassDepthStencilAttachment.view);
-    if (!view)
-        return std::nullopt;
 
     return { { view, renderPassDepthStencilAttachment.depthClearValue, renderPassDepthStencilAttachment.depthLoadOp, renderPassDepthStencilAttachment.depthStoreOp, renderPassDepthStencilAttachment.depthReadOnly, renderPassDepthStencilAttachment.stencilClearValue, renderPassDepthStencilAttachment.stencilLoadOp, renderPassDepthStencilAttachment.stencilStoreOp, renderPassDepthStencilAttachment.stencilReadOnly } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
@@ -41,8 +41,6 @@ std::optional<RenderPassTimestampWrites> ConvertToBackingContext::convertToBacki
         return std::nullopt;
 
     auto querySet = convertToBacking(*renderPassTimestampWrite.querySet);
-    if (!querySet)
-        return std::nullopt;
 
     return { { querySet, renderPassTimestampWrite.beginningOfPassWriteIndex, renderPassTimestampWrite.endOfPassWriteIndex } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp
@@ -38,8 +38,6 @@ namespace WebKit::WebGPU {
 std::optional<ShaderModuleCompilationHint> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ShaderModuleCompilationHint& shaderModuleCompilationHint)
 {
     WebGPUIdentifier pipelineLayout = convertToBacking(shaderModuleCompilationHint.protectedPipelineLayout());
-    if (!pipelineLayout)
-        return std::nullopt;
 
     return { { pipelineLayout } };
 }

--- a/Source/WebKit/Shared/wc/WCContentBufferIdentifier.h
+++ b/Source/WebKit/Shared/wc/WCContentBufferIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class WCContentBufferIdentifierType { };
-using WCContentBufferIdentifier = LegacyNullableAtomicObjectIdentifier<WCContentBufferIdentifierType>;
+using WCContentBufferIdentifier = AtomicObjectIdentifier<WCContentBufferIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class GraphicsContextGLIdentifierType { };
-using GraphicsContextGLIdentifier = LegacyNullableAtomicObjectIdentifier<GraphicsContextGLIdentifierType>;
+using GraphicsContextGLIdentifier = AtomicObjectIdentifier<GraphicsContextGLIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RenderingBackendIdentifierType { };
-using RenderingBackendIdentifier = LegacyNullableAtomicObjectIdentifier<RenderingBackendIdentifierType>;
+using RenderingBackendIdentifier = AtomicObjectIdentifier<RenderingBackendIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -95,11 +95,7 @@ void RemoteCommandEncoderProxy::copyBufferToBuffer(
     WebCore::WebGPU::Size64 size)
 {
     auto convertedSource = m_convertToBackingContext->convertToBacking(source);
-    ASSERT(convertedSource);
     auto convertedDestination = m_convertToBackingContext->convertToBacking(destination);
-    ASSERT(convertedDestination);
-    if (!convertedSource || !convertedDestination)
-        return;
 
     auto sendResult = send(Messages::RemoteCommandEncoder::CopyBufferToBuffer(convertedSource, sourceOffset, convertedDestination, destinationOffset, size));
     UNUSED_VARIABLE(sendResult);
@@ -165,9 +161,6 @@ void RemoteCommandEncoderProxy::clearBuffer(
     std::optional<WebCore::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteCommandEncoder::ClearBuffer(convertedBuffer, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -194,9 +187,6 @@ void RemoteCommandEncoderProxy::insertDebugMarker(String&& markerLabel)
 void RemoteCommandEncoderProxy::writeTimestamp(const WebCore::WebGPU::QuerySet& querySet, WebCore::WebGPU::Size32 queryIndex)
 {
     auto convertedQuerySet = m_convertToBackingContext->convertToBacking(querySet);
-    ASSERT(convertedQuerySet);
-    if (!convertedQuerySet)
-        return;
 
     auto sendResult = send(Messages::RemoteCommandEncoder::WriteTimestamp(convertedQuerySet, queryIndex));
     UNUSED_VARIABLE(sendResult);
@@ -210,11 +200,7 @@ void RemoteCommandEncoderProxy::resolveQuerySet(
     WebCore::WebGPU::Size64 destinationOffset)
 {
     auto convertedQuerySet = m_convertToBackingContext->convertToBacking(querySet);
-    ASSERT(convertedQuerySet);
     auto convertedDestination = m_convertToBackingContext->convertToBacking(destination);
-    ASSERT(convertedDestination);
-    if (!convertedQuerySet || !convertedDestination)
-        return;
 
     auto sendResult = send(Messages::RemoteCommandEncoder::ResolveQuerySet(convertedQuerySet, firstQuery, queryCount, convertedDestination, destinationOffset));
     UNUSED_VARIABLE(sendResult);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -52,9 +52,6 @@ RemoteComputePassEncoderProxy::~RemoteComputePassEncoderProxy()
 void RemoteComputePassEncoderProxy::setPipeline(const WebCore::WebGPU::ComputePipeline& computePipeline)
 {
     auto convertedComputePipeline = m_convertToBackingContext->convertToBacking(computePipeline);
-    ASSERT(convertedComputePipeline);
-    if (!convertedComputePipeline)
-        return;
 
     auto sendResult = send(Messages::RemoteComputePassEncoder::SetPipeline(convertedComputePipeline));
     UNUSED_VARIABLE(sendResult);
@@ -69,9 +66,6 @@ void RemoteComputePassEncoderProxy::dispatch(WebCore::WebGPU::Size32 workgroupCo
 void RemoteComputePassEncoderProxy::dispatchIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
-    if (!convertedIndirectBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteComputePassEncoder::DispatchIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -87,9 +81,6 @@ void RemoteComputePassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& offsets)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
-    ASSERT(convertedBindGroup);
-    if (!convertedBindGroup)
-        return;
 
     auto sendResult = send(Messages::RemoteComputePassEncoder::SetBindGroup(index, convertedBindGroup, WTFMove(offsets)));
     UNUSED_VARIABLE(sendResult);
@@ -102,9 +93,6 @@ void RemoteComputePassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index,
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
-    ASSERT(convertedBindGroup);
-    if (!convertedBindGroup)
-        return;
 
     auto sendResult = send(Messages::RemoteComputePassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -115,7 +115,6 @@ private:
     void resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&&) final;
 
     WebGPUIdentifier m_backing;
-    WebGPUIdentifier m_queueBacking;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteAdapterProxy> m_parent;
     Ref<RemoteQueueProxy> m_queue;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -53,9 +53,6 @@ void RemoteQueueProxy::submit(Vector<std::reference_wrapper<WebCore::WebGPU::Com
 {
     auto convertedCommandBuffers = WTF::compactMap(commandBuffers, [&](auto& commandBuffer) -> std::optional<WebGPUIdentifier> {
         auto convertedCommandBuffer = m_convertToBackingContext->convertToBacking(commandBuffer);
-        ASSERT(convertedCommandBuffer);
-        if (!convertedCommandBuffer)
-            return std::nullopt;
         return convertedCommandBuffer;
     });
 
@@ -79,9 +76,6 @@ void RemoteQueueProxy::writeBuffer(
     std::optional<WebCore::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
 
     auto sharedMemory = WebCore::SharedMemory::copySpan(source.subspan(dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset))));
     std::optional<WebCore::SharedMemoryHandle> handle;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -53,9 +53,6 @@ RemoteRenderBundleEncoderProxy::~RemoteRenderBundleEncoderProxy()
 void RemoteRenderBundleEncoderProxy::setPipeline(const WebCore::WebGPU::RenderPipeline& renderPipeline)
 {
     auto convertedRenderPipeline = m_convertToBackingContext->convertToBacking(renderPipeline);
-    ASSERT(convertedRenderPipeline);
-    if (!convertedRenderPipeline)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetPipeline(convertedRenderPipeline));
     UNUSED_VARIABLE(sendResult);
@@ -64,9 +61,6 @@ void RemoteRenderBundleEncoderProxy::setPipeline(const WebCore::WebGPU::RenderPi
 void RemoteRenderBundleEncoderProxy::setIndexBuffer(const WebCore::WebGPU::Buffer& buffer, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetIndexBuffer(convertedBuffer, indexFormat, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -80,9 +74,6 @@ void RemoteRenderBundleEncoderProxy::setVertexBuffer(WebCore::WebGPU::Index32 sl
         return;
     }
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(*buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetVertexBuffer(slot, convertedBuffer, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -108,9 +99,6 @@ void RemoteRenderBundleEncoderProxy::drawIndexed(WebCore::WebGPU::Size32 indexCo
 void RemoteRenderBundleEncoderProxy::drawIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
-    if (!convertedIndirectBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::DrawIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -119,9 +107,6 @@ void RemoteRenderBundleEncoderProxy::drawIndirect(const WebCore::WebGPU::Buffer&
 void RemoteRenderBundleEncoderProxy::drawIndexedIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
-    if (!convertedIndirectBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::DrawIndexedIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -131,9 +116,6 @@ void RemoteRenderBundleEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
-    ASSERT(convertedBindGroup);
-    if (!convertedBindGroup)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetBindGroup(index, convertedBindGroup, dynamicOffsets));
     UNUSED_VARIABLE(sendResult);
@@ -146,9 +128,6 @@ void RemoteRenderBundleEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
-    ASSERT(convertedBindGroup);
-    if (!convertedBindGroup)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -52,9 +52,6 @@ RemoteRenderPassEncoderProxy::~RemoteRenderPassEncoderProxy()
 void RemoteRenderPassEncoderProxy::setPipeline(const WebCore::WebGPU::RenderPipeline& renderPipeline)
 {
     auto convertedRenderPipeline = m_convertToBackingContext->convertToBacking(renderPipeline);
-    ASSERT(convertedRenderPipeline);
-    if (!convertedRenderPipeline)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetPipeline(convertedRenderPipeline));
     UNUSED_VARIABLE(sendResult);
@@ -63,9 +60,6 @@ void RemoteRenderPassEncoderProxy::setPipeline(const WebCore::WebGPU::RenderPipe
 void RemoteRenderPassEncoderProxy::setIndexBuffer(const WebCore::WebGPU::Buffer& buffer, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetIndexBuffer(convertedBuffer, indexFormat, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -80,9 +74,6 @@ void RemoteRenderPassEncoderProxy::setVertexBuffer(WebCore::WebGPU::Index32 slot
     }
 
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(*buffer);
-    ASSERT(convertedBuffer);
-    if (!convertedBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetVertexBuffer(slot, convertedBuffer, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -107,9 +98,6 @@ void RemoteRenderPassEncoderProxy::drawIndexed(WebCore::WebGPU::Size32 indexCoun
 void RemoteRenderPassEncoderProxy::drawIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
-    if (!convertedIndirectBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::DrawIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -118,9 +106,6 @@ void RemoteRenderPassEncoderProxy::drawIndirect(const WebCore::WebGPU::Buffer& i
 void RemoteRenderPassEncoderProxy::drawIndexedIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
     auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
-    ASSERT(convertedIndirectBuffer);
-    if (!convertedIndirectBuffer)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::DrawIndexedIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -130,9 +115,6 @@ void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, 
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
-    ASSERT(convertedBindGroup);
-    if (!convertedBindGroup)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, dynamicOffsets));
     UNUSED_VARIABLE(sendResult);
@@ -145,9 +127,6 @@ void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, 
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
     auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
-    ASSERT(convertedBindGroup);
-    if (!convertedBindGroup)
-        return;
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);
@@ -218,11 +197,7 @@ void RemoteRenderPassEncoderProxy::endOcclusionQuery()
 void RemoteRenderPassEncoderProxy::executeBundles(Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>>&& renderBundles)
 {
     auto convertedRenderBundles = WTF::compactMap(renderBundles, [&](auto& renderBundle) -> std::optional<WebGPUIdentifier> {
-        auto convertedRenderBundle = m_convertToBackingContext->convertToBacking(renderBundle);
-        ASSERT(convertedRenderBundle);
-        if (!convertedRenderBundle)
-            return std::nullopt;
-        return convertedRenderBundle;
+        return m_convertToBackingContext->convertToBacking(renderBundle);
     });
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::ExecuteBundles(WTFMove(convertedRenderBundles)));

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 enum class RemoteVideoFrameIdentifierType { };
-using RemoteVideoFrameIdentifier = LegacyNullableAtomicObjectIdentifier<RemoteVideoFrameIdentifierType>;
+using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>;
 using RemoteVideoFrameReadReference = IPC::ObjectIdentifierReadReference<RemoteVideoFrameIdentifier>;
 using RemoteVideoFrameWriteReference = IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;
 using RemoteVideoFrameReference = IPC::ObjectIdentifierReference<RemoteVideoFrameIdentifier>;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -343,9 +343,8 @@ void LibWebRTCCodecs::createDecoderAndWaitUntilReady(WebCore::VideoCodecType typ
 
 LibWebRTCCodecs::Decoder* LibWebRTCCodecs::createDecoderInternal(WebCore::VideoCodecType type, const String& codec, Function<void(Decoder*)>&& callback)
 {
-    auto decoder = makeUnique<Decoder>();
+    auto decoder = makeUnique<Decoder>(VideoDecoderIdentifier::generate());
     auto* result = decoder.get();
-    decoder->identifier = VideoDecoderIdentifier::generate();
     decoder->type = type;
     decoder->codec = codec.isolatedCopy();
 
@@ -594,9 +593,8 @@ static void createRemoteEncoder(LibWebRTCCodecs::Encoder& encoder, IPC::Connecti
 
 LibWebRTCCodecs::Encoder* LibWebRTCCodecs::createEncoderInternal(WebCore::VideoCodecType type, const String& codec, const std::map<std::string, std::string>& formatParameters, bool isRealtime, bool useAnnexB, VideoEncoderScalabilityMode scalabilityMode, Function<void(Encoder*)>&& callback)
 {
-    auto encoder = makeUnique<Encoder>();
+    auto encoder = makeUnique<Encoder>(VideoEncoderIdentifier::generate());
     auto* result = encoder.get();
-    encoder->identifier = VideoEncoderIdentifier::generate();
     encoder->type = type;
     encoder->useAnnexB = useAnnexB;
     encoder->isRealtime = isRealtime;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -94,6 +94,10 @@ public:
             FramePromise::AutoRejectProducer producer;
         };
 
+        explicit Decoder(VideoDecoderIdentifier identifier)
+            : identifier(identifier)
+        { }
+
         VideoDecoderIdentifier identifier;
         WebCore::VideoCodecType type;
         String codec;
@@ -131,6 +135,10 @@ public:
     struct Encoder {
         WTF_MAKE_TZONE_ALLOCATED(Encoder);
     public:
+        explicit Encoder(VideoEncoderIdentifier identifier)
+            : identifier(identifier)
+        { }
+
         VideoEncoderIdentifier identifier;
         WebCore::VideoCodecType type;
         String codec;

--- a/Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class VideoDecoderIdentifierType { };
-using VideoDecoderIdentifier = LegacyNullableAtomicObjectIdentifier<VideoDecoderIdentifierType>;
+using VideoDecoderIdentifier = AtomicObjectIdentifier<VideoDecoderIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class VideoEncoderIdentifierType { };
-using VideoEncoderIdentifier = LegacyNullableAtomicObjectIdentifier<VideoEncoderIdentifierType>;
+using VideoEncoderIdentifier = AtomicObjectIdentifier<VideoEncoderIdentifierType>;
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 namespace {
 
 enum class TestedObjectIdentifierType { };
-using TestedObjectIdentifier = LegacyNullableAtomicObjectIdentifier<TestedObjectIdentifierType>;
+using TestedObjectIdentifier = AtomicObjectIdentifier<TestedObjectIdentifierType>;
 using TestedObjectReadReference = IPC::ObjectIdentifierReadReference<TestedObjectIdentifier>;
 using TestedObjectWriteReference = IPC::ObjectIdentifierWriteReference<TestedObjectIdentifier>;
 using TestedObjectReference = IPC::ObjectIdentifierReference<TestedObjectIdentifier>;


### PR DESCRIPTION
#### bf27fd5f662754deb3d5d957324975979c1bfb5a
<pre>
Further reduce use of LegacyNullableAtomicObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=280497">https://bugs.webkit.org/show_bug.cgi?id=280497</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h:
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseConnectionIdentifier.h:
* Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUBindGroupEntry.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h:
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.h:
* Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/wc/WCContentBufferIdentifier.h:
* Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h:
* Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::copyBufferToBuffer):
(WebKit::WebGPU::RemoteCommandEncoderProxy::clearBuffer):
(WebKit::WebGPU::RemoteCommandEncoderProxy::writeTimestamp):
(WebKit::WebGPU::RemoteCommandEncoderProxy::resolveQuerySet):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteComputePassEncoderProxy::setPipeline):
(WebKit::WebGPU::RemoteComputePassEncoderProxy::dispatchIndirect):
(WebKit::WebGPU::RemoteComputePassEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::submit):
(WebKit::WebGPU::RemoteQueueProxy::writeBuffer):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setPipeline):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setIndexBuffer):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setVertexBuffer):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::drawIndirect):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::drawIndexedIndirect):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setPipeline):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setIndexBuffer):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setVertexBuffer):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::drawIndirect):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::drawIndexedIndirect):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setBindGroup):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::executeBundles):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::createDecoderInternal):
(WebKit::LibWebRTCCodecs::createEncoderInternal):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::Decoder::Decoder):
(WebKit::LibWebRTCCodecs::Encoder::Encoder):
* Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h:
* Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp:

Canonical link: <a href="https://commits.webkit.org/284397@main">https://commits.webkit.org/284397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ffbe59d545a0868dd0869f0e574b4896cc920a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21893 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73303 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20228 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/73303 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13530 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59763 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/73303 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16766 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62640 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4258 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44425 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->