### PR TITLE
Cut unneeded includes from Lock.h, PersistentCoder.h, ThreadingPrimitives.h

### DIFF
--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -508,15 +508,11 @@ JSStringRef JSContextGroupTakeSamplesFromSamplingProfiler(JSContextGroupRef grou
     JSLockHolder locker(&vm);
 
 #if ENABLE(SAMPLING_PROFILER)
-    auto json = vm.takeSamplingProfilerSamplesAsJSON();
-    if (UNLIKELY(!json))
+    auto samples = vm.takeSamplingProfilerSamplesAsJSONString();
+    if (samples.isNull())
         return nullptr;
 
-    auto jsonData = json->toJSONString();
-    if (UNLIKELY(jsonData.isNull()))
-        return nullptr;
-
-    return OpaqueJSString::tryCreate(WTFMove(jsonData)).leakRef();
+    return OpaqueJSString::tryCreate(WTFMove(samples)).leakRef();
 #else
     return nullptr;
 #endif

--- a/Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.cpp
@@ -27,6 +27,7 @@
 #include "IsoAlignedMemoryAllocator.h"
 
 #include "MarkedBlock.h"
+#include <wtf/text/CString.h>
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 #include <wtf/text/MakeString.h>

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.h
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.h
@@ -32,10 +32,10 @@
 
 #include "ConsoleTypes.h"
 #include "Strong.h"
-#include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/inspector/ScriptFunctionCall.h
+++ b/Source/JavaScriptCore/inspector/ScriptFunctionCall.h
@@ -32,14 +32,12 @@
 #pragma once
 
 #include "ArgList.h"
-#include "Exception.h"
 #include "JSCJSValue.h"
 #include "JSCJSValueInlines.h"
 #include "JSObject.h"
 #include "Strong.h"
 #include "StrongInlines.h"
 #include <wtf/Expected.h>
-#include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3227,9 +3227,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSamplingProfilerStackTraces, (JSGlobalObject* g
     if (!vm.samplingProfiler())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Sampling profiler was never started"_s)));
 
-    auto json = vm.samplingProfiler()->stackTracesAsJSON();
-    auto jsonString = json->toJSONString();
-    EncodedJSValue result = JSValue::encode(JSONParse(globalObject, WTFMove(jsonString)));
+    EncodedJSValue result = JSValue::encode(JSONParse(globalObject, vm.samplingProfiler()->stackTracesAsJSONString()));
     scope.releaseAssertNoException();
     return result;
 }

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h
@@ -27,8 +27,6 @@
 
 #include "ProfilerBytecode.h"
 #include <wtf/Vector.h>
-#include <wtf/text/CString.h>
-#include <wtf/text/WTFString.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
@@ -28,7 +28,7 @@
 #include "CodeBlockHash.h"
 #include "JSCJSValue.h"
 #include "ProfilerBytecodeSequence.h"
-#include <wtf/PrintStream.h>
+#include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC { namespace Profiler {

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
@@ -31,7 +31,6 @@
 #include "ProfilerBytecodes.h"
 #include "ProfilerCompilation.h"
 #include "ProfilerDumper.h"
