### PR TITLE
[SwiftUI] Introduce WebPage.Configuration, URLSchemeHandler, and supporting types

### DIFF
--- a/Source/WebKit/Modules/Internal/WebKitInternal.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternal.h
@@ -26,4 +26,5 @@
 // Add project-level Objective-C header files here to be able to access them from within Swift sources.
 
 #import "WKPreferencesInternal.h"
+#import "WKWebViewConfigurationInternal.h"
 #import "WKWebViewInternal.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h
@@ -25,6 +25,8 @@
 
 #import "WKPreferencesPrivate.h"
 
+#import <wtf/Platform.h>
+
 #ifdef __cplusplus
 
 #import "WKObject.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -567,6 +567,18 @@ static NSString *defaultApplicationNameForUserAgent()
     return static_cast<WebKit::WebURLSchemeHandlerCocoa*>(handler.get())->apiHandler();
 }
 
++ (BOOL)_isValidCustomScheme:(NSString *)urlScheme
+{
+    if ([WKWebView handlesURLScheme:urlScheme])
+        return NO;
+
+    auto canonicalScheme = WTF::URLParser::maybeCanonicalizeScheme(String(urlScheme));
+    if (!canonicalScheme)
+        return NO;
+
+    return YES;
+}
+
 #if PLATFORM(IOS_FAMILY)
 - (BOOL)limitsNavigationsToAppBoundDomains
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -23,9 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+
+#ifdef __cplusplus
+
 #import "APIPageConfiguration.h"
 #import "WKObject.h"
