### PR TITLE
Provide more crash-info in when checking for runs of zero-bytes

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -119,6 +119,92 @@ JS_EXPORT_PRIVATE void dumpJITMemory(const void*, const void*, size_t);
 JS_EXPORT_PRIVATE void* performJITMemcpyWithMProtect(void *dst, const void *src, size_t n);
 #endif
 
+#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
+// This helps with error logging in the case of a crash, as it places the crash
+// PC at the point in the instruction stream which would be corrupted --
+// while preserving the stack so that we can use that to figure out who might be
+// responsible for generating the corrupted instructions.
+static NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void dieByJumpingIntoJITBufferWithInfo(int line, void* buffer, size_t offset, size_t size, auto info1, auto info2, auto info3)
+{
+    RELEASE_ASSERT(offset <= size);
+    RELEASE_ASSERT(offset <= std::numeric_limits<uint32_t>::max());
+    RELEASE_ASSERT(size <= std::numeric_limits<uint32_t>::max());
+    void* targetInstr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(buffer) + offset);
+
+    // Since this function should only be called w/ buffer+offset pointing at
+    // already-zeroed memory, re-zeroing it is somewhat superflous on ARM64E,
+    // but necessary on x86-64 (where 0x00 0x00 encodes addb %al, (%rax)), and
+    // even on the former ensures that execution will never continue past the
+    // branch out of this function even if it is called improperly.
+#if OS(DARWIN) && CPU(X86_64)
+    memset(reinterpret_cast<char*>(targetInstr), 0xF4, 1);
+    sys_icache_invalidate(buffer, size);
+#elif OS(DARWIN) && CPU(ARM64)
+    memset(reinterpret_cast<char*>(targetInstr), 0, 4);
+    sys_icache_invalidate(buffer, size);
+#else
+#error "JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES not supported on this platform."
+#endif
+
+    uint64_t lineGpr = static_cast<uint64_t>(static_cast<int64_t>(line));
+    uint64_t bufferGpr = reinterpret_cast<uintptr_t>(buffer);
+    uint64_t sizeOffsetGpr = static_cast<uint64_t>(offset | size << 32);
+    uint64_t info1Gpr = wtfCrashArg(info1);
+    uint64_t info2Gpr = wtfCrashArg(info2);
+    uint64_t info3Gpr = wtfCrashArg(info3);
+
+    // We do this instead of using explicit register variables because clang
+    // seems to struggle with placing those in the same function as an outward
+    // function call
+#if CPU(X86_64)
+    __asm__ volatile(
+        "mov %1, %%" CRASH_GPR0 "\n"
+        "mov %2, %%" CRASH_GPR1 "\n"
+        "mov %3, %%" CRASH_GPR2 "\n"
+        "mov %4, %%" CRASH_GPR3 "\n"
+        "mov %5, %%" CRASH_GPR4 "\n"
+        "mov %6, %%" CRASH_GPR5 "\n"
+        "jmp *%0"
+            : : "r"(targetInstr), "r"(lineGpr), "r"(bufferGpr), "r"(sizeOffsetGpr), "r"(info1Gpr), "r"(info2Gpr), "r"(info3Gpr)
+            : CRASH_GPR0, CRASH_GPR1, CRASH_GPR2, CRASH_GPR3, CRASH_GPR4, CRASH_GPR5);
+#elif CPU(ARM64)
+    __asm__ volatile(
+        "mov " CRASH_GPR0 ", %1\n"
+        "mov " CRASH_GPR1 ", %2\n"
+        "mov " CRASH_GPR2 ", %3\n"
+        "mov " CRASH_GPR3 ", %4\n"
+        "mov " CRASH_GPR4 ", %5\n"
+        "mov " CRASH_GPR5 ", %6\n"
+        "br %0"
+            : : "r"(targetInstr), "r"(lineGpr), "r"(bufferGpr), "r"(sizeOffsetGpr), "r"(info1Gpr), "r"(info2Gpr), "r"(info3Gpr)
+            : CRASH_GPR0, CRASH_GPR1, CRASH_GPR2, CRASH_GPR3, CRASH_GPR4, CRASH_GPR5);
+#else
+#error "JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES not supported on this platform."
+#endif
+
+            __builtin_unreachable();
+}
+
+#define CRASH_BY_JUMPING_INTO_JIT_BUFFER_WITH_INFO(...) do { \
+        WTF::isIntegralOrPointerType(__VA_ARGS__); \
+        compilerFenceForCrash(); \
+        dieByJumpingIntoJITBufferWithInfo(__LINE__, __VA_ARGS__); \
+    } while (false)
+
+// We only check whether the run also exists in the source buffer
+// once we know we're going to crash and thus can afford the
+// overhead.
+#define RELEASE_ASSERT_ZERO_CHECK(zeroCount, dstBuff, srcBuff, buffSize, nextIndex) do { \
+        if (UNLIKELY(zeroCount > maxZeroByteRunLength)) { \
+            size_t firstZeroIndex = nextIndex - zeroCount; \
+            auto dstBuffZeroes = reinterpret_cast<const char*>(dstBuff) + firstZeroIndex; \
+            auto srcBuffZeroes = reinterpret_cast<const char*>(srcBuff) + firstZeroIndex; \
+            bool sourceBufferBytesAlsoZero = !(std::memcmp(dstBuffZeroes, srcBuffZeroes, runLength)); \
+            CRASH_BY_JUMPING_INTO_JIT_BUFFER_WITH_INFO(dstBuff, firstZeroIndex, buffSize, nextIndex, srcBuff, sourceBufferBytesAlsoZero); \
+        } \
+    } while (false)
+#endif // ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
+
 static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
 {
 #if CPU(ARM64)
@@ -131,7 +217,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
         RELEASE_ASSERT(static_cast<uint8_t*>(dst) + n <= endOfFixedExecutableMemoryPool());
 
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-        auto checkForZeroes = [n] (const void* buffer_v) {
+        auto checkForZeroes = [dst, src, n] () {
             // On x86-64, the maximum immediate size is 8B, no opcodes/prefixes have 0x00
             // On other architectures this could be smaller
             constexpr size_t maxZeroByteRunLength = 16;
@@ -140,31 +226,31 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
             constexpr size_t stride = sizeof(uint64_t);
             static_assert(stride <= maxZeroByteRunLength);
 
-            const char* buffer = reinterpret_cast<const char*>(buffer_v);
+            const char* dstBuff = reinterpret_cast<const char*>(dst);
             size_t runLength = 0;
             size_t i = 0;
             if (n > stride) {
-                for (; (reinterpret_cast<uintptr_t>(buffer) + i) % stride; i++) {
-                    if (!(buffer[i]))
+                for (; (reinterpret_cast<uintptr_t>(dstBuff) + i) % stride; i++) {
+                    if (!(dstBuff[i]))
                         runLength++;
                     else
                         runLength = 0;
                 }
                 for (; i + stride <= n; i += stride) {
-                    uint64_t chunk = *reinterpret_cast<const uint64_t*>(buffer + i);
+                    uint64_t chunk = *reinterpret_cast<const uint64_t*>(dstBuff + i);
                     if (!chunk) {
                         runLength += sizeof(chunk);
-                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer, n, i);
+                        RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + stride);
                     } else {
                         runLength += (std::countr_zero(chunk) / 8);
-                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer, n, i);
+                        RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + (std::countr_zero(chunk) / 8));
                         runLength = std::countl_zero(chunk) / 8;
                     }
                 }
                 for (; i < n; i++) {
-                    if (!(buffer[i])) {
+                    if (!(dstBuff[i])) {
                         runLength++;
-                        RELEASE_ASSERT(runLength <= maxZeroByteRunLength, buffer, n, i);
+                        RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + 1);
                     }
                 }
             }
