### PR TITLE
[JSC] Remove outdated skip files from `test262/config.yaml`

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -53,15 +53,6 @@ skip:
     - test/built-ins/Function/prototype/restricted-property-arguments.js
     - test/built-ins/Function/prototype/restricted-property-caller.js
 
-    # Slightly different formatting. We should update test262 side.
-    - test/intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js
-    - test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
-    - test/intl402/NumberFormat/prototype/format/unit-ja-JP.js
-    - test/intl402/NumberFormat/prototype/format/unit-zh-TW.js
-    - test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js
-    - test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js
-    - test/intl402/DurationFormat/prototype/format/style-narrow-en.js
-
     # New ICU (66~) raises a different failure
     - test/intl402/Locale/constructor-apply-options-canonicalizes-twice.js
     - test/intl402/Locale/constructor-non-iana-canon.js
@@ -88,10 +79,6 @@ skip:
     - test/intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js
     - test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js
     - test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js
-
-    # Test is obsolete. microseconds and nanoseconds are added in the spec.
-    - test/intl402/Intl/supportedValuesOf/units.js
-    - test/intl402/NumberFormat/prototype/format/units-invalid.js
 
     # Approximately sign is only supported after ICU 71.
     - test/intl402/NumberFormat/prototype/formatRangeToParts/en-US.js


### PR DESCRIPTION
#### 001368723c621d2756c72e003171c868e3b6c717
<pre>
[JSC] Remove outdated skip files from `test262/config.yaml`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280564">https://bugs.webkit.org/show_bug.cgi?id=280564</a>

Reviewed by Alexey Shvayka.

There are some outdated skipped files in `JSTests/test262/config.yaml`. it have already been updated
on the test262 side, and JSC now passes these tests.

This patch removes the outdated skipped files from `config.yaml`.

* JSTests/test262/config.yaml:

Canonical link: <a href="https://commits.webkit.org/284426@main">https://commits.webkit.org/284426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8266689503c9c6440164555edab70be80c795fc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55118 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41105 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18839 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62420 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75098 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68550 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62692 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10709 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4318 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90331 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10591 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44508 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16017 "Found 2 new JSC binary failures: testapi, testb3, Found 4087 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_splice_515632.js.default, ChakraCore.yaml/ChakraCore/test/Basics/ArrayConcat.js.default, ChakraCore.yaml/ChakraCore/test/Error/variousErrors.js.default, ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Number/property_and_index_of_number.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, ChakraCore.yaml/ChakraCore/test/RWC/OneNote.ribbon.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/Strings/HTMLHelpers.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->