### PR TITLE
[Canvas] Adopt smart pointers in ContextSwitcher classes

### DIFF
--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp
@@ -59,18 +59,18 @@ std::unique_ptr<CanvasFilterContextSwitcher> CanvasFilterContextSwitcher::create
 CanvasFilterContextSwitcher::CanvasFilterContextSwitcher(CanvasRenderingContext2DBase& context)
     : m_context(context)
 {
-    m_context.save();
-    m_context.realizeSaves();
+    context.save();
+    context.realizeSaves();
 }
 
 CanvasFilterContextSwitcher::~CanvasFilterContextSwitcher()
 {
-    m_context.restore();
+    protectedContext()->restore();
 }
 
 FloatRect CanvasFilterContextSwitcher::expandedBounds() const
 {
-    return m_context.state().targetSwitcher->expandedBounds();
+    return m_context->state().targetSwitcher->expandedBounds();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h
@@ -44,7 +44,8 @@ public:
     FloatRect expandedBounds() const;
 
 private:
-    CanvasRenderingContext2DBase& m_context;
+    Ref<CanvasRenderingContext2DBase> protectedContext() const { return m_context.get(); }
+    WeakRef<CanvasRenderingContext2DBase> m_context;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
@@ -48,13 +48,13 @@ RefPtr<CanvasLayerContextSwitcher> CanvasLayerContextSwitcher::create(CanvasRend
 
 CanvasLayerContextSwitcher::CanvasLayerContextSwitcher(CanvasRenderingContext2DBase& context, const FloatRect& bounds, std::unique_ptr<GraphicsContextSwitcher>&& targetSwitcher)
     : m_context(context)
-    , m_effectiveDrawingContext(m_context.effectiveDrawingContext())
+    , m_effectiveDrawingContext(context.effectiveDrawingContext())
     , m_bounds(bounds)
     , m_targetSwitcher(WTFMove(targetSwitcher))
 {
     ASSERT(m_targetSwitcher);
     ASSERT(m_effectiveDrawingContext);
-    m_targetSwitcher->beginDrawSourceImage(*m_effectiveDrawingContext, m_context.globalAlpha());
+    m_targetSwitcher->beginDrawSourceImage(*m_effectiveDrawingContext, context.globalAlpha());
 }
 
 CanvasLayerContextSwitcher::~CanvasLayerContextSwitcher()
@@ -71,7 +71,7 @@ GraphicsContext* CanvasLayerContextSwitcher::drawingContext() const
 
 FloatBoxExtent CanvasLayerContextSwitcher::outsets() const
 {
-    return m_context.calculateFilterOutsets(m_bounds);
+    return protectedContext()->calculateFilterOutsets(m_bounds);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.h
@@ -49,8 +49,9 @@ private:
     CanvasLayerContextSwitcher(CanvasRenderingContext2DBase&, const FloatRect& bounds, std::unique_ptr<GraphicsContextSwitcher>&&);
 
     FloatBoxExtent outsets() const;
+    Ref<CanvasRenderingContext2DBase> protectedContext() const { return m_context.get(); }
 
-    CanvasRenderingContext2DBase& m_context;
+    WeakRef<CanvasRenderingContext2DBase> m_context;
     GraphicsContext* m_effectiveDrawingContext;
     FloatRect m_bounds;
     std::unique_ptr<GraphicsContextSwitcher> m_targetSwitcher;


### PR DESCRIPTION
#### e054280ec9c0e15e50022ba4e8ad55e9c1f0e9d0
<pre>
[Canvas] Adopt smart pointers in ContextSwitcher classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=280510">https://bugs.webkit.org/show_bug.cgi?id=280510</a>

Reviewed by Chris Dumez.

Use a WeakRef instead of a raw reference for contexts,
preventing static analyzer warnings of uncounted class
members.

* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.cpp:
(WebCore::CanvasFilterContextSwitcher::CanvasFilterContextSwitcher):
(WebCore::CanvasFilterContextSwitcher::~CanvasFilterContextSwitcher):
(WebCore::CanvasFilterContextSwitcher::expandedBounds const):
* Source/WebCore/html/canvas/CanvasFilterContextSwitcher.h:
(WebCore::CanvasFilterContextSwitcher::protectedContext const):
* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp:
(WebCore::CanvasLayerContextSwitcher::CanvasLayerContextSwitcher):
(WebCore::CanvasLayerContextSwitcher::outsets const):
* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.h:
(WebCore::CanvasLayerContextSwitcher::protectedContext const):

Canonical link: <a href="https://commits.webkit.org/284408@main">https://commits.webkit.org/284408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8b2c02ca0d585a29cf12e9f09655ca017174e4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55058 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13510 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62618 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10624 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4230 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44390 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->