### PR TITLE
Fix more NumberToStringBuffer conversions to use std::span

### DIFF
--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -415,7 +415,7 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToExponential, (JSGlobalObject* globalOb
         const DoubleToStringConverter& converter = DoubleToStringConverter::EcmaScriptConverter();
         converter.ToExponential(x, decimalPlaces, &builder);
     }
-    return JSValue::encode(jsString(vm, String::fromLatin1(builder.Finalize())));
+    return JSValue::encode(jsString(vm, String { builder.Finalize() }));
 }
 
 // toFixed converts a number to a string, always formatting as an a decimal fraction.

--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -164,8 +164,8 @@ ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName
 
     double index = jsToNumber(propertyName);
     NumberToStringBuffer buffer;
-    size_t length = WTF::numberToStringAndSize(index, buffer);
-    return equal(propertyName, std::span { bitwise_cast<const LChar*>(buffer.data()), length });
+    auto span = WTF::numberToStringAndSize(index, buffer);
+    return equal(propertyName, spanReinterpretCast<const LChar>(span));
 }
 
 } // namespace JSC

--- a/Source/WTF/wtf/dragonbox/dragonbox_to_chars.h
+++ b/Source/WTF/wtf/dragonbox/dragonbox_to_chars.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -137,7 +137,7 @@ typedef WTF::double_conversion::StringBuilder StringBuilder;
 template<class Float>
 void ToExponential(Float value, StringBuilder* result_builder)
 {
-    ASSERT((std::is_same<Float, double>::value) || (std::is_same<Float, float>::value));
+    static_assert(std::is_same_v<Float, double> || std::is_same_v<Float, float>);
     constexpr size_t buffer_length = 1 + (std::is_same<Float, float>::value ? to_exponential_max_string_length<ieee754_binary32>() : to_exponential_max_string_length<ieee754_binary64>());
     char buffer[buffer_length];
     auto* cursor = detail::to_chars_n<Mode::ToExponential>(value, buffer);
@@ -148,7 +148,7 @@ void ToExponential(Float value, StringBuilder* result_builder)
 template<class Float>
 void ToShortest(Float value, StringBuilder* result_builder)
 {
-    ASSERT((std::is_same<Float, double>::value) || (std::is_same<Float, float>::value));
+    static_assert(std::is_same_v<Float, double> || std::is_same_v<Float, float>);
     constexpr size_t buffer_length = 1 + (std::is_same<Float, float>::value ? max_string_length<ieee754_binary32>() : max_string_length<ieee754_binary64>());
     char buffer[buffer_length];
     auto* cursor = detail::to_chars_n<Mode::ToShortest>(value, buffer);

--- a/Source/WTF/wtf/dtoa.cpp
+++ b/Source/WTF/wtf/dtoa.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -24,21 +24,21 @@
 
 namespace WTF {
 
-size_t numberToStringAndSize(float number, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToStringAndSize(float number, NumberToStringBuffer& buffer)
 {
     static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary32>() + 1));
     auto* result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, buffer.data());
-    return result - buffer.data();
+    return std::span { buffer }.first(result - buffer.data());
 }
 
-size_t numberToStringAndSize(double number, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToStringAndSize(double number, NumberToStringBuffer& buffer)
 {
     static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary64>() + 1));
     auto* result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, buffer.data());
-    return result - buffer.data();
+    return std::span { buffer }.first(result - buffer.data());
 }
 
