### PR TITLE
[WTF] HexNumberBuffer::span() should not ignore std::array size

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -238,6 +238,20 @@
 #define FALLTHROUGH
 #endif
 
+/* LIFETIME_BOUND */
+
+#if !defined(LIFETIME_BOUND) && defined(__cplusplus)
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::lifetimebound)
+#define LIFETIME_BOUND [[clang::lifetimebound]]
+#elif COMPILER_HAS_ATTRIBUTE(lifetimebound)
+#define LIFETIME_BOUND __attribute__((lifetimebound))
+#endif
+#endif
+
+#if !defined(LIFETIME_BOUND)
+#define LIFETIME_BOUND
+#endif
+
 /* LIKELY */
 
 #if !defined(LIKELY)

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -52,8 +52,7 @@ struct HexNumberBuffer {
     std::array<LChar, 16> buffer;
     unsigned length;
 
-    const LChar* characters() const { return &*(buffer.end() - length); }
-    std::span<const LChar> span() const { return { characters(), length }; }
+    std::span<const LChar> span() const LIFETIME_BOUND { return std::span { buffer }.last(length); }
 };
 
 template<typename NumberType> HexNumberBuffer hex(NumberType number, unsigned minimumDigits = 0, HexConversionMode mode = Uppercase)
@@ -83,8 +82,6 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_buffer.span()); }
 
 private:
-    const LChar* characters() const { return m_buffer.characters(); }
-
     const HexNumberBuffer& m_buffer;
 };
 

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -105,8 +105,9 @@ static void appendFormURLEncoded(Vector<uint8_t>& buffer, std::span<const uint8_
         else if (character != '\r') {
             append(buffer, '%');
             auto hexBuffer = hex(character, 2);
-            append(buffer, hexBuffer.characters()[0]);
-            append(buffer, hexBuffer.characters()[1]);
+            auto hexSpan = hexBuffer.span();
+            append(buffer, hexSpan[0]);
+            append(buffer, hexSpan[1]);
         }
     }
 }


### PR DESCRIPTION
#### 8b5404a28cd2be95475cb4e7faa1d3f451359c2a
<pre>
[WTF] HexNumberBuffer::span() should not ignore std::array size
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=280496">https://bugs.webkit.org/show_bug.cgi?id=280496</a>&gt;
&lt;<a href="https://rdar.apple.com/136802343">rdar://136802343</a>&gt;

Reviewed by Geoffrey Garen.

Fix construction of HexNumberBuffer::span() to convert std::array first,
then create a subspan from the last N characters.

Remove unsafe characters() methods and use span() instead.

Introduce LIFETIME_BOUND attribute to prevent use-after-free bugs with
C++ temporary objects.  (I accidentally introduced this bug in a local
version of this change before posting it.)

* Source/WTF/wtf/Compiler.h:
(LIFETIME_BOUND): Add.
- Add support for the lifetimebound attribute in clang and gcc.

* Source/WTF/wtf/HexNumber.h:
(WTF::HexNumberBuffer::characters const): Delete.
- Remove unsafe method.
(WTF::HexNumberBuffer::span const):
- Adopt LIFETIME_BOUND attribute for this method.
- Change to construct std::span directly from std::array, then use
  std::span::last() to create a span of the last N elements.
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::characters const): Delete.
- Remove unused method.

* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::appendFormURLEncoded):
- Switch to use HexNumberBuffer::span(), but keep hexBuffer alive on the
  stack.

Canonical link: <a href="https://commits.webkit.org/284396@main">https://commits.webkit.org/284396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9556a695d708a957f187927b50595175307102ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69183 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71300 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56384 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55060 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13508 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18715 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62299 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74975 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68429 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62713 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62617 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4228 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90210 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44387 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16001 "Found 94 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Basics/ArrayConcat.js.default, ChakraCore.yaml/ChakraCore/test/Boolean/property_and_index_of_boolean.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/sets.js.default, ChakraCore.yaml/ChakraCore/test/es6/proxytest6.js.default, ChakraCore.yaml/ChakraCore/test/es6/regex-quantifiers.js.default, ChakraCore.yaml/ChakraCore/test/es6/weakmap_basic.js.default, ChakraCore.yaml/ChakraCore/test/es6/weakset_basic.js.default, ChakraCore.yaml/ChakraCore/test/strict/14.var_sm.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->