### PR TITLE
Add a test for the `buttonNumber` and `modifierFlags` properties of `WKNavigationAction`

### DIFF
--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -45,6 +45,7 @@ cocoa/TestWebExtensionsDelegate.mm
 cocoa/TestWKWebView.mm
 cocoa/TestWKWebViewConfiguration.mm
 cocoa/UserMediaCaptureUIDelegate.mm
+ios/IOSMouseEventTestHarness.mm
 
 Tests/WebKitCocoa/AVFoundationPreference.mm
 Tests/WebKitCocoa/AdaptiveImageGlyph.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2115,6 +2115,8 @@
 		07EDEFAC1EB9400C00D43292 /* UserMediaDisabled.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaDisabled.mm; sourceTree = "<group>"; };
 		07EF76D42540FC060053ED53 /* MediaMutedState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaMutedState.mm; sourceTree = "<group>"; };
 		07F4E92D20AF58D3002E3803 /* UserMediaSimulateFailedSandbox.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaSimulateFailedSandbox.mm; sourceTree = "<group>"; };
+		07F7696C2CA8BAC500FF004B /* IOSMouseEventTestHarness.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IOSMouseEventTestHarness.h; sourceTree = "<group>"; };
+		07F7696D2CA8BAC500FF004B /* IOSMouseEventTestHarness.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = IOSMouseEventTestHarness.mm; sourceTree = "<group>"; };
 		0BCD833414857CE400EA2003 /* HashMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HashMap.cpp; sourceTree = "<group>"; };
 		0BCD85691485C98B00EA2003 /* SetForScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SetForScope.cpp; sourceTree = "<group>"; };
 		0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewResize.mm; sourceTree = "<group>"; };
@@ -4518,6 +4520,8 @@
 			children = (
 				A17C58032C9AA12F009DD0B5 /* app */,
 				F4D4F3B41E4E2BCB00BB2767 /* DragAndDropSimulatorIOS.mm */,
+				07F7696C2CA8BAC500FF004B /* IOSMouseEventTestHarness.h */,
+				07F7696D2CA8BAC500FF004B /* IOSMouseEventTestHarness.mm */,
 				2E7765CC16C4D80A00BA2BB1 /* mainIOS.mm */,
 				F48D6C0F224B377000E3E2FB /* PreferredContentMode.mm */,
 				F4CB8A7B2856447F0017ECD3 /* TestPDFHostViewController.h */,

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "TestDownloadDelegate.h"
+#import "Utilities.h"
 
 #import <WebKit/WKNavigationDelegatePrivate.h>
 

--- a/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.h
+++ b/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
+
+#import "InstanceMethodSwizzler.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import "UIKitSPIForTesting.h"
+#import <WebKit/WebKit.h>
+#import <wtf/RetainPtr.h>
+
+@protocol WKMouseInteractionForTesting<UIGestureRecognizerDelegate>
+@property (readonly, nonatomic, getter=isEnabled) BOOL enabled;
+- (void)_hoverGestureRecognized:(UIHoverGestureRecognizer *)gestureRecognizer;
+@end
+
+@interface WKTestingTouch : UITouch
+@end
+
+namespace TestWebKitAPI {
+
+class MouseEventTestHarness {
+public:
+    MouseEventTestHarness(TestWKWebView *);
+
+    MouseEventTestHarness() = delete;
+
+    void mouseMove(CGFloat x, CGFloat y);
+
+    void mouseDown(UIEventButtonMask buttons = UIEventButtonMaskPrimary, UIKeyModifierFlags = 0);
+
+    void mouseUp();
+
+    void mouseCancel();
+
+    NSSet *activeTouches() const { return [NSSet setWithObject:m_activeTouch.get()]; }
+    TestWKWebView *webView() const { return m_webView; }
+    id<WKMouseInteractionForTesting> mouseInteraction() const { return m_mouseInteraction; }
+
+private:
+    std::unique_ptr<InstanceMethodSwizzler> m_gestureLocationSwizzler;
+    std::unique_ptr<InstanceMethodSwizzler> m_hoverGestureLocationSwizzler;
+    std::unique_ptr<InstanceMethodSwizzler> m_gestureButtonMaskSwizzler;
+    std::unique_ptr<InstanceMethodSwizzler> m_gestureModifierFlagsSwizzler;
+    RetainPtr<WKTestingTouch> m_activeTouch;
+    RetainPtr<UIEvent> m_unusedEvent;
+    __weak UIHoverGestureRecognizer *m_hoverGestureRecognizer { nil };
+    __weak UIGestureRecognizer *m_mouseTouchGestureRecognizer { nil };
+    __weak id<WKMouseInteractionForTesting> m_mouseInteraction;
+    __weak TestWKWebView *m_webView { nil };
+    CGPoint m_locationInRootView { CGPointZero };
+    UIEventButtonMask m_buttonMask { 0 };
+    UIKeyModifierFlags m_modifierFlags { 0 };
+    bool m_needsToDispatchHoverGestureBegan { true };
+};
+
+}
+
+#endif
+

