### PR TITLE
[Static Analyzer CI] Fix various bugs in the build summary

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -9283,7 +9283,7 @@ class TestDisplaySmartPointerResults(BuildStepMixinAdditions, unittest.TestCase)
                 "passes": {
                     "WebCore": {
                         "NoUncountedMemberChecker": ['File17.cpp'],
-                        "RefCntblBaseVirtualDtor": ['File123.cpp'],
+                        "RefCntblBaseVirtualDtor": ['File17.cpp'],
                         "UncountedCallArgsChecker": [],
                         "UncountedLocalVarsChecker": []
                     },
@@ -9297,7 +9297,7 @@ class TestDisplaySmartPointerResults(BuildStepMixinAdditions, unittest.TestCase)
                 "failures": {
                     "WebCore": {
                         "NoUncountedMemberChecker": ['File1.cpp'],
-                        "RefCntblBaseVirtualDtor": ['File2.cpp'],
+                        "RefCntblBaseVirtualDtor": [],
                         "UncountedCallArgsChecker": [],
                         "UncountedLocalVarsChecker": []
                     },
@@ -9318,32 +9318,32 @@ class TestDisplaySmartPointerResults(BuildStepMixinAdditions, unittest.TestCase)
 
         self.expectOutcome(result=SUCCESS, state_string='Ignored 10 pre-existing failures')
         rc = self.runStep()
-        self.assertEqual(self.getProperty('build_finish_summary'), 'Ignored 10 pre-existing failures')
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored 10 pre-existing failures')
 
     def test_success_only_fixes(self):
         self.configureStep()
-        self.setProperty('unexpected_passing_files', 2)
+        self.setProperty('unexpected_passing_files', 1)
 
-        self.expectOutcome(result=SUCCESS, state_string='Found 2 fixed files: File17.cpp, File123.cpp')
+        self.expectOutcome(result=SUCCESS, state_string='Found 1 fixed file: File17.cpp')
         rc = self.runStep()
-        self.assertEqual(self.getProperty('passes'), ['File17.cpp', 'File123.cpp'])
-        expected_comment = "Smart Pointer Build [#123](http://localhost:8080/#/builders/1/builds/13): Found 2 fixed files!\n"
+        self.assertEqual(self.getProperty('passes'), ['File17.cpp'])
+        expected_comment = "Smart Pointer Build [#123](http://localhost:8080/#/builders/1/builds/13): Found 1 fixed file!\n"
         expected_comment += "Please update expectations using `smart-pointer-tool --update-expectations` before landing."
         self.assertEqual(self.getProperty('comment_text'), expected_comment)
-        self.assertEqual(self.getProperty('build_finish_summary'), 'Found 2 fixed files: File17.cpp, File123.cpp')
+        self.assertEqual(self.getProperty('build_summary'), 'Found 1 fixed file: File17.cpp')
 
     def test_failure_new_failures(self):
         self.configureStep()
         self.setProperty('unexpected_new_issues', 10)
-        self.setProperty('unexpected_passing_files', 2)
-        self.setProperty('unexpected_failing_files', 2)
+        self.setProperty('unexpected_passing_files', 1)
+        self.setProperty('unexpected_failing_files', 1)
 
-        self.expectOutcome(result=FAILURE, state_string='Found 10 new failures in File1.cpp, File2.cpp and found 2 fixed files: File17.cpp, File123.cpp')
+        self.expectOutcome(result=FAILURE, state_string='Found 10 new failures in File1.cpp and found 1 fixed file: File17.cpp')
         rc = self.runStep()
         expected_comment = "Smart Pointer Build [#123](http://localhost:8080/#/builders/1/builds/13): Found [10 new failures](https://ews-build.s3-us-west-2.amazonaws.com/None/None-123/scan-build-output/new-results.html), blocking PR #17."
         expected_comment += "\nPlease address these issues before landing. See [WebKit Guidelines for Safer C++ Programming](https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines).\n(cc @rniwa)"
         self.assertEqual(self.getProperty('comment_text'), expected_comment)
-        self.assertEqual(self.getProperty('build_finish_summary'), 'Found 10 new failures in File1.cpp, File2.cpp')
+        self.assertEqual(self.getProperty('build_finish_summary'), 'Found 10 new failures in File1.cpp')
 
 
 class TestPrintClangVersion(BuildStepMixinAdditions, unittest.TestCase):


### PR DESCRIPTION
#### cec46c832d43e424e30f7d802ca92dd489373c9c
<pre>
[Static Analyzer CI] Fix various bugs in the build summary
<a href="https://bugs.webkit.org/show_bug.cgi?id=280527">https://bugs.webkit.org/show_bug.cgi?id=280527</a>
<a href="https://rdar.apple.com/136843493">rdar://136843493</a>

Reviewed by Aakash Jain.

1) Set property &apos;build_summary&apos; instead of &apos;build_finish_summary&apos; when step succeeds.
2) Add conditional &apos;pluralSuffix&apos; to summary string.
3) Turn list of files into a set to remove duplicates.

* Tools/CISupport/ews-build/steps.py:
(DisplaySmartPointerResults.getFilesPerProject):
(DisplaySmartPointerResults.getResultSummary):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/284388@main">https://commits.webkit.org/284388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71320ccd680c421fb399512802d03e9581698f05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69228 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/48628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21901 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20235 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72294 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/41045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/13210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/68906 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/13249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10575 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/44432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/45247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->