### PR TITLE
Do more smart pointer adoption in webpushd code

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -283,7 +283,7 @@ void PushDatabase::create(const String& path, CreationHandler&& completionHandle
                 return;
             }
 
-            completionHandler(std::unique_ptr<PushDatabase>(new PushDatabase(WTFMove(queue), makeUniqueRefFromNonNullUniquePtr(WTFMove(database)))));
+            completionHandler(adoptRef(*new PushDatabase(WTFMove(queue), makeUniqueRefFromNonNullUniquePtr(WTFMove(database)))));
         });
     });
 }

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/UniqueRef.h>
@@ -85,10 +86,10 @@ struct PushTopics {
     WEBCORE_EXPORT PushTopics isolatedCopy() &&;
 };
 
-class PushDatabase {
+class PushDatabase : public RefCountedAndCanMakeWeakPtr<PushDatabase> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PushDatabase, WEBCORE_EXPORT);
 public:
-    using CreationHandler = CompletionHandler<void(std::unique_ptr<PushDatabase>&&)>;
+    using CreationHandler = CompletionHandler<void(RefPtr<PushDatabase>&&)>;
 
     WEBCORE_EXPORT static void create(const String& path, CreationHandler&&);
     WEBCORE_EXPORT ~PushDatabase();

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -34,6 +34,7 @@
 #include <wtf/Deque.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
@@ -47,7 +48,7 @@ class PushServiceRequest;
 class SubscribeRequest;
 class UnsubscribeRequest;
 
