### PR TITLE
Make WebContent suspension delay configurable

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -449,6 +449,13 @@ public:
 
 #endif // PLATFORM(VISION)
 
+#if PLATFORM(MAC)
+    static constexpr Seconds defaultWebProcessSuspensionDelay { 8_min };
+
+    Seconds webProcessSuspensionDelay() const { return m_data.webProcessSuspensionDelay; }
+    void setWebProcessSuspensionDelay(Seconds delay) { m_data.webProcessSuspensionDelay = delay; }
+#endif
+
 private:
     struct Data {
         template<typename T, Ref<T>(*initializer)()> class LazyInitializedRef {
@@ -635,6 +642,10 @@ private:
 #endif
 
         WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
+
+#if PLATFORM(MAC)
+        Seconds webProcessSuspensionDelay { defaultWebProcessSuspensionDelay };
+#endif
     };
 
     // All data members should be added to the Data structure to avoid breaking PageConfiguration::copy().

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1541,6 +1541,20 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 #endif // PLATFORM(VISION)
 
+#if PLATFORM(MAC)
+
+- (NSTimeInterval)_webProcessSuspensionDelay
+{
+    return _pageConfiguration->webProcessSuspensionDelay().seconds();
+}
+
+- (void)_setWebProcessSuspensionDelay:(NSTimeInterval)delay
+{
+    _pageConfiguration->setWebProcessSuspensionDelay(Seconds(delay));
+}
+
+#endif
+
 @end
 
 @implementation WKWebViewConfiguration (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -181,6 +181,10 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setOverlayRegionsEnabled:) BOOL _overlayRegionsEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 #endif
 
+#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+@property (nonatomic, setter=_setWebProcessSuspensionDelay:) NSTimeInterval _webProcessSuspensionDelay;
+#endif
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -26,16 +26,26 @@
 #include "config.h"
 #include "WebProcessActivityState.h"
 
+#include "APIPageConfiguration.h"
 #include "RemotePageProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 
 namespace WebKit {
 
+#if PLATFORM(MAC)
+static Seconds webProcessSuspensionDelay(WebPageProxy* page)
+{
+    if (!page)
+        return API::PageConfiguration::defaultWebProcessSuspensionDelay;
+    return page->configuration().webProcessSuspensionDelay();
+}
+#endif
+
 WebProcessActivityState::WebProcessActivityState(WebPageProxy& page)
     : m_page(page)
 #if PLATFORM(MAC)
-    , m_wasRecentlyVisibleActivity(makeUniqueRef<ProcessThrottlerTimedActivity>(8_min))
+    , m_wasRecentlyVisibleActivity(makeUniqueRef<ProcessThrottlerTimedActivity>(webProcessSuspensionDelay(&page)))
 #endif
 {
 }
@@ -43,7 +53,7 @@ WebProcessActivityState::WebProcessActivityState(WebPageProxy& page)
 WebProcessActivityState::WebProcessActivityState(RemotePageProxy& page)
     : m_page(page)
 #if PLATFORM(MAC)
-    , m_wasRecentlyVisibleActivity(makeUniqueRef<ProcessThrottlerTimedActivity>(8_min))
+    , m_wasRecentlyVisibleActivity(makeUniqueRef<ProcessThrottlerTimedActivity>(webProcessSuspensionDelay(page.protectedPage().get())))
 #endif
 {
 }


### PR DESCRIPTION
#### 64d06ccddaceb4a942dd422e82a190190a76bca3
<pre>
Make WebContent suspension delay configurable
<a href="https://bugs.webkit.org/show_bug.cgi?id=280499">https://bugs.webkit.org/show_bug.cgi?id=280499</a>
<a href="https://rdar.apple.com/136803502">rdar://136803502</a>

Reviewed by Chris Dumez.

We should allow the embedder to customize the suspension delay for WebContent. I&apos;ve been using this
to set a much shorter delay to help flush out issues with spurious wakeups of suspended processes.

Originally I tried doing this via UnifiedWebPreferences, but that doesn&apos;t really buy us a whole lot
since a preference with a float or int type doesn&apos;t seem to participate in a lot of the useful
auto-generated _WKInternalDebugFeature lists that the browser consumes. So I just put the value in
PageConfiguration instead.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::webProcessSuspensionDelay const):
(API::PageConfiguration::setWebProcessSuspensionDelay):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _webProcessSuspensionDelay]):
(-[WKWebViewConfiguration _setWebProcessSuspensionDelay:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::webProcessSuspensionDelay):
(WebKit::WebProcessActivityState::WebProcessActivityState):

Canonical link: <a href="https://commits.webkit.org/284357@main">https://commits.webkit.org/284357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e071488c71b8247c3ff39741851d9d27ee20a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20276 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13455 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40952 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74910 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62660 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62559 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4170 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44322 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->