### PR TITLE
[iOS] Allow WKWebView clients to customize the file upload flow for file inputs

### DIFF
--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -307,11 +307,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         wrapper = [WKNavigationResponse alloc];
         break;
 
-#if PLATFORM(MAC)
     case Type::OpenPanelParameters:
         wrapper = [WKOpenPanelParameters alloc];
         break;
-#endif
 
     case Type::SecurityOrigin:
         wrapper = [WKSecurityOrigin alloc];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h
@@ -23,18 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
-
-#if !TARGET_OS_IPHONE
-
 #import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /*! WKOpenPanelParameters contains parameters that a file upload control has specified.
  */
 WK_SWIFT_UI_ACTOR
-WK_CLASS_AVAILABLE(macos(10.12))
+WK_CLASS_AVAILABLE(macos(10.12), ios(WK_IOS_TBA))
 @interface WKOpenPanelParameters : NSObject
 
 /*! @abstract Whether the file upload control supports multiple files.
@@ -43,10 +40,8 @@ WK_CLASS_AVAILABLE(macos(10.12))
 
 /*! @abstract Whether the file upload control supports selecting directories.
  */
-@property (nonatomic, readonly) BOOL allowsDirectories WK_API_AVAILABLE(macos(10.13.4));
+@property (nonatomic, readonly) BOOL allowsDirectories WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
 
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm
@@ -24,12 +24,9 @@
  */
 
 #import "config.h"
+#import "WKNSArray.h"
 #import "WKOpenPanelParametersInternal.h"
 #import <WebCore/MIMETypeRegistry.h>
-
-#if PLATFORM(MAC)
-
-#import "WKNSArray.h"
 
 @implementation WKOpenPanelParameters
 
@@ -70,5 +67,3 @@
 }
 
 @end
-
-#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersInternal.h
@@ -23,12 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "WKOpenPanelParametersPrivate.h"
-
-#if PLATFORM(MAC)
-
 #import "APIOpenPanelParameters.h"
 #import "WKObject.h"
+#import "WKOpenPanelParametersPrivate.h"
 
 namespace WebKit {
 
@@ -43,5 +40,3 @@ template<> struct WrapperTraits<API::OpenPanelParameters> {
     API::ObjectStorage<API::OpenPanelParameters> _openPanelParameters;
 }
 @end
-
-#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h
@@ -25,14 +25,10 @@
 
 #import <WebKit/WKOpenPanelParameters.h>
 
-#if !TARGET_OS_IPHONE
-
 @interface WKOpenPanelParameters (WKPrivate)
 
-@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedMIMETypes WK_API_AVAILABLE(macos(10.13.4));
-@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedFileExtensions WK_API_AVAILABLE(macos(10.13.4));
-@property (nonatomic, readonly, copy) NSArray<NSString *> *_allowedFileExtensions WK_API_AVAILABLE(macos(11.0));
+@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedMIMETypes WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
+@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedFileExtensions WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
+@property (nonatomic, readonly, copy) NSArray<NSString *> *_allowedFileExtensions WK_API_AVAILABLE(macos(11.0), ios(WK_IOS_TBA));
 
 @end
-
-#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -278,8 +278,6 @@ WK_SWIFT_UI_ACTOR
 
 #endif // TARGET_OS_IOS || (defined(TARGET_OS_VISION) && TARGET_OS_VISION) || (defined(TARGET_OS_TV) && TARGET_OS_TV)
 
-#if !TARGET_OS_IPHONE
-
 /*! @abstract Displays a file upload panel.
  @param webView The web view invoking the delegate method.
  @param parameters Parameters describing the file upload control.
@@ -288,9 +286,7 @@ WK_SWIFT_UI_ACTOR
 
  If you do not implement this method, the web view will behave as if the user selected the Cancel button.
  */
-- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSArray<NSURL *> * _Nullable URLs))completionHandler WK_API_AVAILABLE(macos(10.12));
-
-#endif
+- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSArray<NSURL *> * _Nullable URLs))completionHandler WK_API_AVAILABLE(macos(10.12), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -120,6 +120,7 @@ private:
         void decidePolicyForNotificationPermissionRequest(WebPageProxy&, API::SecurityOrigin&, CompletionHandler<void(bool allowed)>&&) final;
         void requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&&) final;
         bool focusFromServiceWorker(WebKit::WebPageProxy&) final;
+        bool runOpenPanel(WebPageProxy&, WebFrameProxy*, FrameInfoData&&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) final;
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
         void mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData&, OptionSet<WebEventModifier>, API::Object*);
 #endif
@@ -145,7 +146,6 @@ private:
 
         void didClickAutoFillButton(WebPageProxy&, API::Object*) final;
         void toolbarsAreVisible(WebPageProxy&, Function<void(bool)>&&) final;
