### PR TITLE
Run in cross-origin frame testharness.js test fixes broke some other test in cross-origin frames

### DIFF
--- a/LayoutTests/fast/dom/empty-hash-and-search.html
+++ b/LayoutTests/fast/dom/empty-hash-and-search.html
@@ -32,9 +32,6 @@ if (window.location.toString().charAt(window.location.toString().length - 1) != 
         window.location += "?#";
 
 } else { // Added "?#" and reloaded.
-    var link1 = document.getElementById("link1");
-    var link2 = document.getElementById("link2");
-    var out = document.getElementById("out");
     out.innerHTML = "<br>"
                   + "location.hash: " + location.hash + "<br>"
                   + "link1.hash: " + link1.hash + "<br>"

--- a/LayoutTests/resources/testharnessreport.js
+++ b/LayoutTests/resources/testharnessreport.js
@@ -61,7 +61,7 @@ if (self.testRunner) {
 
     // window.opener is a configurable property, so store it before we run anything.
     const orig_opener = window.opener;
-    const isRunInCrossOriginFrame = new URLSearchParams(window.location.search).has("runInCrossOriginFrame", "true");
+    const isRunInCrossOriginFrame = window.location.startsWith("http://127.0.0.1:8000/root/");
 
     /*  Using a callback function, test results will be added to the page in a
     *   manner that allows dumpAsText to produce readable test results

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -150,26 +150,14 @@ WKRetainPtr<WKMutableDictionaryRef> TestInvocation::createTestSettingsDictionary
     return beginTestMessageBody;
 }
 
-static String addQueryParameter(const String& urlString, ASCIILiteral parameter)
-{
-    auto index = urlString.find('?');
-    if (index != notFound)
-        return makeString(urlString.left(index + 1), parameter, '&', urlString.substring(index + 1));
-    index = urlString.find('#');
-    if (index == notFound)
-        index = urlString.length();
-    return makeString(urlString.left(index), '?', parameter, urlString.substring(index));
-}
-
 void TestInvocation::loadTestInCrossOriginIframe()
 {
     WKRetainPtr<WKURLRef> baseURL = adoptWK(WKURLCreateWithUTF8CString("http://localhost:8000"));
-    auto url = addQueryParameter(m_urlString, "runInCrossOriginFrame=true"_s);
     WKRetainPtr<WKStringRef> htmlString = toWK(makeString(
         "<script>"
         "    testRunner.dumpChildFramesAsText()"
         "</script>"
-        "<iframe src=\""_s, url.utf8().span(), "\" style=\"position:absolute; top:0; left:0; width:100%; height:100%; border:0\">"_s));
+        "<iframe src=\""_s, m_urlString.utf8().span(), "\" style=\"position:absolute; top:0; left:0; width:100%; height:100%; border:0\">"_s));
     WKPageLoadHTMLString(TestController::singleton().mainWebView()->page(), htmlString.get(), baseURL.get());
 }
 


### PR DESCRIPTION
#### 7373e13e778eae2494dda3f577d4cff60288453e
<pre>
Run in cross-origin frame testharness.js test fixes broke some other test in cross-origin frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=280516">https://bugs.webkit.org/show_bug.cgi?id=280516</a>
<a href="https://rdar.apple.com/136831018">rdar://136831018</a>

Reviewed by NOBODY (OOPS!).

Previous changes would add a url search query parameter to indicate
that the test is run in cross-origin frame mode. However, this parameter
would break tests that assumed the query be empty.
Change the detection to key on 127.1.1.1:8080/root. The root alias
was added to support runInCrossOriginFrame.

* LayoutTests/fast/dom/empty-hash-and-search.html:
Update a test that would timeout with search query. Fix the error path
to work without an exception.
* LayoutTests/resources/testharnessreport.js:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::loadTestInCrossOriginIframe):
(WTR::addQueryParameter): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7373e13e778eae2494dda3f577d4cff60288453e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20168 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55046 "Failure limit exceed. At least found 467 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html animations/animation-iteration-event-destroy-renderer.html animations/animation-order-overflow.html animations/animation-z-order-overflow.html animations/change-keyframes-name.html animations/play-state-paused.html compositing/video/video-update-rendering.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13494 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html animations/animation-order-overflow.html animations/animation-z-order-overflow.html animations/change-keyframes-name.html animations/play-state-paused.html css-dark-mode/color-scheme-css-parse.html css-dark-mode/color-scheme-css.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72227 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44328 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html animations/animation-iteration-event-destroy-renderer.html animations/animation-order-overflow.html animations/animation-z-order-overflow.html animations/change-keyframes-name.html animations/play-state-paused.html css-custom-properties-api/crash.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35525 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40996 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17142 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html compositing/video/video-update-rendering.html css3/calc/cross-fade-calc.html css3/calc/webkit-gradient-calc.html css3/color-filters/color-filter-parsing.html css3/filters/filter-property-computed-style.html css3/flexbox/auto-height-dynamic.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18693 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62940 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17487 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html animations/animation-iteration-event-destroy-renderer.html animations/animation-order-overflow.html compositing/video/video-update-rendering.html css-custom-properties-api/crash.html css-custom-properties-api/cycles.html css-custom-properties-api/inherits.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13143 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16720 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html animations/animation-iteration-event-destroy-renderer.html animations/animation-order-overflow.html animations/animation-z-order-overflow.html css-custom-properties-api/crash.html css-custom-properties-api/cycles.html css-custom-properties-api/inherits.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62754 "Failure limit exceed. At least found 462 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html animations/animation-iteration-event-destroy-renderer.html animations/animation-order-overflow.html animations/animation-z-order-overflow.html animations/change-keyframes-name.html animations/play-state-paused.html compositing/video/video-update-rendering.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62638 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10601 "Found 60 new test failures: http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html http/wpt/webxr/xrHand.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4212 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-fill-forwards-removal.html compositing/show-composited-iframe-on-back-button.html compositing/video/video-update-rendering.html css-custom-properties-api/crash.html css-custom-properties-api/cycles.html css-custom-properties-api/inherits.html css-dark-mode/color-scheme-css-parse.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44365 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->