### PR TITLE
[css-anchor-position-1] Use calc() based anchor() in all cases

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -376,7 +376,7 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<P
     serializeCalculationTree(builder, fn->to, state);
 }
 
-void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Anchor>& anchor, SerializationState&)
+void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Anchor>& anchor, SerializationState& state)
 {
     if (!anchor->elementName.isNull()) {
         serializeIdentifier(anchor->elementName, builder);
@@ -394,11 +394,13 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<A
     if (anchor->fallback) {
         builder.append(", "_s);
 
-        if (std::holds_alternative<IndirectNode<Sum>>(*anchor->fallback))
-            builder.append("calc"_s);
-
-        SerializationState state { };
-        serializeCalculationTree(builder, *anchor->fallback, state);
+        WTF::switchOn(*anchor->fallback,
+            [&](Leaf auto& op) {
+                serializeCalculationTree(builder, op, state);
+            }, [&](auto& op) {
+                serializeMathFunction(builder, op, state);
+            }
+        );
     }
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp
@@ -177,18 +177,6 @@ RefPtr<CSSPrimitiveValue> consumeLengthPercentage(CSSParserTokenRange& range, co
         .unitlessZero = unitlessZero
     };
 
-    // FIXME: 'anchor' should be handled and exposed as a calc() function type.
-    auto rangeCopy = range;
-    if (rangeCopy.peek().functionId() == CSSValueAnchor) {
-        if (options.anchorPolicy == AnchorPolicy::Allow) {
-            if (auto anchor = consumeAnchor(rangeCopy, context)) {
-                range = rangeCopy;
-                return anchor.releaseNonNull();
-            }
-        }
-        return nullptr;
-    }
-
     return CSSPrimitiveValueResolver<CSS::LengthPercentage>::consumeAndResolve(range, context, { }, { }, options);
 }
 
@@ -202,18 +190,6 @@ RefPtr<CSSPrimitiveValue> consumeLengthPercentage(CSSParserTokenRange& range, co
         .unitless = unitless,
         .unitlessZero = unitlessZero
     };
-
-    // FIXME: 'anchor' should be handled and exposed as a calc() function type.
-    auto rangeCopy = range;
-    if (rangeCopy.peek().functionId() == CSSValueAnchor) {
-        if (options.anchorPolicy == AnchorPolicy::Allow) {
-            if (auto anchor = consumeAnchor(rangeCopy, context)) {
-                range = rangeCopy;
-                return anchor.releaseNonNull();
-            }
-        }
-        return nullptr;
-    }
 
     return CSSPrimitiveValueResolver<CSS::LengthPercentage>::consumeAndResolve(range, context, { }, { }, options);
 }


### PR DESCRIPTION
#### b98b627a9d065a4742e1629037d7bb314aa636ac
<pre>
[css-anchor-position-1] Use calc() based anchor() in all cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=280514">https://bugs.webkit.org/show_bug.cgi?id=280514</a>
<a href="https://rdar.apple.com/136830360">rdar://136830360</a>

Reviewed by Darin Adler and Sam Weinig.

Also use calc machinery based anchor() for the (common) top level case.
Fix some remaining minor issues.

With this CSSAnchorValue and the related code can be removed.

* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeAnchor):

Bail out if the policy does not allow anchors.
Determine if percentHint is needed for the fallback.

* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::serializeMathFunctionArguments):

Ensure we add &quot;calc(&quot; prefix correctly when needed for the fallback serialization.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentage.cpp:
(WebCore::CSSPropertyParserHelpers::consumeLengthPercentage):

Don&apos;t call into CSSAnchorValue parsing code anymore.

Canonical link: <a href="https://commits.webkit.org/284384@main">https://commits.webkit.org/284384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5e34e0703c715f7a195d556ffeebd7de63bcf73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21862 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20197 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13513 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59736 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17166 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74982 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16746 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4234 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44394 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->