### PR TITLE
[WPE][Qt6] Fix wpe_toplevel_qt and quick wpe_view_resize issue

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -84,7 +84,9 @@ void WPEQtView::geometryChange(const QRectF& newGeometry, const QRectF&)
         return;
 
     auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
-    wpe_view_resize(wpeView, d->m_size.width(), d->m_size.height());
+    if (auto* wpeToplevel = wpe_view_get_toplevel(wpeView))
+        wpe_toplevel_resize(wpeToplevel, d->m_size.width(), d->m_size.height());
+
 }
 
 void WPEQtView::configureWindow()
@@ -119,7 +121,9 @@ void WPEQtView::createWebView()
         "settings", settings.get(), nullptr)));
 
     auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
-    wpe_view_resize(wpeView, d->m_size.width(), d->m_size.height());
+    if (auto* wpeToplevel = wpe_view_get_toplevel(wpeView))
+        wpe_toplevel_resize(wpeToplevel, d->m_size.width(), d->m_size.height());
+
     wpe_view_map(wpeView); // FIXME: unmap when appropriate and implement can_be_mapped if needed.
 
     if (!wpe_view_qtquick_initialize_rendering(WPE_VIEW_QTQUICK(wpeView), this, &error.outPtr())) {

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WPEToplevelQtQuick.h"
 
+#include <wtf/glib/WTFGType.h>
+
 /**
  * WPEToplevelQtQuick:
  *


### PR DESCRIPTION
#### cf39d48831d61ad639a2291eb09f7b1517356d09
<pre>
[WPE][Qt6] Fix wpe_toplevel_qt and quick wpe_view_resize issue

<a href="https://bugs.webkit.org/show_bug.cgi?id=282019">https://bugs.webkit.org/show_bug.cgi?id=282019</a>

Reviewed by Nikolas Zimmermann.

Fix the following compile failed issue for Qt6:

Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp:35:46:
error: &apos;wpe_toplevel_qtquick&apos; has not been declared

Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:87:5:
error: &apos;wpe_view_resize&apos; was not declared in this scope;
did you mean &apos;wpe_view_resized&apos;?

Signed-off-by: LI Qingwu &lt;Qing-wu.Li@leica-geosystems.com.cn&gt;
Canonical link: <a href="https://commits.webkit.org/285634@main">https://commits.webkit.org/285634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f271c6482f6230891ca96f1b05b5f427012b5b86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26161 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/24591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/565 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/77589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/24591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63114 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/77589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44298 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/22920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79235 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/664 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/66052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63126 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16146 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/632 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/662 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->