-#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <wtf/Ref.h>
 
 namespace WebKit {
@@ -41,7 +44,7 @@ template<> struct WrapperTraits<API::PageConfiguration> {
     API::ObjectStorage<API::PageConfiguration> _pageConfiguration;
 }
 
-@property (nonatomic, readonly) NSString *_applicationNameForDesktopUserAgent;
+@property (nonatomic, readonly, nullable) NSString *_applicationNameForDesktopUserAgent;
 
 @end
 
@@ -50,3 +53,15 @@ _WKDragLiftDelay toDragLiftDelay(NSUInteger);
 _WKDragLiftDelay toWKDragLiftDelay(WebKit::DragLiftDelay);
 WebKit::DragLiftDelay fromWKDragLiftDelay(_WKDragLiftDelay);
 #endif
+
+#endif // __cplusplus
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKWebViewConfiguration ()
+
++ (BOOL)_isValidCustomScheme:(NSString *)urlScheme;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
+++ b/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
@@ -1,0 +1,94 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+internal import WebKit_Internal
+
+@_spi(Private)
+public struct URLScheme_v0: Hashable, Sendable {
+    public init?(_ rawValue: String) {
+        guard WKWebViewConfiguration._isValidCustomScheme(rawValue) else {
+            return nil
+        }
+
+        self.rawValue = rawValue
+    }
+
+    let rawValue: String
+}
+
+@_spi(Private)
+public enum URLSchemeTaskResult_v0: Sendable {
+    case response(URLResponse)
+
+    case data(Data)
+}
+
+@_spi(Private)
+public protocol URLSchemeHandler_v0 {
+    associatedtype TaskSequence: AsyncSequence<URLSchemeTaskResult_v0, any Error>
+
+    func reply(for request: URLRequest) -> TaskSequence
+}
+
+// MARK: Adapters
+
+final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
+    init(wrapping wrapped: any URLSchemeHandler_v0) {
+        self.wrapped = wrapped
+    }
+
+    private let wrapped: any URLSchemeHandler_v0
+
+    private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
+        let task = Task {
+            do {
+                for try await result in wrapped.reply(for: urlSchemeTask.request) {
+                    switch result {
+                    case let .response(response):
+                        urlSchemeTask.didReceive(response)
+
+                    case let .data(data):
+                        urlSchemeTask.didReceive(data)
+                    }
+                }
+
+                urlSchemeTask.didFinish()
+            } catch {
+                urlSchemeTask.didFailWithError(error)
+            }
+        }
+
+        tasks[ObjectIdentifier(urlSchemeTask)] = task
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+        tasks.removeValue(forKey: ObjectIdentifier(urlSchemeTask))?.cancel()
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift
@@ -26,11 +26,11 @@
 import Foundation
 
 final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
-    private let navigationProgressContinuation: AsyncStream<WebPage_v0.NavigationEvent>.Continuation
-
     init(navigationProgressContinuation: AsyncStream<WebPage_v0.NavigationEvent>.Continuation) {
         self.navigationProgressContinuation = navigationProgressContinuation
     }
+
+    private let navigationProgressContinuation: AsyncStream<WebPage_v0.NavigationEvent>.Continuation
 
     // MARK: Navigation progress reporting
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -1,0 +1,97 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+internal import WebKit_Internal
+
+extension WebPage_v0 {
+    @MainActor
+    @_spi(Private)
+    public struct Configuration: Sendable {
+        public init() {
+        }
+
+        public var websiteDataStore: WKWebsiteDataStore = .default()
+
+        public var userContentController: WKUserContentController = WKUserContentController()
+
+        public var webExtensionController: WKWebExtensionController? = nil
+
+        public var defaultNavigationPreferences: WebPage_v0.NavigationPreferences = WebPage_v0.NavigationPreferences()
+
+        public var urlSchemeHandlers: [URLScheme_v0 : any URLSchemeHandler_v0] = [:]
+
+        public var applicationNameForUserAgent: String? = nil
+
+        public var limitsNavigationsToAppBoundDomains: Bool = false
+
+        public var upgradeKnownHostsToHTTPS: Bool = true
+
+        public var suppressesIncrementalRendering: Bool = false
+
+        public var allowsInlinePredictions: Bool = false
+
+        public var supportsAdaptiveImageGlyph: Bool = false
+
+#if os(iOS)
+        public var dataDetectorTypes: WKDataDetectorTypes = .none
+
+        public var ignoresViewportScaleLimits: Bool = false
+#endif
+    }
+}
+
+// MARK: Adapters
+
+extension WKWebViewConfiguration {
+    convenience init(_ wrapped: WebPage_v0.Configuration) {
+        self.init()
+
+        self.websiteDataStore = wrapped.websiteDataStore
+        self.userContentController = wrapped.userContentController
+        self.webExtensionController = wrapped.webExtensionController
+
+        self.defaultWebpagePreferences = WKWebpagePreferences(wrapped.defaultNavigationPreferences)
+
+        self.applicationNameForUserAgent = wrapped.applicationNameForUserAgent
+        self.limitsNavigationsToAppBoundDomains = wrapped.limitsNavigationsToAppBoundDomains
+        self.upgradeKnownHostsToHTTPS = wrapped.upgradeKnownHostsToHTTPS
+        self.suppressesIncrementalRendering = wrapped.suppressesIncrementalRendering
+        self.allowsInlinePredictions = wrapped.allowsInlinePredictions
+        self.supportsAdaptiveImageGlyph = wrapped.supportsAdaptiveImageGlyph
+
+#if os(iOS)
+        self.dataDetectorTypes = wrapped.dataDetectorTypes
+        self.ignoresViewportScaleLimits = wrapped.ignoresViewportScaleLimits
+#endif
+
+        for (scheme, handler) in wrapped.urlSchemeHandlers {
+            let handlerAdapter = WKURLSchemeHandlerAdapter(wrapping: handler)
+            self.setURLSchemeHandler(handlerAdapter, forURLScheme: scheme.rawValue)
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -51,15 +51,15 @@ extension WebPage_v0 {
             case failed(underlyingError: any Error)
         }
 
-        public let kind: Kind
-
-        public let navigationID: NavigationID
-
         @_spi(Testing)
         public init(kind: Kind, navigationID: NavigationID) {
             self.kind = kind
             self.navigationID = navigationID
         }
+
+        public let kind: Kind
+
+        public let navigationID: NavigationID
     }
 
     @_spi(Private)
@@ -70,11 +70,11 @@ extension WebPage_v0 {
 
         public typealias Failure = Never
 
-        private let source: AsyncStream<Element>
-
         init(source: AsyncStream<Element>) {
             self.source = source
         }
+
+        private let source: AsyncStream<Element>
         
         public func makeAsyncIterator() -> AsyncIterator {
             Iterator(source: source.makeAsyncIterator())
@@ -89,11 +89,11 @@ extension WebPage_v0.Navigations {
 
         public typealias Failure = Never
 
-        private var source: AsyncStream<Element>.AsyncIterator
-
         init(source: AsyncStream<Element>.AsyncIterator) {
             self.source = source
         }
+
+        private var source: AsyncStream<Element>.AsyncIterator
         
         public mutating func next() async -> Element? {
             await source.next()

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -1,0 +1,79 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+internal import WebKit_Internal
+
+extension WebPage_v0 {
+    @MainActor
+    @_spi(Private)
+    public struct NavigationPreferences: Sendable {
+        public enum ContentMode: Sendable {
+            case recommended
+            case mobile
+            case desktop
+        }
+
+        public init() {
+        }
+
+        public var preferredContentMode: ContentMode = .recommended
+
+        public var allowsContentJavaScript: Bool = true
+
+        fileprivate var _isLockdownModeEnabled: Bool? = nil
+        public var isLockdownModeEnabled: Bool {
+            get { _isLockdownModeEnabled ?? false }
+            set { _isLockdownModeEnabled = newValue }
+        }
+    }
+}
+
+// MARK: Adapters
+
+extension WKWebpagePreferences {
+    convenience init(_ wrapped: WebPage_v0.NavigationPreferences) {
+        self.init()
+
+        self.preferredContentMode = .init(wrapped.preferredContentMode)
+        self.allowsContentJavaScript = wrapped.allowsContentJavaScript
+
+        if let isLockdownModeEnabled = wrapped._isLockdownModeEnabled {
+            self.isLockdownModeEnabled = isLockdownModeEnabled
+        }
+    }
+}
+
+extension WKWebpagePreferences.ContentMode {
+    init(_ wrapped: WebPage_v0.NavigationPreferences.ContentMode) {
+        self = switch wrapped {
+        case .recommended: .recommended
+        case .mobile: .mobile
+        case .desktop: .desktop
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebView.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebView.swift
@@ -33,11 +33,11 @@ fileprivate typealias PlatformView = NSView
 
 @_spi(Private)
 public struct WebView_v0: View {
-    fileprivate let page: WebPage_v0
-
     public init(_ page: WebPage_v0) {
         self.page = page
     }
+
+    fileprivate let page: WebPage_v0
 
     public var body: some View {
         WebViewRepresentable(owner: self)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		0772811D21234FF600C8EF2E /* UserMediaPermissionRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F4319AF7B27002EBAB5 /* UserMediaPermissionRequestManager.h */; };
 		077FD1A02CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FD19F2CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift */; };
 		0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */; };
+		078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04432CF1149200B453A6 /* URLSchemeHandler.swift */; };
+		078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */; };
+		078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */; };
 		0792314B239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07923145239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessageReceiver.cpp */; };
 		0792314C239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07923146239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessages.h */; };
 		079D1D9A26960CD300883577 /* SystemStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 079D1D9926960CD300883577 /* SystemStatusSPI.h */; };
@@ -3171,6 +3174,9 @@
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
 		077FD19F2CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceTextEffectCoordinator.swift; sourceTree = "<group>"; };
 		0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformIntelligenceTextEffectView.swift; sourceTree = "<group>"; };
+		078B04432CF1149200B453A6 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
+		078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Configuration.swift"; sourceTree = "<group>"; };
+		078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationPreferences.swift"; sourceTree = "<group>"; };
 		07923130239B3B0C009598E2 /* RemoteMediaPlayerManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerManager.cpp; sourceTree = "<group>"; };
 		07923131239B3B0C009598E2 /* MediaPlayerPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlayerPrivateRemote.cpp; sourceTree = "<group>"; };
 		07923132239B3B0C009598E2 /* MediaPlayerPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerPrivateRemote.h; sourceTree = "<group>"; };
@@ -8777,7 +8783,10 @@
 		07CB79942CE9432D00199C49 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
+				078B04432CF1149200B453A6 /* URLSchemeHandler.swift */,
+				078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */,
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
+				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
 				07CB79952CE9435700199C49 /* WebPage.swift */,
 				076CEF0B2CEEE79900E4ABD6 /* WebView.swift */,
 				07CB79972CE943E400199C49 /* WKNavigationDelegateAdapter.swift */,
@@ -18624,7 +18633,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${ACTION}\" = \"installhdrs\" ] || [ \"${ACTION}\" = \"installapi\" ]; then\n    exit 0;\nfi\n\nif [ -f ../../Tools/Scripts/check-for-inappropriate-objc-class-names ]; then\n    ../../Tools/Scripts/check-for-inappropriate-objc-class-names WK _WK _TtC6WebKit27WK || exit $?\nfi\n";
+			shellScript = "if [ \"${ACTION}\" = \"installhdrs\" ] || [ \"${ACTION}\" = \"installapi\" ]; then\n    exit 0;\nfi\n\nif [ -f ../../Tools/Scripts/check-for-inappropriate-objc-class-names ]; then\n    ../../Tools/Scripts/check-for-inappropriate-objc-class-names WK _WK _TtC6WebKit _TtCC6WebKit || exit $?\nfi\n";
 		};
 		3AB34B6228D4F01C009DAAB6 /* Update Info.plist for RunningBoard management */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -20011,6 +20020,7 @@
 				5C411DAA27CED4220068241A /* UnifiedSource128.cpp in Sources */,
 				5C411DAD27CED4220068241A /* UnifiedSource129.cpp in Sources */,
 				5C411DA727CED4220068241A /* UnifiedSource130.cpp in Sources */,
