### PR TITLE
Update tests to align for `widow` and `orphans` specifications

### DIFF
--- a/LayoutTests/fast/multicol/border-padding-pagination.html
+++ b/LayoutTests/fast/multicol/border-padding-pagination.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-<div style="-webkit-column-count:2;-moz-column-count:2; border:2px solid maroon">
+<div style="column-count:2; widows: 1; orphans: 1; border:2px solid maroon">
 <div style="height:110px"></div>
 <div style="background-color:lime; border:2px solid black; width:375px; ">
 <div style="margin: 0 10px; background-color:green; border: 2px solid blue">

--- a/LayoutTests/fast/multicol/float-big-line.html
+++ b/LayoutTests/fast/multicol/float-big-line.html
@@ -7,6 +7,8 @@
         border: 2px solid black;
         height: 400px;
         line-height: 20px;
+        orphans: 1;
+        widows: 1;
     }
     .big {
         font-size: 128px;

--- a/LayoutTests/fast/multicol/float-truncation.html
+++ b/LayoutTests/fast/multicol/float-truncation.html
@@ -14,6 +14,8 @@
         font-size: 10px;
         margin: 5px;
         overflow: hidden;
+        orphans: 1;
+        widows: 1;
     }
 
     div.float {

--- a/LayoutTests/fast/multicol/hit-test-above-or-below.html
+++ b/LayoutTests/fast/multicol/hit-test-above-or-below.html
@@ -1,5 +1,5 @@
 <body style="margin: 0">
-<div style="margin: 50px; background-color: lightblue; width: 800px; height: 200px; -webkit-column-width:185px; -webkit-column-gap:15px; -webkit-column-fill:auto; column-width:185px; column-gap:15px; column-fill:auto; font-family: Ahem; font-size: 50px; line-height: 1;">
+<div style="margin: 50px; background-color: lightblue; width: 800px; height: 200px; -webkit-column-width:185px; -webkit-column-gap:15px; column-width:185px; column-gap:15px; column-fill:auto; font-family: Ahem; font-size: 50px; line-height: 1; orphans:1; widows:1;">
     123<div style="background-color: blue; height: 70px;"></div>abc<br>def<div style="background-color: blue; height: 60px;"></div>ghi<br>jkl<div style="background-color: blue; height: 110px;"></div>mno</div>
 <pre id="console" style="display: none;"></pre>
 <script>

--- a/LayoutTests/fast/multicol/nested-columns.html
+++ b/LayoutTests/fast/multicol/nested-columns.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <p>The word 'PASSED' should be seen below.</p>
-<div style="width:6em; height:2em; columns:3; column-gap:0; column-fill:auto; line-height:2em;">
+<div style="width:6em; height:2em; columns:3; column-gap:0; column-fill:auto; widows: 1; orphans: 1; line-height:2em;">
     <div style="column-count:2; column-gap:0;">
         P<br>A
     </div>

--- a/LayoutTests/fast/multicol/newmulticol/adjacent-spanners.html
+++ b/LayoutTests/fast/multicol/newmulticol/adjacent-spanners.html
@@ -5,7 +5,7 @@
     </head>
     <body>
         <p>You should see the word 'PASS' twice below, and no red:</p>
-        <div style="-webkit-columns:2; columns:2; -webkit-column-gap:0; column-gap:0; width:400px">
+        <div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;"></div>
             <div style="background:red;">
                 <div style="-webkit-column-span:all; column-span:all;border:1px solid black">PASS<br>&nbsp;</div>
                 <div style="-webkit-column-span:all; column-span:all;border:1px solid black">PASS<br>&nbsp;</div>

--- a/LayoutTests/fast/multicol/newmulticol/change-spanner-display-expected.html
+++ b/LayoutTests/fast/multicol/newmulticol/change-spanner-display-expected.html
@@ -1,20 +1,16 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Change display property of spanner</title>
-    </head>
-    <body style="margin:5em;">
-        <p>You should see three lines with the word "PASS" below, all with a bullet in front. Letter
+<style>
+    span { display:inline-block; width:1em; }
+</style>
+<body style="margin:5em;">
+    <p>Test that changing display type on a spanner (to another valid display type for spanners) works.</p>
+    <p>You should see three lines with the word "PASS" below, all with a bullet in front. Letter
         spacing is expected to vary.</p>
-        <div style="float:left;">
-            <div style="-webkit-columns:4; columns:4; -webkit-column-gap:0; column-gap:0;">
-                <div style="display:list-item;">P<br>A<br>S<br>S
-                    <div id="elm" style="display:list-item; -webkit-column-span:all; column-span:all;">
-                        PASS
-                    </div>
-                </div>
-                <div style="display:list-item;">P<br>A<br>S<br>S</div>
-            </div>
-        </div>
-    </body>
-</html>
+    <div style="display:list-item;">
+        <span>P</span><span>A</span><span>S</span><span>S</span>
+    </div>
+    <div style="display:list-item;">PASS</div>
+    <div style="display:list-item;">
+        <span>P</span><span>A</span><span>S</span><span>S</span>
+    </div>
+</body>

--- a/LayoutTests/fast/multicol/newmulticol/change-spanner-display.html
+++ b/LayoutTests/fast/multicol/newmulticol/change-spanner-display.html
@@ -1,27 +1,21 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Change display property of spanner</title>
-        <script>
-            function test() {
-                var elm = document.getElementById('elm');
-                document.body.offsetTop; // trigger layout
-                elm.style.display = 'list-item';
-            }
-        </script>
-    </head>
-    <body style="margin:5em;" onload="test()">
-        <p>You should see three lines with the word "PASS" below, all with a bullet in front. Letter
+<script>
+    onload = function() {
+        var elm = document.getElementById('elm');
+        document.body.offsetTop; // trigger layout
+        elm.style.display = 'list-item';
+    }
+</script>
+<body style="margin:5em;">
+    <p>Test that changing display type on a spanner (to another valid display type for spanners) works.</p>
+    <p>You should see three lines with the word "PASS" below, all with a bullet in front. Letter
         spacing is expected to vary.</p>
-        <div style="float:left;">
-            <div style="-webkit-columns:4; columns:4; -webkit-column-gap:0; column-gap:0;">
-                <div style="display:list-item;">P<br>A<br>S<br>S
-                    <div id="elm" style="-webkit-column-span:all; column-span:all;">
-                        PASS
-                    </div>
-                </div>
-                <div style="display:list-item;">P<br>A<br>S<br>S</div>
+    <div style="columns:4; column-gap:0; width:4em; orphans:1; widows:1;">
+        <div style="display:list-item;">P<br>A<br>S<br>S
+            <div id="elm" style="column-span:all;">
+                PASS
             </div>
         </div>
-    </body>
-</html>
+        <div style="display:list-item;">P<br>A<br>S<br>S</div>
+    </div>
+</body>

--- a/LayoutTests/fast/multicol/newmulticol/fixed-height-fill-balance-2.html
+++ b/LayoutTests/fast/multicol/newmulticol/fixed-height-fill-balance-2.html
@@ -5,7 +5,7 @@
     </head>
     <body style="overflow:hidden;">
         <p>There should be three identical blue rectangles below.</p>
-        <div style="-webkit-columns:3; -webkit-column-gap:1em; columns:3; column-gap:1em; line-height:2em; height:3.9em; width:20em;">
+        <div style="-webkit-columns:3; -webkit-column-gap:1em; columns:3; column-gap:1em; line-height:2em; height:3.9em; width:20em; orphans:1; widows:1;">
             <div style="background:blue;"><br><br><br></div>
         </div>
     </body>

--- a/LayoutTests/fast/multicol/newmulticol/spanner-inline-block-expected.html
+++ b/LayoutTests/fast/multicol/newmulticol/spanner-inline-block-expected.html
@@ -1,15 +1,2 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Inline-block as spanner (not allowed)</title>
-    </head>
-    <body>
-        <p>The inline block should be contained in a single column below.</p>
-        <div style="width:200px; ">
-            <div style="display:inline-block; width:100%; height:100px;-webkit-column-span:all; column-span:all; margin-left:1em;border:5px solid green">
-                
-            </div>
-            <br><br>
-        </div>
-    </body>
-</html>
+<p>There should be nothing below.</p>

--- a/LayoutTests/fast/multicol/newmulticol/spanner-inline-block.html
+++ b/LayoutTests/fast/multicol/newmulticol/spanner-inline-block.html
@@ -1,15 +1,9 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Inline-block as spanner (not allowed)</title>
-    </head>
-    <body>
-        <p>The inline block should be contained in a single column below.</p>
-        <div style="-webkit-columns:2; columns:2; -webkit-column-gap:0; column-gap:0; width:400px; ">
-            <div style="display:inline-block; width:100%; height:100px;-webkit-column-span:all; column-span:all; margin-left:1em;border:5px solid green">
-                
-            </div>
-            <br><br>
-        </div>
-    </body>
-</html>
+<p>There should be nothing below.</p>
+<div style="-webkit-columns:6; -webkit-column-gap:0; width:4em; overflow:hidden; orphans:1; widows:1;">
+    <!-- column-span:all only applies to in-flow block-level elements, so it will have no effect here. -->
+    <div style="display:inline-block; -webkit-column-span:all; margin-left:1em;">
+        FAIL
+    </div>
+    <br><br>
+</div>

--- a/LayoutTests/fast/multicol/orphans-relayout.html
+++ b/LayoutTests/fast/multicol/orphans-relayout.html
@@ -20,6 +20,7 @@ body.hide-containers .container {
     padding: 0;
     overflow: hidden;
     orphans: 2;
+    widows: 1;
 }
 
 .block {

--- a/LayoutTests/fast/multicol/span/span-as-nested-inline-block-child.html
+++ b/LayoutTests/fast/multicol/span/span-as-nested-inline-block-child.html
@@ -4,9 +4,9 @@
 <title>Nested spanning elements inside of an inline-block</title>
 </head>
 <body>
-<div style="-webkit-column-count: 2">
+<div style="column-count: 2; widows: 1; orphans: 1;">
 <div style="display: inline-block">
-<p style="-webkit-column-span: all">
+<p style="column-span: all">
 This text should not be spanned across two columns.
 </p>
 

--- a/LayoutTests/fast/multicol/tall-image-behavior-lr-mixed.html
+++ b/LayoutTests/fast/multicol/tall-image-behavior-lr-mixed.html
@@ -1,6 +1,6 @@
 <!doctype html>
-<body style="-webkit-writing-mode:vertical-lr; -webkit-text-orientation: mixed;">
-<div style="-webkit-columns:2; width:300px; border:2px solid blue;-webkit-line-box-contain:font replaced">
+<body style="writing-mode:vertical-lr; text-orientation: mixed;">
+<div style="columns:2; widows: 1; orphans: 1; width:300px; border:2px solid blue;-webkit-line-box-contain:font replaced">
 <p>This image should not be split across columns.<br>
 The reason it should not be split is that the line contains no
 text and so we should be willing to allow it to sit at the top of a new

--- a/LayoutTests/fast/multicol/tall-image-behavior-lr.html
+++ b/LayoutTests/fast/multicol/tall-image-behavior-lr.html
@@ -1,6 +1,6 @@
 <!doctype html>
-<body style="-webkit-writing-mode:vertical-lr; -webkit-text-orientation: sideways;">
-<div style="-webkit-columns:2; width:300px; border:2px solid blue;-webkit-line-box-contain:font replaced">
+<body style="writing-mode:vertical-lr; text-orientation: sideways;">
+<div style="columns:2; widows:1; orphans:1; width:300px; border:2px solid blue;-webkit-line-box-contain:font replaced">
 <p>This image should not be split across columns.<br>
 The reason it should not be split is that the line contains no
 text and so we should be willing to allow it to sit at the top of a new

--- a/LayoutTests/fast/multicol/tall-image-behavior-rl.html
+++ b/LayoutTests/fast/multicol/tall-image-behavior-rl.html
@@ -1,6 +1,6 @@
 <!doctype html>
-<body style="-webkit-writing-mode:vertical-rl">
-<div style="-webkit-columns:2; width:300px; border:2px solid blue;-webkit-line-box-contain:font replaced">
+<body style="-writing-mode:vertical-rl">
+<div style="columns:2; width:300px; widows:1; orphans:1; border:2px solid blue;-webkit-line-box-contain:font replaced">
 <p>This image should not be split across columns.<br>
 The reason it should not be split is that the line contains no
 text and so we should be willing to allow it to sit at the top of a new

--- a/LayoutTests/fast/multicol/tall-image-behavior.html
+++ b/LayoutTests/fast/multicol/tall-image-behavior.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<div style="-webkit-columns:2; height:300px; border:2px solid blue;-webkit-line-box-contain:glyphs replaced">
+<div style="columns:2; widows:1; orphans:1; height:300px; border:2px solid blue;-webkit-line-box-contain:glyphs replaced">
 <p>This image should not be split across columns.<br>
 The reason it should not be split is that the line contains no
 text and so we should be willing to allow it to sit at the top of a new

--- a/LayoutTests/fast/multicol/vertical-lr/border-padding-pagination.html
+++ b/LayoutTests/fast/multicol/vertical-lr/border-padding-pagination.html
@@ -1,6 +1,6 @@
 <html>
-<body style="-webkit-writing-mode:vertical-lr">
-<div style="-webkit-column-count:2;-moz-column-count:2; border:2px solid maroon">
+<body style="writing-mode:vertical-lr">
+<div style="column-count:2; widows: 1; orphans: 1; border:2px solid maroon">
 <div style="width:110px"></div>
 <div style="background-color:lime; border:2px solid black; height:375px;">
 <div style="margin: 10px 0; background-color:green; border: 2px solid blue">

--- a/LayoutTests/fast/multicol/vertical-lr/float-big-line.html
+++ b/LayoutTests/fast/multicol/vertical-lr/float-big-line.html
@@ -10,6 +10,8 @@
         border: 2px solid black;
         width: 400px;
         line-height: 20px;
+        orphans: 1;
+        widows: 1;
     }
     .big {
         font-size: 128px;

--- a/LayoutTests/fast/multicol/vertical-lr/float-truncation.html
+++ b/LayoutTests/fast/multicol/vertical-lr/float-truncation.html
@@ -13,6 +13,8 @@
         font-size: 10px;
         margin: 5px;
         overflow: hidden;
+        orphans: 1;
+        widows: 1;
     }
 
     div.float {

--- a/LayoutTests/fast/multicol/vertical-lr/nested-columns.html
+++ b/LayoutTests/fast/multicol/vertical-lr/nested-columns.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <p>The word 'PASSED' should be seen below (writing-mode is vertical-lr).</p>
-<div style="width:2em; height:6em; -webkit-columns:3; -webkit-column-gap:0; column-fill:auto; line-height:2em; -webkit-writing-mode:vertical-lr;">
-    <div style="-webkit-column-count:2; -webkit-column-gap:0;">
+<div style="width:2em; height:6em; columns:3; column-gap:0; column-fill:auto; widows: 1; orphans: 1; line-height:2em; writing-mode:vertical-lr;">
+    <div style="column-count:2; column-gap:0;">
         P<br>A
     </div>
-    <div style="-webkit-column-count:2; -webkit-column-gap:0;">
+    <div style="column-count:2; column-gap:0;">
         S<br>S
     </div>
-    <div style="-webkit-column-count:2; -webkit-column-gap:0;">
+    <div style="column-count:2; column-gap:0;">
         E<br>D
     </div>
 </div>

--- a/LayoutTests/fast/multicol/vertical-rl/border-padding-pagination.html
+++ b/LayoutTests/fast/multicol/vertical-rl/border-padding-pagination.html
@@ -1,6 +1,6 @@
 <html>
-<body style="-webkit-writing-mode:vertical-rl">
-<div style="-webkit-column-count:2;-moz-column-count:2; border:2px solid maroon">
+<body style="writing-mode:vertical-rl">
+<div style="column-count:2; widows: 1; orphans: 1; border:2px solid maroon">
 <div style="width:110px"></div>
 <div style="background-color:lime; border:2px solid black; height:375px;">
 <div style="margin: 10px 0; background-color:green; border: 2px solid blue">

--- a/LayoutTests/fast/multicol/vertical-rl/float-big-line.html
+++ b/LayoutTests/fast/multicol/vertical-rl/float-big-line.html
@@ -10,6 +10,8 @@
         border: 2px solid black;
         width: 400px;
         line-height: 20px;
+        orphans: 1;
+        widows: 1;
     }
     .big {
         font-size: 128px;

--- a/LayoutTests/fast/multicol/vertical-rl/float-truncation.html
+++ b/LayoutTests/fast/multicol/vertical-rl/float-truncation.html
@@ -14,6 +14,8 @@
         font-size: 10px;
         margin: 5px;
         overflow: hidden;
+        orphans: 1;
+        widows: 1;
     }
 
     div.float {

--- a/LayoutTests/fast/multicol/vertical-rl/nested-columns.html
+++ b/LayoutTests/fast/multicol/vertical-rl/nested-columns.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <p>The word 'PASSED' should be seen below (writing-mode is vertical-rl).</p>
-<div style="width:2em; height:6em; -webkit-columns:3; -webkit-column-gap:0; column-fill:auto; line-height:2em; -webkit-writing-mode:vertical-rl;">
-    <div style="-webkit-column-count:2; -webkit-column-gap:0;">
+<div style="width:2em; height:6em; columns:3; column-gap:0; widows: 1; orphans: 1; column-fill:auto; line-height:2em; writing-mode:vertical-rl;">
+    <div style="column-count:2; column-gap:0;">
         P<br>A
     </div>
-    <div style="-webkit-column-count:2; -webkit-column-gap:0;">
+    <div style="column-count:2; column-gap:0;">
         S<br>S
     </div>
-    <div style="-webkit-column-count:2; -webkit-column-gap:0;">
+    <div style="column-count:2; column-gap:0;">
         E<br>D
     </div>
 </div>

--- a/LayoutTests/fast/multicol/widows-and-orphans.html
+++ b/LayoutTests/fast/multicol/widows-and-orphans.html
@@ -10,8 +10,6 @@ body.hide-containers .container {
 .container {
     width: 600px;
     height: 200px;
-    -webkit-columns: 3;
-    -webkit-column-fill: auto;
     columns: 3;
     column-fill: auto;
     line-height: 20px; /* 10 lines per page */
@@ -19,6 +17,8 @@ body.hide-containers .container {
     margin: 0 0 20px 0;
     padding: 0;
     overflow: hidden;
+    orphans: 1;
+    widows: 1;
 }
 
 .block {

--- a/LayoutTests/imported/blink/fast/multicol/basic-rtl.html
+++ b/LayoutTests/imported/blink/fast/multicol/basic-rtl.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <p>Below, the numbers from 1 to 4 should be seen, in ascending order.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; direction:rtl;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; direction:rtl; orphans:1; widows:1;">
     4<br>
     3<br>
     2<br>

--- a/LayoutTests/imported/blink/fast/multicol/client-rects-rtl.html
+++ b/LayoutTests/imported/blink/fast/multicol/client-rects-rtl.html
@@ -17,6 +17,8 @@
         column-fill: auto;
         display: inline-block;
         vertical-align: bottom;
+        orphans: 1;
+        widows: 1;
     }
 
     div.marker {

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-among-text-in-anonymous-wrapper.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-among-text-in-anonymous-wrapper.html
@@ -8,7 +8,7 @@
 </script>
 <p>Test inserting a block in the middle of inline content that has an anonymous wrapper block around it.</p>
 <p>There should be three lines below with the word "PASS". Letter spacing is expected to vary</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     <div style="-webkit-column-span:all;">PASS</div>
     P<br>P
     <div id="elm" style="display:none;">A</div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-before-spanner-before-content.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-before-spanner-before-content.html
@@ -11,7 +11,7 @@
 </style>
 <p>Test insertion of column content right in front of a spanner that is followed by more column content.</p>
 <p>There should be three lines below with the word "PASS". Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     <div id="elm" style="display:none;">P<br>A<br>S<br>S</div>
     <div class="spanner">PASS</div>
     P<br>A<br>S<br>S

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-before-spanner.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-before-spanner.html
@@ -11,7 +11,7 @@
 </style>
 <p>Test insertion of column content right in front of a spanner</p>
 <p>There should be two lines below with the word "PASS". Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     <div id="elm" style="display:none;">P<br>A<br>S<br>S</div>
     <div class="spanner">PASS</div>
 </div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-between-spanners.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-block-between-spanners.html
@@ -11,7 +11,7 @@
 </style>
 <p>Test insertion of a spanner in the middle of column content, so that we need to split a column row in two.</p>
 <p>There should be three lines below with the word "PASS". Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     <div class="spanner">PASS</div>
     <div id="elm" style="display:none;">P<br>A<br>S<br>S</div>
     <div class="spanner">PASS</div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-after-content.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-after-content.html
@@ -10,7 +10,7 @@
 <p>There should be two lines below with the word "PASS". Letter spacing is expected to
 vary. The first word should be in <span style="color:blue;">blue</span>. The second one
 in <span style="color:olive;">olive</span>.</p>
-<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; color:blue;">
+<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; orphans:1; widows:1; color:blue;">
     P<br>A<br>S<br>S
     <div id="elm" style="display:none; -webkit-column-span:all; color:olive;">PASS</div>
 </div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-after-spanner-before-content.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-after-spanner-before-content.html
@@ -12,7 +12,7 @@ vary. The first line should be in <span style="color:green;">green</span>. The s
 in <span style="color:blue;">blue</span>, the third one
 in <span style="color:olive;">olive</span>, and the fourth one
 in <span style="color:orange;">orange</span>.</p>
-<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; color:green;">
+<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; orphans:1; widows:1; color:green;">
     P<br>A<br>S<br>S
     <div style="-webkit-column-span:all; color:blue;">PASS</div>
     <div id="elm" style="display:none; -webkit-column-span:all; color:olive;">PASS</div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-before-content.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-before-content.html
@@ -10,7 +10,7 @@
 <p>There should be two lines below with the word "PASS". Letter spacing is expected to
 vary. The first word should be in <span style="color:blue;">blue</span>. The second one
 in <span style="color:olive;">olive</span>.</p>
-<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; color:olive;">
+<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; orphans:1; widows:1; color:olive;">
     <div id="elm" style="display:none; -webkit-column-span:all; color:blue;">PASS</div>
     P<br>A<br>S<br>S
 </div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-into-content.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/insert-spanner-into-content.html
@@ -8,7 +8,7 @@
 </script>
 <p>Test insertion of a spanner into column content, so that the existing column row needs to be split into two.</p>
 <p>There should be three lines below with the word "PASS". Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em;">
+<div style="-webkit-columns:5; -webkit-column-gap:0; width:5em; orphans:1; widows:1;">
     P<br>A<br>S<br>S
     <div id="elm" style="display:none; -webkit-column-span:all;">PASS</div>
     P<br>A<br>S<br>S

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/remove-and-insert-block-after-spanner.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/remove-and-insert-block-after-spanner.html
@@ -14,5 +14,5 @@
 </style>
 <p>Test removal of of a block right after a spanner, then insertion of another block at the same position.</p>
 <p>You should see two lines with the word "PASS" on a lime background below. Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; overflow:hidden; background:lime;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; overflow:hidden; orphans:1; widows:1; background:lime;">
     <div class="spanner">PASS</div><div id="elm" style="background:red;">F<br>A<br>I<br>L</div><div id="elm2" style="display:none;">P<br>A<br>S<br>S</div></div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/remove-and-insert-block-before-spanner.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/remove-and-insert-block-before-spanner.html
@@ -14,5 +14,5 @@
 </style>
 <p>Test removal of of a block right before a spanner, then insertion of another block at the same position.</p>
 <p>You should see two lines with the word "PASS" on a lime background below. Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; overflow:hidden; width:4em; background:lime;"><div id="elm" style="background:red;">F<br>A<br>I<br>L</div><div id="elm2" style="display:none;">P<br>A<br>S<br>S</div><div class="spanner">PASS</div>
+<div style="-webkit-columns:4; -webkit-column-gap:0; overflow:hidden; width:4em; orphans:1; widows:1; background:lime;"><div id="elm" style="background:red;">F<br>A<br>I<br>L</div><div id="elm2" style="display:none;">P<br>A<br>S<br>S</div><div class="spanner">PASS</div>
 </div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/remove-and-insert-block-between-spanners.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/remove-and-insert-block-between-spanners.html
@@ -14,4 +14,4 @@
 </style>
 <p>Test removal of of a block between two spanners, then insertion of another block at the same position.</p>
 <p>You should see three lines with the word "PASS" on a lime background below. Letter spacing is expected to vary.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; overflow:hidden; width:4em; background:lime;"><div class="spanner">PASS</div><div id="elm" style="background:red;">F<br>A<br>I<br>L</div><div id="elm2" style="display:none;">P<br>A<br>S<br>S</div><div class="spanner">PASS</div></div>
+<div style="-webkit-columns:4; -webkit-column-gap:0; overflow:hidden; width:4em; orphans:1; widows:1; background:lime;"><div class="spanner">PASS</div><div id="elm" style="background:red;">F<br>A<br>I<br>L</div><div id="elm2" style="display:none;">P<br>A<br>S<br>S</div><div class="spanner">PASS</div></div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/spanner-after-content-becomes-regular-block.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/spanner-after-content-becomes-regular-block.html
@@ -8,7 +8,7 @@
 </script>
 <p>Test changing a spanner that follows column content to a regular block.</p>
 <p>You should see the word 'PASS' below, with large letter spacing:</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     P<br>A
     <div id="elm" style="-webkit-column-span:all; column-span:all;">S<br>S</div>
 </div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/spanner-before-content-becomes-regular-block.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/spanner-before-content-becomes-regular-block.html
@@ -8,7 +8,7 @@
 </script>
 <p>Test changing a spanner that precedes column content to a regular block.</p>
 <p>You should see the word 'PASS' below, with large letter spacing:</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     <div id="elm" style="-webkit-column-span:all;">P</div>
     A<br>S<br>S
 </div>

--- a/LayoutTests/imported/blink/fast/multicol/dynamic/spanner-in-content-becomes-regular-block.html
+++ b/LayoutTests/imported/blink/fast/multicol/dynamic/spanner-in-content-becomes-regular-block.html
@@ -8,7 +8,7 @@
 </script>
 <p>Test changing a spanner in the middle of column content to a regular block.</p>
 <p>You should see the word 'PASS' below, with large letter spacing:</p>
-<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div style="-webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     P
     <div id="elm" style="-webkit-column-span:all; column-span:all;">A</div>
     S<br>S

--- a/LayoutTests/imported/blink/fast/multicol/span/invalid-spanner-in-abspos.html
+++ b/LayoutTests/imported/blink/fast/multicol/span/invalid-spanner-in-abspos.html
@@ -2,7 +2,7 @@
 <p>Test that a spanner inside an absolutely positioned box whose containing block is outside the
     multicol container isn't affected by the multicol container.</p>
 <p>Below you should see the word 'PASS' (with large letter spacing), and a green square in the bottom right corner.</p>
-<div style="-webkit-columns:4; -webkit-column-gap:1em; width:7em;">
+<div style="-webkit-columns:4; -webkit-column-gap:1em; width:7em; orphans:1; widows:1;">
     P<br>
     A<br>
     <div style="position:absolute; right:0; bottom:0; width:50px; height:50px; background:red;">

--- a/LayoutTests/imported/blink/fast/multicol/span/relpos-spanner-with-abspos-child.html
+++ b/LayoutTests/imported/blink/fast/multicol/span/relpos-spanner-with-abspos-child.html
@@ -3,7 +3,7 @@
     descendants.</p>
 <p>Below you should see the word 'PASS' (with large letter spacing). Below the word there should be
     a green square with a black border.</p>
-<div style="-webkit-columns:1em; -webkit-column-gap:1em; width:13em;">
+<div style="-webkit-columns:1em; -webkit-column-gap:1em; width:13em; orphans:1; widows:1;">
     P<br>A<br>S<br>S
     <div style="-webkit-column-span:all; position:relative; border:1px solid black; padding:10px; width:100px; height:100px; background:red;">
         <div style="position:absolute; bottom:0; right:0; width:100%; height:100%; background:green;"></div>

--- a/LayoutTests/imported/blink/fast/multicol/span/spanner-with-relpos-child.html
+++ b/LayoutTests/imported/blink/fast/multicol/span/spanner-with-relpos-child.html
@@ -2,7 +2,7 @@
 <p>Test that relatively positioned content inside a spanner is positioned correctly.</p>
 <p>Below you should see the word 'PASS' (with large letter spacing). Below there should be a green
     square.</p>
-<div style="-webkit-columns:1em; -webkit-column-gap:1em; width:13em;">
+<div style="-webkit-columns:1em; -webkit-column-gap:1em; width:13em; orphans:1; widows:1;">
     P<br>A<br>S<br>S
     <div style="-webkit-column-span:all; width:50px; background:green;">
         <div style="position:relative; left:50px; width:50px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/blink/fast/multicol/span/summary-split.html
+++ b/LayoutTests/imported/blink/fast/multicol/span/summary-split.html
@@ -2,7 +2,7 @@
 <p>Test that summary elements will always be blocks, even if attempted displayed as table-row, and
     that a spanner splitting it doesn't have any ill effects.</p>
 <p>Below you should see 'PASS' three times. Letter spacing will vary.</p>
-<div id="container" style="display:none; -webkit-columns:4; -webkit-column-gap:0; width:4em;">
+<div id="container" style="display:none; -webkit-columns:4; -webkit-column-gap:0; width:4em; orphans:1; widows:1;">
     <summary style="display:table-row;">
         P<br>A<br>S<br>S
         <div style="-webkit-column-span:all;">PASS</div>

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-expected.txt
@@ -1,23 +1,23 @@
-layer at (0,0) size 1188x600
-  RenderView at (0,0) size 800x600
+layer at (0,0) size 1188x585
+  RenderView at (0,0) size 800x585
 layer at (0,0) size 800x320
   RenderBlock {HTML} at (0,0) size 800x320
     RenderBody {BODY} at (8,8) size 784x304
 layer at (8,8) size 784x304
   RenderBlock {DIV} at (0,0) size 784x304 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 780x300
-layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x600 clip at (0,0) size 1188x600
+layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x585 clip at (0,0) size 1188x585
   RenderMultiColumnFlowThread at (2,2) size 382x650
-    RenderBlock {P} at (0,16) size 382x64
-      RenderText {#text} at (0,-3) size 300x19
+    RenderBlock {P} at (0,16) size 382x60
+      RenderText {#text} at (0,-3) size 300x18
         text run at (0,-3) width 300: "This image should not be split across columns."
-      RenderBR {BR} at (299,-3) size 1x19
-      RenderText {#text} at (0,13) size 377x51
-        text run at (0,13) width 377: "The reason it should not be split is that the line contains no"
-        text run at (0,29) width 376: "text and so we should be willing to allow it to sit at the top"
-        text run at (0,45) width 94: "of a new page."
-    RenderBlock (anonymous) at (0,96) size 382x554
-      RenderBlock {DIV} at (0,204) size 50x300 [bgcolor=#00FF00]
+      RenderBR {BR} at (299,-3) size 1x18
+      RenderText {#text} at (0,12) size 377x48
+        text run at (0,12) width 377: "The reason it should not be split is that the line contains no"
+        text run at (0,27) width 376: "text and so we should be willing to allow it to sit at the top"
+        text run at (0,42) width 94: "of a new page."
+    RenderBlock (anonymous) at (0,300) size 382x350
+      RenderBlock {DIV} at (0,0) size 50x300 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,504) size 382x50 [bgcolor=#800080]
+      RenderBlock {DIV} at (0,300) size 382x50 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 800x888
-  RenderView at (0,0) size 800x600
+layer at (0,0) size 785x888
+  RenderView at (0,0) size 785x600
 layer at (0,0) size 320x600
   RenderBlock {HTML} at (0,0) size 320x600
     RenderBody {BODY} at (8,8) size 304x584
@@ -8,18 +8,18 @@ layer at (8,8) size 304x584
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
   RenderMultiColumnFlowThread at (2,2) size 650x282
-    RenderBlock {P} at (16,0) size 126x282
-      RenderText {#text} at (1,0) size 40x238
-        text run at (1,0) width 238: "This image should not be split across"
-        text run at (22,0) width 59: "columns."
-      RenderBR {BR} at (22,58) size 19x1
-      RenderText {#text} at (43,0) size 82x273
-        text run at (43,0) width 272: "The reason it should not be split is that the"
-        text run at (64,0) width 264: "line contains no text and so we should be"
-        text run at (85,0) width 273: "willing to allow it to sit at the top of a new"
-        text run at (106,0) width 35: "page."
-    RenderBlock (anonymous) at (158,0) size 492x282
-      RenderBlock {DIV} at (142,0) size 300x50 [bgcolor=#00FF00]
+    RenderBlock {P} at (16,0) size 108x282
+      RenderText {#text} at (0,0) size 36x238
+        text run at (0,0) width 238: "This image should not be split across"
+        text run at (18,0) width 59: "columns."
+      RenderBR {BR} at (18,58) size 18x1
+      RenderText {#text} at (36,0) size 72x273
+        text run at (36,0) width 272: "The reason it should not be split is that the"
+        text run at (54,0) width 264: "line contains no text and so we should be"
+        text run at (72,0) width 273: "willing to allow it to sit at the top of a new"
+        text run at (90,0) width 35: "page."
+    RenderBlock (anonymous) at (300,0) size 350x282
+      RenderBlock {DIV} at (0,0) size 300x50 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (442,0) size 50x282 [bgcolor=#800080]
+      RenderBlock {DIV} at (300,0) size 50x282 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
@@ -1,5 +1,5 @@
-layer at (0,0) size 800x888
-  RenderView at (0,0) size 800x600
+layer at (0,0) size 785x888
+  RenderView at (0,0) size 785x600
 layer at (0,0) size 320x600
   RenderBlock {HTML} at (0,0) size 320x600
     RenderBody {BODY} at (8,8) size 304x584
@@ -8,18 +8,18 @@ layer at (8,8) size 304x584
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
   RenderMultiColumnFlowThread at (2,2) size 650x282
-    RenderBlock {P} at (16,0) size 126x282
-      RenderText {#text} at (1,0) size 40x238
-        text run at (1,0) width 238: "This image should not be split across"
-        text run at (22,0) width 59: "columns."
-      RenderBR {BR} at (22,58) size 19x1
-      RenderText {#text} at (43,0) size 82x273
-        text run at (43,0) width 272: "The reason it should not be split is that the"
-        text run at (64,0) width 264: "line contains no text and so we should be"
-        text run at (85,0) width 273: "willing to allow it to sit at the top of a new"
-        text run at (106,0) width 35: "page."
-    RenderBlock (anonymous) at (158,0) size 492x282
-      RenderBlock {DIV} at (142,0) size 300x50 [bgcolor=#00FF00]
+    RenderBlock {P} at (16,0) size 108x282
+      RenderText {#text} at (0,0) size 36x238
+        text run at (0,0) width 238: "This image should not be split across"
+        text run at (18,0) width 59: "columns."
+      RenderBR {BR} at (18,58) size 18x1
+      RenderText {#text} at (36,0) size 72x273
+        text run at (36,0) width 272: "The reason it should not be split is that the"
+        text run at (54,0) width 264: "line contains no text and so we should be"
+        text run at (72,0) width 273: "willing to allow it to sit at the top of a new"
+        text run at (90,0) width 35: "page."
+    RenderBlock (anonymous) at (300,0) size 350x282
+      RenderBlock {DIV} at (0,0) size 300x50 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (442,0) size 50x282 [bgcolor=#800080]
+      RenderBlock {DIV} at (300,0) size 50x282 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-rl-expected.txt
@@ -1,25 +1,29 @@
-layer at (0,0) size 800x888
+layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (480,0) size 320x600
-  RenderBlock {HTML} at (0,0) size 320x600
-    RenderBody {BODY} at (8,8) size 304x584
-layer at (488,8) size 304x584
-  RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
-    RenderMultiColumnSet at (2,2) size 300x580
-layer at (140,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
-    RenderBlock {P} at (16,0) size 126x282
-      RenderText {#text} at (1,0) size 40x238
-        text run at (1,0) width 238: "This image should not be split across"
-        text run at (22,0) width 59: "columns."
-      RenderBR {BR} at (22,58) size 19x1
-      RenderText {#text} at (43,0) size 82x273
-        text run at (43,0) width 272: "The reason it should not be split is that the"
-        text run at (64,0) width 264: "line contains no text and so we should be"
-        text run at (85,0) width 273: "willing to allow it to sit at the top of a new"
-        text run at (106,0) width 35: "page."
-    RenderBlock (anonymous) at (158,0) size 492x282
-      RenderBlock {DIV} at (142,0) size 300x50 [bgcolor=#00FF00]
+layer at (0,0) size 800x158
+  RenderBlock {HTML} at (0,0) size 800x158
+    RenderBody {BODY} at (8,8) size 784x142
+layer at (8,8) size 304x142
+  RenderBlock {DIV} at (0,0) size 304x142 [border: (2px solid #0000FF)]
+    RenderMultiColumnSet at (2,2) size 300x138
+layer at (10,10) size 142x276
+  RenderMultiColumnFlowThread at (2,2) size 142x276
+    RenderBlock {P} at (0,16) size 142x194
+      RenderText {#text} at (0,0) size 119x54
+        text run at (0,0) width 119: "This image should"
+        text run at (0,18) width 116: "not be split across"
+        text run at (0,36) width 59: "columns."
+      RenderBR {BR} at (58,36) size 1x18
+      RenderText {#text} at (0,54) size 138x140
+        text run at (0,54) width 131: "The reason it should"
+        text run at (0,72) width 138: "not be split is that the"
+        text run at (0,90) width 130: "line contains no text"
+        text run at (0,122) width 130: "and so we should be"
+        text run at (0,140) width 131: "willing to allow it to"
+        text run at (0,158) width 138: "sit at the top of a new"
+        text run at (0,176) width 35: "page."
+    RenderBlock (anonymous) at (0,226) size 142x50
+      RenderBlock {DIV} at (0,0) size 142x50 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (442,0) size 50x282 [bgcolor=#800080]
+      RenderBlock {DIV} at (0,50) size 50x0 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-expected.txt
@@ -16,8 +16,8 @@ layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x585 clip at (0,0
         text run at (0,12) width 377: "The reason it should not be split is that the line contains no"
         text run at (0,27) width 376: "text and so we should be willing to allow it to sit at the top"
         text run at (0,42) width 94: "of a new page."
-    RenderBlock (anonymous) at (0,92) size 382x558
-      RenderBlock {DIV} at (0,208) size 50x300 [bgcolor=#00FF00]
+    RenderBlock (anonymous) at (0,300) size 382x350
+      RenderBlock {DIV} at (0,0) size 50x300 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,508) size 382x50 [bgcolor=#800080]
+      RenderBlock {DIV} at (0,300) size 382x50 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-expected.txt
@@ -18,8 +18,8 @@ layer at (10,10) size 650x282
         text run at (54,0) width 264: "line contains no text and so we should be"
         text run at (72,0) width 273: "willing to allow it to sit at the top of a new"
         text run at (90,0) width 35: "page."
-    RenderBlock (anonymous) at (140,0) size 510x282
-      RenderBlock {DIV} at (160,0) size 300x50 [bgcolor=#00FF00]
+    RenderBlock (anonymous) at (300,0) size 350x282
+      RenderBlock {DIV} at (0,0) size 300x50 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (460,0) size 50x282 [bgcolor=#800080]
+      RenderBlock {DIV} at (300,0) size 50x282 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
@@ -18,8 +18,8 @@ layer at (10,10) size 650x282
         text run at (54,0) width 264: "line contains no text and so we should be"
         text run at (72,0) width 273: "willing to allow it to sit at the top of a new"
         text run at (90,0) width 35: "page."
-    RenderBlock (anonymous) at (140,0) size 510x282
-      RenderBlock {DIV} at (160,0) size 300x50 [bgcolor=#00FF00]
+    RenderBlock (anonymous) at (300,0) size 350x282
+      RenderBlock {DIV} at (0,0) size 300x50 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (460,0) size 50x282 [bgcolor=#800080]
+      RenderBlock {DIV} at (300,0) size 50x282 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-rl-expected.txt
@@ -1,25 +1,29 @@
-layer at (0,0) size 785x888
-  RenderView at (0,0) size 785x600
-layer at (465,0) size 320x600
-  RenderBlock {HTML} at (0,0) size 320x600
-    RenderBody {BODY} at (8,8) size 304x584
-layer at (473,8) size 304x584
-  RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
-    RenderMultiColumnSet at (2,2) size 300x580
-layer at (125,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
-    RenderBlock {P} at (16,0) size 108x282
-      RenderText {#text} at (0,0) size 36x238
-        text run at (0,0) width 238: "This image should not be split across"
-        text run at (18,0) width 59: "columns."
-      RenderBR {BR} at (18,58) size 18x1
-      RenderText {#text} at (36,0) size 72x273
-        text run at (36,0) width 272: "The reason it should not be split is that the"
-        text run at (54,0) width 264: "line contains no text and so we should be"
-        text run at (72,0) width 273: "willing to allow it to sit at the top of a new"
-        text run at (90,0) width 35: "page."
-    RenderBlock (anonymous) at (140,0) size 510x282
-      RenderBlock {DIV} at (160,0) size 300x50 [bgcolor=#00FF00]
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x158
+  RenderBlock {HTML} at (0,0) size 800x158
+    RenderBody {BODY} at (8,8) size 784x142
+layer at (8,8) size 304x142
+  RenderBlock {DIV} at (0,0) size 304x142 [border: (2px solid #0000FF)]
+    RenderMultiColumnSet at (2,2) size 300x138
+layer at (10,10) size 142x276
+  RenderMultiColumnFlowThread at (2,2) size 142x276
+    RenderBlock {P} at (0,16) size 142x194
+      RenderText {#text} at (0,0) size 119x54
+        text run at (0,0) width 119: "This image should"
+        text run at (0,18) width 116: "not be split across"
+        text run at (0,36) width 59: "columns."
+      RenderBR {BR} at (58,36) size 1x18
+      RenderText {#text} at (0,54) size 138x140
+        text run at (0,54) width 131: "The reason it should"
+        text run at (0,72) width 138: "not be split is that the"
+        text run at (0,90) width 130: "line contains no text"
+        text run at (0,122) width 130: "and so we should be"
+        text run at (0,140) width 131: "willing to allow it to"
+        text run at (0,158) width 138: "sit at the top of a new"
+        text run at (0,176) width 35: "page."
+    RenderBlock (anonymous) at (0,226) size 142x50
+      RenderBlock {DIV} at (0,0) size 142x50 [bgcolor=#00FF00]
       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (460,0) size 50x282 [bgcolor=#800080]
+      RenderBlock {DIV} at (0,50) size 50x0 [bgcolor=#800080]
       RenderText {#text} at (0,0) size 0x0


### PR DESCRIPTION
<pre>
< bug title >
WIP
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73e2c8d48b100ba178846322de72217b00f3f53e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21533 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21373 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55750 "Found 6 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html fast/multicol/tall-image-behavior-lr-mixed.html fast/multicol/tall-image-behavior-lr.html fast/multicol/tall-image-behavior-rl.html fast/multicol/tall-image-behavior.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73421 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45275 "Found 6 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html fast/multicol/tall-image-behavior-lr-mixed.html fast/multicol/tall-image-behavior-lr.html fast/multicol/tall-image-behavior-rl.html fast/multicol/tall-image-behavior.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36212 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41934 "Exiting early after 10 failures. 90 tests run. 4 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18086 "Found 2 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63865 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18430 "Found 2 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14581 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17665 "Found 2 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63470 "Found 6 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html fast/multicol/tall-image-behavior-lr-mixed.html fast/multicol/tall-image-behavior-lr.html fast/multicol/tall-image-behavior-rl.html fast/multicol/tall-image-behavior.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14623 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60717 "Exiting early after 10 failures. 295 tests run. 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63407 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11445 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5078 "Found 2 new test failures: fast/multicol/newmulticol/adjacent-spanners.html fast/multicol/newmulticol/spanner-inline-block.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/330 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->