-#include "ProfilerUID.h"
 
 namespace JSC { namespace Profiler {
 

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.h
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "JSCJSValue.h"
-#include <wtf/PrintStream.h>
+#include <wtf/JSONValues.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/CString.h>
 

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ExitKind.h"
-#include "JSCJSValue.h"
 #include "ProfilerOriginStack.h"
 
 namespace JSC { namespace Profiler {

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h
@@ -27,6 +27,7 @@
 
 #include "JSCJSValue.h"
 #include "MacroAssemblerCodeRef.h"
+#include <wtf/JSONValues.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace Profiler {

--- a/Source/JavaScriptCore/profiler/ProfilerOrigin.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOrigin.h
@@ -28,7 +28,7 @@
 #include "BytecodeIndex.h"
 #include "CodeBlockHash.h"
 #include "JSCJSValue.h"
-#include <wtf/PrintStream.h>
+#include <wtf/JSONValues.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/profiler/ProfilerOriginStack.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOriginStack.h
@@ -25,9 +25,7 @@
 
 #pragma once
 
-#include "JSCJSValue.h"
 #include "ProfilerOrigin.h"
-#include <wtf/PrintStream.h>
 #include <wtf/Vector.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/profiler/ProfilerUID.h
+++ b/Source/JavaScriptCore/profiler/ProfilerUID.h
@@ -25,13 +25,12 @@
 
 #pragma once
 
-#include "JSCJSValue.h"
-#include <wtf/JSONValues.h>
-#include <wtf/PrintStream.h>
+#include <wtf/Forward.h>
 
-namespace JSC::Profiler {
+namespace JSC { namespace Profiler {
 
 struct UIDType;
+
 using UID = AtomicObjectIdentifier<UIDType>;
 
-} // namespace JSC::Profiler
+} } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h
@@ -31,6 +31,7 @@
 #include "Opcode.h"
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -456,11 +456,10 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
         RETURN_IF_EXCEPTION(scope, { });
     }
 
-    auto json = vm.takeSamplingProfilerSamplesAsJSON();
-    if (UNLIKELY(!json))
+    auto samples = vm.takeSamplingProfilerSamplesAsJSONString();
+    if (samples.isNull())
         return JSValue::encode(jsUndefined());
 
-    auto jsonData = json->toJSONString();
     {
         auto [tempFilePath, fileHandle] = FileSystem::openTemporaryFile(filenamePrefix);
         if (!FileSystem::isHandleValid(fileHandle)) {
@@ -468,7 +467,7 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
             return JSValue::encode(jsUndefined());
         }
 
-        CString utf8String = jsonData.utf8();
+        CString utf8String = samples.utf8();
 
         FileSystem::writeToFile(fileHandle, utf8String.span());
         FileSystem::closeFile(fileHandle);

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1086,7 +1086,7 @@ static String tierName(SamplingProfiler::StackFrame& frame)
     return Tiers::unknownFrame;
 }
 
-Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
+String SamplingProfiler::stackTracesAsJSONString()
 {
     DeferGC deferGC(m_vm);
     Locker locker { m_lock };
@@ -1167,7 +1167,7 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
 
     clearData();
 
-    return result;
+    return result->asString();
 }
 
 void SamplingProfiler::registerForReportAtExit()

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -190,7 +190,7 @@ public:
     JS_EXPORT_PRIVATE void start();
     void startWithLock() WTF_REQUIRES_LOCK(m_lock);
     Vector<StackTrace> releaseStackTraces() WTF_REQUIRES_LOCK(m_lock);
-    JS_EXPORT_PRIVATE Ref<JSON::Value> stackTracesAsJSON();
+    JS_EXPORT_PRIVATE String stackTracesAsJSONString();
     JS_EXPORT_PRIVATE void noticeCurrentThreadAsJSCExecutionThread();
     void noticeCurrentThreadAsJSCExecutionThreadWithLock() WTF_REQUIRES_LOCK(m_lock);
     void processUnverifiedStackTraces() WTF_REQUIRES_LOCK(m_lock);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -606,12 +606,12 @@ void VM::disableSamplingProfiler()
     }
 }
 
-RefPtr<JSON::Value> VM::takeSamplingProfilerSamplesAsJSON()
+String VM::takeSamplingProfilerSamplesAsJSONString()
 {
-    SamplingProfiler* profiler = samplingProfiler();
+    auto* profiler = samplingProfiler();
     if (!profiler)
-        return nullptr;
-    return profiler->stackTracesAsJSON();
+        return { };
+    return profiler->stackTracesAsJSONString();
 }
 
 #endif // ENABLE(SAMPLING_PROFILER)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -327,7 +327,7 @@ public:
 
     JS_EXPORT_PRIVATE void enableSamplingProfiler();
     JS_EXPORT_PRIVATE void disableSamplingProfiler();
-    JS_EXPORT_PRIVATE RefPtr<JSON::Value> takeSamplingProfilerSamplesAsJSON();
+    JS_EXPORT_PRIVATE String takeSamplingProfilerSamplesAsJSONString();
 #endif
 
     FuzzerAgent* fuzzerAgent() const { return m_fuzzerAgent.get(); }

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -201,6 +201,7 @@ using WTF::RefPtr;
 using WTF::RetainPtr;
 using WTF::SHA1;
 using WTF::ScopedLambda;
+using WTF::Seconds;
 using WTF::SerialFunctionDispatcher;
 using WTF::String;
 using WTF::StringBuffer;
@@ -215,6 +216,7 @@ using WTF::URL;
 using WTF::UncheckedKeyHashMap;
 using WTF::UniqueRef;
 using WTF::Vector;
+using WTF::WallTime;
 using WTF::WeakPtr;
 using WTF::WeakRef;
 

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -25,6 +25,7 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include <initializer_list>
+#include <optional>
 #include <wtf/Forward.h>
 #include <wtf/HashTable.h>
 #include <wtf/IteratorRange.h>

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -26,10 +26,10 @@
 #pragma once
 
 #include <mutex>
+#include <wtf/Forward.h>
 #include <wtf/LockAlgorithm.h>
 #include <wtf/Locker.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/Seconds.h>
 #include <wtf/ThreadSafetyAnalysis.h>
 
 #if ENABLE(UNFAIR_LOCK)

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -37,6 +37,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
+#include <wtf/Seconds.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
@@ -134,6 +135,11 @@ MediaTime MediaTime::createWithDouble(double doubleTime, uint32_t timeScale)
     while (doubleTime * timeScale >= maxPlusOne<int64_t>)
         timeScale /= 2;
     return MediaTime(static_cast<int64_t>(std::round(doubleTime * timeScale)), timeScale, Valid);
+}
+
+MediaTime MediaTime::createWithSeconds(Seconds seconds)
+{
+    return createWithDouble(seconds.value());
 }
 
 float MediaTime::toFloat() const
