### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make SpeechSynthesisClient ref-counted

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(SpeechSynthesis);
 
-Ref<SpeechSynthesis>SpeechSynthesis::create(ScriptExecutionContext& context)
+Ref<SpeechSynthesis> SpeechSynthesis::create(ScriptExecutionContext& context)
 {
     auto synthesis = adoptRef(*new SpeechSynthesis(context));
     synthesis->suspendIfNeeded();
@@ -69,9 +69,9 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
         m_speechSynthesisClient = document->frame()->page()->speechSynthesisClient();
     }
 
-    if (m_speechSynthesisClient) {
-        m_speechSynthesisClient->setObserver(*this);
-        m_speechSynthesisClient->resetState();
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get()) {
+        speechSynthesisClient->setObserver(*this);
+        speechSynthesisClient->resetState();
     }
 }
 
@@ -117,7 +117,8 @@ const Vector<Ref<SpeechSynthesisVoice>>& SpeechSynthesis::getVoices()
         return *m_voiceList;
 
     // If the voiceList is empty, that's the cue to get the voices from the platform again.
-    auto& voiceList = m_speechSynthesisClient ? m_speechSynthesisClient->voiceList() : ensurePlatformSpeechSynthesizer().voiceList();
+    RefPtr speechSynthesisClient = m_speechSynthesisClient.get();
+    auto& voiceList = speechSynthesisClient ? speechSynthesisClient->voiceList() : ensurePlatformSpeechSynthesizer().voiceList();
     m_voiceList = voiceList.map([](auto& voice) {
         return SpeechSynthesisVoice::create(*voice);
     });
@@ -150,8 +151,8 @@ void SpeechSynthesis::startSpeakingImmediately(SpeechSynthesisUtterance& utteran
     m_currentSpeechUtterance = makeUnique<SpeechSynthesisUtteranceActivity>(Ref { utterance });
     m_isPaused = false;
 
-    if (m_speechSynthesisClient)
-        m_speechSynthesisClient->speak(utterance.platformUtterance());
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
+        speechSynthesisClient->speak(utterance.platformUtterance());
     else
         ensurePlatformSpeechSynthesizer().speak(utterance.platformUtterance());
 }
@@ -178,8 +179,8 @@ void SpeechSynthesis::cancel()
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
     RefPtr current = protectedCurrentSpeechUtterance();
     m_utteranceQueue.clear();
