### PR TITLE
Use more smart pointers for data members in WebKit/WebProcess/

### DIFF
--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -88,7 +88,7 @@ void MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest(MediaKeyS
     ASSERT(webFrame);
 
     auto* topLevelDocumentOrigin = userRequest.topLevelDocumentOrigin();
-    m_page.send(Messages::WebPageProxy::RequestMediaKeySystemPermissionForFrame(userRequest.identifier(), webFrame->frameID(), topLevelDocumentOrigin->data(), userRequest.keySystem()));
+    Ref { m_page.get() }->send(Messages::WebPageProxy::RequestMediaKeySystemPermissionForFrame(userRequest.identifier(), webFrame->frameID(), topLevelDocumentOrigin->data(), userRequest.keySystem()));
 }
 
 void MediaKeySystemPermissionRequestManager::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
@@ -35,6 +35,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -57,7 +58,7 @@ private:
     // WebCore::MediaCanStartListener
     void mediaCanStart(WebCore::Document&) final;
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 
     HashMap<WebCore::MediaKeySystemRequestIdentifier, Ref<WebCore::MediaKeySystemRequest>> m_ongoingMediaKeySystemRequests;
     HashMap<RefPtr<WebCore::Document>, Vector<Ref<WebCore::MediaKeySystemRequest>>> m_pendingMediaKeySystemRequests;

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -64,7 +64,7 @@ GPUProcessConnection& RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection()
         m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->connection().send(
-            Messages::GPUConnectionToWebProcess::CreateWCLayerTreeHost(wcLayerTreeHostIdentifier(), m_page.nativeWindowHandle(), m_usesOffscreenRendering),
+            Messages::GPUConnectionToWebProcess::CreateWCLayerTreeHost(wcLayerTreeHostIdentifier(), m_page->nativeWindowHandle(), m_usesOffscreenRendering),
             0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
     }
     return *gpuProcessConnection;

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
@@ -33,6 +33,7 @@
 #include "UpdateInfo.h"
 #include "WCLayerTreeHostIdentifier.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -67,7 +68,7 @@ private:
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WCLayerTreeHostIdentifier m_wcLayerTreeHostIdentifier { WCLayerTreeHostIdentifier::generate() };
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     bool m_usesOffscreenRendering { false };
 };
 

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -55,6 +55,11 @@ GeolocationPermissionRequestManager::GeolocationPermissionRequestManager(WebPage
 
 GeolocationPermissionRequestManager::~GeolocationPermissionRequestManager() = default;
 
+Ref<WebPage> GeolocationPermissionRequestManager::protectedPage() const
+{
+    return m_page.get();
+}
+
 void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation& geolocation)
 {
     auto* frame = geolocation.frame();
@@ -73,12 +78,12 @@ void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation
     auto webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
-    m_page.send(Messages::WebPageProxy::RequestGeolocationPermissionForFrame(geolocationID, webFrame->info()));
+    protectedPage()->send(Messages::WebPageProxy::RequestGeolocationPermissionForFrame(geolocationID, webFrame->info()));
 }
 
 void GeolocationPermissionRequestManager::revokeAuthorizationToken(const String& authorizationToken)
 {
-    m_page.send(Messages::WebPageProxy::RevokeGeolocationAuthorizationToken(authorizationToken));
+    protectedPage()->send(Messages::WebPageProxy::RevokeGeolocationAuthorizationToken(authorizationToken));
 }
 
 void GeolocationPermissionRequestManager::cancelRequestForGeolocation(Geolocation& geolocation)
@@ -99,12 +104,12 @@ void GeolocationPermissionRequestManager::didReceiveGeolocationPermissionDecisio
 
 void GeolocationPermissionRequestManager::ref() const
 {
-    m_page.ref();
+    m_page->ref();
 }
 
 void GeolocationPermissionRequestManager::deref() const
 {
-    m_page.deref();
+    m_page->deref();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class Geolocation;
@@ -60,7 +61,9 @@ private:
     IDToGeolocationMap m_idToGeolocationMap;
     GeolocationToIDMap m_geolocationToIDMap;
 
-    WebPage& m_page;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -67,13 +67,13 @@ RemoteWebInspectorUI::~RemoteWebInspectorUI() = default;
 void RemoteWebInspectorUI::initialize(DebuggableInfoData&& debuggableInfo, const String& backendCommandsURL)
 {
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this, m_page.identifier());
+    m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this, m_page->identifier());
 #endif
 
     m_debuggableInfo = WTFMove(debuggableInfo);
     m_backendCommandsURL = backendCommandsURL;
 
-    m_page.corePage()->inspectorController().setInspectorFrontendClient(this);
+    m_page->protectedCorePage()->inspectorController().setInspectorFrontendClient(this);
 
     m_frontendAPIDispatcher->reset();
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockingUnavailable"_s, { JSON::Value::create(true) });
@@ -91,7 +91,7 @@ void RemoteWebInspectorUI::sendMessageToFrontend(const String& message)
 
 void RemoteWebInspectorUI::sendMessageToBackend(const String& message)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SendMessageToBackend(message), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SendMessageToBackend(message), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::windowObjectCleared()
@@ -99,7 +99,7 @@ void RemoteWebInspectorUI::windowObjectCleared()
     if (m_frontendHost)
         m_frontendHost->disconnectClient();
 
-    m_frontendHost = InspectorFrontendHost::create(this, m_page.corePage());
+    m_frontendHost = InspectorFrontendHost::create(this, m_page->protectedCorePage().get());
     m_frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorld());
 }
 
@@ -109,7 +109,7 @@ void RemoteWebInspectorUI::frontendLoaded()
 
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setIsVisible"_s, { JSON::Value::create(true) });
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::FrontendLoaded(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::FrontendLoaded(), m_page->identifier());
 
     bringToFront();
 }