@@ -177,7 +263,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 #if ENABLE(MPROTECT_RX_TO_RWX)
         auto ret = performJITMemcpyWithMProtect(dst, src, n);
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-        checkForZeroes(dst);
+        checkForZeroes();
 #endif
         return ret;
 #endif
@@ -187,7 +273,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
             memcpy(dst, src, n);
             threadSelfRestrict<MemoryRestriction::kRwxToRx>();
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-            checkForZeroes(dst);
+            checkForZeroes();
 #endif
             return dst;
         }
@@ -200,7 +286,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
             retagCodePtr<JITThunkPtrTag, CFunctionPtrTag>(g_jscConfig.jitWriteSeparateHeaps)(offset, src, n);
             RELEASE_ASSERT(!Gigacage::contains(src));
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-            checkForZeroes(dst);
+            checkForZeroes();
 #endif
             return dst;
         }
@@ -208,7 +294,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 
         auto ret = memcpy(dst, src, n);
 #if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-        checkForZeroes(dst);
+        checkForZeroes();
 #endif
         return ret;
     }


### PR DESCRIPTION
#### 34d00da35e69a4c7f352e7070ab877e7a409ff70
<pre>
Provide more crash-info in when checking for runs of zero-bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=280547">https://bugs.webkit.org/show_bug.cgi?id=280547</a>
<a href="https://rdar.apple.com/136858657">rdar://136858657</a>

Reviewed by Keith Miller.

Previously, the crash told us that zero-bytes were present in the
destination buffer, but not whether they were present in the source
buffer. This patch fixes that without performance overhead by checking
the source buffer only if a run is detected in the destination buffer.
Moreover, while the crash stack afforded by this diagnostic is more
useful than the &apos;raw&apos; crash would be, it does lose us the ability to see
the actually-corrupted instruction stream: instead of just asserting,
this patch jumps into the JIT buffer to induce a crash.

* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::dieByJumpingIntoJITBufferWithInfo):
(JSC::performJITMemcpy):

Canonical link: <a href="https://commits.webkit.org/284559@main">https://commits.webkit.org/284559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41b06edb267622687006e4697772c879e41b4f25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20888 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13856 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19265 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62846 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75539 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68976 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62999 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15500 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11021 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4607 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90758 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44934 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16113 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->