### PR TITLE
[iOS] Add support for rendering native selection UI inside scrolled content

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6369,6 +6369,18 @@ SelectionFlippingEnabled:
       "PLATFORM(VISION)" : false
       default: true
 
+SelectionHonorsOverflowScrolling:
+  type: bool
+  status: internal
+  humanReadableName: "Selection Honors Overflow Scrolling"
+  humanReadableDescription: "Selection honors overflow scrolling"
+  webcoreBinding: none
+  condition: PLATFORM(IOS_FAMILY)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: false
+
 SendMouseEventsToDisabledFormControlsEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -198,7 +198,7 @@ public:
     IntPoint convertFromScrollbarToContainingView(const Scrollbar&, const IntPoint&) const final;
     IntPoint convertFromContainingViewToScrollbar(const Scrollbar&, const IntPoint&) const final;
     void setScrollOffset(const ScrollOffset&) final;
-    ScrollingNodeID scrollingNodeID() const final;
+    WEBCORE_EXPORT ScrollingNodeID scrollingNodeID() const final;
 
     IntRect visibleContentRectInternal(VisibleContentRectIncludesScrollbars, VisibleContentRectBehavior) const final;
     IntSize overhangAmount() const final;

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -31,6 +31,7 @@
 #include <WebCore/ElementContext.h>
 #include <WebCore/FontAttributes.h>
 #include <WebCore/IntRect.h>
+#include <WebCore/ScrollingNodeID.h>
 #include <WebCore/WritingDirection.h>
 #include <wtf/text/WTFString.h>
 
@@ -152,6 +153,7 @@ struct EditorState {
         Vector<WebCore::SelectionGeometry> markedTextRects;
         WebCore::IntRect markedTextCaretRectAtStart;
         WebCore::IntRect markedTextCaretRectAtEnd;
+        std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
 #endif
     };
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -124,5 +124,6 @@ struct WebKit::EditorState {
     Vector<WebCore::SelectionGeometry> markedTextRects;
     WebCore::IntRect markedTextCaretRectAtStart;
     WebCore::IntRect markedTextCaretRectAtEnd;
+    std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
 #endif
 };

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -49,6 +49,8 @@
 @property (nonatomic, weak) id<WKBaseScrollViewDelegate> baseScrollViewDelegate;
 @property (nonatomic, readonly) UIAxis axesToPreventMomentumScrolling;
 
+@property (nonatomic, readonly) UIView *scrolledContentView;
+
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 @property (nonatomic) NSUInteger _scrollingBehavior;
 @property (nonatomic, readonly, getter=overlayRegionsForTesting) HashSet<WebCore::IntRect>& overlayRegionRects;

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -28,7 +28,9 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "RemoteLayerTreeViews.h"
 #import "UIKitSPI.h"
+#import "WKContentView.h"
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <objc/runtime.h>
 #import <wtf/RetainPtr.h>
@@ -212,6 +214,24 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return YES;
 
     return [super gestureRecognizerShouldBegin:gestureRecognizer];
