### PR TITLE
Use the correct API for generating public key.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
@@ -66,17 +66,17 @@ PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, tru
 PASS Good parameters with ignored JWK alg: X25519 (jwk, object(kty, crv, x), {name: X25519}, true, [])
 PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, true, [])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits, deriveKey])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
 PASS Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, false, [])
 PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, false, [])
 PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, false, [])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
@@ -66,17 +66,17 @@ PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, tru
 PASS Good parameters with ignored JWK alg: X25519 (jwk, object(kty, crv, x), {name: X25519}, true, [])
 PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, true, [])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits, deriveKey])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits])
 PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_true: Round trip works expected true got false
-FAIL Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Good parameters with ignored JWK alg: X25519 (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
 PASS Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, false, [])
 PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, false, [])
 PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, false, [])


### PR DESCRIPTION
#### 34986dbe6f18ccb32965d6c8a476c5b49b108c53
<pre>
Use the correct API for generating public key.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279963">https://bugs.webkit.org/show_bug.cgi?id=279963</a>
<a href="https://rdar.apple.com/136282739">rdar://136282739</a>

Reviewed by David Kilzer.

For CommonCrypto using the correct API depending on X25519/Ed25519 as they both are going to a different path
in the internal implementation.
Updating test expectations as now the import/export tests all pass.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt:
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::generateJwkX const):

Canonical link: <a href="https://commits.webkit.org/284459@main">https://commits.webkit.org/284459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cfcd2eba8222168d45e8a3597b288db3e2be47f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20615 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13697 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17394 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18992 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75251 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16964 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62906 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-animated-001.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-element-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-fit-none.html imported/w3c/web-platform-tests/css/css-view-transitions/no-root-capture.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62812 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10837 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4447 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10603 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44661 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->