-const char* numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer)
 {
     double_conversion::StringBuilder builder(&buffer[0], sizeof(buffer));
     auto& converter = double_conversion::DoubleToStringConverter::EcmaScriptConverterWithTrailingPoint();
@@ -83,14 +83,14 @@ static inline void truncateTrailingZeros(const char* buffer, double_conversion::
     builder.RemoveCharacters(truncatedLength, pastMantissa);
 }
 
-const char* numberToFixedPrecisionString(float number, unsigned significantFigures, NumberToStringBuffer& buffer, bool shouldTruncateTrailingZeros)
+NumberToStringSpan numberToFixedPrecisionString(float number, unsigned significantFigures, NumberToStringBuffer& buffer, bool shouldTruncateTrailingZeros)
 {
     // For now, just call the double precision version.
     // Do that here instead of at callers to pave the way to add a more efficient code path later.
     return numberToFixedPrecisionString(static_cast<double>(number), significantFigures, buffer, shouldTruncateTrailingZeros);
 }
 
-const char* numberToFixedPrecisionString(double d, unsigned significantFigures, NumberToStringBuffer& buffer, bool shouldTruncateTrailingZeros)
+NumberToStringSpan numberToFixedPrecisionString(double d, unsigned significantFigures, NumberToStringBuffer& buffer, bool shouldTruncateTrailingZeros)
 {
     // Mimic sprintf("%.[precision]g", ...).
     // "g": Signed value printed in f or e format, whichever is more compact for the given value and precision.
@@ -105,14 +105,14 @@ const char* numberToFixedPrecisionString(double d, unsigned significantFigures, 
     return builder.Finalize();
 }
 
-const char* numberToFixedWidthString(float number, unsigned decimalPlaces, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToFixedWidthString(float number, unsigned decimalPlaces, NumberToStringBuffer& buffer)
 {
     // For now, just call the double precision version.
     // Do that here instead of at callers to pave the way to add a more efficient code path later.
     return numberToFixedWidthString(static_cast<double>(number), decimalPlaces, buffer);
 }
 
-const char* numberToFixedWidthString(double d, unsigned decimalPlaces, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToFixedWidthString(double d, unsigned decimalPlaces, NumberToStringBuffer& buffer)
 {
     // Mimic sprintf("%.[precision]f", ...).
     // "f": Signed value having the form [ – ]dddd.dddd, where dddd is one or more decimal digits.
@@ -127,7 +127,7 @@ const char* numberToFixedWidthString(double d, unsigned decimalPlaces, NumberToS
     return builder.Finalize();
 }
 
-const char* numberToCSSString(double d, NumberToCSSStringBuffer& buffer)
+NumberToStringSpan numberToCSSString(double d, NumberToCSSStringBuffer& buffer)
 {
     // Mimic sprintf("%.[precision]f", ...).
     // "f": Signed value having the form [ – ]dddd.dddd, where dddd is one or more decimal digits.

--- a/Source/WTF/wtf/dtoa.h
+++ b/Source/WTF/wtf/dtoa.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -36,18 +36,20 @@ using NumberToStringBuffer = std::array<char, 124>;
 // <-> + <320 digits> + decimal point + <6 digits> + null char = 329
 using NumberToCSSStringBuffer = std::array<char, 329>;
 
-WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(float, unsigned significantFigures, NumberToStringBuffer&, bool truncateTrailingZeros = false);
-WTF_EXPORT_PRIVATE const char* numberToFixedWidthString(float, unsigned decimalPlaces, NumberToStringBuffer&);
+using NumberToStringSpan = std::span<const char>;
 
-WTF_EXPORT_PRIVATE const char* numberToStringWithTrailingPoint(double, NumberToStringBuffer&);
-WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(double, unsigned significantFigures, NumberToStringBuffer&, bool truncateTrailingZeros = false);
-WTF_EXPORT_PRIVATE const char* numberToFixedWidthString(double, unsigned decimalPlaces, NumberToStringBuffer&);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToFixedPrecisionString(float, unsigned significantFigures, NumberToStringBuffer& LIFETIME_BOUND, bool truncateTrailingZeros = false);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToFixedWidthString(float, unsigned decimalPlaces, NumberToStringBuffer& LIFETIME_BOUND);
 
-WTF_EXPORT_PRIVATE size_t numberToStringAndSize(float, NumberToStringBuffer&);
-WTF_EXPORT_PRIVATE size_t numberToStringAndSize(double, NumberToStringBuffer&);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToStringWithTrailingPoint(double, NumberToStringBuffer& LIFETIME_BOUND);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToFixedPrecisionString(double, unsigned significantFigures, NumberToStringBuffer& LIFETIME_BOUND, bool truncateTrailingZeros = false);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToFixedWidthString(double, unsigned decimalPlaces, NumberToStringBuffer& LIFETIME_BOUND);
+
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToStringAndSize(float, NumberToStringBuffer& LIFETIME_BOUND);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToStringAndSize(double, NumberToStringBuffer& LIFETIME_BOUND);
 
 // Fixed width with up to 6 decimal places, trailing zeros truncated.
-WTF_EXPORT_PRIVATE const char* numberToCSSString(double, NumberToCSSStringBuffer&);
+WTF_EXPORT_PRIVATE NumberToStringSpan numberToCSSString(double, NumberToCSSStringBuffer& LIFETIME_BOUND);
 
 inline double parseDouble(StringView string, size_t& parsedLength)
 {

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -1,4 +1,5 @@
 // Copyright 2010 the V8 project authors. All rights reserved.
+// Copyright (C) 2011-2024 Apple Inc. All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -90,9 +91,9 @@ void DoubleToStringConverter::CreateExponentialRepresentation(
     int length,
     int exponent,
     StringBuilder* result_builder) const {
-  ASSERT(length != 0);
+  ASSERT_WITH_SECURITY_IMPLICATION(length != 0);
   result_builder->AddCharacter(decimal_digits[0]);
-  if (length != 1) {
+  if (length > 1) {
     result_builder->AddCharacter('.');
     result_builder->AddSubstring(&decimal_digits[1], length-1);
   }
@@ -109,12 +110,12 @@ void DoubleToStringConverter::CreateExponentialRepresentation(
     result_builder->AddCharacter('0');
     return;
   }
-  ASSERT(exponent < 1e4);
-  const int kMaxExponentLength = 5;
+  ASSERT_WITH_SECURITY_IMPLICATION(exponent < 1e4);
+  constexpr int kMaxExponentLength = 5;
   char buffer[kMaxExponentLength + 1];
   buffer[kMaxExponentLength] = '\0';
-  int first_char_pos = kMaxExponentLength;
-  while (exponent > 0) {
+  size_t first_char_pos = kMaxExponentLength;
+  while (exponent > 0 && first_char_pos > 0) {
     buffer[--first_char_pos] = '0' + (exponent % 10);
     exponent /= 10;
   }
@@ -136,7 +137,7 @@ void DoubleToStringConverter::CreateDecimalRepresentation(
     if (digits_after_point > 0) {
       result_builder->AddCharacter('.');
       result_builder->AddPadding('0', -decimal_point);
-      ASSERT(length <= digits_after_point - (-decimal_point));
+      ASSERT_WITH_SECURITY_IMPLICATION(length <= digits_after_point - (-decimal_point));
       result_builder->AddSubstring(decimal_digits, length);
       int remaining_digits = digits_after_point - (-decimal_point) - length;
       result_builder->AddPadding('0', remaining_digits);
@@ -151,10 +152,10 @@ void DoubleToStringConverter::CreateDecimalRepresentation(
     }
   } else {
     // "decima.l_rep000".
-    ASSERT(digits_after_point > 0);
+    ASSERT_WITH_SECURITY_IMPLICATION(digits_after_point > 0);
     result_builder->AddSubstring(decimal_digits, decimal_point);
     result_builder->AddCharacter('.');
-    ASSERT(length - decimal_point <= digits_after_point);
+    ASSERT_WITH_SECURITY_IMPLICATION(length - decimal_point <= digits_after_point);
     result_builder->AddSubstring(&decimal_digits[decimal_point],
                                  length - decimal_point);
     int remaining_digits = digits_after_point - (length - decimal_point);
@@ -182,7 +183,7 @@ bool DoubleToStringConverter::ToShortestIeeeNumber(
 
   int decimal_point;
   bool sign;
-  const int kDecimalRepCapacity = kBase10MaximalLength + 1;
+  constexpr size_t kDecimalRepCapacity = kBase10MaximalLength + 1;
   char decimal_rep[kDecimalRepCapacity];
   int decimal_rep_length;
 
@@ -234,7 +235,7 @@ bool DoubleToStringConverter::ToFixedInternal(double value,
 bool DoubleToStringConverter::ToFixed(double value,
                                       int requested_digits,
                                       StringBuilder* result_builder) const {
-  ASSERT(kMaxFixedDigitsBeforePoint == 21);
+  static_assert(kMaxFixedDigitsBeforePoint == 21);
   const double kFirstNonFixed = 1e21;
 
   if (Double(value).IsSpecial()) {
@@ -245,7 +246,7 @@ bool DoubleToStringConverter::ToFixed(double value,
   if (value >= kFirstNonFixed || value <= -kFirstNonFixed) return false;
 
   // Add space for the '\0' byte.
-  const int kDecimalRepCapacity =
+  constexpr size_t kDecimalRepCapacity =
       kMaxFixedDigitsBeforePoint + kMaxFixedDigitsAfterPoint + 1;
   char decimal_rep[kDecimalRepCapacity];
   return ToFixedInternal(value, requested_digits, decimal_rep, kDecimalRepCapacity, result_builder);
@@ -264,7 +265,7 @@ bool DoubleToStringConverter::ToFixedUncapped(double value,
   if (requested_digits > kMaxFixedDigitsAfterPoint) return false;
 
   // Add space for the '\0' byte.
-  const int kDecimalRepCapacity =
+  constexpr size_t kDecimalRepCapacity =
       kMaxPossibleDigitsBeforePoint + kMaxFixedDigitsAfterPoint + 1;
   char decimal_rep[kDecimalRepCapacity];
   return ToFixedInternal(value, requested_digits, decimal_rep, kDecimalRepCapacity, result_builder);
@@ -285,8 +286,8 @@ bool DoubleToStringConverter::ToExponential(
   int decimal_point;
   bool sign;
   // Add space for digit before the decimal point and the '\0' character.
-  const int kDecimalRepCapacity = kMaxExponentialDigits + 2;
-  ASSERT(kDecimalRepCapacity > kBase10MaximalLength);
+  constexpr size_t kDecimalRepCapacity = kMaxExponentialDigits + 2;
+  static_assert(kDecimalRepCapacity > kBase10MaximalLength);
   char decimal_rep[kDecimalRepCapacity];
   int decimal_rep_length;
 
@@ -298,7 +299,7 @@ bool DoubleToStringConverter::ToExponential(
     DoubleToAscii(value, PRECISION, requested_digits + 1,
                   decimal_rep, kDecimalRepCapacity,
                   &sign, &decimal_rep_length, &decimal_point);
-    ASSERT(decimal_rep_length <= requested_digits + 1);
+    ASSERT_WITH_SECURITY_IMPLICATION(decimal_rep_length <= requested_digits + 1);
 
     if (decimal_rep_length < requested_digits + 1) {
       for (int i = decimal_rep_length; i < requested_digits + 1; ++i)
@@ -337,14 +338,14 @@ bool DoubleToStringConverter::ToPrecision(double value,
   int decimal_point;
   bool sign;
   // Add one for the terminating null character.
-  const int kDecimalRepCapacity = kMaxPrecisionDigits + 1;
+  constexpr size_t kDecimalRepCapacity = kMaxPrecisionDigits + 1;
   char decimal_rep[kDecimalRepCapacity];
   int decimal_rep_length;
 
   DoubleToAscii(value, PRECISION, precision,
                 decimal_rep, kDecimalRepCapacity,
                 &sign, &decimal_rep_length, &decimal_point);
-  ASSERT(decimal_rep_length <= precision);
+  ASSERT_WITH_SECURITY_IMPLICATION(decimal_rep_length <= precision);
 
   bool unique_zero = ((flags_ & UNIQUE_ZERO) != 0);
   if (sign && (value != 0.0 || !unique_zero)) {
@@ -552,7 +553,7 @@ static FloatingPointType StringToIeee(
   // Copy significant digits of the integer part (if any) to the buffer.
   while (isASCIIDigit(*current)) {
     if (significant_digits < kMaxSignificantDigits) {
-      ASSERT(buffer_pos < kBufferSize);
+      ASSERT_WITH_SECURITY_IMPLICATION(buffer_pos < kBufferSize);
       buffer[buffer_pos++] = static_cast<char>(*current);
       significant_digits++;
     } else {
@@ -587,7 +588,7 @@ static FloatingPointType StringToIeee(
     // We don't emit a '.', but adjust the exponent instead.
     while (isASCIIDigit(*current)) {
       if (significant_digits < kMaxSignificantDigits) {
-        ASSERT(buffer_pos < kBufferSize);
+        ASSERT_WITH_SECURITY_IMPLICATION(buffer_pos < kBufferSize);
         buffer[buffer_pos++] = static_cast<char>(*current);
         significant_digits++;
         exponent--;
@@ -632,7 +633,7 @@ static FloatingPointType StringToIeee(
     }
 
     const int max_exponent = INT_MAX / 2;
-    ASSERT(-max_exponent / 2 <= exponent && exponent <= max_exponent / 2);
+    ASSERT_WITH_SECURITY_IMPLICATION(-max_exponent / 2 <= exponent && exponent <= max_exponent / 2);
     int num = 0;
     do {
       // Check overflow.
@@ -657,7 +658,7 @@ static FloatingPointType StringToIeee(
     exponent--;
   }
 
-  ASSERT(buffer_pos < kBufferSize);
+  ASSERT_WITH_SECURITY_IMPLICATION(buffer_pos < kBufferSize);
   buffer[buffer_pos] = '\0';
 
   auto converted = StringToFloatingPointType<FloatingPointType>(BufferReference<const char>(buffer, buffer_pos), exponent);

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -108,15 +108,15 @@ AtomString AtomString::number(unsigned long long number)
 AtomString AtomString::number(float number)
 {
     NumberToStringBuffer buffer;
-    size_t length = numberToStringAndSize(number, buffer);
-    return AtomString { std::span { bitwise_cast<const LChar*>(buffer.data()), length } };
+    auto span = numberToStringAndSize(number, buffer);
+    return AtomString { spanReinterpretCast<const LChar>(span) };
 }
 
 AtomString AtomString::number(double number)
 {
     NumberToStringBuffer buffer;
-    size_t length = numberToStringAndSize(number, buffer);
-    return AtomString { std::span { bitwise_cast<const LChar*>(buffer.data()), length } };
+    auto span = numberToStringAndSize(number, buffer);
+    return AtomString { spanReinterpretCast<const LChar>(span) };
 }
 
 AtomString AtomString::fromUTF8Internal(std::span<const char> characters)

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,7 +75,7 @@ class StringTypeAdapter<FloatingPoint, typename std::enable_if_t<std::is_floatin
 public:
     StringTypeAdapter(FloatingPoint number)
     {
-        m_length = numberToStringAndSize(number, m_buffer);
+        m_length = numberToStringAndSize(number, m_buffer).size();
     }
 
     unsigned length() const { return m_length; }
@@ -95,16 +95,14 @@ public:
     static FormattedNumber fixedPrecision(double number, unsigned significantFigures = 6, TrailingZerosPolicy trailingZerosTruncatingPolicy = TrailingZerosPolicy::Truncate)
     {
         FormattedNumber numberFormatter;
-        numberToFixedPrecisionString(number, significantFigures, numberFormatter.m_buffer, trailingZerosTruncatingPolicy == TrailingZerosPolicy::Truncate);
-        numberFormatter.m_length = std::strlen(&numberFormatter.m_buffer[0]);
+        numberFormatter.m_length = numberToFixedPrecisionString(number, significantFigures, numberFormatter.m_buffer, trailingZerosTruncatingPolicy == TrailingZerosPolicy::Truncate).size();
         return numberFormatter;
     }
 
     static FormattedNumber fixedWidth(double number, unsigned decimalPlaces)
     {
         FormattedNumber numberFormatter;
-        numberToFixedWidthString(number, decimalPlaces, numberFormatter.m_buffer);
-        numberFormatter.m_length = std::strlen(&numberFormatter.m_buffer[0]);
+        numberFormatter.m_length = numberToFixedWidthString(number, decimalPlaces, numberFormatter.m_buffer).size();
         return numberFormatter;
     }
 
@@ -138,8 +136,7 @@ public:
     static FormattedCSSNumber create(double number)
     {
         FormattedCSSNumber numberFormatter;
-        numberToCSSString(number, numberFormatter.m_buffer);
-        numberFormatter.m_length = std::strlen(&numberFormatter.m_buffer[0]);
+        numberFormatter.m_length = numberToCSSString(number, numberFormatter.m_buffer).size();
         return numberFormatter;
     } 
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -241,15 +241,13 @@ String String::numberToStringFixedPrecision(double number, unsigned precision, T
 String String::number(float number)
 {
     NumberToStringBuffer buffer;
-    size_t length = numberToStringAndSize(number, buffer);
-    return String { std::span { buffer.data(), length } };
+    return String { numberToStringAndSize(number, buffer) };
 }
 
 String String::number(double number)
 {
     NumberToStringBuffer buffer;
-    size_t length = numberToStringAndSize(number, buffer);
-    return String { std::span { buffer.data(), length } };
+    return String { numberToStringAndSize(number, buffer) };
 }
 
 String String::numberToStringFixedWidth(double number, unsigned decimalPlaces)

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -547,8 +547,7 @@ Decimal Decimal::fromDouble(double doubleValue)
 {
     if (std::isfinite(doubleValue)) {
         NumberToStringBuffer buffer;
-        size_t length = numberToStringAndSize(doubleValue, buffer);
-        return fromString(StringView { std::span { buffer.data(), length } });
+        return fromString(StringView { numberToStringAndSize(doubleValue, buffer) });
     }
 
     if (std::isinf(doubleValue))

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -2222,25 +2222,19 @@ void FunctionDefinitionWriter::visit(AST::Unsigned32Literal& literal)
 void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
 {
     NumberToStringBuffer buffer;
-    WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
-
-    m_stringBuilder.append(span(&buffer[0]));
+    m_stringBuilder.append(WTF::numberToStringWithTrailingPoint(literal.value(), buffer));
 }
 
 void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
 {
     NumberToStringBuffer buffer;
-    WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
-
-    m_stringBuilder.append(span(&buffer[0]));
+    m_stringBuilder.append(WTF::numberToStringWithTrailingPoint(literal.value(), buffer));
 }
 
 void FunctionDefinitionWriter::visit(AST::Float16Literal& literal)
 {
     NumberToStringBuffer buffer;
-    WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
-
-    m_stringBuilder.append(span(&buffer[0]));
+    m_stringBuilder.append(WTF::numberToStringWithTrailingPoint(literal.value(), buffer));
 }
 
 void FunctionDefinitionWriter::visit(AST::Statement& statement)
@@ -2559,20 +2553,17 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
                 break;
             case Primitive::AbstractFloat: {
                 NumberToStringBuffer buffer;
-                WTF::numberToStringWithTrailingPoint(std::get<double>(value), buffer);
-                m_stringBuilder.append(span(&buffer[0]));
+                m_stringBuilder.append(WTF::numberToStringWithTrailingPoint(std::get<double>(value), buffer));
                 break;
             }
             case Primitive::F32: {
                 NumberToStringBuffer buffer;
-                WTF::numberToStringWithTrailingPoint(std::get<float>(value), buffer);
-                m_stringBuilder.append(span(&buffer[0]));
+                m_stringBuilder.append(WTF::numberToStringWithTrailingPoint(std::get<float>(value), buffer));
                 break;
             }
             case Primitive::F16: {
                 NumberToStringBuffer buffer;
-                WTF::numberToStringWithTrailingPoint(std::get<half>(value), buffer);
-                m_stringBuilder.append(span(&buffer[0]), 'h');
+                m_stringBuilder.append(WTF::numberToStringWithTrailingPoint(std::get<half>(value), buffer), 'h');
                 break;
             }
             case Primitive::Bool:

--- a/Tools/TestWebKitAPI/Tests/WTF/DragonBoxTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DragonBoxTest.cpp
@@ -67,46 +67,58 @@ public:
     {
         builder1.Reset();
         WTF::dragonbox::ToShortest(x, &builder1);
-        return builder1.Finalize();
+        auto span = builder1.Finalize();
+        EXPECT_EQ(span.size(), strlen(span.data()));
+        return span.data();
     }
 
     char* dragonBoxToString(float x)
     {
         builder1.Reset();
         WTF::dragonbox::ToShortest(x, &builder1);
-        return builder1.Finalize();
+        auto span = builder1.Finalize();
+        EXPECT_EQ(span.size(), strlen(span.data()));
+        return span.data();
     }
 
     char* dragonBoxToExponential(double x)
     {
         builder1.Reset();
         WTF::dragonbox::ToExponential(x, &builder1);
-        return builder1.Finalize();
+        auto span = builder1.Finalize();
+        EXPECT_EQ(span.size(), strlen(span.data()));
+        return span.data();
     }
 
     char* doubleConversionToString(double x)
     {
         builder2.Reset();
         converter.ToShortest(x, &builder2);
-        return builder2.Finalize();
+        auto span = builder2.Finalize();
+        EXPECT_EQ(span.size(), strlen(span.data()));
+        return span.data();
     }
 
     char* doubleConversionToString(float x)
     {
         builder2.Reset();
         converter.ToShortestSingle(x, &builder2);
-        return builder2.Finalize();
+        auto span = builder2.Finalize();
+        EXPECT_EQ(span.size(), strlen(span.data()));
+        return span.data();
     }
 
     char* doubleConversionToExponential(double x, int requested_decimal_digits = -1)
     {
         builder2.Reset();
         converter.ToExponential(x, requested_decimal_digits, &builder2);
-        return builder2.Finalize();
+        auto span = builder2.Finalize();
+        EXPECT_EQ(span.size(), strlen(span.data()));
+        return span.data();
     }
 
-    NumberToStringBuffer buffer1;
-    NumberToStringBuffer buffer2;
+    NumberToStringBuffer buffer1 { 0 };
+    NumberToStringBuffer buffer2 { 0 };
     DoubleConversionStringBuilder builder1;
     DoubleConversionStringBuilder builder2;
     const DoubleToStringConverter& converter;


### PR DESCRIPTION
#### 058660103448a14477572e3509a632991934c777
<pre>
Fix more NumberToStringBuffer conversions to use std::span
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=280596">https://bugs.webkit.org/show_bug.cgi?id=280596</a>&gt;
&lt;<a href="https://rdar.apple.com/136944262">rdar://136944262</a>&gt;

Reviewed by Dan Glastonbury, Darin Adler, and Mike Wyrzykowski.

Updating WTF::numberTo...String...() functions in dtoa.{cpp,h} to return
std::span values frequently eliminates a call to strlen() to get the
length of the C-string bytes stored in the std::array.

* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToExponential, ...)):
- Stop calling String::fromLatin1() since StringBuilder::Finalize()
  returns a std::span now.  Eliminates a call to strlen().
* Source/JavaScriptCore/runtime/PropertyName.h:
(JSC::isCanonicalNumericIndexString):
- Simplify now that WTF::numberToStringAndSize() returns std::span.

* Source/WTF/wtf/dragonbox/dragonbox_to_chars.h:
(WTF::dragonbox::ToExponential):
(WTF::dragonbox::ToShortest):
- Change ASSERT() to static_assert() when possible to catch bugs
  earlier.
* Source/WTF/wtf/dtoa.cpp:
(WTF::numberToStringAndSize):
(WTF::numberToStringWithTrailingPoint):
(WTF::numberToFixedPrecisionString):
(WTF::numberToFixedWidthString):
(WTF::numberToCSSString):
- Update to return std::span.
* Source/WTF/wtf/dtoa.h:
(WTF::numberToStringAndSize):
(WTF::numberToStringWithTrailingPoint):
(WTF::numberToFixedPrecisionString):
(WTF::numberToFixedWidthString):
(WTF::numberToCSSString):
- Add LIFETIME_BOUND attribute since std::span return value depends on
  the lifetime of the NumberToStringBuffer&amp; argument.
- Update to return std::span.
* Source/WTF/wtf/dtoa/double-conversion.cc:
(WTF::double_conversion::DoubleToStringConverter::CreateExponentialRepresentation):
- Make sure length is always valid.
- Change while() loop to check value of first_char_pos as well.
(WTF::double_conversion::DoubleToStringConverter::CreateDecimalRepresentation):
(WTF::double_conversion::DoubleToStringConverter::ToShortestIeeeNumber):
(WTF::double_conversion::DoubleToStringConverter::ToFixed):
(WTF::double_conversion::DoubleToStringConverter::ToFixedUncapped):
(WTF::double_conversion::DoubleToStringConverter::ToExponential):
(WTF::double_conversion::DoubleToStringConverter::ToPrecision):
(WTF::double_conversion::StringToIeee):
- Change `const int` buffer lengths to `constexpr size_t`.
- Change ASSERT() to static_assert() when possible to catch bugs
  earlier.
- Change ASSERT() to ASSERT_WITH_SECURITY_IMPLICATION() to catch bugs.
* Source/WTF/wtf/dtoa/utils.h:
(WTF::double_conversion::StrLength):
(WTF::double_conversion::BufferReference::BufferReference):
(WTF::double_conversion::BufferReference::SubBufferReference):
(WTF::double_conversion::BufferReference::operator[] const):
(WTF::double_conversion::StringBuilder::position const):
(WTF::double_conversion::StringBuilder::AddCharacter):
(WTF::double_conversion::StringBuilder::AddSubstring):
(WTF::double_conversion::StringBuilder::RemoveCharacters):
- Change ASSERT() to ASSERT_WITH_SECURITY_IMPLICATION() to catch bugs.
(WTF::double_conversion::StringBuilder::Finalize):
- Never write out-of-bounds even if position_ is negative.
- Change to return std::span instead of pointer.
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::number):
- Simplify now that WTF::numberToStringAndSize() returns std::span.
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::StringTypeAdapter::StringTypeAdapter):
(WTF::FormattedNumber::fixedPrecision):
(WTF::FormattedNumber::fixedWidth):
(WTF::FormattedCSSNumber::create):
- Set m_length from std::span::size().
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::number):
* Source/WebCore/platform/Decimal.cpp:
(WebCore::Decimal::fromDouble):
- Simplify now that WTF::numberToStringAndSize() returns std::span.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
- Simplify now that WTF::numberToStringAndSize() returns std::span.
- Avoiding use of WTF::span(const char*) eliminates a call to strlen().

* Tools/TestWebKitAPI/Tests/WTF/DragonBoxTest.cpp:
(TestWebKitAPI::DragonBoxTest::dragonBoxToString):
(TestWebKitAPI::DragonBoxTest::dragonBoxToExponential):
(TestWebKitAPI::DragonBoxTest::doubleConversionToString):
(TestWebKitAPI::DragonBoxTest::doubleConversionToExponential):
- Update for std::span returned from StringBuilder::Finalize() method.
- Assert that length returned from Finalize() matches strlen() of the
  buffer backed by the std::array.

Canonical link: <a href="https://commits.webkit.org/285520@main">https://commits.webkit.org/285520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/765157dc7be86aebee12366768e89ceb242ef0a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72853 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57287 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15773 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20170 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22416 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65986 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78722 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72109 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19671 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65731 "Found 32 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html compositing/shared-backing/overlap-after-end-sharing.html fast/text/crash-letter-spacing-infinite.html fast/text/crash-word-spacing-infinite.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-color-animation-half-opaque.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-color-transparent-animation-in-body.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-clip-path.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-changes-overflow.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-container-writing-modes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62710 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65005 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6972 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93888 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11213 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2863 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20659 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->