### PR TITLE
Enable ImageCapture by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3400,17 +3400,17 @@ ImageAnimationControlEnabled:
 
 ImageCaptureEnabled:
   type: bool
-  status: testable
+  status: stable
   category: media
   humanReadableName: "Image Capture API"
   humanReadableDescription: "Enable Image Capture API"
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 ImageControlsEnabled:


### PR DESCRIPTION
#### f41c983741dbda9425c7967a61cafcf0f53cc809
<pre>
Enable ImageCapture by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=280550">https://bugs.webkit.org/show_bug.cgi?id=280550</a>
<a href="https://rdar.apple.com/136860809">rdar://136860809</a>

Reviewed by Youenn Fablet.

Change the `ImageCaptureEnabled` setting&apos;s status to stable and enable it by default for
Cocoa platforms.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/284447@main">https://commits.webkit.org/284447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17d1de623a676a77b51d9852442b4f63f940273c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20416 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55092 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13554 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18791 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62374 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75052 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68504 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16802 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62757 "Found 22 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html fast/css/view-transitions-zoom.html imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing.html imported/w3c/web-platform-tests/css/css-view-transitions/class-specificity.html imported/w3c/web-platform-tests/css/css-view-transitions/content-visibility-auto-shared-element.html imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-shared-element.html imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62663 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4285 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90285 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44462 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16013 "Found 29 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/es6/map_basic.js.default, exceptionFuzz.yaml/exceptionFuzz/earley-boyer.js.exception-fuzz, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-alias.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-compare-final-object-to-final-object-or-other-when-both-proven-final-object.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-dead-speculation.js.layout, stress/array-methods-should-not-modify-string.js.bytecode-cache, stress/array-methods-should-not-modify-string.js.dfg-eager, stress/big-int-subtraction-type-error.js.bytecode-cache, stress/iterator-from.js.dfg-eager ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->