### PR TITLE
[css-anchor-position-1] Declaration referencing invalid anchor should be invalid at computed-value time

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt
@@ -19,8 +19,8 @@ PASS Invalid anchor function,  cross-axis query (horizontal)
 PASS Invalid anchor function, anchor-size() in inset
 PASS Invalid anchor function, anchor() in sizing property
 PASS Invalid anchor function, nested left
-FAIL Invalid anchor function, nested right assert_equals: left expected "0px" but got "188.4375px"
-FAIL Invalid anchor function, nested bottom assert_equals: top expected "0px" but got "182px"
+PASS Invalid anchor function, nested right
+PASS Invalid anchor function, nested bottom
 PASS Invalid anchor function, nested top
 PASS Invalid anchor function, nested min-width
 PASS Invalid anchor function, nested min-height

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, const Style::BuilderState& builderState)
+CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, Style::BuilderState& builderState)
     : m_style(&style)
     , m_rootStyle(builderState.rootElementStyle())
     , m_parentStyle(&builderState.parentStyle())

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -50,7 +50,7 @@ class BuilderState;
 class CSSToLengthConversionData {
 public:
     // This is used during style building. The 'zoom' property is taken into account.
-    CSSToLengthConversionData(const RenderStyle&, const Style::BuilderState&);
+    CSSToLengthConversionData(const RenderStyle&, Style::BuilderState&);
     // This constructor ignores the `zoom` property.
     CSSToLengthConversionData(const RenderStyle&, const RenderStyle* rootStyle, const RenderStyle* parentStyle, const RenderView*, const Element* elementForContainerUnitResolution = nullptr);
 
@@ -99,7 +99,7 @@ public:
 
     void setUsesContainerUnits() const;
 
-    const Style::BuilderState* styleBuilderState() const { return m_styleBuilderState; }
+    Style::BuilderState* styleBuilderState() const { return m_styleBuilderState; }
 
 private:
     const RenderStyle* m_style { nullptr };
@@ -112,7 +112,7 @@ private:
     // FIXME: Remove this hack.
     RenderStyle* m_viewportDependencyDetectionStyle { nullptr };
 
-    const Style::BuilderState* m_styleBuilderState { nullptr };
+    Style::BuilderState* m_styleBuilderState { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -281,5 +281,15 @@ CSSPropertyID BuilderState::cssPropertyID() const
     return m_currentProperty ? m_currentProperty->id : CSSPropertyInvalid;
 }
 
+bool BuilderState::isCurrentPropertyInvalidAtComputedValueTime() const
+{
+    return m_invalidAtComputedValueTimeProperties.get(cssPropertyID());
+}
+
+void BuilderState::setCurrentPropertyInvalidAtComputedValueTime()
+{
+    m_invalidAtComputedValueTimeProperties.set(cssPropertyID());
+}
+
 }
 }

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -115,6 +115,9 @@ public:
 
     CSSPropertyID cssPropertyID() const;
 
+    bool isCurrentPropertyInvalidAtComputedValueTime() const;
+    void setCurrentPropertyInvalidAtComputedValueTime();
+
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.
     friend void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);
@@ -143,7 +146,7 @@ private:
     HashSet<AtomString> m_inProgressCustomProperties;
     HashSet<AtomString> m_inCycleCustomProperties;
     WTF::BitSet<numCSSProperties> m_inProgressProperties;
-    WTF::BitSet<numCSSProperties> m_inUnitCycleProperties;
+    WTF::BitSet<numCSSProperties> m_invalidAtComputedValueTimeProperties;
 
     const PropertyCascade::Property* m_currentProperty { nullptr };
     SelectorChecker::LinkMatchMask m_linkMatch { };


### PR DESCRIPTION
#### 62cb2d15cfc80d1029a7fee940fcfa07d89bf0e8
<pre>
[css-anchor-position-1] Declaration referencing invalid anchor should be invalid at computed-value time
<a href="https://bugs.webkit.org/show_bug.cgi?id=280507">https://bugs.webkit.org/show_bug.cgi?id=280507</a>
<a href="https://rdar.apple.com/problem/136822454">rdar://problem/136822454</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-anchor-position-1/#anchor-valid">https://drafts.csswg.org/css-anchor-position-1/#anchor-valid</a>

&quot;If any of these conditions are false, the anchor() function resolves to its specified fallback value.
If no fallback value is specified, it makes the declaration referencing it invalid at computed-value time.&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-invalid-fallback-expected.txt:
* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::CSSToLengthConversionData):
* Source/WebCore/css/CSSToLengthConversionData.h:
(WebCore::CSSToLengthConversionData::styleBuilderState const):

Make non-const. The anchor code may mutate the builder state.

* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):

Mark the property invalid at computed-value time if evaluation fails and there is no fallback.

* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):

Mark the property invalid at computed-value time if evaluation fails and there is no fallback.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):

See if the property has became invalid during applying and apply value &apos;unset&apos; if so.

(WebCore::Style::Builder::resolveVariableReferences):
(WebCore::Style::Builder::resolveCustomPropertyValue):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::isCurrentPropertyInvalidAtComputedValueTime const):
(WebCore::Style::BuilderState::setCurrentPropertyInvalidAtComputedValueTime):
* Source/WebCore/style/StyleBuilderState.h:

Rename m_inUnitCycleProperties -&gt; m_invalidAtComputedValueTimeProperties since it used in other
cases than unit cycles too.

Canonical link: <a href="https://commits.webkit.org/284362@main">https://commits.webkit.org/284362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3281622fbdcb291e571438df8b7327ce2fc0d45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20157 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13485 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40981 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16710 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62592 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4198 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44354 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45427 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46623 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->