### PR TITLE
Added nullptr checks for RenderObject

### DIFF
--- a/LayoutTests/fast/repaint/repaint-renderer-with-layout-crash-expected.txt
+++ b/LayoutTests/fast/repaint/repaint-renderer-with-layout-crash-expected.txt
@@ -1,0 +1,8 @@
+This test passes if WebKit does not crash.
+A
+
+
+A
+
+
+

--- a/LayoutTests/fast/repaint/repaint-renderer-with-layout-crash.html
+++ b/LayoutTests/fast/repaint/repaint-renderer-with-layout-crash.html
@@ -1,0 +1,29 @@
+<style>
+listing { backdrop-filter: brightness(20%); column-span: all; }
+listing, section, fieldset, legend, body { min-height: 69vw; overflow-y: -webkit-paged-y; transform-style: preserve-3d; }
+section { outline-style: auto }
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+
+function main() {
+    document.querySelector('div').outerHTML = `A<listing></listing>`;
+    fieldset.addEventListener("DOMNodeInserted", () => {
+        document.execCommand("insertOrderedList",false,null);
+    });
+    document.designMode = "on";
+    document.execCommand("selectAll", false, null);
+    document.execCommand("fontName", false, "serif");
+}
+
+</script>
+<body onload="main()">
+<p>This test passes if WebKit does not crash.</p>
+<span>A<listing></listing></span>
+<section>
+<fieldset id="fieldset">
+<legend></legend>
+<div>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -981,6 +981,9 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
             renderer = WTFMove(renderMultiColumnPlaceholder);
         }
 
+        if (!renderer || !originalRenderer)
+            return;
+
         bool rendererHasOutlineAutoAncestor = renderer->hasOutlineAutoAncestor() || originalRenderer->hasOutlineAutoAncestor();
         ASSERT(rendererHasOutlineAutoAncestor
             || originalRenderer->outlineStyleForRepaint().outlineStyleIsAuto() == OutlineIsAuto::On


### PR DESCRIPTION
#### ac941d96e47907797eb4f0c7fb352164b5512873
<pre>
Added nullptr checks for RenderObject
Need the bug URL (OOPS!).
<a href="https://rdar.apple.com/135596465">rdar://135596465</a>.

Reviewed by NOBODY (OOPS!).

Added nullptr checks for RenderObject before de-referencing.

* LayoutTests/fast/repaint/repaint-renderer-with-layout-crash-expected.txt: Added.
* LayoutTests/fast/repaint/repaint-renderer-with-layout-crash.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
 (WebCore::RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac941d96e47907797eb4f0c7fb352164b5512873

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22676 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20932 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60314 "Passed tests") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19458 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75723 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14148 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17320 "20 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63122 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4753 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45127 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->