### PR TITLE
Use smart pointer for StorageAreaMap::m_namespace

### DIFF
--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -106,8 +106,10 @@ private:
     void connectSync();
     void didConnect(std::optional<StorageAreaIdentifier>, HashMap<String, String>&&, uint64_t messageIdentifier);
 
+    Ref<StorageNamespaceImpl> protectedNamespace() const;
+
     uint64_t m_lastHandledMessageIdentifier { 0 };
-    StorageNamespaceImpl& m_namespace;
+    WeakRef<StorageNamespaceImpl> m_namespace;
     Ref<const WebCore::SecurityOrigin> m_securityOrigin;
     std::unique_ptr<WebCore::StorageMap> m_map;
     std::optional<StorageAreaIdentifier> m_remoteAreaIdentifier;

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
@@ -100,10 +100,4 @@ void StorageNamespaceImpl::setSessionIDForTesting(PAL::SessionID)
     ASSERT_NOT_REACHED();
 }
 
-PageIdentifier StorageNamespaceImpl::sessionStoragePageID() const
-{
-    ASSERT(m_storageType == StorageType::Session);
-    return *m_sessionPageID;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
@@ -33,15 +33,17 @@
 #include <WebCore/StorageArea.h>
 #include <WebCore/StorageMap.h>
 #include <WebCore/StorageNamespace.h>
+#include <WebCore/StorageType.h>
 #include <pal/SessionID.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class StorageAreaMap;
 class WebPage;
 
-class StorageNamespaceImpl final : public WebCore::StorageNamespace {
+class StorageNamespaceImpl final : public WebCore::StorageNamespace, public CanMakeWeakPtr<StorageNamespaceImpl> {
 public:
     using Identifier = StorageNamespaceIdentifier;
 
@@ -81,5 +83,11 @@ private:
 
     HashMap<WebCore::SecurityOriginData, Ref<StorageAreaMap>> m_storageAreaMaps;
 };
+
+inline WebCore::PageIdentifier StorageNamespaceImpl::sessionStoragePageID() const
+{
+    ASSERT(m_storageType == WebCore::StorageType::Session);
+    return *m_sessionPageID;
+}
 
 } // namespace WebKit


### PR DESCRIPTION
#### 5c4a5566950f3454d8ce450889059393886688dc
<pre>
Use smart pointer for StorageAreaMap::m_namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=280524">https://bugs.webkit.org/show_bug.cgi?id=280524</a>

Reviewed by Alex Christensen.

* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::dispatchSessionStorageEvent):
(WebKit::StorageAreaMap::computeStorageType const):
(WebKit::StorageAreaMap::clientOrigin const):
(WebKit::StorageAreaMap::sendConnectMessage):
(WebKit::StorageAreaMap::disconnect):
(WebKit::StorageAreaMap::decrementUseCount):
(WebKit::StorageAreaMap::protectedNamespace const):
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp:
(WebKit::StorageNamespaceImpl::sessionStoragePageID const): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h:
(WebKit::StorageNamespaceImpl::sessionStoragePageID const):

Canonical link: <a href="https://commits.webkit.org/284389@main">https://commits.webkit.org/284389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6459da7fd3a5a5dbab9d726f580f5a179b49646

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20342 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35536 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41011 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18716 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16741 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62615 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10621 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4221 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44388 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->