### PR TITLE
Expose WKNavigationAction/buttonNumber and WKNavigationAction/modifierFlags as API on iOS

### DIFF
--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.h
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.h
@@ -51,6 +51,7 @@ public:
 
     static OptionSet<WebKit::WebEventModifier> webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags);
     static UIKeyModifierFlags toUIKeyModifierFlags(OptionSet<WebKit::WebEventModifier>);
+    static UIEventButtonMask toUIEventButtonMask(WebKit::WebMouseEventButton);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
@@ -67,6 +67,22 @@ UIKeyModifierFlags WebIOSEventFactory::toUIKeyModifierFlags(OptionSet<WebEventMo
     return modifierFlags;
 }
 
+UIEventButtonMask WebIOSEventFactory::toUIEventButtonMask(WebKit::WebMouseEventButton mouseButton)
+{
+    switch (mouseButton) {
+    case WebKit::WebMouseEventButton::None:
+        return 0;
+    case WebKit::WebMouseEventButton::Left:
+        return UIEventButtonMaskPrimary;
+    case WebKit::WebMouseEventButton::Right:
+        return UIEventButtonMaskSecondary;
+    case WebKit::WebMouseEventButton::Middle:
+        // iOS does not currently support any mouse buttons other than Primary and Secondary.
+        ASSERT_NOT_REACHED();
+        return UIEventButtonMaskPrimary;
+    }
+}
+
 static OptionSet<WebEventModifier> modifiersForEvent(::WebEvent *event)
 {
     OptionSet<WebEventModifier> modifiers;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
@@ -26,7 +26,7 @@
 #import <WebKit/WKFoundation.h>
 
 #if TARGET_OS_IPHONE
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #else
 #import <AppKit/AppKit.h>
 #endif
@@ -81,7 +81,17 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 */
 @property (nonatomic, readonly) BOOL shouldPerformDownload WK_API_AVAILABLE(macos(11.3), ios(14.5));
 
-#if !TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
+
+/*! @abstract The modifier keys that were in effect when the navigation was requested.
+ */
+@property (nonatomic, readonly) UIKeyModifierFlags modifierFlags WK_API_AVAILABLE(ios(WK_IOS_TBA), visionOS(WK_XROS_TBA));
+
+/*! @abstract The button mask of the index of the mouse button causing the navigation to be requested.
+ */
+@property (nonatomic, readonly) UIEventButtonMask buttonNumber WK_API_AVAILABLE(ios(WK_IOS_TBA), visionOS(WK_XROS_TBA));
+
+#else
 
 /*! @abstract The modifier keys that were in effect when the navigation was requested.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -159,6 +159,11 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
     return WebKit::WebIOSEventFactory::toUIKeyModifierFlags(_navigationAction->modifiers());
 }
 
+- (UIEventButtonMask)buttonNumber
+{
+    return WebKit::WebIOSEventFactory::toUIEventButtonMask(_navigationAction->mouseButton());
+}
+
 #endif
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
@@ -56,8 +56,6 @@ typedef NS_ENUM(NSInteger, WKSyntheticClickType) {
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) WKSyntheticClickType _syntheticClickType WK_API_AVAILABLE(ios(10.0));
 @property (nonatomic, readonly) CGPoint _clickLocationInRootViewCoordinates WK_API_AVAILABLE(ios(11.0));
-
-@property (nonatomic, readonly) UIKeyModifierFlags modifierFlags WK_API_AVAILABLE(ios(13.0));
 #endif
 
 @property (nonatomic, readonly) BOOL _isRedirect WK_API_AVAILABLE(macos(10.13), ios(11.0));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
@@ -328,6 +328,7 @@ TEST(WKNavigationAction, UserInputState)
     EXPECT_EQ(navigationAction.buttonNumber, 1);
     EXPECT_EQ(navigationAction.modifierFlags, NSEventModifierFlagCommand);
 #else
+    EXPECT_EQ(navigationAction.buttonNumber, UIEventButtonMaskPrimary);
     EXPECT_EQ(navigationAction.modifierFlags, UIKeyModifierCommand);
 #endif
 }


### PR DESCRIPTION
#### d3aa89a6eb78e0735a68bb60fac1fb16cdd7ffff
<pre>
Expose WKNavigationAction/buttonNumber and WKNavigationAction/modifierFlags as API on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=280577">https://bugs.webkit.org/show_bug.cgi?id=280577</a>
<a href="https://rdar.apple.com/136865172">rdar://136865172</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/Shared/ios/WebIOSEventFactory.h:
* Source/WebKit/Shared/ios/WebIOSEventFactory.mm:
(WebKit::WebIOSEventFactory::toUIEventButtonMask):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction buttonNumber]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm:
(TEST(WKNavigationAction, UserInputState)):

Canonical link: <a href="https://commits.webkit.org/286985@main">https://commits.webkit.org/286985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183e02cdc1739736e34097b335b761e9403cdc86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60935 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18882 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41235 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24266 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83804 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5175 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69158 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68401 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12421 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10513 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5122 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->