### PR TITLE
Implement `Element.currentCSSZoom`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/Element-currentCSSZoom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/Element-currentCSSZoom-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Element.currentCSSZoom basic test assert_equals: Unzoomed content expected (number) 1 but got (undefined) undefined
-FAIL Element.currentCSSZoom reacts to style changes assert_equals: currentCSSZoom reacts to style changes expected (number) 2 but got (undefined) undefined
+PASS Element.currentCSSZoom basic test
+PASS Element.currentCSSZoom reacts to style changes
 

--- a/Source/WebCore/dom/Element+CSSOMView.idl
+++ b/Source/WebCore/dom/Element+CSSOMView.idl
@@ -45,6 +45,7 @@ partial interface Element {
     readonly attribute long clientLeft;
     readonly attribute long clientWidth;
     readonly attribute long clientHeight;
+    readonly attribute double currentCSSZoom;
 
     // Non-standard: https://www.w3.org/Bugs/Public/show_bug.cgi?id=17152.
     undefined scrollIntoViewIfNeeded(optional boolean centerIfNeeded = true);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1560,6 +1560,15 @@ int Element::clientHeight()
     return 0;
 }
 
+double Element::currentCSSZoom()
+{
+    protectedDocument()->updateStyleIfNeeded();
+
+    if (CheckedPtr renderer = this->renderer())
+        return renderer->style().usedZoom() / RenderStyle::initialZoom();
+    return 1.0;
+}
+
 ALWAYS_INLINE LocalFrame* Element::documentFrameWithNonNullView() const
 {
     auto* frame = document().frame();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -274,6 +274,7 @@ public:
     WEBCORE_EXPORT int clientTop();
     WEBCORE_EXPORT int clientWidth();
     WEBCORE_EXPORT int clientHeight();
+    double currentCSSZoom();
 
     virtual int scrollLeft();
     virtual int scrollTop();


### PR DESCRIPTION
#### 2d83fe5b565d36b4ec19c06c6383c150e54d983a
<pre>
Implement `Element.currentCSSZoom`

<a href="https://bugs.webkit.org/show_bug.cgi?id=279881">https://bugs.webkit.org/show_bug.cgi?id=279881</a>
<a href="https://rdar.apple.com/136662584">rdar://136662584</a>

Reviewed by Tim Nguyen.

This patch implements `currentCSSZoom` as per web specification [1] and
aligns with Gecko / Firefox and Blink / Chrome.

[1] <a href="https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom">https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom</a>

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::currentCSSZoom):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element+CSSOMView.idl:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/Element-currentCSSZoom-expected.txt:

Canonical link: <a href="https://commits.webkit.org/284510@main">https://commits.webkit.org/284510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89dad2a3193f95bc7318e3f538375e9fdb555eaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55337 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13802 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75410 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17090 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63017 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4560 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44816 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->