-class PushService : public CanMakeWeakPtr<PushService> {
+class PushService : public RefCountedAndCanMakeWeakPtr<PushService> {
     WTF_MAKE_TZONE_ALLOCATED(PushService);
 public:
     friend class SubscribeRequest;
@@ -55,12 +56,14 @@ public:
 
     using IncomingPushMessageHandler = Function<void(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&)>;
 
-    static void create(const String& incomingPushServiceName, const String& databasePath, IncomingPushMessageHandler&&, CompletionHandler<void(std::unique_ptr<PushService>&&)>&&);
-    static void createMockService(IncomingPushMessageHandler&&, CompletionHandler<void(std::unique_ptr<PushService>&&)>&&);
+    static void create(const String& incomingPushServiceName, const String& databasePath, IncomingPushMessageHandler&&, CompletionHandler<void(RefPtr<PushService>&&)>&&);
+    static void createMockService(IncomingPushMessageHandler&&, CompletionHandler<void(RefPtr<PushService>&&)>&&);
     ~PushService();
 
     PushServiceConnection& connection() { return m_connection; }
+    Ref<PushServiceConnection> protectedConnection() { return m_connection; }
     WebCore::PushDatabase& database() { return m_database; }
+    Ref<WebCore::PushDatabase> protectedDatabase() { return m_database; }
 
     Vector<String> enabledTopics() { return m_connection->enabledTopics(); }
     Vector<String> ignoredTopics() { return m_connection->ignoredTopics(); }
@@ -90,10 +93,10 @@ public:
 #endif
 
 private:
-    PushService(Ref<PushServiceConnection>&&, UniqueRef<WebCore::PushDatabase>&&, IncomingPushMessageHandler&&);
+    PushService(Ref<PushServiceConnection>&&, Ref<WebCore::PushDatabase>&&, IncomingPushMessageHandler&&);
 
-    using PushServiceRequestMap = HashMap<String, Deque<std::unique_ptr<PushServiceRequest>>>;
-    void enqueuePushServiceRequest(PushServiceRequestMap&, std::unique_ptr<PushServiceRequest>&&);
+    using PushServiceRequestMap = HashMap<String, Deque<Ref<PushServiceRequest>>>;
+    void enqueuePushServiceRequest(PushServiceRequestMap&, Ref<PushServiceRequest>&&);
     void finishedPushServiceRequest(PushServiceRequestMap&, PushServiceRequest&);
 
     void removeRecordsImpl(const WebCore::PushSubscriptionSetIdentifier&, const std::optional<String>& securityOrigin, CompletionHandler<void(unsigned)>&&);
@@ -101,7 +104,7 @@ private:
     void updateTopicLists(CompletionHandler<void()>&&);
 
     Ref<PushServiceConnection> m_connection;
-    UniqueRef<WebCore::PushDatabase> m_database;
+    Ref<WebCore::PushDatabase> m_database;
 
     IncomingPushMessageHandler m_incomingPushMessageHandler;
 

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -117,7 +117,7 @@ private:
 
     void notifyClientPushMessageIsAvailable(const WebCore::PushSubscriptionSetIdentifier&);
 
-    void setPushService(std::unique_ptr<PushService>&&);
+    void setPushService(RefPtr<PushService>&&);
     void runAfterStartingPushService(Function<void()>&&);
 
     void handleIncomingPushImpl(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
@@ -138,7 +138,7 @@ private:
     HashSet<xpc_connection_t> m_pendingConnectionSet;
     HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;
 
-    std::unique_ptr<PushService> m_pushService;
+    RefPtr<PushService> m_pushService;
     bool m_usingMockPushService { false };
     bool m_pushServiceStarted { false };
     Deque<Function<void()>> m_pendingPushServiceFunctions;

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -237,7 +237,7 @@ WebClipCache& WebPushDaemon::ensureWebClipCache()
 
 #endif
 
-void WebPushDaemon::setPushService(std::unique_ptr<PushService>&& pushService)
+void WebPushDaemon::setPushService(RefPtr<PushService>&& pushService)
 {
     m_pushService = WTFMove(pushService);
     m_pushServiceStarted = true;

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -105,12 +105,12 @@ static String makeTemporaryDatabasePath()
     return FileSystem::createTemporaryFile("PushDatabase"_s, ".db"_s);
 }
 
-static std::unique_ptr<PushDatabase> createDatabaseSync(const String& path)
+static RefPtr<PushDatabase> createDatabaseSync(const String& path)
 {
-    std::unique_ptr<PushDatabase> result;
+    RefPtr<PushDatabase> result;
     bool done = false;
 
-    PushDatabase::create(path, [&done, &result](std::unique_ptr<PushDatabase>&& database) {
+    PushDatabase::create(path, [&done, &result](RefPtr<PushDatabase>&& database) {
         result = WTFMove(database);
         done = true;
     });
@@ -206,7 +206,7 @@ static PushTopics getTopicsSync(PushDatabase& database)
 
 class PushDatabaseTest : public testing::Test {
 public:
-    std::unique_ptr<PushDatabase> db;
+    RefPtr<PushDatabase> db;
 
     IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
     PushRecord record1 {


### PR DESCRIPTION
#### e04b7061edfeb81f8cc262c12b02a029fe14da35
<pre>
Do more smart pointer adoption in webpushd code
<a href="https://bugs.webkit.org/show_bug.cgi?id=280546">https://bugs.webkit.org/show_bug.cgi?id=280546</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::create):
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebKit/webpushd/PushService.h:
(WebPushD::PushService::protectedConnection):
(WebPushD::PushService::protectedDatabase):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::create):
(WebPushD::PushService::createMockService):
(WebPushD::PushService::PushService):
(WebPushD::PushServiceRequest::PushServiceRequest):
(WebPushD::PushServiceRequest::service const):
(WebPushD::PushServiceRequest::protectedService const):
(WebPushD::PushServiceRequest::connection const):
(WebPushD::PushServiceRequest::protectedConnection const):
(WebPushD::PushServiceRequest::database const):
(WebPushD::PushServiceRequest::protectedDatabase const):
(WebPushD::GetSubscriptionRequest::startInternal):
(WebPushD::SubscribeRequest::startImpl):
(WebPushD::SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError):
(WebPushD::UnsubscribeRequest::startInternal):
(WebPushD::PushService::enqueuePushServiceRequest):
(WebPushD::PushService::finishedPushServiceRequest):
(WebPushD::PushService::getSubscription):
(WebPushD::PushService::subscribe):
(WebPushD::PushService::unsubscribe):
(WebPushD::PushService::incrementSilentPushCount):
(WebPushD::PushService::setPushesEnabledForSubscriptionSetAndOrigin):
(WebPushD::PushService::removeRecordsImpl):
(WebPushD::PushService::removeRecordsForBundleIdentifierAndDataStore):
(WebPushD::PushService::updateSubscriptionSetState):
(WebPushD::PushService::updateTopicLists):
(WebPushD::PushService::setPublicTokenForTesting):
(WebPushD::PushService::didReceivePublicToken):
(WebPushD::PushService::didReceivePushMessage):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::setPushService):
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::createDatabaseSync):

Canonical link: <a href="https://commits.webkit.org/284454@main">https://commits.webkit.org/284454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e603463badc7727bc7b76e361d42c5f569d0d5a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55088 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41065 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17215 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-child-with-border.html imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75044 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62655 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4280 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10601 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44454 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->