### PR TITLE
Implement i18n.getSystemUILanguage and i18n.getPreferredSystemLanguages.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -369,7 +369,7 @@ JSObjectRef toJSRejectedPromise(JSContextRef context, NSString *callingAPIName, 
 NSString *toWebAPI(NSLocale *locale)
 {
     if (!locale.languageCode)
-        return nil;
+        return @"und";
 
     if (locale.countryCode.length)
         return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -88,6 +88,16 @@ void WebExtensionAPILocalization::getAcceptLanguages(Ref<WebExtensionCallbackHan
     callback->call(acceptLanguages.array);
 }
 
+void WebExtensionAPILocalization::getPreferredSystemLanguages(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    callback->call(NSLocale.preferredLanguages);
+}
+
+void WebExtensionAPILocalization::getSystemUILanguage(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    callback->call(toWebAPI(NSLocale.systemLocale));
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
@@ -39,6 +39,8 @@ public:
     NSString *getMessage(NSString* messageName, id substitutions);
     NSString *getUILanguage();
     void getAcceptLanguages(Ref<WebExtensionCallbackHandler>&&);
+    void getPreferredSystemLanguages(Ref<WebExtensionCallbackHandler>&&);
+    void getSystemUILanguage(Ref<WebExtensionCallbackHandler>&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
@@ -36,4 +36,7 @@
 
     void getAcceptLanguages([Optional, CallbackHandler] function callback);
 
+    void getPreferredSystemLanguages([Optional, CallbackHandler] function callback);
+
+    void getSystemUILanguage([Optional, CallbackHandler] function callback);
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
@@ -39,6 +39,7 @@ static NSString * const placeholdersKey = @"placeholders";
 static NSString * const placeholderDictionaryContentKey = @"content";
 
 static NSLocale *currentLocale = NSLocale.currentLocale;
+static NSLocale *currentSystemLocale = NSLocale.systemLocale;
 static NSWritingDirection writingDirection = [NSParagraphStyle defaultWritingDirectionForLanguage:currentLocale.languageCode];
 static NSString *textDirection = writingDirection == NSWritingDirectionLeftToRight ? @"ltr" : @"rtl";
 static NSString *reversedTextDirection = writingDirection == NSWritingDirectionLeftToRight ? @"rtl" : @"ltr";
@@ -78,7 +79,7 @@ static auto *messages = @{
 static NSString *localeStringInWebExtensionFormat(NSLocale *locale)
 {
     if (!locale.languageCode)
-        return @"";
+        return @"und";
 
     if (locale.countryCode.length)
         return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];
@@ -86,6 +87,7 @@ static NSString *localeStringInWebExtensionFormat(NSLocale *locale)
 }
 
 static NSString *currentLocaleString = localeStringInWebExtensionFormat(currentLocale);
+static NSString *currentSystemLocaleString = localeStringInWebExtensionFormat(currentSystemLocale);
 
 static auto *baseURLString = @"test-extension://76C788B8-3374-400D-8259-40E5B9DF79D3";
 
@@ -122,10 +124,13 @@ TEST(WKWebExtensionAPILocalization, i18n)
     }
 
     auto *acceptedLanguagesString = Util::constructJSArrayOfStrings(acceptedLanguages.array);
+    auto *preferredLanguagesString = Util::constructJSArrayOfStrings(preferredLocaleIdentifiers);
 
     auto *backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const acceptedLanguages = %@", acceptedLanguagesString],
+        [NSString stringWithFormat:@"const preferredLanguages = %@", preferredLanguagesString],
         [NSString stringWithFormat:@"const currentUILanguage = '%@'", currentLocaleString],
+        [NSString stringWithFormat:@"const currentSystemUILanguage = '%@'", currentSystemLocaleString],
         [NSString stringWithFormat:@"const textDirection = '%@'", textDirection],
         [NSString stringWithFormat:@"const reversedTextDirection = '%@'", reversedTextDirection],
         [NSString stringWithFormat:@"const startEdge = '%@'", startEdge],
@@ -142,6 +147,8 @@ TEST(WKWebExtensionAPILocalization, i18n)
 
         @"browser.test.assertEq(browser.i18n.getUILanguage(), currentUILanguage)",
         @"browser.test.assertDeepEq(await browser.i18n.getAcceptLanguages(), acceptedLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getPreferredSystemLanguages(), preferredLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getSystemUILanguage(), currentSystemUILanguage)",
 
         @"browser.test.notifyPass()",
     ]);
@@ -166,10 +173,13 @@ TEST(WKWebExtensionAPILocalization, i18nWithFallback)
     }
 
     auto *acceptedLanguagesString = Util::constructJSArrayOfStrings(acceptedLanguages.array);
+    auto *preferredLanguagesString = Util::constructJSArrayOfStrings(preferredLocaleIdentifiers);
 
     auto *backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const acceptedLanguages = %@", acceptedLanguagesString],