--- a/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
+++ b/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "IOSMouseEventTestHarness.h"
+
+#import <wtf/MonotonicTime.h>
+
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
+
+@implementation WKTestingTouch {
+    NSUInteger _tapCount;
+    CGPoint _overriddenLocation;
+    UITouchPhase _overriddenPhase;
+}
+
+- (CGPoint)locationInView:(UIView *)view
+{
+    return _overriddenLocation;
+}
+
+- (void)setLocationInView:(CGPoint)location
+{
+    _overriddenLocation = location;
+}
+
+- (void)setTapCount:(NSUInteger)tapCount
+{
+    _tapCount = tapCount;
+}
+
+- (void)setPhase:(UITouchPhase)phase
+{
+    _overriddenPhase = phase;
+}
+
+- (UITouchPhase)phase
+{
+    return _overriddenPhase;
+}
+
+- (NSUInteger)tapCount
+{
+    return _tapCount;
+}
+
+- (NSTimeInterval)timestamp
+{
+    return MonotonicTime::now().secondsSinceEpoch().value();
+}
+
+- (BOOL)_isPointerTouch
+{
+    return YES;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+MouseEventTestHarness::MouseEventTestHarness(TestWKWebView *webView)
+    : m_webView(webView)
+{
+    auto contentView = m_webView.wkContentView;
+    for (id<UIInteraction> interaction in contentView.interactions) {
+        if ([interaction respondsToSelector:@selector(_hoverGestureRecognized:)]) {
+            m_mouseInteraction = static_cast<id<WKMouseInteractionForTesting>>(interaction);
+            break;
+        }
+    }
+
+    for (UIGestureRecognizer *gestureRecognizer in contentView.gestureRecognizers) {
+        if ([gestureRecognizer.name isEqualToString:@"WKMouseHover"])
+            m_hoverGestureRecognizer = dynamic_objc_cast<UIHoverGestureRecognizer>(gestureRecognizer);
+        else if ([gestureRecognizer.name isEqualToString:@"WKMouseTouch"])
+            m_mouseTouchGestureRecognizer = gestureRecognizer;
+    }
+
+    RELEASE_ASSERT(m_mouseInteraction);
+    RELEASE_ASSERT(m_hoverGestureRecognizer);
+    RELEASE_ASSERT(m_mouseTouchGestureRecognizer);
+
+    auto overrideLocationInView = imp_implementationWithBlock([&](UIGestureRecognizer *) {
+        return m_locationInRootView;
+    });
+    m_gestureLocationSwizzler = makeUnique<InstanceMethodSwizzler>(UIGestureRecognizer.class, @selector(locationInView:), overrideLocationInView);
+    m_hoverGestureLocationSwizzler = makeUnique<InstanceMethodSwizzler>(UIHoverGestureRecognizer.class, @selector(locationInView:), overrideLocationInView);
+    m_gestureButtonMaskSwizzler = makeUnique<InstanceMethodSwizzler>(UIGestureRecognizer.class, @selector(buttonMask), imp_implementationWithBlock([&](UIGestureRecognizer *) {
+        return m_buttonMask;
+    }));
+    m_gestureModifierFlagsSwizzler = makeUnique<InstanceMethodSwizzler>(UIGestureRecognizer.class, @selector(modifierFlags), imp_implementationWithBlock([&](UIGestureRecognizer *) {
+        return m_modifierFlags;
+    }));
+    m_unusedEvent = adoptNS([UIEvent new]);
+}
+
+void MouseEventTestHarness::mouseMove(CGFloat x, CGFloat y)
+{
+    // FIXME(262757): This test helper should handle mouse drags.
+    if (!m_activeTouch) {
+        m_activeTouch = adoptNS([[WKTestingTouch alloc] init]);
+        EXPECT_TRUE([m_mouseInteraction gestureRecognizer:m_hoverGestureRecognizer shouldReceiveTouch:m_activeTouch.get()]);
+    }
+
+    m_locationInRootView = CGPointMake(x, y);
+    [m_activeTouch setLocationInView:m_locationInRootView];
+
+    bool shouldBeginGesture = std::exchange(m_needsToDispatchHoverGestureBegan, false);
+    [m_activeTouch setPhase:shouldBeginGesture ? UITouchPhaseRegionEntered : UITouchPhaseRegionMoved];
+    m_hoverGestureRecognizer.state = shouldBeginGesture ? UIGestureRecognizerStateBegan : UIGestureRecognizerStateChanged;
+    [m_mouseInteraction _hoverGestureRecognized:m_hoverGestureRecognizer];
+}
+
+void MouseEventTestHarness::mouseDown(UIEventButtonMask buttons, UIKeyModifierFlags modifierFlags)
+{
+    [m_activeTouch setPhase:UITouchPhaseBegan];
+    [m_activeTouch setTapCount:1];
+    m_buttonMask = buttons;
+    m_modifierFlags = modifierFlags;
+    [m_mouseTouchGestureRecognizer touchesBegan:activeTouches() withEvent:m_unusedEvent.get()];
+    EXPECT_EQ(m_mouseTouchGestureRecognizer.state, UIGestureRecognizerStateBegan);
+}
+
+void MouseEventTestHarness::mouseUp()
+{
+    [m_activeTouch setPhase:UITouchPhaseEnded];
+    [m_activeTouch setTapCount:0];
+    m_buttonMask = 0;
+    [m_mouseTouchGestureRecognizer touchesEnded:activeTouches() withEvent:m_unusedEvent.get()];
+    m_modifierFlags = 0;
+    EXPECT_EQ(m_mouseTouchGestureRecognizer.state, UIGestureRecognizerStateEnded);
+}
+
+void MouseEventTestHarness::mouseCancel()
+{
+    [m_activeTouch setPhase:UITouchPhaseCancelled];
+    [m_activeTouch setTapCount:0];
+    m_buttonMask = 0;
+    [m_mouseTouchGestureRecognizer touchesCancelled:activeTouches() withEvent:m_unusedEvent.get()];
+    m_modifierFlags = 0;
+    EXPECT_EQ(m_mouseTouchGestureRecognizer.state, UIGestureRecognizerStateCancelled);
+}
+
+};
+
+#endif


