### PR TITLE
Support HAVE_SCENEKIT and ENABLE_ARKIT_INLINE_PREVIEW when MODEL_PROCESS is 1

### DIFF
--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h
@@ -49,6 +49,9 @@ public:
     static Ref<SceneKitModelPlayer> create(ModelPlayerClient&);
     virtual ~SceneKitModelPlayer();
 
+#if ENABLE(MODEL_PROCESS)
+    WebCore::ModelPlayerIdentifier identifier() const final;
+#endif
 private:
     SceneKitModelPlayer(ModelPlayerClient&);
 
@@ -87,6 +90,9 @@ private:
     RefPtr<SceneKitModel> m_model;
 
     RetainPtr<SCNMetalLayer> m_layer;
+#if ENABLE(MODEL_PROCESS)
+    WebCore::ModelPlayerIdentifier m_id;
+#endif
 };
 
 }

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
@@ -197,6 +197,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return makeVector<RetainPtr<id>>(children);
 }
 
+#if ENABLE(MODEL_PROCESS)
+WebCore::ModelPlayerIdentifier SceneKitModelPlayer::identifier() const
+{
+    return m_id;
+}
+#endif
+
 }
 
 #endif

--- a/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h
@@ -47,6 +47,9 @@ protected:
     WebCore::ModelPlayerClient* client() { return m_client.get(); }
 
     virtual std::optional<ModelIdentifier> modelIdentifier() = 0;
+#if ENABLE(MODEL_PROCESS)
+    WebCore::ModelPlayerIdentifier identifier() const final;
+#endif
 
 private:
     // WebCore::ModelPlayer overrides.
@@ -71,6 +74,9 @@ private:
 
     WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::ModelPlayerClient> m_client;
+#if ENABLE(MODEL_PROCESS)
+    WebCore::ModelPlayerIdentifier m_id;
+#endif
 };
 
 }

--- a/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm
@@ -43,6 +43,13 @@ ARKitInlinePreviewModelPlayer::~ARKitInlinePreviewModelPlayer()
 {
 }
 
+#if ENABLE(MODEL_PROCESS)
+WebCore::ModelPlayerIdentifier ARKitInlinePreviewModelPlayer::identifier() const
+{
+    return m_id;
+}
+#endif
+
 void ARKitInlinePreviewModelPlayer::load(WebCore::Model&, WebCore::LayoutSize)
 {
 }


### PR DESCRIPTION
#### 3b257d2e64d9acefcfc14de389541dc8a38530a1
<pre>
Support HAVE_SCENEKIT and ENABLE_ARKIT_INLINE_PREVIEW when MODEL_PROCESS is 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=280539">https://bugs.webkit.org/show_bug.cgi?id=280539</a>
<a href="https://rdar.apple.com/problem/136852127">rdar://problem/136852127</a>

Reviewed by Ada Chan.

Allow ENABLE_MODEL_PROCESS to be 1 while still compiling for model process
bringup on macOS.

* Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h:
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm:
(WebCore::SceneKitModelPlayer::identifier const):
* Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h:
* Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm:
(WebKit::ARKitInlinePreviewModelPlayer::identifier const):

Canonical link: <a href="https://commits.webkit.org/284933@main">https://commits.webkit.org/284933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c5367ea81b58c923ccdb674cfa664a20b6761ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55300 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13761 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72632 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44656 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 13 new passes 6 flakes 1 failures; Uploaded test results; 13 new passes 5 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62967 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62881 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10908 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4532 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44770 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->