### PR TITLE
Sync IPC message cancellation is not consistent

### DIFF
--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -28,6 +28,7 @@
 #include "Attachment.h"
 #include "MessageNames.h"
 #include "ReceiverMatcher.h"
+#include "SyncRequestID.h"
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
@@ -88,15 +89,13 @@ public:
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
     uint64_t destinationID() const { return m_destinationID; }
+    SyncRequestID syncRequestID() const { ASSERT(m_syncRequestID); return *m_syncRequestID; }
     bool matches(const ReceiverMatcher& matcher) const { return matcher.matches(messageReceiverName(), destinationID()); }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
     ShouldDispatchWhenWaitingForSyncReply shouldDispatchMessageWhenWaitingForSyncReply() const;
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || m_isAllowedWhenWaitingForSyncReplyOverride; }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
-#if ENABLE(IPC_TESTING_API)
-    bool hasSyncMessageDeserializationFailure() const;
-#endif
     bool shouldUseFullySynchronousModeForTesting() const;
     bool shouldMaintainOrderingWithAsyncMessages() const;
     void setIsAllowedWhenWaitingForSyncReplyOverride(bool value) { m_isAllowedWhenWaitingForSyncReplyOverride = value; }
@@ -188,6 +187,7 @@ private:
 #endif
 
     uint64_t m_destinationID;
+    Markable<SyncRequestID> m_syncRequestID;
 
     int32_t m_indexOfObjectFailingDecoding { -1 };
 };

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -111,13 +111,6 @@ void Encoder::setFullySynchronousModeForTesting()
     messageFlags().add(MessageFlags::UseFullySynchronousModeForTesting);
 }
 
-#if ENABLE(IPC_TESTING_API)
-void Encoder::setSyncMessageDeserializationFailure()
-{
-    messageFlags().add(MessageFlags::SyncMessageDeserializationFailure);
-}
-#endif
-
 void Encoder::setShouldMaintainOrderingWithAsyncMessages()
 {
     messageFlags().add(MessageFlags::MaintainOrderingWithAsyncMessages);

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -66,9 +66,6 @@ public:
     void setShouldMaintainOrderingWithAsyncMessages();
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || isFullySynchronousModeForTesting(); }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
-#if ENABLE(IPC_TESTING_API)
-    void setSyncMessageDeserializationFailure();
-#endif
 
     void wrapForTesting(UniqueRef<Encoder>&&);
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -102,7 +102,6 @@ public:
 #if ENABLE(IPC_TESTING_API)
     void setIgnoreInvalidMessageForTesting() { m_connection->setIgnoreInvalidMessageForTesting(); }
     bool ignoreInvalidMessageForTesting() const { return m_connection->ignoreInvalidMessageForTesting(); }
-    void sendDeserializationErrorSyncReply(Connection::SyncRequestID);
 #endif
 
     template<typename T, typename... Arguments>
@@ -122,9 +121,10 @@ private:
     void didClose(Connection&) final;
     void didReceiveInvalidMessage(Connection&, MessageName, int32_t indexOfObjectFailingDecoding) final;
 
-    bool processSetStreamDestinationID(Decoder&&, RefPtr<StreamMessageReceiver>& currentReceiver);
-    bool dispatchStreamMessage(Decoder&&, StreamMessageReceiver&);
-    bool dispatchOutOfStreamMessage(Decoder&&);
+    bool processSetStreamDestinationID(Decoder&, RefPtr<StreamMessageReceiver>& currentReceiver);
+    bool processStreamMessage(Decoder&, StreamMessageReceiver&);
+    bool processOutOfStreamMessage(Decoder&);
+    bool dispatchStreamMessage(Decoder&, StreamMessageReceiver&);
 
     RefPtr<StreamConnectionWorkQueue> protectedWorkQueue() const;
 
@@ -136,7 +136,7 @@ private:
     Lock m_outOfStreamMessagesLock;
     Deque<UniqueRef<Decoder>> m_outOfStreamMessages WTF_GUARDED_BY_LOCK(m_outOfStreamMessagesLock);
 
-    bool m_isDispatchingStreamMessage { false };
+    bool m_isProcessingStreamMessage { false };
     std::unique_ptr<IPC::Encoder> m_syncReplyToDispatch;
     Lock m_receiversLock;
     using ReceiversMap = HashMap<std::pair<uint8_t, uint64_t>, Ref<StreamMessageReceiver>>;