### PR DESCRIPTION
#### 81b0097021b1003a3942a1b470bf750a846e3b45
<pre>
Add a test for the `buttonNumber` and `modifierFlags` properties of `WKNavigationAction`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280569">https://bugs.webkit.org/show_bug.cgi?id=280569</a>
<a href="https://rdar.apple.com/136894323">rdar://136894323</a>

Reviewed by Wenson Hsieh.

There isn&apos;t an existing test for the `buttonNumber` and `modifierFlags` properties of `WKNavigationAction`,
so this PR adds one.

To facilitate this, the `MouseEventTestHarness` helper class is factored out to a new file so that it can
be re-used in multiple files.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm:
(TEST(WKNavigationAction, UserInputState)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TEST(iOSMouseSupport, DoNotChangeSelectionWithRightClick)):
(TEST(iOSMouseSupport, RightClickDoesNotShowMenuIfPreventDefault)):
(TEST(iOSMouseSupport, TrackButtonMaskFromTouchStart)):
(TEST(iOSMouseSupport, MouseTimestampTimebase)):
(TEST(iOSMouseSupport, EndedTouchesTriggerClick)):
(TEST(iOSMouseSupport, CancelledTouchesDoNotTriggerClick)):
(TEST(iOSMouseSupport, MouseDidMoveOverElement)):
(TEST(iOSMouseSupport, WebsiteMouseEventPolicies)):
(-[WKTestingTouch locationInView:]): Deleted.
(-[WKTestingTouch setLocationInView:]): Deleted.
(-[WKTestingTouch setTapCount:]): Deleted.
(-[WKTestingTouch setPhase:]): Deleted.
(-[WKTestingTouch phase]): Deleted.
(-[WKTestingTouch tapCount]): Deleted.
(-[WKTestingTouch timestamp]): Deleted.
(-[WKTestingTouch _isPointerTouch]): Deleted.
(TestWebKitAPI::MouseEventTestHarness::MouseEventTestHarness): Deleted.
(TestWebKitAPI::MouseEventTestHarness::mouseMove): Deleted.
(TestWebKitAPI::MouseEventTestHarness::mouseDown): Deleted.
(TestWebKitAPI::MouseEventTestHarness::mouseUp): Deleted.
(TestWebKitAPI::MouseEventTestHarness::mouseCancel): Deleted.
(TestWebKitAPI::MouseEventTestHarness::activeTouches const): Deleted.
(TestWebKitAPI::MouseEventTestHarness::webView const): Deleted.
(TestWebKitAPI::MouseEventTestHarness::mouseInteraction const): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, DoNotChangeSelectionWithRightClick)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, RightClickOutsideOfTextNodeDoesNotSelect)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, RightClickDoesNotShowMenuIfPreventDefault)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, TrackButtonMaskFromTouchStart)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseTimestampTimebase)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, EndedTouchesTriggerClick)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, CancelledTouchesDoNotTriggerClick)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseDidMoveOverElement)): Deleted.
(TestWebKitAPI::handleUpdatedSelection): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, SelectionUpdatesBeforeContextMenuAppears)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, DisablingTextIteractionPreventsSelectionWhenShowingContextMenu)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, ShowingContextMenuSelectsEditableText)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, ShowingContextMenuSelectsNonEditableText)): Deleted.
(TestWebKitAPI::simulateEditContextMenuAppearance): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, ContextClickAtEndOfSelection)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, WebsiteMouseEventPolicies)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseInitiallyDisconnected)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseInitiallyConnected)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseLaterDisconnected)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseLaterConnected)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, MouseAlwaysConnected)): Deleted.
(TestWebKitAPI::TEST(iOSMouseSupport, BasicPointerInteractionRegions)): Deleted.
* Tools/TestWebKitAPI/cocoa/IOSMouseEventTestHarness.h: Added.
(TestWebKitAPI::MouseEventTestHarness::activeTouches const):
(TestWebKitAPI::MouseEventTestHarness::webView const):
(TestWebKitAPI::MouseEventTestHarness::mouseInteraction const):
* Tools/TestWebKitAPI/cocoa/IOSMouseEventTestHarness.mm: Added.
(-[WKTestingTouch locationInView:]):
(-[WKTestingTouch setLocationInView:]):
(-[WKTestingTouch setTapCount:]):
(-[WKTestingTouch setPhase:]):
(-[WKTestingTouch phase]):
(-[WKTestingTouch tapCount]):
(-[WKTestingTouch timestamp]):
(-[WKTestingTouch _isPointerTouch]):
(TestWebKitAPI::MouseEventTestHarness::MouseEventTestHarness):
(TestWebKitAPI::MouseEventTestHarness::mouseMove):
(TestWebKitAPI::MouseEventTestHarness::mouseDown):
(TestWebKitAPI::MouseEventTestHarness::mouseUp):
(TestWebKitAPI::MouseEventTestHarness::mouseCancel):
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm:

Canonical link: <a href="https://commits.webkit.org/284425@main">https://commits.webkit.org/284425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559bc4d9987f563ac26e5a25581041adca9a669e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20333 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18860 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16852 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10727 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4338 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10590 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44529 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->