@@ -126,29 +126,29 @@ void RemoteWebInspectorUI::pageUnpaused()
 
 void RemoteWebInspectorUI::changeSheetRect(const FloatRect& rect)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetSheetRect(rect), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetSheetRect(rect), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::setForcedAppearance(WebCore::InspectorFrontendClient::Appearance appearance)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetForcedAppearance(appearance), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetForcedAppearance(appearance), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::startWindowDrag()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::StartWindowDrag(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::StartWindowDrag(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::moveWindowBy(float x, float y)
 {
-    FloatRect frameRect = m_page.corePage()->chrome().windowRect();
+    FloatRect frameRect = m_page->corePage()->chrome().windowRect();
     frameRect.move(x, y);
-    m_page.corePage()->chrome().setWindowRect(frameRect);
+    m_page->corePage()->chrome().setWindowRect(frameRect);
 }
 
 WebCore::UserInterfaceLayoutDirection RemoteWebInspectorUI::userInterfaceLayoutDirection() const
 {
-    return m_page.corePage()->userInterfaceLayoutDirection();
+    return m_page->corePage()->userInterfaceLayoutDirection();
 }
 
 bool RemoteWebInspectorUI::supportsDockSide(DockSide dockSide)
@@ -169,28 +169,28 @@ bool RemoteWebInspectorUI::supportsDockSide(DockSide dockSide)
 
 void RemoteWebInspectorUI::bringToFront()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::BringToFront(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::BringToFront(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::closeWindow()
 {
-    m_page.corePage()->inspectorController().setInspectorFrontendClient(nullptr);
+    m_page->protectedCorePage()->inspectorController().setInspectorFrontendClient(nullptr);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = nullptr;
 #endif
     
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::FrontendDidClose(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::FrontendDidClose(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::reopen()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::Reopen(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::Reopen(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::resetState()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::ResetState(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::ResetState(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::showConsole()
@@ -205,27 +205,27 @@ void RemoteWebInspectorUI::showResources()
 
 void RemoteWebInspectorUI::openURLExternally(const String& url)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::OpenURLExternally(url), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::OpenURLExternally(url), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::revealFileExternally(const String& path)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::RevealFileExternally(path), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::RevealFileExternally(path), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::save(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::Save(WTFMove(saveDatas), forceSaveAs), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::Save(WTFMove(saveDatas), forceSaveAs), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::load(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::Load(path), WTFMove(completionHandler), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::Load(path), WTFMove(completionHandler), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::pickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&& completionHandler)
 {
-    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::PickColorFromScreen(), WTFMove(completionHandler), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::PickColorFromScreen(), WTFMove(completionHandler), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::inspectedURLChanged(const String& urlString)
@@ -235,12 +235,12 @@ void RemoteWebInspectorUI::inspectedURLChanged(const String& urlString)
 
 void RemoteWebInspectorUI::showCertificate(const CertificateInfo& certificateInfo)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::ShowCertificate(certificateInfo), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::ShowCertificate(certificateInfo), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::setInspectorPageDeveloperExtrasEnabled(bool enabled)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetInspectorPageDeveloperExtrasEnabled(enabled), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetInspectorPageDeveloperExtrasEnabled(enabled), m_page->identifier());
 }
 
 Inspector::DebuggableType RemoteWebInspectorUI::debuggableType() const
@@ -271,12 +271,12 @@ bool RemoteWebInspectorUI::targetIsSimulator() const
 #if ENABLE(INSPECTOR_TELEMETRY)
 bool RemoteWebInspectorUI::supportsDiagnosticLogging()
 {
-    return m_page.corePage()->settings().diagnosticLoggingEnabled();
+    return m_page->corePage()->settings().diagnosticLoggingEnabled();
 }
 
 void RemoteWebInspectorUI::logDiagnosticEvent(const String& eventName,  const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    m_page.corePage()->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    m_page->corePage()->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void RemoteWebInspectorUI::setDiagnosticLoggingAvailable(bool available)
@@ -330,7 +330,7 @@ void RemoteWebInspectorUI::inspectedPageDidNavigate(const URL& newURL)
 
 WebCore::Page* RemoteWebInspectorUI::frontendPage()
 {
-    return m_page.corePage();
+    return m_page->corePage();
 }
 
 

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
@@ -33,6 +33,7 @@
 #include <WebCore/InspectorFrontendClient.h>
 #include <WebCore/InspectorFrontendHost.h>
 #include <wtf/Deque.h>
+#include <wtf/WeakRef.h>
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 #include "InspectorExtensionTypes.h"
@@ -141,7 +142,7 @@ public:
 private:
     explicit RemoteWebInspectorUI(WebPage&);
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     Ref<WebCore::InspectorFrontendAPIDispatcher> m_frontendAPIDispatcher;
     RefPtr<WebCore::InspectorFrontendHost> m_frontendHost;
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
@@ -48,31 +48,32 @@ WebPageInspectorTarget::~WebPageInspectorTarget() = default;
 
 String WebPageInspectorTarget::identifier() const
 {
-    return toTargetID(m_page.identifier());
+    return toTargetID(m_page->identifier());
 }
 
 void WebPageInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType connectionType)
 {
     if (m_channel)
         return;
-    m_channel = makeUnique<WebPageInspectorTargetFrontendChannel>(m_page, identifier(), connectionType);
-    if (m_page.corePage())
-        m_page.corePage()->inspectorController().connectFrontend(*m_channel);
+    Ref page = m_page.get();
+    m_channel = makeUnique<WebPageInspectorTargetFrontendChannel>(page, identifier(), connectionType);
+    if (RefPtr corePage = page->corePage())
+        corePage->inspectorController().connectFrontend(*m_channel);
 }
 
 void WebPageInspectorTarget::disconnect()
 {
     if (!m_channel)
         return;
-    if (m_page.corePage())
-        m_page.corePage()->inspectorController().disconnectFrontend(*m_channel);
+    if (RefPtr corePage = m_page->corePage())
+        corePage->inspectorController().disconnectFrontend(*m_channel);
     m_channel.reset();
 }
 
 void WebPageInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
-    if (m_page.corePage())
-        m_page.corePage()->inspectorController().dispatchMessageFromFrontend(message);
+    if (RefPtr corePage = m_page->corePage())
+        corePage->inspectorController().dispatchMessageFromFrontend(message);
 }
 
 String WebPageInspectorTarget::toTargetID(WebCore::PageIdentifier pageID)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
@@ -29,6 +29,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -53,7 +54,7 @@ public:
     static String toTargetID(WebCore::PageIdentifier);
 
 private:
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     std::unique_ptr<WebPageInspectorTargetFrontendChannel> m_channel;
 };
 

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp
@@ -44,8 +44,11 @@ WebPageInspectorTargetController::WebPageInspectorTargetController(WebPage& page
     m_targets.set(m_pageTarget.identifier(), &m_pageTarget);
 }
 
-WebPageInspectorTargetController::~WebPageInspectorTargetController()
+WebPageInspectorTargetController::~WebPageInspectorTargetController() = default;
+
+Ref<WebPage> WebPageInspectorTargetController::protectedPage() const
 {
+    return m_page.get();
 }
 
 void WebPageInspectorTargetController::addTarget(Inspector::InspectorTarget& target)
@@ -53,14 +56,14 @@ void WebPageInspectorTargetController::addTarget(Inspector::InspectorTarget& tar
     auto addResult = m_targets.set(target.identifier(), &target);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 
-    m_page.send(Messages::WebPageProxy::CreateInspectorTarget(target.identifier(), target.type()));
+    protectedPage()->send(Messages::WebPageProxy::CreateInspectorTarget(target.identifier(), target.type()));
 }
 
 void WebPageInspectorTargetController::removeTarget(Inspector::InspectorTarget& target)
 {
     ASSERT_WITH_MESSAGE(target.identifier() != m_pageTarget.identifier(), "Should never remove the main target.");
 
-    m_page.send(Messages::WebPageProxy::DestroyInspectorTarget(target.identifier()));
+    protectedPage()->send(Messages::WebPageProxy::DestroyInspectorTarget(target.identifier()));
 
     m_targets.remove(target.identifier());
 }

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
@@ -29,6 +29,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -53,7 +54,9 @@ public:
     void sendMessageToTargetBackend(const String& targetId, const String& message);
 
 private:
-    WebPage& m_page;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_page;
     WebPageInspectorTarget m_pageTarget;
     HashMap<String, WeakPtr<Inspector::InspectorTarget>> m_targets;
 };

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp
@@ -44,7 +44,7 @@ WebPageInspectorTargetFrontendChannel::WebPageInspectorTargetFrontendChannel(Web
 
 void WebPageInspectorTargetFrontendChannel::sendMessageToFrontend(const String& message)
 {
-    m_page.send(Messages::WebPageProxy::SendMessageToInspectorFrontend(m_targetId, message));
+    Ref { m_page.get() }->send(Messages::WebPageProxy::SendMessageToInspectorFrontend(m_targetId, message));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -45,7 +46,7 @@ private:
     ConnectionType connectionType() const override { return m_connectionType; }
     void sendMessageToFrontend(const String& message) override;
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     String m_targetId;
     Inspector::FrontendChannel::ConnectionType m_connectionType { Inspector::FrontendChannel::ConnectionType::Remote };
 };

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
@@ -59,18 +59,23 @@ RemoteMediaSessionCoordinator::RemoteMediaSessionCoordinator(WebPage& page, cons
     : m_page(page)
     , m_identifier(identifier)
 {
-    WebProcess::singleton().addMessageReceiver(Messages::RemoteMediaSessionCoordinator::messageReceiverName(), m_page.identifier(), *this);
+    WebProcess::singleton().addMessageReceiver(Messages::RemoteMediaSessionCoordinator::messageReceiverName(), m_page->identifier(), *this);
 }
 
 RemoteMediaSessionCoordinator::~RemoteMediaSessionCoordinator()
 {
-    WebProcess::singleton().removeMessageReceiver(Messages::RemoteMediaSessionCoordinator::messageReceiverName(), m_page.identifier());
+    WebProcess::singleton().removeMessageReceiver(Messages::RemoteMediaSessionCoordinator::messageReceiverName(), m_page->identifier());
+}
+
+Ref<WebPage> RemoteMediaSessionCoordinator::protectedPage() const
+{
+    return m_page.get();
 }
 
 void RemoteMediaSessionCoordinator::join(CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    m_page.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::Join { }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
+    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::Join { }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -87,13 +92,13 @@ void RemoteMediaSessionCoordinator::join(CompletionHandler<void(std::optional<We
 
 void RemoteMediaSessionCoordinator::leave()
 {
-    m_page.send(Messages::RemoteMediaSessionCoordinatorProxy::Leave { });
+    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::Leave { });
 }
 
 void RemoteMediaSessionCoordinator::seekTo(double time, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, time);
-    m_page.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSeekTo { time }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
+    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSeekTo { time }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -111,7 +116,7 @@ void RemoteMediaSessionCoordinator::seekTo(double time, CompletionHandler<void(s
 void RemoteMediaSessionCoordinator::play(CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    m_page.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePlay { }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
+    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePlay { }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -129,7 +134,7 @@ void RemoteMediaSessionCoordinator::play(CompletionHandler<void(std::optional<We
 void RemoteMediaSessionCoordinator::pause(CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    m_page.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePause { }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
+    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePause { }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -147,7 +152,7 @@ void RemoteMediaSessionCoordinator::pause(CompletionHandler<void(std::optional<W
 void RemoteMediaSessionCoordinator::setTrack(const String& trackIdentifier, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    m_page.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSetTrack { trackIdentifier }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
+    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSetTrack { trackIdentifier }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -165,25 +170,25 @@ void RemoteMediaSessionCoordinator::setTrack(const String& trackIdentifier, Comp
 void RemoteMediaSessionCoordinator::positionStateChanged(const std::optional<WebCore::MediaPositionState>& state)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    m_page.send(Messages::RemoteMediaSessionCoordinatorProxy::PositionStateChanged { state });
+    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::PositionStateChanged { state });
 }
 
 void RemoteMediaSessionCoordinator::readyStateChanged(WebCore::MediaSessionReadyState state)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, state);
-    m_page.send(Messages::RemoteMediaSessionCoordinatorProxy::ReadyStateChanged { state });
+    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::ReadyStateChanged { state });
 }
 
 void RemoteMediaSessionCoordinator::playbackStateChanged(WebCore::MediaSessionPlaybackState state)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, state);
-    m_page.send(Messages::RemoteMediaSessionCoordinatorProxy::PlaybackStateChanged { state });
+    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::PlaybackStateChanged { state });
 }
 
 void RemoteMediaSessionCoordinator::trackIdentifierChanged(const String& identifier)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, identifier);
-    m_page.send(Messages::RemoteMediaSessionCoordinatorProxy::TrackIdentifierChanged { identifier });
+    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::TrackIdentifierChanged { identifier });
 }
 
 void RemoteMediaSessionCoordinator::seekSessionToTime(double time, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -31,6 +31,7 @@
 #include <WebCore/MediaSessionCoordinatorPrivate.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Connection;
@@ -78,7 +79,9 @@ private:
     ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinator"_s; }
     WTFLogChannel& logChannel() const;
 
-    WebPage& m_page;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_page;
     String m_identifier;
 };
 

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -49,6 +49,11 @@ UserMediaPermissionRequestManager::UserMediaPermissionRequestManager(WebPage& pa
 {
 }
 
+Ref<WebPage> UserMediaPermissionRequestManager::protectedPage() const
+{
+    return m_page.get();
+}
+
 void UserMediaPermissionRequestManager::startUserMediaRequest(UserMediaRequest& request)
 {
     Document* document = request.document();
@@ -84,7 +89,7 @@ void UserMediaPermissionRequestManager::sendUserMediaRequest(UserMediaRequest& u
     ASSERT(webFrame);
 
     auto* topLevelDocumentOrigin = userRequest.topLevelDocumentOrigin();
-    m_page.send(Messages::WebPageProxy::RequestUserMediaPermissionForFrame(userRequest.identifier(), webFrame->frameID(), userRequest.userMediaDocumentOrigin()->data(), topLevelDocumentOrigin->data(), userRequest.request()));
+    protectedPage()->send(Messages::WebPageProxy::RequestUserMediaPermissionForFrame(userRequest.identifier(), webFrame->frameID(), userRequest.userMediaDocumentOrigin()->data(), topLevelDocumentOrigin->data(), userRequest.request()));
 }
 
 void UserMediaPermissionRequestManager::cancelUserMediaRequest(UserMediaRequest& request)
@@ -149,7 +154,7 @@ void UserMediaPermissionRequestManager::enumerateMediaDevices(Document& document
         return;
     }
 
-    m_page.sendWithAsyncReply(Messages::WebPageProxy::EnumerateMediaDevicesForFrame { WebFrame::fromCoreFrame(*frame)->frameID(), document.securityOrigin().data(), document.topOrigin().data() }, WTFMove(completionHandler));
+    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::EnumerateMediaDevicesForFrame { WebFrame::fromCoreFrame(*frame)->frameID(), document.securityOrigin().data(), document.topOrigin().data() }, WTFMove(completionHandler));
 }
 
 #if USE(GSTREAMER)
@@ -185,7 +190,7 @@ UserMediaClient::DeviceChangeObserverToken UserMediaPermissionRequestManager::ad
         updateCaptureDevices(ShouldNotify::No);
         WebCore::RealtimeMediaSourceCenter::singleton().addDevicesChangedObserver(*this);
 #else
-        m_page.send(Messages::WebPageProxy::BeginMonitoringCaptureDevices());
+        protectedPage()->send(Messages::WebPageProxy::BeginMonitoringCaptureDevices());
 #endif
     }
     return identifier;
@@ -199,7 +204,7 @@ void UserMediaPermissionRequestManager::removeDeviceChangeObserver(UserMediaClie
 
 void UserMediaPermissionRequestManager::updateCaptureState(const WebCore::Document& document, bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
-    m_page.updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
+    protectedPage()->updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
 }
 
 void UserMediaPermissionRequestManager::captureDevicesChanged()

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -32,6 +32,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 class UserMediaPermissionRequestManager;
@@ -83,7 +84,9 @@ private:
     // WebCore::MediaCanStartListener
     void mediaCanStart(WebCore::Document&) final;
 
-    WebPage& m_page;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_page;
 
     HashMap<WebCore::UserMediaRequestIdentifier, Ref<WebCore::UserMediaRequest>> m_ongoingUserMediaRequests;
     HashMap<RefPtr<WebCore::Document>, Vector<Ref<WebCore::UserMediaRequest>>> m_pendingUserMediaRequests;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
@@ -42,7 +42,7 @@ WebAttachmentElementClient::WebAttachmentElementClient(WebPage& page)
 
 void WebAttachmentElementClient::requestAttachmentIcon(const String& identifier, const WebCore::FloatSize& size)
 {
-    m_page.requestAttachmentIcon(identifier, size);
+    Ref { m_page.get() }->requestAttachmentIcon(identifier, size);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/AttachmentElementClient.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -42,7 +43,7 @@ public:
     void requestAttachmentIcon(const String& identifier, const WebCore::FloatSize&) final;
 
 private:
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
@@ -44,65 +44,68 @@ WebDiagnosticLoggingClient::WebDiagnosticLoggingClient(WebPage& page)
 {
 }
 
-WebDiagnosticLoggingClient::~WebDiagnosticLoggingClient()
+WebDiagnosticLoggingClient::~WebDiagnosticLoggingClient() = default;
+
+Ref<WebPage> WebDiagnosticLoggingClient::protectedPage() const
 {
+    return m_page.get();
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessage(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page.corePage() || m_page.corePage()->settings().diagnosticLoggingEnabled());
+    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    m_page.send(Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess(message, description, ShouldSample::No));
+    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess(message, description, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithResult(const String& message, const String& description, WebCore::DiagnosticLoggingResultType result, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page.corePage() || m_page.corePage()->settings().diagnosticLoggingEnabled());
+    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    m_page.send(Messages::WebPageProxy::LogDiagnosticMessageWithResultFromWebProcess(message, description, result, ShouldSample::No));
+    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithResultFromWebProcess(message, description, result, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithValue(const String& message, const String& description, double value, unsigned significantFigures, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page.corePage() || m_page.corePage()->settings().diagnosticLoggingEnabled());
+    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    m_page.send(Messages::WebPageProxy::LogDiagnosticMessageWithValueFromWebProcess(message, description, value, significantFigures, ShouldSample::No));
+    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithValueFromWebProcess(message, description, value, significantFigures, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page.corePage() || m_page.corePage()->settings().diagnosticLoggingEnabled());
+    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    m_page.send(Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess(message, description, ShouldSample::No));
+    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess(message, description, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary(const String& message, const String& description, const ValueDictionary& value, ShouldSample shouldSample)
 {
-    ASSERT(!m_page.corePage() || m_page.corePage()->settings().diagnosticLoggingEnabled());
+    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    m_page.send(Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess(message, description, value, ShouldSample::No));
+    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess(message, description, value, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithDomain(const String& message, WebCore::DiagnosticLoggingDomain domain)
 {
-    ASSERT(!m_page.corePage() || m_page.corePage()->settings().diagnosticLoggingEnabled());
+    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
 
-    m_page.send(Messages::WebPageProxy::LogDiagnosticMessageWithDomainFromWebProcess(message, domain));
+    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithDomainFromWebProcess(message, domain));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
@@ -28,6 +28,7 @@
 
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -48,7 +49,9 @@ private:
     void logDiagnosticMessageWithValueDictionary(const String& message, const String& description, const ValueDictionary&, WebCore::ShouldSample) override;
     void logDiagnosticMessageWithDomain(const String& message, WebCore::DiagnosticLoggingDomain) override;
 
-    WebPage& m_page;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_page;
 };
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPerformanceLoggingClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPerformanceLoggingClient.cpp
@@ -44,7 +44,7 @@ WebPerformanceLoggingClient::WebPerformanceLoggingClient(WebPage& page)
 
 void WebPerformanceLoggingClient::logScrollingEvent(ScrollingEvent event, MonotonicTime timestamp, uint64_t data)
 {
-    m_page.send(Messages::WebPageProxy::LogScrollingEvent(static_cast<uint32_t>(event), timestamp, data));
+    Ref { m_page.get() }->send(Messages::WebPageProxy::LogScrollingEvent(static_cast<uint32_t>(event), timestamp, data));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPerformanceLoggingClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPerformanceLoggingClient.h
@@ -28,6 +28,7 @@
 #include <WebCore/PerformanceLoggingClient.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -42,7 +43,7 @@ public:
 private:
     void logScrollingEvent(ScrollingEvent, MonotonicTime, uint64_t) override;
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 };
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -29,6 +29,7 @@
 #include <WebCore/ScreenOrientationManager.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -53,7 +54,9 @@ private:
     void addObserver(WebCore::ScreenOrientationManagerObserver&) final;
     void removeObserver(WebCore::ScreenOrientationManagerObserver&) final;
 
-    WebPage& m_page;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_page;
     WeakHashSet<WebCore::ScreenOrientationManagerObserver> m_observers;
     mutable std::optional<WebCore::ScreenOrientationType> m_currentOrientation;
 };

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -73,13 +73,13 @@ AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Client& client)
     , m_size(webPage.size())
     , m_isOpaque(!webPage.backgroundColor().has_value() || webPage.backgroundColor()->isOpaque())
 {
-    m_size.scale(m_webPage.deviceScaleFactor());
+    m_size.scale(m_webPage->deviceScaleFactor());
 }
 
 bool AcceleratedSurface::hostResize(const IntSize& size)
 {
     IntSize scaledSize(size);
-    scaledSize.scale(m_webPage.deviceScaleFactor());
+    scaledSize.scale(m_webPage->deviceScaleFactor());
     if (scaledSize == m_size)
         return false;
 
@@ -89,7 +89,7 @@ bool AcceleratedSurface::hostResize(const IntSize& size)
 
 bool AcceleratedSurface::backgroundColorDidChange()
 {
-    const auto& color = m_webPage.backgroundColor();
+    const auto& color = m_webPage->backgroundColor();
     auto isOpaque = !color.has_value() || color->isOpaque();
     if (m_isOpaque == isOpaque)
         return false;

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -28,6 +28,7 @@
 #include <WebCore/IntSize.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WTF {
 class RunLoop;
@@ -82,7 +83,7 @@ public:
 protected:
     AcceleratedSurface(WebPage&, Client&);
 
-    WebPage& m_webPage;
+    WeakRef<WebPage> m_webPage;
     Client& m_client;
     WebCore::IntSize m_size;
     std::atomic<bool> m_isOpaque { true };

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/SimpleRange.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Decoder;
@@ -70,7 +71,7 @@ private:
     void replaceRelativeToSelection(const WebCore::AttributedString&, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength);
     void removeAnnotationRelativeToSelection(const String& annotationName, int64_t selectionOffset, uint64_t length);
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -61,12 +61,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCheckingControllerProxy);
 TextCheckingControllerProxy::TextCheckingControllerProxy(WebPage& page)
     : m_page(page)
 {
-    WebProcess::singleton().addMessageReceiver(Messages::TextCheckingControllerProxy::messageReceiverName(), m_page.identifier(), *this);
+    WebProcess::singleton().addMessageReceiver(Messages::TextCheckingControllerProxy::messageReceiverName(), m_page->identifier(), *this);
 }
 
 TextCheckingControllerProxy::~TextCheckingControllerProxy()
 {
-    WebProcess::singleton().removeMessageReceiver(Messages::TextCheckingControllerProxy::messageReceiverName(), m_page.identifier());
+    WebProcess::singleton().removeMessageReceiver(Messages::TextCheckingControllerProxy::messageReceiverName(), m_page->identifier());
 }
 
 static OptionSet<DocumentMarker::Type> relevantMarkerTypes()
@@ -76,7 +76,7 @@ static OptionSet<DocumentMarker::Type> relevantMarkerTypes()
 
 std::optional<TextCheckingControllerProxy::RangeAndOffset> TextCheckingControllerProxy::rangeAndOffsetRelativeToSelection(int64_t offset, uint64_t length)
 {
-    RefPtr focusedOrMainFrame = m_page.corePage()->checkedFocusController()->focusedOrMainFrame();
+    RefPtr focusedOrMainFrame = m_page->corePage()->checkedFocusController()->focusedOrMainFrame();
     if (!focusedOrMainFrame)
         return std::nullopt;
     auto& frameSelection = focusedOrMainFrame->selection();
@@ -102,7 +102,7 @@ std::optional<TextCheckingControllerProxy::RangeAndOffset> TextCheckingControlle
 
 void TextCheckingControllerProxy::replaceRelativeToSelection(const WebCore::AttributedString& annotatedString, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength)
 {
-    RefPtr frame = m_page.corePage()->checkedFocusController()->focusedOrMainFrame();
+    RefPtr frame = m_page->corePage()->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
         return;
     auto& frameSelection = frame->selection();
@@ -166,7 +166,7 @@ void TextCheckingControllerProxy::removeAnnotationRelativeToSelection(const Stri
 
     auto removeCoreSpellingMarkers = annotation == "NSSpellingState"_s;
     auto types = removeCoreSpellingMarkers ? relevantMarkerTypes() : WebCore::DocumentMarker::Type::PlatformTextChecking;
-    RefPtr focusedOrMainFrame = m_page.corePage()->checkedFocusController()->focusedOrMainFrame();
+    RefPtr focusedOrMainFrame = m_page->corePage()->checkedFocusController()->focusedOrMainFrame();
     if (!focusedOrMainFrame)
         return;
     RefPtr document = focusedOrMainFrame->document();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -103,7 +103,7 @@ CompositingCoordinator::CompositingCoordinator(WebPage& page, CompositingCoordin
     m_rootLayer->setName(MAKE_STATIC_STRING_IMPL("CompositingCoordinator root layer"));
 #endif
     m_rootLayer->setDrawsContent(false);
-    m_rootLayer->setSize(m_page.size());
+    m_rootLayer->setSize(m_page->size());
 }
 
 CompositingCoordinator::~CompositingCoordinator()
@@ -165,8 +165,9 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
 
     bool shouldSyncFrame = initializeRootCompositingLayerIfNeeded();
 
-    m_page.updateRendering();
-    m_page.flushPendingEditorStateUpdate();
+    Ref page = m_page.get();
+    page->updateRendering();
+    page->flushPendingEditorStateUpdate();
 
     WTFBeginSignpost(this, FlushRootCompositingLayer);
     m_rootLayer->flushCompositingStateForThisLayerOnly();
@@ -176,7 +177,7 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
     if (m_overlayCompositingLayer)
         m_overlayCompositingLayer->flushCompositingState(FloatRect(FloatPoint(), m_rootLayer->size()));
 
-    m_page.finalizeRenderingUpdate(flags);
+    page->finalizeRenderingUpdate(flags);
 
     WTFBeginSignpost(this, FinalizeCompositingStateFlush);
     auto& coordinatedLayer = downcast<CoordinatedGraphicsLayer>(*m_rootLayer);
@@ -213,7 +214,7 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
         m_client.commitSceneState(nullptr);
 #endif
 
-    m_page.didUpdateRendering();
+    page->didUpdateRendering();
 
     // Eject any backing stores whose only reference is held in the HashMap cache.
     m_imageBackingStores.removeIf(
@@ -226,7 +227,7 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
 
 double CompositingCoordinator::timestamp() const
 {
-    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page.corePage()->mainFrame());
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page->corePage()->mainFrame());
     auto* document = localMainFrame ? localMainFrame->document() : nullptr;
     if (!document)
         return 0;
@@ -235,7 +236,7 @@ double CompositingCoordinator::timestamp() const
 
 void CompositingCoordinator::syncDisplayState()
 {
-    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page.corePage()->mainFrame()))
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page->corePage()->mainFrame()))
         localMainFrame->view()->updateLayoutAndStyleIfNeededRecursive();
 }
 
@@ -279,7 +280,7 @@ void CompositingCoordinator::setVisibleContentsRect(const FloatRect& rect)
             registeredLayer->setNeedsVisibleRectAdjustment();
     }
 
-    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page.corePage()->mainFrame());
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page->corePage()->mainFrame());
     auto* view = localMainFrame ? localMainFrame->view() : nullptr;
     if (view->useFixedLayout() && contentsRectDidChange) {
         // Round the rect instead of enclosing it to make sure that its size stays

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -116,7 +116,7 @@ private:
 
     double timestamp() const;
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
     CompositingCoordinator::Client& m_client;
 
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -104,7 +104,8 @@ public:
     bool canShowWhileLocked() const;
 #endif
 
-    WebPage& webPage() { return m_webPage; }
+    WebPage& webPage();
+    Ref<WebPage> protectedWebPage();
 
 private:
     explicit RemoteLayerTreeContext(WebPage&);
@@ -112,7 +113,7 @@ private:
     // WebCore::GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;
 
-    WebPage& m_webPage;
+    WeakRef<WebPage> m_webPage;
 
     HashMap<WebCore::PlatformLayerIdentifier, RemoteLayerTreeTransaction::LayerCreationProperties> m_createdLayers;
     Vector<WebCore::PlatformLayerIdentifier> m_destroyedLayers;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -76,24 +76,24 @@ void RemoteLayerTreeContext::adoptLayersFromContext(RemoteLayerTreeContext& oldC
 
 float RemoteLayerTreeContext::deviceScaleFactor() const
 {
-    return m_webPage.deviceScaleFactor();
+    return m_webPage->deviceScaleFactor();
 }
 
 LayerHostingMode RemoteLayerTreeContext::layerHostingMode() const
 {
-    return m_webPage.layerHostingMode();
+    return m_webPage->layerHostingMode();
 }
 
 DrawingAreaIdentifier RemoteLayerTreeContext::drawingAreaIdentifier() const
 {
-    if (!m_webPage.drawingArea())
+    if (!m_webPage->drawingArea())
         return DrawingAreaIdentifier();
-    return m_webPage.drawingArea()->identifier();
+    return m_webPage->drawingArea()->identifier();
 }
 
 std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeContext::displayColorSpace() const
 {
-    if (auto* drawingArea = m_webPage.drawingArea())
+    if (auto* drawingArea = m_webPage->drawingArea())
         return drawingArea->displayColorSpace();
     
     return { };
@@ -102,7 +102,7 @@ std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeContext::displayCol
 #if PLATFORM(IOS_FAMILY)
 bool RemoteLayerTreeContext::canShowWhileLocked() const
 {
-    return m_webPage.canShowWhileLocked();
+    return m_webPage->canShowWhileLocked();
 }
 #endif
 
@@ -131,13 +131,23 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
         videoElement.naturalSize()
     };
 
-    m_webPage.videoPresentationManager().setupRemoteLayerHosting(videoElement);
+    protectedWebPage()->protectedVideoPresentationManager()->setupRemoteLayerHosting(videoElement);
     m_videoLayers.add(layerID, videoElement.identifier());
 
     m_createdLayers.add(layerID, WTFMove(creationProperties));
     m_livePlatformLayers.add(layerID, &layer);
 }
 #endif
+
+WebPage& RemoteLayerTreeContext::webPage()
+{
+    return m_webPage.get();
+}
+
+Ref<WebPage> RemoteLayerTreeContext::protectedWebPage()
+{
+    return m_webPage.get();
+}
 
 void RemoteLayerTreeContext::layerWillLeaveContext(PlatformCALayerRemote& layer)
 {
@@ -146,7 +156,7 @@ void RemoteLayerTreeContext::layerWillLeaveContext(PlatformCALayerRemote& layer)
 #if HAVE(AVKIT)
     auto videoLayerIter = m_videoLayers.find(layerID);
     if (videoLayerIter != m_videoLayers.end()) {
-        m_webPage.videoPresentationManager().willRemoveLayerForID(videoLayerIter->value);
+        protectedWebPage()->protectedVideoPresentationManager()->willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
     }
 #endif
@@ -225,7 +235,7 @@ void RemoteLayerTreeContext::animationDidEnd(WebCore::PlatformLayerIdentifier la
 
 RemoteRenderingBackendProxy& RemoteLayerTreeContext::ensureRemoteRenderingBackendProxy()
 {
-    return m_webPage.ensureRemoteRenderingBackendProxy();
+    return protectedWebPage()->ensureRemoteRenderingBackendProxy();
 }
 
 void RemoteLayerTreeContext::gpuProcessConnectionWasDestroyed()

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
@@ -29,6 +29,7 @@
 #include "MessageReceiver.h"
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class FloatPoint;
@@ -71,7 +72,9 @@ private:
     std::optional<std::pair<double, double>> computeTextLegibilityScales(double& viewportMinimumScale, double& viewportMaximumScale);
 #endif
 
-    WebPage& m_webPage;
+    Ref<WebPage> protectedWebPage() const;
+
+    WeakRef<WebPage> m_webPage;
 
 #if !PLATFORM(IOS_FAMILY)
     uint64_t m_renderTreeSizeNotificationThreshold;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5168,6 +5168,11 @@ VideoPresentationManager& WebPage::videoPresentationManager()
     return *m_videoPresentationManager;
 }
 
+Ref<VideoPresentationManager> WebPage::protectedVideoPresentationManager()
+{
+    return videoPresentationManager();
+}
+
 void WebPage::videoControlsManagerDidChange()
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -538,6 +538,7 @@ public:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     VideoPresentationManager& videoPresentationManager();
+    Ref<VideoPresentationManager> protectedVideoPresentationManager();
 
     void startPlayingPredominantVideo(CompletionHandler<void(bool)>&&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
@@ -63,10 +63,15 @@ void WebURLSchemeHandlerProxy::startNewTask(ResourceLoader& loader, WebFrame& we
     result.iterator->value->startLoading();
 }
 
+Ref<WebPage> WebURLSchemeHandlerProxy::protectedPage()
+{
+    return m_webPage.get();
+}
+
 void WebURLSchemeHandlerProxy::loadSynchronously(WebCore::ResourceLoaderIdentifier loadIdentifier, WebFrame& webFrame, const ResourceRequest& request, ResourceResponse& response, ResourceError& error, Vector<uint8_t>& data)
 {
     data.shrink(0);
-    auto sendResult = m_webPage.sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }));
+    auto sendResult = protectedPage()->sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }));
     if (sendResult.succeeded())
         std::tie(response, error, data) = sendResult.takeReply();
     else

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
@@ -30,6 +30,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class ResourceError;
@@ -57,7 +58,8 @@ public:
     void loadSynchronously(WebCore::ResourceLoaderIdentifier, WebFrame&, const WebCore::ResourceRequest&, WebCore::ResourceResponse&, WebCore::ResourceError&, Vector<uint8_t>&);
 
     WebURLSchemeHandlerIdentifier identifier() const { return m_identifier; }
-    WebPage& page() { return m_webPage; }
+    WebPage& page() { return m_webPage.get(); }
+    Ref<WebPage> protectedPage();
 
     void taskDidPerformRedirection(WebCore::ResourceLoaderIdentifier, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     void taskDidReceiveResponse(WebCore::ResourceLoaderIdentifier, const WebCore::ResourceResponse&);
@@ -70,7 +72,7 @@ private:
 
     RefPtr<WebURLSchemeTaskProxy> removeTask(WebCore::ResourceLoaderIdentifier);
 
-    WebPage& m_webPage;
+    WeakRef<WebPage> m_webPage;
     WebURLSchemeHandlerIdentifier m_identifier;
 
     HashMap<WebCore::ResourceLoaderIdentifier, RefPtr<WebURLSchemeTaskProxy>> m_tasks;

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
@@ -69,7 +69,7 @@ private:
     void queueTask(Function<void()>&& task) { m_queuedTasks.append(WTFMove(task)); }
     void processNextPendingTask();
 
-    WebURLSchemeHandlerProxy& m_urlSchemeHandler;
+    WeakRef<WebURLSchemeHandlerProxy> m_urlSchemeHandler;
     RefPtr<WebCore::ResourceLoader> m_coreLoader;
     RefPtr<WebFrame> m_frame;
     WebCore::ResourceRequest m_request;

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -83,7 +83,7 @@ AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf(WebPage& webPage, Client& cli
 {
 #if USE(GBM)
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
-        m_swapChain.setupBufferFormat(m_webPage.preferredBufferFormats(), m_isOpaque);
+        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), m_isOpaque);
 #endif
 }
 
@@ -545,7 +545,7 @@ void AcceleratedSurfaceDMABuf::preferredBufferFormatsDidChange()
     if (m_swapChain.type() != SwapChain::Type::EGLImage)
         return;
 
-    m_swapChain.setupBufferFormat(m_webPage.preferredBufferFormats(), m_isOpaque);
+    m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), m_isOpaque);
 }
 #endif
 
@@ -573,7 +573,7 @@ bool AcceleratedSurfaceDMABuf::backgroundColorDidChange()
 
 #if USE(GBM)
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
-        m_swapChain.setupBufferFormat(m_webPage.preferredBufferFormats(), m_isOpaque);
+        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), m_isOpaque);
 #endif
 
     return true;

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -56,7 +56,7 @@ AcceleratedSurfaceLibWPE::~AcceleratedSurfaceLibWPE()
 
 void AcceleratedSurfaceLibWPE::initialize()
 {
-    m_backend = wpe_renderer_backend_egl_target_create(dupCloseOnExec(m_webPage.hostFileDescriptor()));
+    m_backend = wpe_renderer_backend_egl_target_create(dupCloseOnExec(m_webPage->hostFileDescriptor()));
     static struct wpe_renderer_backend_egl_target_client s_client = {
         // frame_complete
         [](void* data)
@@ -94,7 +94,7 @@ uint64_t AcceleratedSurfaceLibWPE::window() const
 
 uint64_t AcceleratedSurfaceLibWPE::surfaceID() const
 {
-    return m_webPage.identifier().toUInt64();
+    return m_webPage->identifier().toUInt64();
 }
 
 void AcceleratedSurfaceLibWPE::clientResize(const IntSize& size)


### PR DESCRIPTION
#### 2ad6ae20fe0c423d82529e23c7b1dd360d14d03e
<pre>
Use more smart pointers for data members in WebKit/WebProcess/
<a href="https://bugs.webkit.org/show_bug.cgi?id=280533">https://bugs.webkit.org/show_bug.cgi?id=280533</a>

Reviewed by Darin Adler.

* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
(WebKit::MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest):
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h:
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp:
(WebKit::RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
(WebKit::GeolocationPermissionRequestManager::protectedPage const):
(WebKit::GeolocationPermissionRequestManager::startRequestForGeolocation):
(WebKit::GeolocationPermissionRequestManager::revokeAuthorizationToken):
(WebKit::GeolocationPermissionRequestManager::ref const):
(WebKit::GeolocationPermissionRequestManager::deref const):
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::initialize):
(WebKit::RemoteWebInspectorUI::sendMessageToBackend):
(WebKit::RemoteWebInspectorUI::windowObjectCleared):
(WebKit::RemoteWebInspectorUI::frontendLoaded):
(WebKit::RemoteWebInspectorUI::changeSheetRect):
(WebKit::RemoteWebInspectorUI::setForcedAppearance):
(WebKit::RemoteWebInspectorUI::startWindowDrag):
(WebKit::RemoteWebInspectorUI::moveWindowBy):
(WebKit::RemoteWebInspectorUI::userInterfaceLayoutDirection const):
(WebKit::RemoteWebInspectorUI::bringToFront):
(WebKit::RemoteWebInspectorUI::closeWindow):
(WebKit::RemoteWebInspectorUI::reopen):
(WebKit::RemoteWebInspectorUI::resetState):
(WebKit::RemoteWebInspectorUI::openURLExternally):
(WebKit::RemoteWebInspectorUI::revealFileExternally):
(WebKit::RemoteWebInspectorUI::save):
(WebKit::RemoteWebInspectorUI::load):
(WebKit::RemoteWebInspectorUI::pickColorFromScreen):
(WebKit::RemoteWebInspectorUI::showCertificate):
(WebKit::RemoteWebInspectorUI::setInspectorPageDeveloperExtrasEnabled):
(WebKit::RemoteWebInspectorUI::supportsDiagnosticLogging):
(WebKit::RemoteWebInspectorUI::logDiagnosticEvent):
(WebKit::RemoteWebInspectorUI::frontendPage):
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp:
(WebKit::WebPageInspectorTarget::identifier const):
(WebKit::WebPageInspectorTarget::connect):
(WebKit::WebPageInspectorTarget::disconnect):
(WebKit::WebPageInspectorTarget::sendMessageToTargetBackend):
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp:
(WebKit::WebPageInspectorTargetController::protectedPage const):
(WebKit::WebPageInspectorTargetController::addTarget):
(WebKit::WebPageInspectorTargetController::removeTarget):
(WebKit::WebPageInspectorTargetController::~WebPageInspectorTargetController): Deleted.
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp:
(WebKit::WebPageInspectorTargetFrontendChannel::sendMessageToFrontend):
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp:
(WebKit::RemoteMediaSessionCoordinator::RemoteMediaSessionCoordinator):
(WebKit::RemoteMediaSessionCoordinator::~RemoteMediaSessionCoordinator):
(WebKit::RemoteMediaSessionCoordinator::protectedPage const):
(WebKit::RemoteMediaSessionCoordinator::join):
(WebKit::RemoteMediaSessionCoordinator::leave):
(WebKit::RemoteMediaSessionCoordinator::seekTo):
(WebKit::RemoteMediaSessionCoordinator::play):
(WebKit::RemoteMediaSessionCoordinator::pause):
(WebKit::RemoteMediaSessionCoordinator::setTrack):
(WebKit::RemoteMediaSessionCoordinator::positionStateChanged):
(WebKit::RemoteMediaSessionCoordinator::readyStateChanged):
(WebKit::RemoteMediaSessionCoordinator::playbackStateChanged):
(WebKit::RemoteMediaSessionCoordinator::trackIdentifierChanged):
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
(WebKit::UserMediaPermissionRequestManager::protectedPage const):
(WebKit::UserMediaPermissionRequestManager::sendUserMediaRequest):
(WebKit::UserMediaPermissionRequestManager::enumerateMediaDevices):
(WebKit::UserMediaPermissionRequestManager::addDeviceChangeObserver):
(WebKit::UserMediaPermissionRequestManager::updateCaptureState):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp:
(WebKit::WebAttachmentElementClient::requestAttachmentIcon):
* Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp:
(WebKit::WebDiagnosticLoggingClient::protectedPage const):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessage):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithResult):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithValue):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithDomain):
(WebKit::WebDiagnosticLoggingClient::~WebDiagnosticLoggingClient): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPerformanceLoggingClient.cpp:
(WebKit::WebPerformanceLoggingClient::logScrollingEvent):
* Source/WebKit/WebProcess/WebCoreSupport/WebPerformanceLoggingClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
(WebKit::WebScreenOrientationManager::WebScreenOrientationManager):
(WebKit::WebScreenOrientationManager::~WebScreenOrientationManager):
(WebKit::WebScreenOrientationManager::protectedPage const):
(WebKit::WebScreenOrientationManager::currentOrientation):
(WebKit::WebScreenOrientationManager::lock):
(WebKit::WebScreenOrientationManager::unlock):
(WebKit::WebScreenOrientationManager::addObserver):
(WebKit::WebScreenOrientationManager::removeObserver):
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::TextCheckingControllerProxy):
(WebKit::TextCheckingControllerProxy::~TextCheckingControllerProxy):
(WebKit::TextCheckingControllerProxy::rangeAndOffsetRelativeToSelection):
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
(WebKit::TextCheckingControllerProxy::removeAnnotationRelativeToSelection):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::CompositingCoordinator):
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
(WebKit::CompositingCoordinator::timestamp const):
(WebKit::CompositingCoordinator::syncDisplayState):
(WebKit::CompositingCoordinator::setVisibleContentsRect):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::webPage): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::deviceScaleFactor const):
(WebKit::RemoteLayerTreeContext::layerHostingMode const):
(WebKit::RemoteLayerTreeContext::drawingAreaIdentifier const):
(WebKit::RemoteLayerTreeContext::displayColorSpace const):
(WebKit::RemoteLayerTreeContext::canShowWhileLocked const):
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):
(WebKit::RemoteLayerTreeContext::webPage):
(WebKit::RemoteLayerTreeContext::protectedWebPage):
(WebKit::RemoteLayerTreeContext::layerWillLeaveContext):
(WebKit::RemoteLayerTreeContext::ensureRemoteRenderingBackendProxy):
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
(WebKit::ViewGestureGeometryCollector::ViewGestureGeometryCollector):
(WebKit::ViewGestureGeometryCollector::~ViewGestureGeometryCollector):
(WebKit::ViewGestureGeometryCollector::dispatchDidCollectGeometryForSmartMagnificationGesture):
(WebKit::ViewGestureGeometryCollector::protectedWebPage const):
(WebKit::ViewGestureGeometryCollector::collectGeometryForSmartMagnificationGesture):
(WebKit::ViewGestureGeometryCollector::computeTextLegibilityScales):
(WebKit::ViewGestureGeometryCollector::computeMinimumAndMaximumViewportScales const):
(WebKit::ViewGestureGeometryCollector::collectGeometryForMagnificationGesture):
(WebKit::ViewGestureGeometryCollector::sendDidHitRenderTreeSizeThresholdIfNeeded):
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::protectedVideoPresentationManager):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp:
(WebKit::WebURLSchemeHandlerProxy::protectedPage):
(WebKit::WebURLSchemeHandlerProxy::loadSynchronously):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h:
(WebKit::WebURLSchemeHandlerProxy::page):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.cpp:
(WebKit::WebURLSchemeTaskProxy::startLoading):
(WebKit::WebURLSchemeTaskProxy::stopLoading):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::preferredBufferFormatsDidChange):
(WebKit::AcceleratedSurfaceDMABuf::backgroundColorDidChange):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::initialize):
(WebKit::AcceleratedSurfaceLibWPE::surfaceID const):

Canonical link: <a href="https://commits.webkit.org/284420@main">https://commits.webkit.org/284420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/634ef3f3be96ff728ebb749c4d6e813c74338a90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20411 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20260 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55089 "17 flakes 105 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41071 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62750 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62657 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10671 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4283 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10587 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44457 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->