### PR TITLE
Use smart pointer for PlatformXRSystemProxy::m_page

### DIFF
--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -63,6 +63,8 @@ private:
     RefPtr<XRDeviceProxy> deviceByIdentifier(XRDeviceIdentifier);
     bool webXREnabled() const;
 
+    Ref<WebPage> protectedPage() const;
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
@@ -71,7 +73,7 @@ private:
     void sessionDidUpdateVisibilityState(XRDeviceIdentifier, PlatformXR::VisibilityState);
 
     PlatformXR::Instance::DeviceList m_devices;
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 };
 
 }


### PR DESCRIPTION
#### d35a8cafe93bf46077d9a0f50c8a162e0b293fe6
<pre>
Use smart pointer for PlatformXRSystemProxy::m_page
<a href="https://bugs.webkit.org/show_bug.cgi?id=280522">https://bugs.webkit.org/show_bug.cgi?id=280522</a>

Reviewed by Alex Christensen.

* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::PlatformXRSystemProxy):
(WebKit::PlatformXRSystemProxy::~PlatformXRSystemProxy):
(WebKit::PlatformXRSystemProxy::protectedPage const):
(WebKit::PlatformXRSystemProxy::enumerateImmersiveXRDevices):
(WebKit::PlatformXRSystemProxy::requestPermissionOnSessionFeatures):
(WebKit::PlatformXRSystemProxy::initializeTrackingAndRendering):
(WebKit::PlatformXRSystemProxy::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystemProxy::didCompleteShutdownTriggeredBySystem):
(WebKit::PlatformXRSystemProxy::requestFrame):
(WebKit::PlatformXRSystemProxy::submitFrame):
(WebKit::PlatformXRSystemProxy::webXREnabled const):
(WebKit::PlatformXRSystemProxy::ref const):
(WebKit::PlatformXRSystemProxy::deref const):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/284381@main">https://commits.webkit.org/284381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40bc28effb13d8b9f7630afca4dbd9806804da9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20183 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13502 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59718 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41002 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16732 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62613 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4217 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10571 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44380 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->