-    if (m_speechSynthesisClient) {
-        m_speechSynthesisClient->cancel();
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get()) {
+        speechSynthesisClient->cancel();
         // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
         // and the event won't be processed. Instead we process the error immediately.
         speakingErrorOccurred();
@@ -193,8 +194,8 @@ void SpeechSynthesis::cancel()
 void SpeechSynthesis::pause()
 {
     if (!m_isPaused) {
-        if (m_speechSynthesisClient)
-            m_speechSynthesisClient->pause();
+        if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
+            speechSynthesisClient->pause();
         else if (m_platformSpeechSynthesizer)
             m_platformSpeechSynthesizer->pause();
     }
@@ -203,8 +204,8 @@ void SpeechSynthesis::pause()
 void SpeechSynthesis::resumeSynthesis()
 {
     if (m_currentSpeechUtterance) {
-        if (m_speechSynthesisClient)
-            m_speechSynthesisClient->resume();
+        if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
+            speechSynthesisClient->resume();
         else if (m_platformSpeechSynthesizer)
             m_platformSpeechSynthesizer->resume();
     }

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -45,10 +45,11 @@ class SpeechSynthesisVoice;
 class SpeechSynthesis : public PlatformSpeechSynthesizerClient, public SpeechSynthesisClientObserver, public RefCounted<SpeechSynthesis>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SpeechSynthesis);
 public:
-    DEFINE_VIRTUAL_REFCOUNTED;
-
     static Ref<SpeechSynthesis> create(ScriptExecutionContext&);
     virtual ~SpeechSynthesis();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool pending() const;
     bool speaking() const;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1322,7 +1322,7 @@ private:
     std::unique_ptr<PerformanceLoggingClient> m_performanceLoggingClient;
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    std::unique_ptr<SpeechSynthesisClient> m_speechSynthesisClient;
+    RefPtr<SpeechSynthesisClient> m_speechSynthesisClient;
 #endif
 
     UniqueRef<SpeechRecognitionProvider> m_speechRecognitionProvider;

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -180,7 +180,7 @@ public:
     std::unique_ptr<DiagnosticLoggingClient> diagnosticLoggingClient;
     std::unique_ptr<PerformanceLoggingClient> performanceLoggingClient;
 #if ENABLE(SPEECH_SYNTHESIS)
-    std::unique_ptr<SpeechSynthesisClient> speechSynthesisClient;
+    RefPtr<SpeechSynthesisClient> speechSynthesisClient;
 #endif
 
     RefPtr<ApplicationCacheStorage> applicationCacheStorage;

--- a/Source/WebCore/page/SpeechSynthesisClient.h
+++ b/Source/WebCore/page/SpeechSynthesisClient.h
@@ -30,17 +30,6 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class SpeechSynthesisClientObserver;
-class SpeechSynthesisClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechSynthesisClientObserver> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpeechSynthesisClient> : std::true_type { };
-}
-
-namespace WebCore {
 
 class PlatformSpeechSynthesisUtterance;
 class SpeechSynthesisClientObserver;
@@ -49,6 +38,9 @@ class PlatformSpeechSynthesisVoice;
 class SpeechSynthesisClient : public CanMakeWeakPtr<SpeechSynthesisClient> {
 public:
     virtual ~SpeechSynthesisClient() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void setObserver(WeakPtr<SpeechSynthesisClientObserver>) = 0;
     virtual WeakPtr<SpeechSynthesisClientObserver> observer() const = 0;
@@ -65,6 +57,9 @@ public:
 class SpeechSynthesisClientObserver : public CanMakeWeakPtr<SpeechSynthesisClientObserver>  {
 public:
     virtual ~SpeechSynthesisClientObserver() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void didStartSpeaking() = 0;
     virtual void didFinishSpeaking() = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
@@ -30,27 +30,26 @@
 #include <WebCore/PlatformSpeechSynthesisUtterance.h>
 #include <WebCore/PlatformSpeechSynthesisVoice.h>
 #include <WebCore/SpeechSynthesisClient.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebKit {
-class WebSpeechSynthesisClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebSpeechSynthesisClient> : std::true_type { };
-}
 
 namespace WebKit {
 
 class WebPage;
     
-class WebSpeechSynthesisClient : public WebCore::SpeechSynthesisClient {
+class WebSpeechSynthesisClient final : public RefCounted<WebSpeechSynthesisClient>, public WebCore::SpeechSynthesisClient {
     WTF_MAKE_TZONE_ALLOCATED(WebSpeechSynthesisClient);
 public:
-    explicit WebSpeechSynthesisClient(WebPage&);
+    static Ref<WebSpeechSynthesisClient> create(WebPage& webPage)
+    {
+        return adoptRef(*new WebSpeechSynthesisClient(webPage));
+    }
+
     virtual ~WebSpeechSynthesisClient() { }
-    
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& voiceList() override;
     void speak(RefPtr<WebCore::PlatformSpeechSynthesisUtterance>) override;
     void cancel() override;
@@ -58,7 +57,7 @@ public:
     void resume() override;
 
 private:
-    Ref<WebPage> protectedPage() const;
+    explicit WebSpeechSynthesisClient(WebPage&);
 
     void setObserver(WeakPtr<WebCore::SpeechSynthesisClientObserver> observer) override { m_observer = observer; }
     WeakPtr<WebCore::SpeechSynthesisClientObserver> observer() const override { return m_observer; }
@@ -66,7 +65,7 @@ private:
 
     WebCore::SpeechSynthesisClientObserver* corePageObserver() const;
     
-    WeakRef<WebPage> m_page;
+    WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::SpeechSynthesisClientObserver> m_observer;
     Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>> m_voices;
 };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -746,7 +746,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.screenOrientationManager = m_screenOrientationManager.get();
 
 #if ENABLE(SPEECH_SYNTHESIS) && !USE(GSTREAMER)
-    pageConfiguration.speechSynthesisClient = makeUnique<WebSpeechSynthesisClient>(*this);
+    pageConfiguration.speechSynthesisClient = WebSpeechSynthesisClient::create(*this);
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)


### PR DESCRIPTION
#### 4e1ba66c57dfdc05d16b3e221ca567d5da4f000e
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make SpeechSynthesisClient ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280555">https://bugs.webkit.org/show_bug.cgi?id=280555</a>
<a href="https://rdar.apple.com/136865003">rdar://136865003</a>

Reviewed by Chris Dumez.

We remove IsDeprecatedWeakRefSmartPointerException by making SpeechSynthesisClient
ref-counted.

WebSpeechSynthesisClient is owned by Page. Since it&apos;s &apos;now ref-counted, it&apos;s possible
for it to out-live the Page, which would be a problem. To ensure that
WebSpeecSynthesisClient never tries to use it&apos;s WebPage member if the Page has been
destroyed, we change the m_page member to be a WeakPtr instead of a WeakRef and
null-check m_page before using it.

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::create):
(WebCore::SpeechSynthesis::SpeechSynthesis):
(WebCore::SpeechSynthesis::getVoices):
(WebCore::SpeechSynthesis::startSpeakingImmediately):
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::pause):
(WebCore::SpeechSynthesis::resumeSynthesis):
(WebCore::Ref&lt;SpeechSynthesis&gt;SpeechSynthesis::create): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/SpeechSynthesisClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
(WebKit::WebSpeechSynthesisClient::voiceList):
(WebKit::WebSpeechSynthesisClient::corePageObserver const):
(WebKit::WebSpeechSynthesisClient::resetState):
(WebKit::WebSpeechSynthesisClient::speak):
(WebKit::WebSpeechSynthesisClient::cancel):
(WebKit::WebSpeechSynthesisClient::pause):
(WebKit::WebSpeechSynthesisClient::resume):
(WebKit::WebSpeechSynthesisClient::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h:
(WebKit::WebSpeechSynthesisClient::~WebSpeechSynthesisClient): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):

Canonical link: <a href="https://commits.webkit.org/284434@main">https://commits.webkit.org/284434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c6ecbe1a29f3741b81eb749d28deca50fdf5fb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55113 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13577 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17260 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4314 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44503 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->