@@ -157,7 +157,7 @@ template<typename T, typename... Arguments>
 void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequestID, Arguments&&... arguments)
 {
     if constexpr(T::isReplyStreamEncodable) {
-        if (m_isDispatchingStreamMessage) {
+        if (m_isProcessingStreamMessage) {
             auto span = m_buffer.acquireAll();
             {
                 StreamConnectionEncoder messageEncoder { MessageName::SyncMessageReply, span.data(), span.size() };
@@ -169,7 +169,7 @@ void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequest
     }
     auto encoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());
     (encoder.get() << ... << std::forward<Arguments>(arguments));
-    if (m_isDispatchingStreamMessage) {
+    if (m_isProcessingStreamMessage) {
         // Send sync reply only after releasing the buffer. Otherwise client might receive the message before server
         // releases the buffer. Client would the send a new message, and release would happen only after.
         m_syncReplyToDispatch = encoder.moveToUniquePtr();

--- a/Source/WebKit/Platform/IPC/SyncRequestID.h
+++ b/Source/WebKit/Platform/IPC/SyncRequestID.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace IPC {
+
+enum class SyncRequestIDType { };
+using SyncRequestID = AtomicObjectIdentifier<SyncRequestIDType>;
+
+}

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -83,6 +83,7 @@ class Parameter(object):
 ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, receiver_enabled_by_conjunction=None, shared_preferences_needs_connection=False, messages=[
     Message('WrappedAsyncMessageForTesting', [], [], attributes=[BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE], condition=None),
     Message('SyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('CancelSyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('InitializeConnection', [], [], attributes=[BUILTIN_ATTRIBUTE], condition="PLATFORM(COCOA)"),
     Message('LegacySessionState', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('SetStreamDestinationID', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -142,6 +142,7 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithoutUsingIPCConnection_MessageWithoutArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
     { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
     { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "CancelSyncMessageReply"_s, ReceiverName::IPC, false, false },
 #if PLATFORM(COCOA)
     { "InitializeConnection"_s, ReceiverName::IPC, false, false },
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -172,6 +172,7 @@ enum class MessageName : uint16_t {
     TestWithoutUsingIPCConnection_MessageWithoutArgument,
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply,
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument,
+    CancelSyncMessageReply,
 #if PLATFORM(COCOA)
     InitializeConnection,
 #endif

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -109,6 +109,11 @@ void IPCStreamTester::syncMessageNotStreamEncodableReply(uint32_t value, Complet
     completionHandler(value);
 }
 
+void IPCStreamTester::syncMessageNotStreamEncodableBoth(uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
+{
+    completionHandler(value);
+}
+
 void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int32_t)>&& completionHandler)
 {
     if (!value) {

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -61,6 +61,7 @@ private:
     // Messages.
     void syncMessage(uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncMessageNotStreamEncodableReply(uint32_t value, CompletionHandler<void(uint32_t)>&&);
+    void syncMessageNotStreamEncodableBoth(uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(std::optional<WebCore::SharedMemory::Handle>&&)>&&);
     void syncMessageEmptyReply(uint32_t, CompletionHandler<void()>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -25,6 +25,7 @@
 messages -> IPCStreamTester NotRefCounted Stream {
     SyncMessage(uint32_t value) -> (uint32_t sameValue) Synchronous
     SyncMessageNotStreamEncodableReply(uint32_t value) -> (uint32_t sameValue) Synchronous NotStreamEncodableReply
+    SyncMessageNotStreamEncodableBoth(uint32_t value) -> (uint32_t sameValue) Synchronous NotStreamEncodable NotStreamEncodableReply
     SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (std::optional<WebCore::SharedMemory::Handle> handle) Synchronous NotStreamEncodableReply
     SyncMessageEmptyReply(uint32_t value) -> () Synchronous
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -168,7 +168,7 @@ template: struct WebKit::WebExtensionWindowIdentifierType
 header: <wtf/ObjectIdentifier.h>
 template: class WebCore::ResourceLoader
 template: class WebCore::WebSocketChannel
-template: enum class IPC::ConnectionSyncRequestIDType
+template: enum class IPC::SyncRequestIDType
 template: enum class JSC::MicrotaskIdentifierType
 template: enum class TestWebKitAPI::TestedObjectIdentifierType
 template: enum class WebCore::DOMCacheIdentifierType

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1228,13 +1228,8 @@ bool WebProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Deco
     if (protectedProcessPool()->dispatchSyncMessage(connection, decoder, replyEncoder))
         return true;
     // WebProcessProxy will receive messages to instances that were removed from
-    // the message receiver map. Filter these out by sending the cancel reply.
-#if ENABLE(IPC_TESTING_API)
-    if (!decoder.isValid())
-        replyEncoder->setSyncMessageDeserializationFailure();
-#endif
-    connection.sendSyncReply(WTFMove(replyEncoder));
-
+    // the message receiver map. Mark all messages as handled. Unreplied messages
+    // will be cancelled by the caller.
     return true;
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6526,6 +6526,7 @@
 		7B22007029B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp; sourceTree = "<group>"; };
 		7B22007129B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.h; sourceTree = "<group>"; };
 		7B2DDD5E27CCD9710060ABAB /* IPCStreamTesterProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTesterProxy.h; sourceTree = "<group>"; };
+		7B2E73472CA2C611002C1A84 /* SyncRequestID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyncRequestID.h; sourceTree = "<group>"; };
 		7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueueMap.h; sourceTree = "<group>"; };
 		7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueue.h; sourceTree = "<group>"; };
 		7B483F1D25CDDA9B00120486 /* MessageReceiveQueueMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageReceiveQueueMap.cpp; sourceTree = "<group>"; };
@@ -9769,6 +9770,7 @@
 				7B73123725CC8524003B2796 /* StreamServerConnection.cpp */,
 				7B73123825CC8524003B2796 /* StreamServerConnection.h */,
 				7BE5134A29768F0E00814F18 /* StreamServerConnectionBuffer.h */,
+				7B2E73472CA2C611002C1A84 /* SyncRequestID.h */,
 				7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */,
 				F48570A22644BEC400C05F71 /* Timeout.h */,
 				7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */,

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2422,8 +2422,8 @@ static JSC::JSObject* jsResultFromReplyDecoder(JSC::JSGlobalObject* globalObject
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (decoder.hasSyncMessageDeserializationFailure()) {
-        throwException(globalObject, scope, JSC::createTypeError(globalObject, "Failed to successfully deserialize the message"_s));
+    if (decoder.messageName() == IPC::MessageName::CancelSyncMessageReply) {
+        throwException(globalObject, scope, JSC::createTypeError(globalObject, "Receiver cancelled the reply due to invalid destination or deserialization error"_s));
         return nullptr;
     }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -107,6 +107,29 @@ private:
     std::tuple<uint32_t> m_arguments;
 };
 
+#if ENABLE(IPC_TESTING_API)
+class MockSyncMessageNotStreamEncodableBoth {
+public:
+    using Arguments = std::tuple<uint32_t>;
+    static IPC::MessageName name() { return IPC::MessageName::IPCStreamTester_SyncMessageNotStreamEncodableBoth; }
+    static constexpr bool isSync = true;
+    static constexpr bool isStreamEncodable = false;
+    static constexpr bool isReplyStreamEncodable = false;
+    using ReplyArguments = std::tuple<uint32_t>;
+    using Reply = CompletionHandler<void(uint32_t)>;
+    explicit MockSyncMessageNotStreamEncodableBoth(uint32_t value)
+        : m_arguments(value)
+    {
+    }
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+private:
+    std::tuple<uint32_t> m_arguments;
+};
+#endif
+
 class MockSyncMessageNotStreamEncodableReply {
 public:
     using Arguments = std::tuple<uint32_t>;
@@ -205,7 +228,9 @@ public:
         if (decoder.isSyncMessage()) {
             if (m_syncMessageHandler && m_syncMessageHandler(connection, decoder))
                 return;
-        } else if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
+            return;
+        }
+        if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
             return;
         addMessage(decoder);
     }
@@ -516,9 +541,8 @@ TEST_P(StreamMessageTest, SendSyncMessage)
     const uint32_t messageCount = 2004u;
     auto cleanup = localReferenceBarrier();
     m_mockServerReceiver->setSyncMessageHandler([](IPC::StreamServerConnection& connection, IPC::Decoder& decoder) {
-        auto listenerID = decoder.decode<IPC::Connection::SyncRequestID>();
         auto value = decoder.decode<uint32_t>();
-        connection.sendSyncReply<MockSyncMessage>(*listenerID, *value);
+        connection.sendSyncReply<MockSyncMessage>(decoder.syncRequestID(), *value);
         return true;
     });
     for (uint32_t i = 0u; i < messageCount; ++i) {
@@ -537,9 +561,8 @@ TEST_P(StreamMessageTest, SendSyncMessageNotStreamEncodableReply)
     const uint32_t messageCount = 2004u;
     auto cleanup = localReferenceBarrier();
     m_mockServerReceiver->setSyncMessageHandler([](IPC::StreamServerConnection& connection, IPC::Decoder& decoder) {
-        auto listenerID = decoder.decode<IPC::Connection::SyncRequestID>();
         auto value = decoder.decode<uint32_t>();
-        connection.sendSyncReply<MockSyncMessageNotStreamEncodableReply>(*listenerID, *value);
+        connection.sendSyncReply<MockSyncMessageNotStreamEncodableReply>(decoder.syncRequestID(), *value);
         return true;
     });
     for (uint32_t i = 0u; i < messageCount; ++i) {
@@ -552,6 +575,46 @@ TEST_P(StreamMessageTest, SendSyncMessageNotStreamEncodableReply)
     }
     m_clientConnection->invalidate();
 }
+
+#if ENABLE(IPC_TESTING_API)
+// Tests the case where we send a sync reply cancel message for a decoding failure. This is
+// for the purposes of JS IPC Testing API to detect when a sync message was not handled.
+TEST_P(StreamMessageTest, SyncMessageDecodeFailureCancelled)
+{
+    const uint32_t messageCount = 20u;
+    auto cleanup = localReferenceBarrier();
+    serverQueue().dispatch([&] {
+        assertIsCurrent(serverQueue());
+        m_serverConnection->setIgnoreInvalidMessageForTesting();
+    });
+    m_mockServerReceiver->setSyncMessageHandler([](IPC::StreamServerConnection& connection, IPC::Decoder& decoder) -> bool {
+        auto value = decoder.decode<uint32_t>();
+        ASSERT(value);
+        if (*value % 2) {
+            connection.sendSyncReply<MockSyncMessageNotStreamEncodableBoth>(decoder.syncRequestID(), *value);
+            return true;
+        }
+        // Cause decode error.
+        EXPECT_FALSE(decoder.decode<uint64_t>());
+        return false;
+    });
+
+    for (uint32_t i = 0u; i < messageCount; ++i) {
+        auto result = m_clientConnection->sendSync(MockSyncMessageNotStreamEncodableBoth { i }, defaultDestinationID());
+        if  (i % 2) {
+            EXPECT_TRUE(result.succeeded());
+            if (result.succeeded()) {
+                auto [sameValue] = result.reply();
+                EXPECT_EQ(i, sameValue);
+            }
+        } else {
+            EXPECT_FALSE(result.succeeded());
+            EXPECT_EQ(IPC::Error::SyncMessageCancelled, result.error());
+        }
+    }
+    m_clientConnection->invalidate();
+}
+#endif
 
 INSTANTIATE_TEST_SUITE_P(StreamConnectionSizedBuffer,
     StreamMessageTest,


### PR DESCRIPTION
#### e06af74daaf6e21925cd1b73a6cf844e8623ff92
<pre>
Sync IPC message cancellation is not consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=280271">https://bugs.webkit.org/show_bug.cgi?id=280271</a>
<a href="https://rdar.apple.com/136584036">rdar://136584036</a>

Reviewed by Matt Woodrow.

IPC::Connection has a feature where unhandled sync messages are intended
to be be cancelled. This is so that the caller does not hang
indefinitively. The cancel was sync message reply with no parameters.
This would lead to inconsistent behavior: accepted reply if the reply
does not have parameters, decode error if the reply has parameters.

Fix by following steps:

Introduce a new message, CancelSyncMessageReply, to signify that the
message was cancelled.

Replaces SyncMessageDeserializationFailure with sending the
CancelSyncMessageReply. This is used in IPC JS testing API to be able
to send multiple arbitrary incorrect messages, while avoiding timeouts.

The same structure will be used for future to implement the same cancel
feature for asynchronous messages.

This is work towards fixing leaks of asynchronous message handlers,
thread-safe sendSync/waitForAsyncReplyAndDispatchImmediately and
unification of sync/async message receive implementations.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::dispatchSyncMessage):
(IPC::errorAsString):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::hasSyncMessageDeserializationFailure const): Deleted.
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::syncRequestID const):
(IPC::Decoder::isAllowedWhenWaitingForUnboundedSyncReply const):
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::setSyncMessageDeserializationFailure): Deleted.
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::didClose):
(IPC::StreamServerConnection::dispatchStreamMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
(IPC::StreamServerConnection::processStreamMessage):
(IPC::StreamServerConnection::processOutOfStreamMessage):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::protectedWorkQueue const):
(IPC::StreamServerConnection::dispatchOutOfStreamMessage): Deleted.
(IPC::StreamServerConnection::sendDeserializationErrorSyncReply): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendSyncReply):
* Source/WebKit/Platform/IPC/SyncRequestID.h: Added.
* Source/WebKit/Scripts/webkit/model.py:
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncMessageNotStreamEncodableBoth):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::dispatchSyncMessage):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::jsResultFromReplyDecoder):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::MockTestSyncMessage::name):
(TestWebKitAPI::MockTestSyncMessageWithDataReply::name):
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/284553@main">https://commits.webkit.org/284553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eaadbe95998ce458a6f4e23692e83d9165c77a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22570 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20826 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13904 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60213 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69326 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19352 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75616 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17237 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63053 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11058 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4672 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45021 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->