+				078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */,
 				CD491B0D1E732E4D00009066 /* UserMediaCaptureManagerMessageReceiver.cpp in Sources */,
 				CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */,
 				3F418EF91887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp in Sources */,
@@ -20134,7 +20144,9 @@
 				CDF1B91B267025550007EC10 /* WebKitSwiftSoftLink.mm in Sources */,
 				E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */,
 				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
+				078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */,
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
+				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,
 				07CB79962CE9435700199C49 /* WebPage.swift in Sources */,
 				C0CE72A01247E71D00BC0EC4 /* WebPageMessageReceiver.cpp in Sources */,
 				BCBD3914125BB1A800D2C29F /* WebPageProxyMessageReceiver.cpp in Sources */,

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		076E507F1F4513D6006E9F5A /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 076E507E1F45031E006E9F5A /* Logging.cpp */; };
 		077489CC2CE4061A00133938 /* WKWebViewSwiftOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 070721142CE2F5F6004D9EC8 /* WKWebViewSwiftOverlay.swift */; };
 		077A5AF3230638A600A7105C /* AccessibilityTestPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0746645822FF630500E3451A /* AccessibilityTestPlugin.mm */; };
+		078B04482CF118BD00B453A6 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04472CF118BD00B453A6 /* URLSchemeHandler.swift */; };
+		078B044A2CF139BF00B453A6 /* Foundation+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04492CF139BF00B453A6 /* Foundation+Extras.swift */; };
 		079D45F22A2A6BBE003830C7 /* Viewport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D45F12A2A6BBE003830C7 /* Viewport.mm */; };
 		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
