### PR TITLE
AddressSanitizer: SEGV under UnifiedPDFPlugin::didChangeSettings()

### DIFF
--- a/LayoutTests/pdf/crash-with-embed-hidden-expected.txt
+++ b/LayoutTests/pdf/crash-with-embed-hidden-expected.txt
@@ -1,0 +1,3 @@
+This test should not crash.
+
+

--- a/LayoutTests/pdf/crash-with-embed-hidden.html
+++ b/LayoutTests/pdf/crash-with-embed-hidden.html
@@ -1,0 +1,6 @@
+<p>This test should not crash.</p>
+<script>
+if (testRunner)
+    testRunner.dumpAsText();
+</script>
+<embed hidden="hidden" type="application/pdf" results="2">

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -299,16 +299,23 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
         layer.setShowRepaintCounter(showRepaintCounters);
     };
 
-    propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
-    propagateSettingsToLayer(*m_contentsLayer);
+    if (m_pageBackgroundsContainerLayer)
+        propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
+
+    if (m_contentsLayer)
+        propagateSettingsToLayer(*m_contentsLayer);
+
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
-    propagateSettingsToLayer(*m_selectionLayer);
+    if (m_selectionLayer)
+        propagateSettingsToLayer(*m_selectionLayer);
 #endif
 
-    for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {
-        propagateSettingsToLayer(pageLayer);
-        if (pageLayer->children().size())
-            propagateSettingsToLayer(pageLayer->children()[0]);
+    if (m_pageBackgroundsContainerLayer) {
+        for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {
+            propagateSettingsToLayer(pageLayer);
+            if (pageLayer->children().size())
+                propagateSettingsToLayer(pageLayer->children()[0]);
+        }
     }
 
     if (RefPtr asyncRenderer = asyncRendererIfExists())

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -610,9 +610,14 @@ void UnifiedPDFPlugin::didChangeSettings()
         layer.setShowDebugBorder(showDebugBorders);
         layer.setShowRepaintCounter(showRepaintCounter);
     };
-    propagateSettingsToLayer(*m_rootLayer);
-    propagateSettingsToLayer(*m_scrollContainerLayer);
-    propagateSettingsToLayer(*m_scrolledContentsLayer);
+    if (m_rootLayer)
+        propagateSettingsToLayer(*m_rootLayer);
+
+    if (m_scrollContainerLayer)
+        propagateSettingsToLayer(*m_scrollContainerLayer);
+
+    if (m_scrolledContentsLayer)
+        propagateSettingsToLayer(*m_scrolledContentsLayer);
 
     if (m_layerForHorizontalScrollbar)
         propagateSettingsToLayer(*m_layerForHorizontalScrollbar);


### PR DESCRIPTION
#### c8c88ee7a96d6eebe0cbff8a10391ab907c8d201
<pre>
AddressSanitizer: SEGV under UnifiedPDFPlugin::didChangeSettings()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280291">https://bugs.webkit.org/show_bug.cgi?id=280291</a>
<a href="https://rdar.apple.com/135586580">rdar://135586580</a>

Reviewed by Abrar Rahman Protyasha.

THe crash was because of referencing NULL pointers. The fix was to do a NULL check on the pointers befoer they are used.
The LayoutTests/pdf/crash-with-embed-hidden.html along with the expected.txt was added to make sure it can be tested in the future

* LayoutTests/pdf/crash-with-embed-hidden-expected.txt: Added.
* LayoutTests/pdf/crash-with-embed-hidden.html: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateDebugBorders):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::didChangeSettings):

Canonical link: <a href="https://commits.webkit.org/284458@main">https://commits.webkit.org/284458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bd91c533fb3747328eaaa92985fa7af4544c46c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55073 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13535 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16771 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62741 "Found 43 new test failures: animations/3d/full-rotation-animation.html animations/shadow-host-child-change.html compositing/animation/keyframe-order.html compositing/animation/repaint-after-clearing-shared-backing.html imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-scale.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-translate-em.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62648 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4257 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44428 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->