### PR TITLE
[WebVTT][Interop] rendering expected test results have inconsistent font styles

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -596,6 +596,10 @@ imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.windo
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
 
 # These are the WebVTT rendering WPT we are already passing.
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_remove_cue_while_paused.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority_layer.html [ Pass ]
@@ -604,6 +608,12 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_selectors.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_urls.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line.html [ Pass ]
 
 # These WebVTT rendering WPT are flaky.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/non-standard-pseudo-elements.html [ ImageOnlyFailure Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-expected.html
@@ -1,32 +1,22 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, repositioning (up) when 2 cues overlap completely</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center;
-}
-.cueText {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>
 <div class="video">
-    <span class="cue">
-        <div><span class="cueText">This is another test subtitle</span></div>
-        <div><span class="cueText">This is a test subtitle</span></div>
-    </span>
+    <span class="cue"><div><span class="cueText">This is another test subtitle</span></div><div><span class="cueText">This is a test subtitle</span></div></span>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering-expected.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>webvtt-white-space-pre-line-expected</title>
     <link rel="stylesheet" type="text/css" href="support/reference.css">
+    <link rel="stylesheet" type="text/css" href="support/test-diff.css">
     <body>
         <div>Test rendering a basic <code>VTTCue</code>.</div>
         <div class="test-diff">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>webvtt-white-space-pre-line</title>
     <link rel="stylesheet" type="text/css" href="support/reference.css">
+    <link rel="stylesheet" type="text/css" href="support/test-diff.css">
     <link rel="match" href="basic-cue-rendering.html">
-    <script src="/common/reftest-wait.js"></script>
     <script src="support/webvtt-rendering-test.js"></script>
     <body>
         <div>Test rendering a basic <code>VTTCue</code>.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-expected.html
@@ -1,26 +1,18 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, bidi U+06E9 no strong direction</title>
+<link rel="stylesheet" type="text/css" href="../support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
-    font-family: sans-serif;
-    background: rgba(0,0,0,0.8);
-    color: white;
+    font: 9px sans-serif;
 }
 </style>
 <div class="video"><span class="cue"><span><bdo dir=ltr>&#x06E9;)</bdo></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-expected.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, decoding of escaped entities</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-expected.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, it is possible to override cue line with the DOM APIs</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-expected.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, line:0 should be top line</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-expected.html
@@ -1,27 +1,20 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, line:1, size:50%, wrapped cue should grow downwards</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     top: 9px;
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-expected.html
@@ -1,34 +1,27 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, line integer and percent mixed with overlap</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
+}
+.cue {
+    font: 9px Ahem;
+    color: green;
 }
 #cue1 {
-    position: absolute;
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
 }
 #cue2 {
-    position: absolute;
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-expected.html
@@ -1,27 +1,20 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, one line cue and cue that wraps - both should be fully visible</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     bottom: 0;
     left: 15%;
     right: 0;
     width: 70%;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-expected.html