@@ -619,6 +625,16 @@ String MediaTimeRange::toJSONString() const
     object->setObject("end"_s, end.toJSONObject());
 
     return object->toJSONString();
+}
+
+String LogArgument<MediaTime>::toString(const MediaTime& time)
+{
+    return time.toJSONString();
+}
+
+String LogArgument<MediaTimeRange>::toString(const MediaTimeRange& range)
+{
+    return range.toJSONString();
 }
 
 TextStream& operator<<(TextStream& stream, const MediaTime& time)

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -29,18 +29,12 @@
 #pragma once
 
 #include <wtf/FastMalloc.h>
-#include <wtf/JSONValues.h>
-#include <wtf/Seconds.h>
-#include <wtf/text/WTFString.h>
-
-#include <cmath>
-#include <limits>
-#include <math.h>
-#include <stdint.h>
 
 namespace WTF {
 
 class PrintStream;
+
+template<typename> struct LogArgument;
 
 class WTF_EXPORT_PRIVATE MediaTime final {
     WTF_MAKE_FAST_ALLOCATED;
@@ -62,7 +56,7 @@ public:
     static MediaTime createWithFloat(float floatTime, uint32_t timeScale);
     static MediaTime createWithDouble(double doubleTime);
     static MediaTime createWithDouble(double doubleTime, uint32_t timeScale);
-    static MediaTime createWithSeconds(Seconds seconds) { return createWithDouble(seconds.value()); }
+    static MediaTime createWithSeconds(Seconds);
 
     float toFloat() const;
     double toDouble() const;
@@ -111,7 +105,7 @@ public:
     const int64_t& timeValue() const { return m_timeValue; }
     const uint32_t& timeScale() const { return m_timeScale; }
 
-    void dump(PrintStream& out) const;
+    void dump(PrintStream&) const;
     String toString() const;
     String toJSONString() const;
     Ref<JSON::Object> toJSONObject() const;
@@ -189,13 +183,11 @@ struct WTF_EXPORT_PRIVATE MediaTimeRange {
     const MediaTime end;
 };
 
-template<typename> struct LogArgument;
-
 template<> struct LogArgument<MediaTime> {
-    static String toString(const MediaTime& time) { return time.toJSONString(); }
+    WTF_EXPORT_PRIVATE static String toString(const MediaTime&);
 };
 template<> struct LogArgument<MediaTimeRange> {
-    static String toString(const MediaTimeRange& range) { return range.toJSONString(); }
+    WTF_EXPORT_PRIVATE static String toString(const MediaTimeRange&);
 };
 
 WTF_EXPORT_PRIVATE TextStream& operator<<(TextStream&, const MediaTime&);

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -27,16 +27,13 @@
 
 #include <optional>
 #include <wtf/FastMalloc.h>
+#include <wtf/Forward.h>
 #include <wtf/MathExtras.h>
 
 namespace WTF {
 
 class ApproximateTime;
-class MonotonicTime;
-class PrintStream;
-class TextStream;
 class TimeWithDynamicClockType;
-class WallTime;
 
 class Seconds final {
     WTF_MAKE_FAST_ALLOCATED;
@@ -333,4 +330,3 @@ WTF_EXPORT_PRIVATE TextStream& operator<<(TextStream&, Seconds);
 using WTF::sleep;
 
 using namespace WTF::seconds_literals;
-using WTF::Seconds;

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
 #if USE(APPLE_INTERNAL_SDK)
 #include <sys/kdebug_private.h>
 #define HAVE_KDEBUG_H 1

--- a/Source/WTF/wtf/ThreadingPrimitives.h
+++ b/Source/WTF/wtf/ThreadingPrimitives.h
@@ -32,9 +32,9 @@
 
 #include <limits.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/Forward.h>
 #include <wtf/Locker.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/WallTime.h>
 
 #if OS(WINDOWS)
 #include <windows.h>

--- a/Source/WTF/wtf/WallTime.h
+++ b/Source/WTF/wtf/WallTime.h
@@ -26,13 +26,11 @@
 #pragma once
 
 #include <wtf/ClockType.h>
+#include <wtf/Forward.h>
 #include <wtf/GenericTimeMixin.h>
 #include <wtf/Int128.h>
 
 namespace WTF {
-
-class MonotonicTime;
-class PrintStream;
 
 // The current time according to a wall clock (aka real time clock). This uses floating point
 // internally so that you can reason about infinity and other things that arise in math. It's
@@ -79,5 +77,3 @@ struct WallTime::MarkableTraits {
 WTF_EXPORT_PRIVATE Int128 currentTimeInNanoseconds();
 
 } // namespace WTF
-
-using WTF::WallTime;

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -28,6 +28,9 @@
 
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
+#include <wtf/WallTime.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -154,19 +157,6 @@ std::optional<URL> Coder<URL>::decodeForPersistence(Decoder& decoder)
     if (!string)
         return std::nullopt;
     return URL(WTFMove(*string));
-}
-
-void Coder<SHA1::Digest>::encodeForPersistence(Encoder& encoder, const SHA1::Digest& digest)
-{
-    encoder.encodeFixedLengthData({ digest });
-}
-
-std::optional<SHA1::Digest> Coder<SHA1::Digest>::decodeForPersistence(Decoder& decoder)
-{
-    SHA1::Digest tmp;
-    if (!decoder.decodeFixedLengthData({ tmp }))
-        return std::nullopt;
-    return tmp;
 }
 
 void Coder<WallTime>::encodeForPersistence(Encoder& encoder, const WallTime& time)

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -25,10 +25,9 @@
 
 #pragma once
 
-#include <span>
+#include <optional>
 #include <wtf/EnumTraits.h>
 #include <wtf/SHA1.h>
-#include <wtf/persistence/PersistentCoders.h>
 
 namespace WTF::Persistence {
 

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -25,12 +25,9 @@
 
 #pragma once
 
-#include <span>
-#include <wtf/EnumTraits.h>
 #include <wtf/SHA1.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
-#include <wtf/persistence/PersistentCoders.h>
 
 namespace WTF::Persistence {
 

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -41,6 +41,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/WTFConfig.h>
+#include <wtf/WallTime.h>
 #include <wtf/WordLock.h>
 
 #if OS(LINUX)

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -94,7 +94,9 @@
 #include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Seconds.h>
 #include <wtf/ThreadingPrimitives.h>
+#include <wtf/WallTime.h>
 
 namespace WTF {
 

--- a/Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp
@@ -40,7 +40,8 @@
 #include "TextIterator.h"
 #include "WebCorePersistentCoders.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -40,7 +40,8 @@
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "ViolationReportType.h"
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/PasteboardCustomData.cpp
+++ b/Source/WebCore/platform/PasteboardCustomData.cpp
@@ -28,7 +28,8 @@
 
 #include "SharedBuffer.h"
 #include <wtf/URLParser.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -33,7 +33,7 @@
 #include <algorithm>
 #include <wtf/HexNumber.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/UTF8Conversion.h>
 

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -38,7 +38,8 @@
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include "SWRegistrationDatabase.h"
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cf/VectorCF.h>

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -32,7 +32,8 @@
 #include "IOSurface.h"
 #include "Logging.h"
 #include <wtf/Scope.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 
 #if USE(LIBWEBRTC)
 

--- a/Source/WebCore/platform/graphics/InbandGenericCue.cpp
+++ b/Source/WebCore/platform/graphics/InbandGenericCue.cpp
@@ -29,10 +29,9 @@
 #if ENABLE(VIDEO)
 
 #include "ColorSerialization.h"
-
+#include <wtf/JSONValues.h>
 
 namespace WebCore {
-
 
 InbandGenericCue::InbandGenericCue()
 {

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -391,3 +391,12 @@ size_t PlatformTimeRanges::findLastRangeIndexBefore(const MediaTime& start, cons
 }
 
 }
+
+namespace WTF {
+
+String LogArgument<WebCore::PlatformTimeRanges>::toString(const WebCore::PlatformTimeRanges& ranges)
+{
+    return ranges.toString();
+}
+
+}

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -143,10 +143,11 @@ private:
 } // namespace WebCore
 
 namespace WTF {
+
 template<typename> struct LogArgument;
 
 template<> struct LogArgument<WebCore::PlatformTimeRanges> {
-    static String toString(const WebCore::PlatformTimeRanges& platformTimeRanges) { return platformTimeRanges.toString(); }
+    WEBCORE_EXPORT static String toString(const WebCore::PlatformTimeRanges&);
 };
 
 } // namespace WTF

--- a/Source/WebCore/platform/graphics/adwaita/Adwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/Adwaita.h
@@ -29,7 +29,7 @@
 #if USE(THEME_ADWAITA)
 
 #include "Color.h"
-#include <wtf/Forward.h>
+#include <wtf/Seconds.h>
 
 namespace WebCore {
 class GraphicsContext;

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <wtf/Expected.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 
 typedef struct AudioFormatVorbisModeInfo AudioFormatVorbisModeInfo;

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -28,14 +28,14 @@
 #if PLATFORM(COCOA)
 
 #include <wtf/RefPtr.h>
-#include <wtf/Vector.h>
+#include <wtf/Seconds.h>
 
 struct AudioStreamBasicDescription;
 
 namespace WebCore {
 
-struct AudioInfo;
 class SharedBuffer;
+struct AudioInfo;
 
 WEBCORE_EXPORT bool isVorbisDecoderAvailable();
 WEBCORE_EXPORT bool registerVorbisDecoderIfNeeded();
@@ -71,4 +71,4 @@ Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription&);
 
 }
 
-#endif // && PLATFORM(COCOA)
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
@@ -28,22 +28,29 @@ namespace WebCore {
 class GLFenceEGL final : public GLFence {
 public:
     static std::unique_ptr<GLFence> create();
+    explicit GLFenceEGL(EGLSync);
+
 #if OS(UNIX)
     static std::unique_ptr<GLFence> createExportable();
     static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
-#endif
     GLFenceEGL(EGLSync, bool);
-    virtual ~GLFenceEGL();
+#endif
+
+    ~GLFenceEGL() final;
 
 private:
-    void clientWait() override;
-    void serverWait() override;
+    void clientWait() final;
+    void serverWait() final;
+
 #if OS(UNIX)
-    WTF::UnixFileDescriptor exportFD() override;
+    WTF::UnixFileDescriptor exportFD() final;
 #endif
 
     EGLSync m_sync { nullptr };
+
+#if OS(UNIX)
     bool m_isExportable { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #if USE(GSTREAMER)
+
 #include "FloatSize.h"
 #include "GRefPtrGStreamer.h"
 #include "GUniquePtrGStreamer.h"
@@ -29,12 +30,12 @@
 #include <gst/video/video-info.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
+#include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
-class IntSize;
 class SharedBuffer;
 
 using TrackID = uint64_t;

--- a/Source/WebCore/platform/ios/LegacyTileLayerPool.h
+++ b/Source/WebCore/platform/ios/LegacyTileLayerPool.h
@@ -37,6 +37,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/Threading.h>
 #include <wtf/Vector.h>
+#include <wtf/WallTime.h>
 
 @class LegacyTileLayer;
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -38,7 +38,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/persistence/PersistentCoders.h>
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -34,6 +34,7 @@
 #include <wtf/DateMath.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/Seconds.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -367,23 +368,23 @@ bool CookieJarDB::hasCookies(const URL& url)
     return statement.step() == SQLITE_ROW;
 }
 
-std::optional<Vector<Cookie>> CookieJarDB::searchCookies(const URL& firstParty, const URL& requestUrl, const std::optional<bool>& httpOnly, const std::optional<bool>& secure, const std::optional<bool>& session)
+std::optional<Vector<Cookie>> CookieJarDB::searchCookies(const URL& firstParty, const URL& requestURL, std::optional<bool> httpOnly, std::optional<bool> secure, std::optional<bool> session)
 {
     if (!isEnabled() || !m_database.isOpen())
         return std::nullopt;
 
-    String requestHost = requestUrl.host().convertToASCIILowercase();
+    String requestHost = requestURL.host().convertToASCIILowercase();
     if (requestHost.isEmpty())
         return std::nullopt;
 
-    if (!checkCookieAcceptPolicy(firstParty, requestUrl))
+    if (!checkCookieAcceptPolicy(firstParty, requestURL))
         return std::nullopt;
 
-    String requestPath = requestUrl.path().toString();
+    String requestPath = requestURL.path().toString();
     if (requestPath.isEmpty())
         requestPath = "/"_s;
 
-    RegistrableDomain registrableDomain { requestUrl };
+    RegistrableDomain registrableDomain { requestURL };
 
     auto pstmt = m_database.prepareStatement("SELECT name, value, domain, path, expires, httponly, secure, session FROM Cookie WHERE "\
         "(NOT ((session = 0) AND (expires < ?)))"
@@ -570,6 +571,11 @@ bool CookieJarDB::setCookie(const URL& firstParty, const URL& url, const String&
     }
 
     return setCookie(*cookie);
+}
+
+bool CookieJarDB::setCookie(const URL& firstParty, const URL& url, const String& body, CookieJarDB::Source source)
+{
+    return setCookie(firstParty, url, body, source, std::nullopt);
 }
 
 HashSet<String> CookieJarDB::allDomains()

--- a/Source/WebCore/platform/network/curl/CookieJarDB.h
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
@@ -59,9 +59,10 @@ public:
     CookieAcceptPolicy acceptPolicy() const { return m_acceptPolicy; }
 
     HashSet<String> allDomains();
-    std::optional<Vector<Cookie>> searchCookies(const URL& firstParty, const URL& requestUrl, const std::optional<bool>& httpOnly, const std::optional<bool>& secure, const std::optional<bool>& session);
+    std::optional<Vector<Cookie>> searchCookies(const URL& firstParty, const URL& requestURL, std::optional<bool> httpOnly, std::optional<bool> secure, std::optional<bool> session);
     Vector<Cookie> getAllCookies();
-    WEBCORE_EXPORT bool setCookie(const URL& firstParty, const URL&, const String& cookie, Source, std::optional<Seconds> cappedLifetime = std::nullopt);
+    WEBCORE_EXPORT bool setCookie(const URL& firstParty, const URL&, const String& cookie, Source, std::optional<Seconds> cappedLifetime);
+    WEBCORE_EXPORT bool setCookie(const URL& firstParty, const URL&, const String& cookie, Source);
     bool setCookie(const Cookie&);
 
     bool deleteCookie(const String& url, const String& name);

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -31,7 +31,8 @@
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Scope.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/Base64.h>
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -37,7 +37,8 @@
 #include "SWServerRegistration.h"
 #include "WebCorePersistentCoders.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -41,8 +41,8 @@
 #include "WebCorePersistentCoders.h"
 #include "WorkerType.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/persistence/PersistentCoders.h>
 #include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ITPThirdPartyDataForSpecificFirstParty.h"
 
+#include <wtf/WallTime.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/RegistrableDomain.h>
-#include <wtf/Forward.h>
+#include <wtf/Seconds.h>
 
 namespace WebKit {
 
@@ -37,7 +37,7 @@ struct ITPThirdPartyDataForSpecificFirstParty {
 
     String toString() const;
 
-    // FIXME: Since this ignores differences in decodedTimeLastUpdated it probably should be a named function, not operator==.
+    // FIXME: Since this intentionally ignores differences in decodedTimeLastUpdated it should be a named function, not operator==.
     bool operator==(const ITPThirdPartyDataForSpecificFirstParty&) const;
 };
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
@@ -28,7 +28,8 @@
 
 #include "NetworkCacheKey.h"
 #include "NetworkCacheSubresourcesEntry.h"
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 
 namespace WTF::Persistence {
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -39,7 +39,8 @@
 #include <wtf/PageBlock.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -32,6 +32,7 @@
 #include "NetworkCacheCoders.h"
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/persistence/PersistentEncoder.h>
 
 namespace WebKit {

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -34,7 +34,6 @@
 #include <wtf/PageBlock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Scope.h>
-#include <wtf/persistence/PersistentCoders.h>
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -70,6 +70,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/persistence/PersistentEncoder.h>
 
 #if HAVE(NW_PROXY_CONFIG)
 #import <Network/Network.h>

--- a/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
@@ -32,6 +32,7 @@
 #include <wtf/Expected.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MediaTime.h>
+#include <wtf/Seconds.h>
 
 namespace WTF {
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
@@ -27,6 +27,7 @@
 
 #include <type_traits>
 #include <wtf/DataLog.h>
+#include <wtf/Seconds.h>
 #include <wtf/Threading.h>
 #include <wtf/WTFConfig.h>
 #if OS(UNIX)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
@@ -35,6 +35,7 @@
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WallTime.h>
 
 static RetainPtr<WKWebView> webViewWithResourceLoadStatisticsEnabledInNetworkProcess()
 {


### PR DESCRIPTION
#### cb22abbf151d2a3806fd116562b310fd73ae98a2
<pre>
Cut unneeded includes from Lock.h, PersistentCoder.h, ThreadingPrimitives.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=280570">https://bugs.webkit.org/show_bug.cgi?id=280570</a>
<a href="https://rdar.apple.com/136895761">rdar://136895761</a>

Reviewed by Simon Fraser.

* Source/JavaScriptCore/API/JSContextRef.cpp:
(JSContextGroupTakeSamplesFromSamplingProfiler): Use
takeSamplingProfilerSamplesAsJSONString.

* Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.cpp: Updated includes.
* Source/JavaScriptCore/inspector/ConsoleMessage.h: Ditto.
* Source/JavaScriptCore/inspector/ScriptFunctionCall.h: Ditto.

* Source/JavaScriptCore/jsc.cpp:
(functionSamplingProfilerStackTraces): Use stackTracesAsJSONString.

* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerBytecodes.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerEvent.cpp: Ditto.
* Source/JavaScriptCore/profiler/ProfilerEvent.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerOSRExit.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerOrigin.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerOriginStack.h: Ditto.
* Source/JavaScriptCore/profiler/ProfilerUID.h: Ditto.
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h: Ditto.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::dumpAndClearSamplingProfilerSamples): Use
takeSamplingProfilerSamplesAsJSONString.

* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::stackTracesAsJSONString): Updated to return
a String. Both callers needed that version, and this prevents us from
having to depend on JSON types in SamplingProfiler.h, which is especially
bad because they can&apos;t be forward declared easily due to namespace shenanigans.
* Source/JavaScriptCore/runtime/SamplingProfiler.h: Ditto.

* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::takeSamplingProfilerSamplesAsJSONString): Updated to return
a String. Both callers needed that version, and this prevents us from
having to depend on JSON types in VM.h, which is especially bad because
they can&apos;t be forward declared easily due to namespace shenanigans.
* Source/JavaScriptCore/runtime/VM.h: Ditto.

* Source/WTF/wtf/Forward.h: Added using for Seconds and WallTime.

* Source/WTF/wtf/HashMap.h: Updated includes.
* Source/WTF/wtf/Lock.h: Ditto.

* Source/WTF/wtf/MediaTime.cpp:
(WTF::MediaTime::createFromSeconds): Moved from header.
(WTF::LogArgument&lt;MediaTime&gt;::toString): Moved from header.
(WTF::LogArgument&lt;MediaTimeRange&gt;::toString): Ditto.

* Source/WTF/wtf/MediaTime.h: Updated includes and moved functions that
depend on JSONValues.h and Seconds.h out of the header.

* Source/WTF/wtf/Seconds.h: Updated includes.
* Source/WTF/wtf/SystemTracing.h: Ditto.
* Source/WTF/wtf/ThreadingPrimitives.h: Ditto.
* Source/WTF/wtf/WallTime.h: Ditto.

* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;SHA1::Digest&gt;::encodeForPersistence): Deleted.
(WTF::Persistence::Coder&lt;SHA1::Digest&gt;::decodeForPersistence): Deleted.

* Source/WTF/wtf/persistence/PersistentCoders.h: Updated includes.
To avoid depending on SHA1.h, made a coder for arrays of int8_t
rather than specifically for SHA1::Digest.

* Source/WTF/wtf/persistence/PersistentDecoder.h: Updated includes.
* Source/WTF/wtf/persistence/PersistentEncoder.h: Ditto.
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp: Ditto.
* Source/WTF/wtf/win/ThreadingWin.cpp: Ditto.
* Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp: Ditto.
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp: Ditto.
* Source/WebCore/platform/PasteboardCustomData.cpp: Ditto.
* Source/WebCore/platform/SharedBuffer.cpp: Ditto.
* Source/WebCore/platform/WebCorePersistentCoders.cpp: Ditto.
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm: Ditto.
* Source/WebCore/platform/graphics/InbandGenericCue.cpp: Ditto.

* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WTF::LogArgument&lt;WebCore::PlatformTimeRanges&gt;::toString): Moved from header.
* Source/WebCore/platform/graphics/PlatformTimeRanges.h: Moved toString out
of header so it can be compiled without including the String class.

* Source/WebCore/platform/graphics/adwaita/Adwaita.h: Updated includes.
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h: Ditto.
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h: Ditto.

* Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp:
(WebCore::createEGLFence): Update conditional code to fix Windows build.
(WebCore::GLFenceEGL::GLFenceEGL): Ditto.
* Source/WebCore/platform/graphics/egl/GLFenceEGL.h: Ditto.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h: Ditto.
* Source/WebCore/platform/ios/LegacyTileLayerPool.h: Ditto.
* Source/WebCore/platform/network/ResourceResponseBase.cpp: Ditto.

* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
(WebCore::CookieJarDB::searchCookies): Drive by fix: Dopped peculiar use of
const&amp; for std::optional&lt;bool&gt;.
(WebCore::CookieJarDB::setCookie): Use overloading so the header doesn&apos;t need
to include Seconds.h.

* Source/WebCore/storage/StorageUtilities.cpp: Updated includes.
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp: Ditto.
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp: Ditto.
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp: Ditto.
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h: Ditto.
* Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp: Ditto.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp: Ditto.
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp: Ditto.
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp: Ditto.
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp: Ditto.
* Tools/TestWebKitAPI/Tests/WTF/Signals.cpp: Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm: Ditto.

Canonical link: <a href="https://commits.webkit.org/287449@main">https://commits.webkit.org/287449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49f94f47b679575b00dec518e1e9f60100e6625b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30711 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62277 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20128 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29142 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72711 "Found 1 new JSC binary failure: testapi, Found 193 new JSC stress test failures: stress/sampling-profiler-anonymous-function.js.bytecode-cache, stress/sampling-profiler-anonymous-function.js.default, stress/sampling-profiler-anonymous-function.js.dfg-eager, stress/sampling-profiler-anonymous-function.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-anonymous-function.js.eager-jettison-no-cjit, stress/sampling-profiler-anonymous-function.js.ftl-eager, stress/sampling-profiler-anonymous-function.js.ftl-eager-no-cjit, stress/sampling-profiler-anonymous-function.js.ftl-eager-no-cjit-b3o1, stress/sampling-profiler-anonymous-function.js.ftl-no-cjit-b3o0, stress/sampling-profiler-anonymous-function.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85632 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78803 "Found 1 new JSC binary failure: testapi, Found 193 new JSC stress test failures: stress/sampling-profiler-anonymous-function.js.bytecode-cache, stress/sampling-profiler-anonymous-function.js.default, stress/sampling-profiler-anonymous-function.js.dfg-eager, stress/sampling-profiler-anonymous-function.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-anonymous-function.js.eager-jettison-no-cjit, stress/sampling-profiler-anonymous-function.js.ftl-eager, stress/sampling-profiler-anonymous-function.js.ftl-eager-no-cjit, stress/sampling-profiler-anonymous-function.js.ftl-eager-no-cjit-b3o1, stress/sampling-profiler-anonymous-function.js.ftl-no-cjit-b3o0, stress/sampling-profiler-anonymous-function.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6920 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4829 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-BroadcastChannel.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-workers.https.window.html inspector/worker/runtime-basic-subworker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70533 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html imported/w3c/web-platform-tests/css/css-view-transitions/inline-element-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69779 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12700 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101145 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12311 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6873 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24678 "Found 1 new JSC binary failure: testapi, Found 97 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/sampling-profiler-anonymous-function.js.bytecode-cache, stress/sampling-profiler-anonymous-function.js.default, stress/sampling-profiler-anonymous-function.js.dfg-eager, stress/sampling-profiler-anonymous-function.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-anonymous-function.js.eager-jettison-no-cjit, stress/sampling-profiler-anonymous-function.js.lockdown, stress/sampling-profiler-anonymous-function.js.mini-mode, stress/sampling-profiler-anonymous-function.js.no-cjit-collect-continuously, stress/sampling-profiler-anonymous-function.js.no-cjit-validate-phases ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6758 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->