### PR TITLE
Make DisplayCaptureSourceCocoa::Capturer refable

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -69,20 +69,30 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(const CaptureDevice& devi
     switch (device.type()) {
     case CaptureDevice::DeviceType::Screen:
 #if HAVE(REPLAYKIT)
-        return create(ReplayKitCaptureSource::create(device.persistentId()), device, WTFMove(hashSalts), constraints, pageIdentifier);
+        if (!ReplayKitCaptureSource::isAvailable())
+            return CaptureSourceOrError { CaptureSourceError { "Screen capture unavailable"_s, MediaAccessDenialReason::NoCaptureDevices } };
+
+        return create([] (auto& source) {
+            return ReplayKitCaptureSource::create(source);
+        }, device, WTFMove(hashSalts), constraints, pageIdentifier);
 #elif HAVE(SCREEN_CAPTURE_KIT)
-        if (ScreenCaptureKitCaptureSource::isAvailable())
-            return create(ScreenCaptureKitCaptureSource::create(device, constraints), device, WTFMove(hashSalts), constraints, pageIdentifier);
-        ASSERT_NOT_REACHED();
-        return { };
+        FALLTHROUGH;
 #else
         ASSERT_NOT_REACHED();
         return { };
 #endif
     case CaptureDevice::DeviceType::Window:
 #if HAVE(SCREEN_CAPTURE_KIT)
-        if (ScreenCaptureKitCaptureSource::isAvailable())
-            return create(ScreenCaptureKitCaptureSource::create(device, constraints), device, WTFMove(hashSalts), constraints, pageIdentifier);
+        if (ScreenCaptureKitCaptureSource::isAvailable()) {
+            auto deviceID = ScreenCaptureKitCaptureSource::computeDeviceID(device);
+            if (!deviceID)
+                return CaptureSourceOrError { WTFMove(deviceID).error() };
+            return create([deviceID = deviceID.value(), &device] (auto& source) {
+                return ScreenCaptureKitCaptureSource::create(source, device, deviceID);
+            }, device, WTFMove(hashSalts), constraints, pageIdentifier);
+        }
+        ASSERT_NOT_REACHED();
+        return { };
 #endif
         break;
     case CaptureDevice::DeviceType::SystemAudio:
@@ -97,12 +107,9 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(const CaptureDevice& devi
     return { };
 }
 
-CaptureSourceOrError DisplayCaptureSourceCocoa::create(Expected<UniqueRef<Capturer>, CaptureSourceError>&& capturer, const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
+CaptureSourceOrError DisplayCaptureSourceCocoa::create(const std::function<UniqueRef<Capturer>(CapturerObserver&)>& createCapturer, const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    if (!capturer.has_value())
-        return CaptureSourceOrError { WTFMove(capturer.error()) };
-
-    auto source = adoptRef(*new DisplayCaptureSourceCocoa(WTFMove(capturer.value()), device, WTFMove(hashSalts), pageIdentifier));
+    auto source = adoptRef(*new DisplayCaptureSourceCocoa(createCapturer, device, WTFMove(hashSalts), pageIdentifier));
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
             return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
@@ -111,13 +118,12 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(Expected<UniqueRef<Captur
     return CaptureSourceOrError(WTFMove(source));
 }
 
-DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa(UniqueRef<Capturer>&& capturer, const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
+DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa(const std::function<UniqueRef<Capturer>(CapturerObserver&)>& createCapturer, const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
     : RealtimeMediaSource(device, WTFMove(hashSalts), pageIdentifier)
-    , m_capturer(WTFMove(capturer))
+    , m_capturer(createCapturer(*this))
     , m_timer(RunLoop::current(), this, &DisplayCaptureSourceCocoa::emitFrame)
     , m_userActivity("App nap disabled for screen capture"_s)
 {
-    m_capturer->setObserver(*this);
 }
 
 DisplayCaptureSourceCocoa::~DisplayCaptureSourceCocoa()
@@ -358,11 +364,6 @@ void DisplayCaptureSourceCocoa::Capturer::setLogger(const Logger& newLogger, uin
 WTFLogChannel& DisplayCaptureSourceCocoa::Capturer::logChannel() const
 {
     return LogWebRTC;
-}
-
-void DisplayCaptureSourceCocoa::Capturer::setObserver(CapturerObserver& observer)
-{
-    m_observer = WeakPtr { observer };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
@@ -35,21 +35,12 @@ OBJC_CLASS RPScreenRecorder;
 OBJC_CLASS WebCoreReplayKitScreenRecorderHelper;
 
 namespace WebCore {
-class ReplayKitCaptureSource;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ReplayKitCaptureSource> : std::true_type { };
-}
-
-namespace WebCore {
 
 class ReplayKitCaptureSource final : public DisplayCaptureSourceCocoa::Capturer, public CanMakeWeakPtr<ReplayKitCaptureSource> {
 public:
-    static Expected<UniqueRef<DisplayCaptureSourceCocoa::Capturer>, CaptureSourceError> create(const String&);
+    static UniqueRef<DisplayCaptureSourceCocoa::Capturer> create(CapturerObserver&);
 
-    ReplayKitCaptureSource();
+    ReplayKitCaptureSource(CapturerObserver&);
     virtual ~ReplayKitCaptureSource();
 
     static bool isAvailable();

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -49,15 +49,6 @@ OBJC_CLASS WebCoreScreenCaptureKitHelper;
 using CMSampleBufferRef = struct opaqueCMSampleBuffer*;
 
 namespace WebCore {
-class ScreenCaptureKitCaptureSource;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScreenCaptureKitCaptureSource> : std::true_type { };
-}
-
-namespace WebCore {
 
 class ImageTransferSessionVT;
 
@@ -65,9 +56,10 @@ class ScreenCaptureKitCaptureSource final
     : public DisplayCaptureSourceCocoa::Capturer
     , public ScreenCaptureSessionSourceObserver {
 public:
-    static Expected<UniqueRef<DisplayCaptureSourceCocoa::Capturer>, CaptureSourceError> create(const CaptureDevice&, const MediaConstraints*);
+    static Expected<uint32_t, CaptureSourceError> computeDeviceID(const CaptureDevice&);
+    static UniqueRef<DisplayCaptureSourceCocoa::Capturer> create(CapturerObserver&, const CaptureDevice&, uint32_t deviceID);
 
-    explicit ScreenCaptureKitCaptureSource(const CaptureDevice&, uint32_t);
+    ScreenCaptureKitCaptureSource(CapturerObserver&, const CaptureDevice&, uint32_t);
     virtual ~ScreenCaptureKitCaptureSource();
 
     WEBCORE_EXPORT static bool isAvailable();
@@ -82,7 +74,6 @@ public:
     void outputVideoEffectDidStopForStream() { m_isVideoEffectEnabled = false; }
 
 private:
-
     // DisplayCaptureSourceCocoa::Capturer
     bool start() final;
     void stop() final;


### PR DESCRIPTION
#### 5125e1418484fbec0e18c1526e84862281d7d6e8
<pre>
Make DisplayCaptureSourceCocoa::Capturer refable
<a href="https://rdar.apple.com/136862121">rdar://136862121</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280552">https://bugs.webkit.org/show_bug.cgi?id=280552</a>

Reviewed by Eric Carlson.

ScreenCaptureKitCaptureSource needs to be a weak pointer, so we should be able to take a ref.
To simplify things, ScreenCaptureKitCaptureSource will ref via its observer, DisplayCaptureSourceCocoa.

Since we need to create ScreenCaptureKitCaptureSource at the time we create DisplayCaptureSourceCocoa,
DisplayCaptureSourceCocoa constructor takes a callback to create ScreenCaptureKitCaptureSource, the callback taking a DisplayCaptureSourceCocoa.

* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::create):
(WebCore::DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa):
(WebCore::DisplayCaptureSourceCocoa::Capturer::setObserver): Deleted.
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h:
* Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm:
(WebCore::ReplayKitCaptureSource::create):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::computeDeviceID):
(WebCore::ScreenCaptureKitCaptureSource::create):
(WebCore::ScreenCaptureKitCaptureSource::ScreenCaptureKitCaptureSource):
(WebCore::ScreenCaptureKitCaptureSource::whenReady):
(WebCore::ScreenCaptureKitCaptureSource::stop):
(WebCore::ScreenCaptureKitCaptureSource::sessionFilterDidChange):
(WebCore::ScreenCaptureKitCaptureSource::startContentStream):
(WebCore::ScreenCaptureKitCaptureSource::updateStreamConfiguration):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockDisplayCapturer::MockDisplayCapturer):

Canonical link: <a href="https://commits.webkit.org/284423@main">https://commits.webkit.org/284423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1af4bf4fa76e482dd0ee4058633384f8bea6bca5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20328 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13595 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75114 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16847 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62705 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4332 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44524 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45598 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->