### PR TITLE
[JSC] Shrink policy must be asymmetry to expand policy

### DIFF
--- a/JSTests/microbenchmarks/set-delete-add.js
+++ b/JSTests/microbenchmarks/set-delete-add.js
@@ -1,0 +1,8 @@
+var map = new Set();
+
+for (var i = 0; i < 1000; i++) {
+    for (var j = 0; j < 1000; j++) {
+        map.delete(j);
+        map.add(j);
+    }
+}

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -392,11 +392,15 @@ public:
         TableSize usedCapacity = Helper::aliveEntryCount(base) + deletedEntryCount;
 
         bool isSmallCapacity = capacity < LargeCapacity;
-        float expandThreshold = isSmallCapacity ? 0.5 : 0.75;
         TableSize expandFactor = isSmallCapacity ? 2 : 1;
 
-        if (usedCapacity < capacity * expandThreshold)
-            return &base;
+        if (isSmallCapacity) {
+            if (usedCapacity < (capacity >> 1))
+                return &base;
+        } else {
+            if (usedCapacity < ((capacity >> 2) * 3))
+                return &base;
+        }
 
         TableSize newCapacity = Checked<TableSize>(capacity) << expandFactor;
         if (deletedEntryCount >= (capacity >> 1))
@@ -461,12 +465,12 @@ public:
         });
     }
 
-    ALWAYS_INLINE static void shrinkIfNeed(JSGlobalObject* globalObject, HashTable* owner, Storage& base)
+    ALWAYS_INLINE static void shrinkIfNeeded(JSGlobalObject* globalObject, HashTable* owner, Storage& base)
     {
         ASSERT(!isObsolete(base));
         TableSize capacity = Helper::capacity(base);
         TableSize aliveEntryCount = Helper::aliveEntryCount(base);
-        if (aliveEntryCount >= (capacity >> 2))
+        if (aliveEntryCount >= (capacity >> 3))
             return;
         if (capacity == InitialCapacity)
             return;
@@ -491,8 +495,9 @@ public:
         incrementDeletedEntryCount(storage);
         decrementAliveEntryCount(storage);
 
-        shrinkIfNeed(globalObject, owner, storage);
-        RELEASE_AND_RETURN(scope, true);
+        scope.release();
+        shrinkIfNeeded(globalObject, owner, storage);
+        return true;
     }
     ALWAYS_INLINE static bool remove(JSGlobalObject* globalObject, HashTable* owner, Storage& storage, JSValue key)
     {


### PR DESCRIPTION
#### 7d22285d572d20184291e7c210481ab3c56fa434
<pre>
[JSC] Shrink policy must be asymmetry to expand policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=280600">https://bugs.webkit.org/show_bug.cgi?id=280600</a>
<a href="https://rdar.apple.com/136912759">rdar://136912759</a>

Reviewed by Yijia Huang.

Changing OrderedHashTableHelper::shrinkIfNeeded policy from &gt;&gt; 2 to &gt;&gt; 3
since expand policy for small table is &lt;&lt; 2. Shrink policy must be
asymmetry to the expand policy, otherwise, we have thrashing behavior of
repeated expand and shrink with one entry addition and deletion.
&gt;&gt; 3 is fine as we normally use / 6 in WTF::HashTable for example.
I also adjust expandIfNeeded code to avoid using float.

                               ToT                     Patched

    set-delete-add      635.0390+-16.6071    ^     40.6197+-2.6151        ^ definitely 15.6338x faster

* JSTests/microbenchmarks/set-delete-add.js: Added.
* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::expandIfNeeded):
(JSC::OrderedHashTableHelper::shrinkIfNeeded):
(JSC::OrderedHashTableHelper::removeImpl):
(JSC::OrderedHashTableHelper::shrinkIfNeed): Deleted.

Canonical link: <a href="https://commits.webkit.org/284450@main">https://commits.webkit.org/284450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d1fa3269dcd20d019523ea1da15e7006b24100e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20561 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55197 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13660 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18938 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62519 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75197 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68649 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62771 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4405 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90431 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10599 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44607 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16042 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->