@@ -2136,6 +2138,8 @@
 		075A9CF426177217006DFA3A /* MediaSessionCoordinatorTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSessionCoordinatorTest.mm; sourceTree = "<group>"; };
 		0766DD1F1A5AD5200023E3BB /* PendingAPIRequestURL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PendingAPIRequestURL.cpp; sourceTree = "<group>"; };
 		076E507E1F45031E006E9F5A /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
+		078B04472CF118BD00B453A6 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
+		078B04492CF139BF00B453A6 /* Foundation+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extras.swift"; sourceTree = "<group>"; };
 		0794740C25CA0BDE00C597EB /* MediaSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSession.mm; sourceTree = "<group>"; };
 		0794742C25CB33B000C597AA /* media-session-capture.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-session-capture.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EB /* media-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-remote.html"; sourceTree = "<group>"; };
@@ -4006,7 +4010,9 @@
 		0707210D2CE2F3A0004D9EC8 /* WebKit Swift */ = {
 			isa = PBXGroup;
 			children = (
+				078B04492CF139BF00B453A6 /* Foundation+Extras.swift */,
 				070721102CE2F4B8004D9EC8 /* TestWebKitAPIBundle-Bridging-Header.h */,
+				078B04472CF118BD00B453A6 /* URLSchemeHandler.swift */,
 				07FAA74C2CE95E3200128360 /* WebPage.swift */,
 				070721142CE2F5F6004D9EC8 /* WKWebViewSwiftOverlay.swift */,
 			);
@@ -7433,7 +7439,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				078B044A2CF139BF00B453A6 /* Foundation+Extras.swift in Sources */,
 				A17C58472C9BF524009DD0B5 /* GoogleTests.mm in Sources */,
+				078B04482CF118BD00B453A6 /* URLSchemeHandler.swift in Sources */,
 				07FAA74D2CE95E3200128360 /* WebPage.swift in Sources */,
 				077489CC2CE4061A00133938 /* WKWebViewSwiftOverlay.swift in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions
+ // are met:
+ // 1. Redistributions of source code must retain the above copyright
+ //    notice, this list of conditions and the following disclaimer.
+ // 2. Redistributions in binary form must reproduce the above copyright
+ //    notice, this list of conditions and the following disclaimer in the
+ //    documentation and/or other materials provided with the distribution.
+ //
+ // THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ // THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ // BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ // CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ // THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+
+import Foundation
+
+extension Array {
+    init(_ sequence: some AsyncSequence<Element, Never>) async {
+        self.init()
+
+        for await element in sequence {
+            append(element)
+        }
+    }
+}
+
+extension URL {
+    static var aboutBlank: URL { URL(string: "about:blank")! }
+}
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandler.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandler.swift
@@ -1,0 +1,113 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+
+import Testing
+@_spi(Private) import WebKit
+
+fileprivate struct TestURLSchemeHandler: URLSchemeHandler_v0, Sendable {
+    struct Failure: Error {
+    }
+
+    init(data: Data, mimeType: String) {
+        self.data = data
+        self.mimeType = mimeType
+
+        (self.replyStream, self.replyContinuation) = AsyncStream.makeStream(of: URL.self)
+    }
+
+    let replyStream: AsyncStream<URL>
+
+    private let data: Data
+    private let mimeType: String
+    private let replyContinuation: AsyncStream<URL>.Continuation
+
+    func reply(for request: URLRequest) -> AsyncThrowingStream<URLSchemeTaskResult_v0, any Error> {
+        AsyncThrowingStream { continuation in
+            defer {
+                replyContinuation.yield(request.url!)
+            }
+
+            guard request.url!.absoluteString != "testing:image" else {
+                continuation.finish(throwing: Failure())
+                return
+            }
+
+            let response = URLResponse(url: request.url!, mimeType: mimeType, expectedContentLength: 2, textEncodingName: nil)
+            continuation.yield(.response(response))
+            continuation.yield(.data(data))
+
+            continuation.finish()
+        }
+    }
+}
+
+// MARK: Tests
+
+@MainActor
+struct URLSchemeHandlerTests {
+    @Test
+    func basicSchemeValidation() async throws {
+        let customScheme = URLScheme_v0("my-custom-scheme")
+        #expect(customScheme != nil)
+
+        let httpsScheme = URLScheme_v0("https")
+        #expect(httpsScheme == nil)
+
+        let invalidScheme = URLScheme_v0("invalid scheme")
+        #expect(invalidScheme == nil)
+    }
+
+    @Test
+    func basicSchemeHandling() async throws {
+        let html = """
+        <html>
+        <img src='testing:image'>
+        </html>
+        """.data(using: .utf8)!
+
+        let handler = TestURLSchemeHandler(data: html, mimeType: "text/html")
+        var configuration = WebPage_v0.Configuration()
+        configuration.urlSchemeHandlers[URLScheme_v0("testing")!] = handler
+
+        let page = WebPage_v0(configuration: configuration)
+
+        let url = URL(string: "testing:main")!
+        let request = URLRequest(url: url)
+
+        async let replyStream = Array(handler.replyStream.prefix(2))
+
+        page.load(request)
+
+        let expectedReplyURLs = [
+            URL(string: "testing:main")!,
+            URL(string: "testing:image")!,
+        ]
+
+        let actualReplyURLs = await replyStream
+        #expect(actualReplyURLs == expectedReplyURLs)
+    }
+}
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift
@@ -29,25 +29,6 @@ import WebKit
 @_spi(Private) import WebKit
 @_spi(Testing) import WebKit
 
-// MARK: Helper extension functions
-
-extension Array {
-    @MainActor
-    fileprivate init(async sequence: some AsyncSequence<Element, Never>) async {
-        self.init()
-
-        for try await element in sequence {
-            append(element)
-        }
-    }
-}
-
-extension URL {
-    fileprivate static var aboutBlank: URL {
-        URL(string: "about:blank")!
-    }
-}
-
 extension WebPage_v0.NavigationEvent.Kind: @retroactive Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {


### PR DESCRIPTION
#### 04b52903636aff9541e432dd6474227993572de7
<pre>
[SwiftUI] Introduce WebPage.Configuration, URLSchemeHandler, and supporting types
<a href="https://bugs.webkit.org/show_bug.cgi?id=280598">https://bugs.webkit.org/show_bug.cgi?id=280598</a>
<a href="https://rdar.apple.com/136945136">rdar://136945136</a>

Reviewed by Wenson Hsieh.

Combined changes:
* Source/WebKit/Modules/Internal/WebKitInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _uncheckedSetURLSchemeHandler:forCanonicalURLScheme:]):
(+[WKWebViewConfiguration _canonicalSchemeForURLScheme:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift: Added.
(URLSchemeHandler_v0.reply(for:)):
(WKURLSchemeHandlerAdapter.tasks):
(WKURLSchemeHandlerAdapter.webView(_:start:)):
(WKURLSchemeHandlerAdapter.webView(_:stop:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift: Added.
(Configuration.websiteDataStore):
(Configuration.userContentController):
(Configuration.webExtensionController):
(Configuration.defaultNavigationPreferences):
(Configuration.urlSchemeHandlers):
(Configuration.applicationNameForUserAgent):
(Configuration.limitsNavigationsToAppBoundDomains):
(Configuration.upgradeKnownHostsToHTTPS):
(Configuration.suppressesIncrementalRendering):
(Configuration.allowsInlinePredictions):
(Configuration.supportsAdaptiveImageGlyph):
(Configuration.dataDetectorTypes):
(Configuration.ignoresViewportScaleLimits):
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift: Added.
(preferredContentMode):
(allowsContentJavaScript):
(isLockdownModeEnabled):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(WebPage_v0.backingWebView):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift: Added.
(URL.aboutBlank):
* Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandler.swift: Added.
(reply(for:)):
(URLSchemeHandlerTests.basicSchemeValidation):
(URLSchemeHandlerTests.basicSchemeHandling):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift:
(URL.aboutBlank): Deleted.

Canonical link: <a href="https://commits.webkit.org/287406@main">https://commits.webkit.org/287406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ab155100aa5392d35b92b5aeb45a98c62aae8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62199 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68325 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69692 "Found 7 new API test failures: /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL, /TestWebKit:WebKit.FailedLoad, /TestWebKit:WebKit.WillSendSubmitEvent, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.ParentFrame, /TestWebKit:WebKit.Find (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12615 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12286 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6755 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->