+}
+
+- (UIView *)scrolledContentView
+{
+    auto firstNonEmptyWebKitChildView = [](UIView *view) -> UIView * {
+        for (UIView *subview in view.subviews) {
+            if (![subview isKindOfClass:WKCompositingView.class] && ![subview isKindOfClass:WKContentView.class])
+                continue;
+
+            if (CGRectIsEmpty(subview.bounds))
+                continue;
+
+            return subview;
+        }
+
+        return nil;
+    };
+    return firstNonEmptyWebKitChildView(self) ?: firstNonEmptyWebKitChildView(self.subviews.firstObject);
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -907,6 +907,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_closeCurrentTypingCommand;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
+@property (nonatomic, readonly) BOOL selectionHonorsOverflowScrolling;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -55,6 +55,7 @@
 - (void)selectWord;
 - (void)selectAll:(id)sender;
 - (void)translate:(NSString *)text fromRect:(CGRect)presentationRect;
+- (void)prepareToMoveSelectionContainer:(UIView *)newContainer;
 
 #if USE(UICONTEXTMENU)
 - (void)setExternalContextMenuInteractionDelegate:(id<UIContextMenuInteractionDelegate>)delegate;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4718,6 +4718,7 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
 #if PLATFORM(IOS_FAMILY)
     setForceAlwaysUserScalable(m_forceAlwaysUserScalable || store.getBoolValueForKey(WebPreferencesKey::forceAlwaysUserScalableKey()));
+    m_selectionHonorsOverflowScrolling = store.getBoolValueForKey(WebPreferencesKey::selectionHonorsOverflowScrollingKey());
 #endif
 
     if (store.getBoolValueForKey(WebPreferencesKey::serviceWorkerEntitlementDisabledForTestingKey()))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2713,6 +2713,7 @@ private:
     std::unique_ptr<WebCore::IgnoreSelectionChangeForScope> m_ignoreSelectionChangeScopeForDictation;
 
     bool m_isMobileDoctype { false };
+    bool m_selectionHonorsOverflowScrolling { false };
 #endif // PLATFORM(IOS_FAMILY)
 
     WebCore::Timer m_layerVolatilityTimer;


### PR DESCRIPTION
#### 9549253a0e1f4ce655aedfa7e140264cae70e298
<pre>
[iOS] Add support for rendering native selection UI inside scrolled content
<a href="https://bugs.webkit.org/show_bug.cgi?id=280591">https://bugs.webkit.org/show_bug.cgi?id=280591</a>

Reviewed by Richard Robinson.

Work towards refactoring selection rendering on iOS, such that native selection UI (e.g. highlight,
caret, etc.) isn&apos;t limited to being installed in `WKContentView`.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add a new runtime preference to make it easier to switch between the new and old selection behavior.

* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Plumb the `ScrollingNodeID` of the scrollable area containing the selection through `EditorState`,
into the UI process.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView scrolledContentView]):

Add a helper property to grab the scrolled content view for the scroll view (i.e. a non-empty
`WKCompositingView` or `WKContentView` under a child or main scroll view, respectively).

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView selectionHonorsOverflowScrolling]):
(-[WKContentView _updateChangedSelection:]):

Call `-prepareToMoveSelectionContainer:` when the selection changes visually (see below).

(-[WKContentView _selectionContainerViewAboveText]):
(-[WKContentView selectionContainerView]):

Implement `-_selectionContainerViewAboveText` and `-selectionContainerView` (both currently SPI) and
return the scrolled contents corresponding to the scroller that currently contains the selection.
Also, add a FIXME to adopt the public API (when it becomes available) and leave behind a call to
`RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED()` after adoption.

(-[WKContentView _selectionContainerViewInternal]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper textSelectionDisplayInteraction]):
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):

(Indirectly) tell the text selection display interaction to remove and reparent all managed
selection UI views when the selection container view changes. When the new behavior is disabled
(i.e. on shipping iOS) this is going to always be `WKContentView`; however, it may change between a
`WKCompositingView` and the content view when the flag is set, depending on whether the selection is
inside of a scrollable region.

(-[WKTextInteractionWrapper activateSelection]):
(-[WKTextInteractionWrapper deactivateSelection]):
(-[WKTextInteractionWrapper willStartScrollingOverflow]):
(-[WKTextInteractionWrapper didEndScrollingOverflow]):

Don&apos;t hide and reveal the selection in the case where the new behavior is enabled. This is no longer
necessary, since the selection will now simply scroll along with the content, instead of appearing
in the wrong place.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeSelectionClipRect const):

Make this additionally compute the enclosing scrolling node ID, along with the selection clip rect.
Once the feature flag is enabled and this behavior becomes the default, this should be renamed to
something like `computeEnclosingNodeIDForSelection` (and the selection clip rect computation should
be moved back out to the call site).

Note that we don&apos;t set the `selectionClipRect` when selection views honor overflow scrolling,
because the selection will be clipped by overflow scrolling with or without the rect.

Canonical link: <a href="https://commits.webkit.org/284461@main">https://commits.webkit.org/284461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9295d28bec7fa84048f68ec01c60876b78833922

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20476 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13705 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19002 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/62583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75261 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68713 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62820 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4459 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90495 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44671 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16057 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->