### PR TITLE
[GTK][WPE][Skia] Refactor threaded CPU rendering code into its own class SkiaThreadedPaintingPool

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -15,6 +15,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/ImageBufferSkiaBackend.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
+    platform/graphics/skia/SkiaThreadedPaintingPool.h
 )
 
 list(APPEND WebCore_LIBRARIES

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -60,5 +60,6 @@ platform/graphics/skia/PlatformDisplaySkia.cpp
 platform/graphics/skia/ShareableBitmapSkia.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
+platform/graphics/skia/SkiaThreadedPaintingPool.cpp
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -641,7 +641,7 @@ void GraphicsLayer::setPaintingPhase(OptionSet<GraphicsLayerPaintingPhase> phase
     m_paintingPhase = phase;
 }
 
-void GraphicsLayer::paintGraphicsLayerContents(GraphicsContext& context, const FloatRect& clip, OptionSet<GraphicsLayerPaintBehavior> layerPaintBehavior)
+void GraphicsLayer::paintGraphicsLayerContents(GraphicsContext& context, const FloatRect& clip, OptionSet<GraphicsLayerPaintBehavior> layerPaintBehavior) const
 {
     auto offset = offsetFromRenderer() - toFloatSize(scrollOffset());
     auto clipRect = clip;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -566,7 +566,7 @@ public:
     virtual bool usesContentsLayer() const { return false; }
 
     // Callback from the underlying graphics system to draw layer contents.
-    WEBCORE_EXPORT void paintGraphicsLayerContents(GraphicsContext&, const FloatRect& clip, OptionSet<GraphicsLayerPaintBehavior> = { });
+    WEBCORE_EXPORT void paintGraphicsLayerContents(GraphicsContext&, const FloatRect& clip, OptionSet<GraphicsLayerPaintBehavior> = { }) const;
 
     // For hosting this GraphicsLayer in a native layer hierarchy.
     virtual PlatformLayer* platformLayer() const { return nullptr; }

--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaThreadedPaintingPool.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "CoordinatedGraphicsLayer.h"
+#include "DisplayListRecorderImpl.h"
+#include "TiledBackingStore.h"
+#include <wtf/NumberOfCores.h>
+#include <wtf/SystemTracing.h>
+#include <wtf/text/StringToIntegerConversion.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaThreadedPaintingPool);
+
+SkiaThreadedPaintingPool::SkiaThreadedPaintingPool(unsigned numberOfThreads)
+    : m_workerPool(WorkerPool::create("SkiaPaintingThread"_s, numberOfThreads))
+{
+}
+
+std::unique_ptr<SkiaThreadedPaintingPool> SkiaThreadedPaintingPool::create()
+{
+    if (auto numberOfThreads = numberOfPaintingThreads(); numberOfThreads > 0)
+        return makeUnique<SkiaThreadedPaintingPool>(numberOfThreads);
+
+    return nullptr;
+}
+
+std::unique_ptr<DisplayList::DisplayList> SkiaThreadedPaintingPool::recordDisplayList(const TiledBackingStore& tiledBackingStore, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect) const
+{
+    auto displayList = makeUnique<DisplayList::DisplayList>();
+    DisplayList::RecorderImpl recordingContext(*displayList, GraphicsContextState(), FloatRect({ }, dirtyRect.size()), AffineTransform());
+    layer.paintIntoGraphicsContext(recordingContext, tiledBackingStore, dirtyRect);
+    return displayList;
+}
+
+void SkiaThreadedPaintingPool::postPaintingTask(Ref<Nicosia::Buffer>& buffer, const TiledBackingStore& tiledBackingStore, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect)
+{
+    WTFBeginSignpost(this, RecordTile);
+    auto displayList = recordDisplayList(tiledBackingStore, layer, dirtyRect);
+    WTFEndSignpost(this, RecordTile);
+
+    buffer->beginPainting();
+
+    m_workerPool->postTask([buffer = Ref { buffer }, displayList = WTFMove(displayList), dirtyRect]() mutable {
+        if (auto* canvas = buffer->canvas()) {
+            canvas->save();
+            canvas->clear(SkColors::kTransparent);
+
+            static thread_local RefPtr<ControlFactory> s_controlFactory;
+            if (!s_controlFactory)
+                s_controlFactory = ControlFactory::create();
+
+            WTFBeginSignpost(canvas, PaintTile, "Skia unaccelerated multithread, dirty region %ix%i+%i+%i", dirtyRect.x(), dirtyRect.y(), dirtyRect.width(), dirtyRect.height());
+
+            GraphicsContextSkia context(*canvas, RenderingMode::Unaccelerated, RenderingPurpose::LayerBacking);
+            context.drawDisplayListItems(displayList->items(), displayList->resourceHeap(), *s_controlFactory, FloatPoint::zero());
+
+            WTFEndSignpost(canvas, PaintTile);
+            canvas->restore();
+        }
+
+        buffer->completePainting();
+
+        // Destruct display list on main thread.
+        ensureOnMainThread([displayList = WTFMove(displayList)]() mutable {
+            displayList = nullptr;
+        });
+    });
+}
+
+unsigned SkiaThreadedPaintingPool::numberOfPaintingThreads()
+{
+    static std::once_flag onceFlag;
+    static unsigned numberOfThreads = 0;
+
+    std::call_once(onceFlag, [] {
+        numberOfThreads = std::max(1, std::min(8, WTF::numberOfProcessorCores() / 2)); // By default, use half the CPU cores, capped at 8.
+
+        if (const char* envString = getenv("WEBKIT_SKIA_PAINTING_THREADS")) {
+            auto newValue = parseInteger<unsigned>(StringView::fromLatin1(envString));
+            if (newValue && *newValue <= 8)
+                numberOfThreads = *newValue;
+            else
+                WTFLogAlways("The number of Skia painting threads is not between 0 and 8. Using the default value %u\n", numberOfThreads);
+        }
+    });
+
+    return numberOfThreads;
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "NicosiaBuffer.h"
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/WorkerPool.h>
+
+namespace WebCore {
+
+class CoordinatedGraphicsLayer;
+class IntRect;
+class TiledBackingStore;
+
+namespace DisplayList {
+class DisplayList;
+}
+
+class SkiaThreadedPaintingPool {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaThreadedPaintingPool);
+    WTF_MAKE_NONCOPYABLE(SkiaThreadedPaintingPool);
+public:
+    SkiaThreadedPaintingPool(unsigned numberOfThreads);
+    ~SkiaThreadedPaintingPool() = default;
+
+    static std::unique_ptr<SkiaThreadedPaintingPool> create();
+
+    void postPaintingTask(Ref<Nicosia::Buffer>&, const TiledBackingStore&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect);
+
+private:
+    std::unique_ptr<DisplayList::DisplayList> recordDisplayList(const TiledBackingStore&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect) const;
+    static unsigned numberOfPaintingThreads();
+
+    Ref<WorkerPool> m_workerPool;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -42,6 +42,7 @@
 namespace WebCore {
 class BitmapTexture;
 class BitmapTexturePool;
+class SkiaThreadedPaintingPool;
 }
 #endif
 
@@ -66,7 +67,7 @@ public:
     virtual Nicosia::PaintingEngine& paintingEngine() = 0;
 #elif USE(SKIA)
     virtual BitmapTexturePool* skiaAcceleratedBitmapTexturePool() const = 0;
-    virtual WorkerPool* skiaUnacceleratedThreadedRenderingPool() const = 0;
+    virtual SkiaThreadedPaintingPool* skiaThreadedPaintingPool() const = 0;
 #endif
 
     virtual Ref<CoordinatedImageBackingStore> imageBackingStore(Ref<NativeImage>&&) = 0;
@@ -185,6 +186,8 @@ public:
 
     Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const final;
 
+    void paintIntoGraphicsContext(GraphicsContext&, const TiledBackingStore&, const IntRect& dirtyRect) const;
+
 private:
     enum class FlushNotification {
         Required,
@@ -209,7 +212,7 @@ private:
     bool checkPendingStateChanges();
     bool checkContentLayerUpdated();
 
-    Ref<Nicosia::Buffer> paintTile(const IntRect&, const IntRect& mappedTileRect, float contentsScale);
+    Ref<Nicosia::Buffer> paintTile(const TiledBackingStore&, const IntRect& dirtyRect);
 
     void notifyFlushRequired();
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
@@ -27,10 +27,11 @@
 
 namespace WebCore {
 
-Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect, const IntRect& mappedTileRect, float contentsScale)
+Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const TiledBackingStore& tiledBackingStore, const IntRect& dirtyRect)
 {
-    auto buffer = Nicosia::UnacceleratedBuffer::create(tileRect.size(), contentsOpaque() ? Nicosia::Buffer::NoFlags : Nicosia::Buffer::SupportsAlpha);
-    m_coordinator->paintingEngine().paint(*this, buffer.get(), tileRect, mappedTileRect, IntRect { { 0, 0 }, tileRect.size() }, contentsScale);
+    auto mappedDirtyRect = tiledBackingStore.mapToContents(dirtyRect);
+    auto buffer = Nicosia::UnacceleratedBuffer::create(dirtyRect.size(), contentsOpaque() ? Nicosia::Buffer::NoFlags : Nicosia::Buffer::SupportsAlpha);
+    m_coordinator->paintingEngine().paint(*this, buffer.get(), dirtyRect, mappedDirtyRect, IntRect { { 0, 0 }, dirtyRect.size() }, tiledBackingStore.contentsScale());
     return buffer;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.h
@@ -47,7 +47,7 @@ public:
     void setTrajectoryVector(const FloatPoint&);
     void createTilesIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
 
-    float contentsScale() { return m_contentsScale; }
+    float contentsScale() const { return m_contentsScale; }
 
     Vector<std::reference_wrapper<Tile>> dirtyTiles();
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -42,16 +42,15 @@
 #include <WebCore/Page.h>
 #include <WebCore/PlatformDisplay.h>
 #include <wtf/MemoryPressureHandler.h>
-#include <wtf/NumberOfCores.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
-#include <wtf/text/StringToIntegerConversion.h>
 
 #if USE(CAIRO)
 #include <WebCore/NicosiaPaintingEngine.h>
 #elif USE(SKIA)
 #include <WebCore/BitmapTexturePool.h>
 #include <WebCore/ProcessCapabilities.h>
+#include <WebCore/SkiaThreadedPaintingPool.h>
 #endif
 
 #if USE(GLIB_EVENT_LOOP)
@@ -60,26 +59,6 @@
 
 namespace WebKit {
 using namespace WebCore;
-
-#if USE(SKIA)
-static unsigned skiaNumberOfCpuPaintingThreads()
-{
-    static std::optional<unsigned> numberOfCpuPaintingThreads;
-    if (!numberOfCpuPaintingThreads.has_value()) {
-        numberOfCpuPaintingThreads = std::max(1, std::min(8, WTF::numberOfProcessorCores() / 2));
-
-        if (const char* numThreadsEnv = getenv("WEBKIT_SKIA_CPU_PAINTING_THREADS")) {
-            auto newValue = parseInteger<unsigned>(StringView::fromLatin1(numThreadsEnv));
-            if (newValue && *newValue <= 8)
-                numberOfCpuPaintingThreads = *newValue;
-            else
-                WTFLogAlways("The number of Skia/CPU painting threads is not between 0 and 8. Using the default value %u\n", numberOfCpuPaintingThreads.value());
-        }
-    }
-
-    return numberOfCpuPaintingThreads.value();
-}
-#endif
 
 CompositingCoordinator::CompositingCoordinator(WebPage& page, CompositingCoordinator::Client& client)
     : m_page(page)
@@ -91,8 +70,8 @@ CompositingCoordinator::CompositingCoordinator(WebPage& page, CompositingCoordin
 #if USE(SKIA)
     if (ProcessCapabilities::canUseAcceleratedBuffers() && PlatformDisplay::sharedDisplay().skiaGLContext())
         m_skiaAcceleratedBitmapTexturePool = makeUnique<BitmapTexturePool>();
-    else if (auto numberOfThreads = skiaNumberOfCpuPaintingThreads(); numberOfThreads > 0)
-        m_skiaUnacceleratedThreadedRenderingPool = WorkerPool::create("SkiaPaintingThread"_s, numberOfThreads);
+    else
+        m_skiaThreadedPaintingPool = SkiaThreadedPaintingPool::create();
 #endif
 
     m_nicosia.scene = Nicosia::Scene::create();
@@ -123,7 +102,7 @@ void CompositingCoordinator::invalidate()
 
 #if USE(SKIA)
     m_skiaAcceleratedBitmapTexturePool = nullptr;
-    m_skiaUnacceleratedThreadedRenderingPool = nullptr;
+    m_skiaThreadedPaintingPool = nullptr;
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -52,6 +52,7 @@ class GraphicsContext;
 class GraphicsLayer;
 class Image;
 class NativeImage;
+class SkiaThreadedPaintingPool;
 }
 
 namespace WebKit {
@@ -100,7 +101,7 @@ private:
     Nicosia::PaintingEngine& paintingEngine() override;
 #elif USE(SKIA)
     WebCore::BitmapTexturePool* skiaAcceleratedBitmapTexturePool() const override { return m_skiaAcceleratedBitmapTexturePool.get(); }
-    WorkerPool* skiaUnacceleratedThreadedRenderingPool() const override { return m_skiaUnacceleratedThreadedRenderingPool.get(); }
+    WebCore::SkiaThreadedPaintingPool* skiaThreadedPaintingPool() const override { return m_skiaThreadedPaintingPool.get(); }
 #endif
     Ref<WebCore::CoordinatedImageBackingStore> imageBackingStore(Ref<WebCore::NativeImage>&&) override;
 
@@ -135,7 +136,7 @@ private:
     std::unique_ptr<Nicosia::PaintingEngine> m_paintingEngine;
 #elif USE(SKIA)
     std::unique_ptr<WebCore::BitmapTexturePool> m_skiaAcceleratedBitmapTexturePool;
-    RefPtr<WorkerPool> m_skiaUnacceleratedThreadedRenderingPool;
+    std::unique_ptr<WebCore::SkiaThreadedPaintingPool> m_skiaThreadedPaintingPool;
 #endif
     HashMap<uint64_t, Ref<WebCore::CoordinatedImageBackingStore>> m_imageBackingStores;
 


### PR DESCRIPTION
#### 6a5f94ce1b5592e092f9e9aa3070dd81c357e9a8
<pre>
[GTK][WPE][Skia] Refactor threaded CPU rendering code into its own class SkiaThreadedPaintingPool
<a href="https://bugs.webkit.org/show_bug.cgi?id=280589">https://bugs.webkit.org/show_bug.cgi?id=280589</a>

Reviewed by Carlos Garcia Campos.

This is a first step towards threaded GPU painting -- refactor the
threaded CPU rendering code (including display list recording tools)
into its own class: SkiaThreadedPaintingPool. Leave the GPU rendering
code as-is.

Covered by existing tests.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::paintGraphicsLayerContents const):
(WebCore::GraphicsLayer::paintGraphicsLayerContents): Deleted.
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::paintGraphicsLayerContents):
* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp: Added.
(WebCore::SkiaThreadedPaintingPool::SkiaThreadedPaintingPool):
(WebCore::SkiaThreadedPaintingPool::create):
(WebCore::SkiaThreadedPaintingPool::recordDisplayList const):
(WebCore::SkiaThreadedPaintingPool::postPaintingTask):
(WebCore::SkiaThreadedPaintingPool::numberOfPaintingThreads):
* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h: Added.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::updateContentBuffers):
(WebCore::CoordinatedGraphicsLayer::paintIntoGraphicsContext const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.h:
(WebCore::TiledBackingStore::contentsScale const):
(WebCore::TiledBackingStore::contentsScale): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::CompositingCoordinator):
(WebKit::CompositingCoordinator::invalidate):
(WebKit::skiaNumberOfCpuPaintingThreads): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/284457@main">https://commits.webkit.org/284457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0812b0a931e49c23af9f04fe5f41ce5f9f090cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55220 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13680 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75218 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4423 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44628 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->