@@ -1,27 +1,20 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, size:50%</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="support/reference.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
 .video {
-    display: inline-block;
     width: 320px;
     height: 180px;
-    position: relative;
-    font-size: 9px;
 }
 .cue {
-    position: absolute;
     bottom: 0;
     left: 25%;
     right: 0;
     width: 50%;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    font: 9px Ahem;
     color: green;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/reference.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/reference.css
@@ -1,47 +1,37 @@
-@font-face {
-    font-family: 'ahem';
-    src: url('/fonts/Ahem.ttf');
-}
+/* 7.4. Applying CSS properties to WebVTT Node Objects */
 
-.test-diff {
-    container-type: inline-size;
-    width: 200px;
-    height: 200px;
+video-reference, .video {
     display: inline-block;
-    isolation: isolate;
     position: relative;
-    border: 1px solid black;
+    container-type: size;
 }
 
-video-reference, cue { display: inline-block; }
-cue-background { display: inline; }
-
-video, video-reference {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    mix-blend-mode: difference;
-}
-
-::cue, cue {
-    font: 5cqmin/1 Ahem;
-}
-
-::cue, cue-background {
-    color: rgb(128, 0, 0);
-    background-color: rgb(255, 0, 0);
-}
-
-cue {
-    position: absolute;
+cue, .cue {
     display: inline-block;
-    text-align: center;
+    position: absolute;
+    unicode-bidi: plaintext;
+    writing-mode: writing-mode;
+    overflow-wrap: break-word;
+    text-wrap: balance;
+    font: 5cqmin sans-serif;
+    color: rgba(255,255,255,1);
     white-space: pre-line;
+
+    /* "By default, the text alignment is set to center." */
+    text-align: center;
+
+    /* "By default, the writing direction is set to to horizontal." */
+    writing-mode: horizontal-tb;
+
+    /* "By default, the WebVTT cue size is set to 100%." */
+    width: 100cqw;
+    height: auto;
 }
 
-video-reference[expected] > cue > cue-background {
-    color: rgb(128, 128, 0);
-    background-color: rgb(255, 255, 0);
+cue-background, .cue > span, .cueText {
+    /* The children of the nodes must be wrapped in an anonymous box whose display
+       property has the value inline. This is the WebVTT cue background box. */
+    display: inline;
+
+    background: rgba(0,0,0,0.8);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/test-diff.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/test-diff.css
@@ -1,0 +1,37 @@
+@font-face {
+    font-family: 'ahem';
+    src: url('/fonts/Ahem.ttf');
+}
+
+.test-diff {
+    width: 200px;
+    height: 200px;
+    display: inline-block;
+    isolation: isolate;
+    position: relative;
+    border: 1px solid black;
+}
+
+video, video-reference {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    mix-blend-mode: difference;
+    container-type: size;
+}
+
+::cue, cue {
+    font: 5cqmin Ahem;
+}
+
+::cue, cue-background {
+    color: rgb(128, 0, 0);
+    background-color: rgb(255, 0, 0);
+}
+
+video-reference[expected] > cue > cue-background {
+    color: rgb(128, 128, 0);
+    background-color: rgb(255, 255, 0);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line-expected.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>webvtt-white-space-pre-line</title>
     <link rel="stylesheet" type="text/css" href="support/reference.css">
+    <link rel="stylesheet" type="text/css" href="support/test-diff.css">
     <body>
         <div>Test rendering of wrapped text when <code>white-space: pre-line</code> is set.</div>
         <div class="test-diff">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>webvtt-white-space-pre-line</title>
     <link rel="stylesheet" type="text/css" href="support/reference.css">
+    <link rel="stylesheet" type="text/css" href="support/test-diff.css">
     <link rel="match" href="white-space-pre-line.html">
     <script src="support/webvtt-rendering-test.js"></script>
     <body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -65,7 +65,7 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 [useragentpart="cue"] ruby > rt { display: ruby-text; }
 
 ::cue {
-    font: 5cqmin/1 sans-serif;
+    font: 5cqmin sans-serif;
     color: rgba(255, 255, 255, 1);
     background: rgba(0, 0, 0, 0.8);
     white-space: pre-line;


### PR DESCRIPTION
#### 2617c23352a28bb51d5ee75efba5bd454e19441c
<pre>
[WebVTT][Interop] rendering expected test results have inconsistent font styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=280587">https://bugs.webkit.org/show_bug.cgi?id=280587</a>
<a href="https://rdar.apple.com/136931198">rdar://136931198</a>

Reviewed by NOBODY (OOPS!).

In rendering expected test references, assign both the font-face and font-size in the same place: the equivalent
of the ::cue pseudoclass, rather than split across the equivalent of the &lt;video&gt; and the ::cue &gt; span.

Move declaration of default initial styles into support/reference.css, and move the &quot;diff&quot; functionality
into its own stylesheet: support/test-diff.css.

Add support/reference.css to 11 tests, remove the unnecessary styles, move font rules into .cue, and mark the
tests as passing.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/reference.css:
(video-reference, .video):
(cue, .cue):
(cue-background, .cue &gt; span, .cueText):
(@font-face): Deleted.
(.test-diff): Deleted.
(video-reference, cue): Deleted.
(cue-background): Deleted.
(video, video-reference): Deleted.
(::cue, cue): Deleted.
(::cue, cue-background): Deleted.
(cue): Deleted.
(video-reference[expected] &gt; cue &gt; cue-background): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/test-diff.css: Copied from LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/reference.css.
(@font-face):
(.test-diff):
(video, video-reference):
(::cue, cue):
(::cue, cue-background):
(video-reference[expected] &gt; cue &gt; cue-background):
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2617c23352a28bb51d5ee75efba5bd454e19441c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21091 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55608 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14087 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36074 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41728 "Exiting early after 10 failures. 56 tests run. 2 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75877 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63248 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4871 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46355 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->