### PR TITLE
AX: accessibility/mac/label-element-all-text-string-value.html and two other label-related tests fail in ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityLabel.h
+++ b/Source/WebCore/accessibility/AccessibilityLabel.h
@@ -40,17 +40,16 @@ public:
     bool containsOnlyStaticText() const;
 private:
     explicit AccessibilityLabel(RenderObject&);
-    bool computeIsIgnored() const final;
+    bool computeIsIgnored() const final { return isIgnoredByDefault(); }
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Label; }
 
     bool isAccessibilityLabelInstance() const final { return true; }
     String stringValue() const final;
-    void updateChildrenIfNecessary() final;
+    void addChildren() final;
     void clearChildren() final;
-    void insertChild(AXCoreObject*, unsigned, DescendIfIgnored = DescendIfIgnored::Yes) final;
-    bool m_containsOnlyStaticTextDirty : 1;
-    bool m_containsOnlyStaticText : 1;
+    mutable bool m_containsOnlyStaticTextDirty : 1;
+    mutable bool m_containsOnlyStaticText : 1;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -530,7 +530,7 @@ public:
     virtual void addChildren() { }
     enum class DescendIfIgnored : bool { No, Yes };
     void addChild(AXCoreObject*, DescendIfIgnored = DescendIfIgnored::Yes);
-    virtual void insertChild(AXCoreObject*, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);
+    void insertChild(AXCoreObject*, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);
     virtual bool canHaveChildren() const { return true; }
     void updateChildrenIfNecessary() override;
     virtual void setNeedsToUpdateChildren() { }


### PR DESCRIPTION
#### 4b39d6a0bfb3df48dd9c4eb11de328d7a9610456
<pre>
AX: accessibility/mac/label-element-all-text-string-value.html and two other label-related tests fail in ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280568">https://bugs.webkit.org/show_bug.cgi?id=280568</a>
<a href="https://rdar.apple.com/problem/136894363">rdar://problem/136894363</a>

Reviewed by Chris Fleizach.

These tests fail in ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) because in <a href="https://commits.webkit.org/284418@main">https://commits.webkit.org/284418@main</a>, we replaced
direct usage of `m_children` with a call to `unignoredChildren(/* updateChildrenIfNecessary */ false)` in AccessibilityLabel::updateChildrenIfNecessary()
with the assumption that this would result in the same behavior. However, that assumption is not true, as without updating
the children of some descendants (because of the transitively passed `/* updateChildrenIfNecessary */ false` value),
AXCoreObject::nextInPreOrder does not return the right objects to compute AccessibilityLabel::containsOnlyStaticText
correctly.

Avoid this problem by dirtying `AccessibilityLabel::m_containsOnlyStaticTextDirty` once in a new `AccessibilityLabel::addChildren`
override, and removing the `updateChildrenIfNecessary` and `insertChild` overrides. This re-ordering allows us to safely
call update-children form of `unignoredChildren()` when requests in `containsOnlyStaticText`.

This is also more performant in a couple ways:

  1. We only resolve `containsOnlyStaticText` when it&apos;s actually
     requested rather than eagerly
  2. `AccessibilityLabel` was the only overrider of `AccessibilityObject::insertChild`, so removing it
     allows us to make `insertChild` non-virtual. This is actually pretty significant as it&apos;s one of the most called
     functions that we have.

We may need to audit other usages of `unignoredChildren(/* updateChildrenIfNecessary */ false)` added in
<a href="https://commits.webkit.org/284418@main">https://commits.webkit.org/284418@main</a> as a follow-up to this patch.

* Source/WebCore/accessibility/AccessibilityLabel.cpp:
(WebCore::childrenContainOnlyStaticText):
(WebCore::AccessibilityLabel::containsOnlyStaticText const):
(WebCore::AccessibilityLabel::addChildren):
(WebCore::AccessibilityLabel::computeIsIgnored const): Deleted.
(WebCore::AccessibilityLabel::updateChildrenIfNecessary): Deleted.
(WebCore::AccessibilityLabel::insertChild): Deleted.
* Source/WebCore/accessibility/AccessibilityLabel.h:
* Source/WebCore/accessibility/AccessibilityObject.h:

Canonical link: <a href="https://commits.webkit.org/284796@main">https://commits.webkit.org/284796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95f90f3a0cde9544b11c0cae653254fc39931c6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75110 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4331 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44520 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->