-        bool runOpenPanel(WebPageProxy&, WebFrameProxy*, FrameInfoData&&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) final;
         void saveDataToFileInDownloadsFolder(WebPageProxy*, const WTF::String&, const WTF::String&, const URL&, API::Data&) final;
         Ref<API::InspectorConfiguration> configurationForLocalInspector(WebPageProxy&, WebInspectorUIProxy&) final;
         void didAttachLocalInspector(WebPageProxy&, WebInspectorUIProxy&) final;
@@ -231,6 +231,7 @@ private:
         bool webViewDidResignInputElementStrongPasswordAppearanceWithUserInfo : 1;
         bool webViewTakeFocus : 1;
         bool webViewHandleAutoplayEventWithFlags : 1;
+        bool webViewRunOpenPanelWithParametersInitiatedByFrameCompletionHandler : 1;
         bool focusWebViewFromServiceWorker : 1;
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
         bool webViewMouseDidMoveOverElementWithFlagsUserInfo : 1;
@@ -253,7 +254,6 @@ private:
         bool webViewGetWindowFrameWithCompletionHandler : 1;
         bool webViewGetToolbarsAreVisibleWithCompletionHandler : 1;
         bool webViewSaveDataToFileSuggestedFilenameMimeTypeOriginatingURL : 1;
-        bool webViewRunOpenPanelWithParametersInitiatedByFrameCompletionHandler : 1;
         bool webViewConfigurationForLocalInspector : 1;
         bool webViewDidAttachLocalInspector : 1;
         bool webViewWillCloseLocalInspector : 1;

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
@@ -52,6 +52,8 @@ enum class PickerDismissalReason : uint8_t;
 
 - (NSArray<NSString *> *)currentAvailableActionTitles;
 - (NSArray<NSString *> *)acceptedTypeIdentifiers;
+
++ (std::pair<RetainPtr<NSURL>, RetainPtr<NSURL>>)_copyToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager;
 @end
 
 @protocol WKFileUploadPanelDelegate <NSObject>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm
@@ -25,13 +25,10 @@
 
 #import "config.h"
 
-#if PLATFORM(MAC)
-
 #import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "Utilities.h"
-#import <AppKit/AppKit.h>
 #import <WebKit/WKOpenPanelParametersPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WebKit.h>
@@ -73,16 +70,12 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, RunOpenPanelNonLatin1)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
     auto uiDelegate = adoptNS([[RunOpenPanelUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
-    [webView loadHTMLString:@"<!DOCTYPE html><input style='width: 100vw; height: 100vh;' type='file'>" baseURL:nil];
+    [webView loadHTMLString:@"<!DOCTYPE html><input style='width: 100vw; height: 100vh;' id='file' type='file'>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
-    
-    NSPoint clickPoint = NSMakePoint(50, 50);
-    NSInteger windowNumber = [webView window].windowNumber;
-    [webView mouseDown:[NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:clickPoint modifierFlags:0 timestamp:0 windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:1]];
-    [webView mouseUp:[NSEvent mouseEventWithType:NSEventTypeLeftMouseUp location:clickPoint modifierFlags:0 timestamp:0 windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:1]];
+    [webView clickOnElementID:@"file"];
     Util::run(&fileSelected);
     Util::runFor(50_ms);
     
@@ -124,12 +117,9 @@ TEST(WebKit, FileInputTypeCancelEvent)
         done = true;
     }];
 
-    NSPoint clickPoint = NSMakePoint(50, 50);
-    [webView sendClickAtPoint:clickPoint];
+    [webView clickOnElementID:@"file"];
 
     Util::run(&done);
 }
     
 } // namespace TestWebKitAPI
-
-#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 0b662f0233021039f359f91308fe4762e78d1f97
<pre>
[iOS] Allow WKWebView clients to customize the file upload flow for file inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=280537">https://bugs.webkit.org/show_bug.cgi?id=280537</a>
<a href="https://rdar.apple.com/130219174">rdar://130219174</a>

Reviewed by Wenson Hsieh.

These changes allow clients to implement &apos;webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:&apos;
on iOS if they desire non-default behavior for the file upload flow in
WKWebView. These changes also make WKFileUploadPanel&apos;s
&apos;_copyToNewTemporaryDirectory&apos; a class method so that the fix for
<a href="https://rdar.apple.com/78448610">rdar://78448610</a> can be reused here without code duplication.

* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h:
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::runOpenPanel):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm:
(TestWebKitAPI::TEST(WebKit, RunOpenPanelNonLatin1)):
(TestWebKitAPI::TEST(WebKit, FileInputTypeCancelEvent)):

Canonical link: <a href="https://commits.webkit.org/284471@main">https://commits.webkit.org/284471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/455859360bb183b4ac7049a6609f6e29176126be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55260 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62928 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15431 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4482 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44698 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->