### PR TITLE
[UnifiedPDF][iOS] Add support for returning find matches and painting holes

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -173,6 +173,9 @@ private:
     bool findString(const String& target, WebCore::FindOptions, unsigned maxMatchCount) override;
     bool drawsFindOverlay() const final { return true; }
 
+    Vector<WebFoundTextRange::PDFData> findTextMatches(const String&, WebCore::FindOptions) final { return { }; }
+    Vector<WebCore::FloatRect> rectsForTextMatch(WebFoundTextRange::PDFData) final { return { }; }
+
     WebCore::DictionaryPopupInfo dictionaryPopupInfoForSelection(PDFSelection *, WebCore::TextIndicatorPresentationTransition) override;
     bool performDictionaryLookupAtLocation(const WebCore::FloatPoint&) override;
     std::pair<String, RetainPtr<PDFSelection>> textForImmediateActionHitTestAtPoint(const WebCore::FloatPoint&, WebHitTestResultData&) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -30,6 +30,7 @@
 #include "FrameInfoData.h"
 #include "PDFPluginIdentifier.h"
 #include "PDFScriptEvaluator.h"
+#include "WebFoundTextRange.h"
 #include "WebMouseEvent.h"
 #include <WebCore/AffineTransform.h>
 #include <WebCore/FindOptions.h>
@@ -171,6 +172,9 @@ public:
     virtual bool drawsFindOverlay() const = 0;
     virtual RefPtr<WebCore::TextIndicator> textIndicatorForCurrentSelection(OptionSet<WebCore::TextIndicatorOption>, WebCore::TextIndicatorPresentationTransition) { return { }; }
     virtual WebCore::DictionaryPopupInfo dictionaryPopupInfoForSelection(PDFSelection *, WebCore::TextIndicatorPresentationTransition) = 0;
+
+    virtual Vector<WebFoundTextRange::PDFData> findTextMatches(const String& target, WebCore::FindOptions) = 0;
+    virtual Vector<WebCore::FloatRect> rectsForTextMatch(WebFoundTextRange::PDFData) = 0;
 
     virtual bool performDictionaryLookupAtLocation(const WebCore::FloatPoint&) = 0;
     void performWebSearch(const String& query);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -413,6 +413,12 @@ private:
     void collectFindMatchRects(const String&, WebCore::FindOptions);
     void updateFindOverlay(HideFindIndicator = HideFindIndicator::No);
 
+    Vector<WebFoundTextRange::PDFData> findTextMatches(const String&, WebCore::FindOptions) final;
+    Vector<WebCore::FloatRect> rectsForTextMatch(WebFoundTextRange::PDFData) final;
+
+    Vector<WebCore::FloatRect> visibleRectsForFindMatchRects(PDFPageCoverage) const;
+    PDFSelection *selectionFromWebFoundTextRangePDFData(WebFoundTextRange::PDFData) const;
+
     RefPtr<WebCore::TextIndicator> textIndicatorForCurrentSelection(OptionSet<WebCore::TextIndicatorOption>, WebCore::TextIndicatorPresentationTransition) final;
     RefPtr<WebCore::TextIndicator> textIndicatorForSelection(PDFSelection *, OptionSet<WebCore::TextIndicatorOption>, WebCore::TextIndicatorPresentationTransition);
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -640,6 +640,22 @@ RefPtr<TextIndicator> PluginView::textIndicatorForCurrentSelection(OptionSet<Web
     return protectedPlugin()->textIndicatorForCurrentSelection(options, transition);
 }
 
+Vector<WebFoundTextRange::PDFData> PluginView::findTextMatches(const String& target, WebCore::FindOptions options)
+{
+    if (!m_isInitialized)
+        return { };
+
+    return protectedPlugin()->findTextMatches(target, options);
+}
+
+Vector<FloatRect> PluginView::rectsForTextMatch(WebFoundTextRange::PDFData match)
+{
+    if (!m_isInitialized)
+        return { };
+
+    return protectedPlugin()->rectsForTextMatch(match);
+}
+
 String PluginView::selectionString() const
 {
     if (!m_isInitialized)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -28,6 +28,7 @@
 #if ENABLE(PDF_PLUGIN)
 
 #include "PDFPluginIdentifier.h"
+#include "WebFoundTextRange.h"
 #include <WebCore/FindOptions.h>
 #include <WebCore/PluginViewBase.h>
 #include <WebCore/ResourceResponse.h>
@@ -102,6 +103,9 @@ public:
     Vector<WebCore::FloatRect> rectsForTextMatchesInRect(const WebCore::IntRect&) const;
     bool drawsFindOverlay() const;
     RefPtr<WebCore::TextIndicator> textIndicatorForCurrentSelection(OptionSet<WebCore::TextIndicatorOption>, WebCore::TextIndicatorPresentationTransition);
+
+    Vector<WebFoundTextRange::PDFData> findTextMatches(const String& target, WebCore::FindOptions);
+    Vector<WebCore::FloatRect> rectsForTextMatch(WebFoundTextRange::PDFData);
 
     String selectionString() const;
 


### PR DESCRIPTION
#### 1a18f37dc88fade68262e218cfc1fe8f29f59d52
<pre>
[UnifiedPDF][iOS] Add support for returning find matches and painting holes
<a href="https://bugs.webkit.org/show_bug.cgi?id=280545">https://bugs.webkit.org/show_bug.cgi?id=280545</a>
<a href="https://rdar.apple.com/136857262">rdar://136857262</a>

Reviewed by Wenson Hsieh.

Integrate `WebFoundTextRangeController` and `UnifiedPDFPlugin` to implement
a version of Find-in-PDF where all found matches are returned up front, as
expected by the UIKit API.

Following this patch the number of matches is accurately reported and holes
in the find overlay are painted for all matches.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::rectsForTextMatchesInRect const):
(WebKit::UnifiedPDFPlugin::findTextMatches):

Encode a `PDFSelection` as a `WebFoundTextRange::PDFData` so that it can be sent
across the process boundary, and restored as necessary.

(WebKit::UnifiedPDFPlugin::rectsForTextMatch):

Feed rects for PDF text matches to `WebFoundTextRangeController`.

(WebKit::UnifiedPDFPlugin::visibleRectsForFindMatchRects const):

Factor out rect computation into a common method.

(WebKit::UnifiedPDFPlugin::selectionFromWebFoundTextRangePDFData const):

Helper to convert `WebFoundTextRange::PDFData` coming from the UI process back
into a `PDFSelection`.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::findTextMatches):
(WebKit::PluginView::rectsForTextMatch):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):

Update method to search in PDFs.

(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):

Ensure the decorate ranges are updated, in order to paint the holes.

Move the DOM / `SimpleRange` specific logic, so that the common code to both
DOM and PDF searching is run.

(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):

Add rects for PDF matches.

(WebKit::WebFoundTextRangeController::simpleRangeFromFoundTextRange):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(configurationForWebViewTestingFindInUnifiedPDF):
(TEST(WebKit, FindInUnifiedPDF)):
(TEST(WebKit, FindInUnifiedPDFAfterReload)):
(TEST(WebKit, FindInUnifiedPDFAfterFindInPage)):

Canonical link: <a href="https://commits.webkit.org/284422@main">https://commits.webkit.org/284422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b883b7a952b627f51ab0583a3637cae605672f5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20427 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55103 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17234 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75063 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62667 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4293 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10589 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44473 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->