### PR TITLE
[JSC] Use build-id in Unix for versioning

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp
+++ b/Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp
@@ -26,33 +26,36 @@
 #include "config.h"
 #include "JSCBytecodeCacheVersion.h"
 
+#include <wtf/DataLog.h>
+#include <wtf/HexNumber.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/SuperFastHash.h>
 
-#if OS(DARWIN)
+#if OS(UNIX)
 #include <dlfcn.h>
+#if OS(DARWIN)
 #include <mach-o/dyld.h>
 #include <uuid/uuid.h>
-#include <wtf/DataLog.h>
-#include <wtf/NeverDestroyed.h>
 #include <wtf/spi/darwin/dyldSPI.h>
+#else
+#include <link.h>
+#endif
 #endif
 
 namespace JSC {
 
-#if OS(DARWIN)
 namespace JSCBytecodeCacheVersionInternal {
 static constexpr bool verbose = false;
 }
-#endif
 
 uint32_t computeJSCBytecodeCacheVersion()
 {
-#if OS(DARWIN)
+    UNUSED_VARIABLE(JSCBytecodeCacheVersionInternal::verbose);
     static LazyNeverDestroyed<uint32_t> cacheVersion;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         void* jsFunctionAddr = bitwise_cast<void*>(&computeJSCBytecodeCacheVersion);
-
+#if OS(DARWIN)
         uuid_t uuid;
         if (const mach_header* header = dyld_image_header_containing_address(jsFunctionAddr); header && _dyld_get_image_uuid(header, uuid)) {
             uuid_string_t uuidString = { };
@@ -61,15 +64,97 @@ uint32_t computeJSCBytecodeCacheVersion()
             dataLogLnIf(JSCBytecodeCacheVersionInternal::verbose, "UUID of JavaScriptCore.framework:", uuidString);
             return;
         }
-
         cacheVersion.construct(0);
         dataLogLnIf(JSCBytecodeCacheVersionInternal::verbose, "Failed to get UUID for JavaScriptCore framework");
+#elif OS(UNIX)
+        auto result = ([&] -> std::optional<uint32_t> {
+            Dl_info info { };
+            if (!dladdr(jsFunctionAddr, &info))
+                return std::nullopt;
+
+            if (!info.dli_fbase)
+                return std::nullopt;
+
+            struct DLParam {
+                void* start { nullptr };
+                std::span<const uint8_t> description;
+            };
+
+            DLParam param { };
+            param.start = info.dli_fbase;
+            if (!dl_iterate_phdr(static_cast<int(*)(struct dl_phdr_info*, size_t, void*)>(
+                [](struct dl_phdr_info* info, size_t, void* priv) -> int {
+                    auto* data = static_cast<DLParam*>(priv);
+                    void* start = nullptr;
+                    for (unsigned i = 0; i < info->dlpi_phnum; ++i) {
+                        if (info->dlpi_phdr[i].p_type == PT_LOAD) {
+                            start = bitwise_cast<void*>(static_cast<uintptr_t>(info->dlpi_addr + info->dlpi_phdr[i].p_vaddr));
+                            break;
+                        }
+                    }
+
+                    if (start != data->start)
+                        return 0;
+
+                    for (unsigned i = 0; i < info->dlpi_phnum; ++i) {
+                        if (info->dlpi_phdr[i].p_type != PT_NOTE)
+                            continue;
+
+                        // https://refspecs.linuxbase.org/elf/gabi4+/ch5.pheader.html#note_section
+                        using NoteHeader = ElfW(Nhdr);
+
+                        auto* payload = bitwise_cast<uint8_t*>(static_cast<uintptr_t>(info->dlpi_addr + info->dlpi_phdr[i].p_vaddr));
+                        size_t length = info->dlpi_phdr[i].p_filesz;
+                        for (size_t index = 0; index < length;) {
+                            auto* cursor  = payload + index;
+                            if ((index + sizeof(NoteHeader)) > length)
+                                return 0;
+
+                            auto* note = bitwise_cast<NoteHeader*>(cursor);
+                            size_t size = sizeof(NoteHeader) + roundUpToMultipleOf<4>(note->n_namesz) + roundUpToMultipleOf<4>(note->n_descsz);
+                            if ((index + size) > length)
+                                return 0;
+
+                            auto* name = cursor + sizeof(NoteHeader);
+                            auto* description = cursor + sizeof(NoteHeader) + roundUpToMultipleOf<4>(note->n_namesz);
+
+                            if (note->n_type == NT_GNU_BUILD_ID && note->n_descsz != 0 && note->n_namesz == 4 && memcmp(name, "GNU", 4) == 0) {
+                                // Found build-id note.
+                                data->description = std::span { description, note->n_descsz };
+                                return 1;
+                            }
+
+                            index += size;
+                        }
+                    }
+                    return 0;
+                }), &param))
+                    return std::nullopt;
+
+                if (param.description.empty())
+                    return std::nullopt;
+
+                if constexpr (JSCBytecodeCacheVersionInternal::verbose) {
+                    for (uint8_t value : param.description)
+                        dataLog(hex(value));
+                    dataLogLn("");
+                }
+
+                return SuperFastHash::computeHash(param.description);
+        }());
+        if (result) {
+            cacheVersion.construct(result.value());
+            return;
+        }
+        cacheVersion.construct(0);
+        dataLogLnIf(JSCBytecodeCacheVersionInternal::verbose, "Failed to get UUID for JavaScriptCore framework");
+#else
+        UNUSED_VARIABLE(jsFunctionAddr);
+        static constexpr uint32_t precomputedCacheVersion = SuperFastHash::computeHash(__TIMESTAMP__);
+        cacheVersion.construct(precomputedCacheVersion);
+#endif
     });
     return cacheVersion.get();
-#else
-    static constexpr uint32_t precomputedCacheVersion = SuperFastHash::computeHash(__TIMESTAMP__);
-    return precomputedCacheVersion;
-#endif
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### e1ddde8449b099297c3f486057a4c38cf40a2f0f
<pre>
[JSC] Use build-id in Unix for versioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=280579">https://bugs.webkit.org/show_bug.cgi?id=280579</a>
&lt;<a href="https://rdar.apple.com/problem/136915282">rdar://problem/136915282</a>&gt;

Reviewed by Keith Miller.

This patch adds build-id value retrieval code for Unix so that we can
use SuperFastHash(build-id) for bytecode version.

* Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp:
(JSC::computeJSCBytecodeCacheVersion):

Canonical link: <a href="https://commits.webkit.org/284495@main">https://commits.webkit.org/284495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a90b9661f668066f3633390e12c92b5da77870d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69667 "2 style errors") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49067 "Build is in progress. Recent messages:") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/22417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/56868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20676 "Build is in progress. Recent messages:") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72733 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/56868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/22417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/56868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/22417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/62783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/56868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/22417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/68913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/13649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/20676 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/13689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/22417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/22417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90695 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10619 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/44871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/16099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/45686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->