+        [NSString stringWithFormat:@"const preferredLanguages = %@", preferredLanguagesString],
         [NSString stringWithFormat:@"const currentUILanguage = '%@'", currentLocaleString],
+        [NSString stringWithFormat:@"const currentSystemUILanguage = '%@'", currentSystemLocaleString],
         [NSString stringWithFormat:@"const textDirection = '%@'", textDirection],
         [NSString stringWithFormat:@"const reversedTextDirection = '%@'", reversedTextDirection],
         [NSString stringWithFormat:@"const startEdge = '%@'", startEdge],
@@ -188,6 +198,8 @@ TEST(WKWebExtensionAPILocalization, i18nWithFallback)
 
         @"browser.test.assertEq(browser.i18n.getUILanguage(), currentUILanguage)",
         @"browser.test.assertDeepEq(await browser.i18n.getAcceptLanguages(), acceptedLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getPreferredSystemLanguages(), preferredLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getSystemUILanguage(), currentSystemUILanguage)",
 
         @"browser.test.notifyPass()",
     ]);
@@ -249,10 +261,13 @@ TEST(WKWebExtensionAPILocalization, i18nWithoutMessages)
     }
 
     auto *acceptedLanguagesString = Util::constructJSArrayOfStrings(acceptedLanguages.array);
+    auto *preferredLanguagesString = Util::constructJSArrayOfStrings(preferredLocaleIdentifiers);
 
     auto *backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const acceptedLanguages = %@", acceptedLanguagesString],
+        [NSString stringWithFormat:@"const preferredLanguages = %@", preferredLanguagesString],
         [NSString stringWithFormat:@"const currentUILanguage = '%@'", currentLocaleString],
+        [NSString stringWithFormat:@"const currentSystemUILanguage = '%@'", currentSystemLocaleString],
 
         @"browser.test.assertEq(browser.i18n.getMessage('@@extension_id'), '76C788B8-3374-400D-8259-40E5B9DF79D3')",
         @"browser.test.assertEq(browser.i18n.getMessage('@@ui_locale'), '')",
@@ -264,6 +279,8 @@ TEST(WKWebExtensionAPILocalization, i18nWithoutMessages)
 
         @"browser.test.assertEq(browser.i18n.getUILanguage(), currentUILanguage)",
         @"browser.test.assertDeepEq(await browser.i18n.getAcceptLanguages(), acceptedLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getPreferredSystemLanguages(), preferredLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getSystemUILanguage(), currentSystemUILanguage)",
 
         @"browser.test.notifyPass()",
     ]);
@@ -302,10 +319,13 @@ TEST(WKWebExtensionAPILocalization, i18nWithoutDefaultLocale)
     };
 
     auto *acceptedLanguagesString = Util::constructJSArrayOfStrings(acceptedLanguages.array);
+    auto *preferredLanguagesString = Util::constructJSArrayOfStrings(preferredLocaleIdentifiers);
 
     auto *backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const acceptedLanguages = %@", acceptedLanguagesString],
+        [NSString stringWithFormat:@"const preferredLanguages = %@", preferredLanguagesString],
         [NSString stringWithFormat:@"const currentUILanguage = '%@'", currentLocaleString],
+        [NSString stringWithFormat:@"const currentSystemUILanguage = '%@'", currentSystemLocaleString],
 
         @"browser.test.assertEq(browser.i18n.getMessage('@@extension_id'), '76C788B8-3374-400D-8259-40E5B9DF79D3')",
         @"browser.test.assertEq(browser.i18n.getMessage('@@ui_locale'), '')",
@@ -317,6 +337,8 @@ TEST(WKWebExtensionAPILocalization, i18nWithoutDefaultLocale)
 
         @"browser.test.assertEq(browser.i18n.getUILanguage(), currentUILanguage)",
         @"browser.test.assertDeepEq(await browser.i18n.getAcceptLanguages(), acceptedLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getPreferredSystemLanguages(), preferredLanguages)",
+        @"browser.test.assertDeepEq(await browser.i18n.getSystemUILanguage(), currentSystemUILanguage)",
 
         @"browser.test.notifyPass()",
     ]);


### PR DESCRIPTION
#### aa0a285f213743efb21bc7c447cc02786ab6c881
<pre>
Implement i18n.getSystemUILanguage and i18n.getPreferredSystemLanguages.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280586">https://bugs.webkit.org/show_bug.cgi?id=280586</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getPreferredSystemLanguages):
(WebKit::WebExtensionAPILocalization::getSystemUILanguage):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18n)):
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithFallback)):
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithoutMessages)):
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithoutDefaultLocale)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56ee75e2bdbd869cabba56c4a2881bb1570a15ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22712 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20968 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13996 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73025 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44967 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60334 "Passed tests") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41632 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17344 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63149 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4771 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->