### PR TITLE
[EWS macOS] imported/w3c/web-platform-tests/web-animations/timing-model/timelines/document-timelines.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2433,5 +2433,3 @@ imported/w3c/web-platform-tests/mathml/presentation-markup/operators/size-and-po
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/stretchy-largeop-with-default-font-2.html [ Failure ]
 
 webkit.org/b/257011 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphenate-character-002.html [ ImageOnlyFailure ]
-
-webkit.org/b/280528 imported/w3c/web-platform-tests/web-animations/timing-model/timelines/document-timelines.html [ Pass Failure ]

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -51,22 +51,4 @@ AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimat
 
 AnimationPlaybackEvent::~AnimationPlaybackEvent() = default;
 
-std::optional<CSSNumberishTime> AnimationPlaybackEvent::bindingsCurrentTime() const
-{
-    if (m_currentTime) {
-        ASSERT(m_currentTime->time());
-        return secondsToWebAnimationsAPITime(*m_currentTime->time());
-    }
-    return std::nullopt;
-}
-
-std::optional<CSSNumberishTime> AnimationPlaybackEvent::bindingsTimelineTime() const
-{
-    if (m_timelineTime) {
-        ASSERT(m_timelineTime->time());
-        return secondsToWebAnimationsAPITime(*m_timelineTime->time());
-    }
-    return std::nullopt;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -50,9 +50,6 @@ public:
     bool isAnimationPlaybackEvent() const final { return true; }
 
     std::optional<CSSNumberishTime> timelineTime() const { return m_timelineTime; }
-    std::optional<CSSNumberishTime> bindingsTimelineTime() const;
-
-    std::optional<CSSNumberishTime> bindingsCurrentTime() const;
     std::optional<CSSNumberishTime> currentTime() const { return m_currentTime; }
 
 private:

--- a/Source/WebCore/animation/AnimationPlaybackEvent.idl
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.idl
@@ -30,6 +30,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 ] interface AnimationPlaybackEvent : Event {
     constructor([AtomString] DOMString type, optional AnimationPlaybackEventInit eventInitDict);
 
-    [ImplementedAs=bindingsCurrentTime] readonly attribute CSSNumberish? currentTime;
-    [ImplementedAs=bindingsTimelineTime] readonly attribute CSSNumberish? timelineTime;
+    readonly attribute CSSNumberish? currentTime;
+    readonly attribute CSSNumberish? timelineTime;
 };

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -216,7 +216,7 @@ CSSNumberishTime CSSNumberishTime::operator/(double scalar) const
 CSSNumberishTime::operator double() const
 {
     if (m_type == Type::Time)
-        return m_value * 1000;
+        return secondsToWebAnimationsAPITime(*this);
     return m_value;
 }
 
@@ -231,16 +231,16 @@ CSSNumberishTime::operator CSSNumberish() const
     switch (m_source) {
     case Source::Literal:
         ASSERT(m_type == Type::Time);
-        return m_value * 1000;
+        return secondsToWebAnimationsAPITime(*this);
     case Source::Number:
         ASSERT(m_type == Type::Time);
-        return CSSNumericFactory::number(m_value * 1000);
+        return CSSNumericFactory::number(secondsToWebAnimationsAPITime(*this));
     case Source::Milliseconds:
         ASSERT(m_type == Type::Time);
-        return CSSNumericFactory::ms(m_value * 1000);
+        return CSSNumericFactory::ms(secondsToWebAnimationsAPITime(*this));
     case Source::Seconds:
         ASSERT(m_type == Type::Time);
-        return CSSNumericFactory::s(m_value);
+        return CSSNumericFactory::s(secondsToWebAnimationsAPITime(*this) / 1000);
     case Source::Percentage:
         ASSERT(m_type == Type::Percentage);
         return CSSNumericFactory::percent(m_value);

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -306,15 +306,6 @@ void WebAnimation::effectTargetDidChange(const std::optional<const Styleable>& p
     InspectorInstrumentation::didChangeWebAnimationEffectTarget(*this);
 }
 
-std::optional<CSSNumberishTime> WebAnimation::bindingsStartTime() const
-{
-    if (m_startTime) {
-        ASSERT(m_startTime->time());
-        return secondsToWebAnimationsAPITime(*m_startTime->time());
-    }
-    return std::nullopt;
-}
-
 ExceptionOr<void> WebAnimation::setBindingsStartTime(const std::optional<CSSNumberishTime>& startTime)
 {
     if (startTime && !startTime->isValid())
@@ -369,15 +360,6 @@ void WebAnimation::setStartTime(std::optional<CSSNumberishTime> newStartTime)
     timingDidChange(DidSeek::Yes, SynchronouslyNotify::No);
 
     invalidateEffect();
-}
-
-std::optional<CSSNumberishTime> WebAnimation::bindingsCurrentTime() const
-{
-    if (auto currentTime = this->currentTime()) {
-        ASSERT(currentTime->time());
-        return secondsToWebAnimationsAPITime(*currentTime->time());
-    }
-    return std::nullopt;
 }
 
 ExceptionOr<void> WebAnimation::setBindingsCurrentTime(const std::optional<CSSNumberishTime>& currentTime)

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -117,11 +117,11 @@ public:
     void persist();
     ExceptionOr<void> commitStyles();
 
-    virtual std::optional<CSSNumberishTime> bindingsStartTime() const;
+    virtual std::optional<CSSNumberishTime> bindingsStartTime() const { return startTime(); }
     virtual ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberishTime>&);
     std::optional<CSSNumberishTime> startTime() const { return m_startTime; }
     void setStartTime(std::optional<CSSNumberishTime>);
-    virtual std::optional<CSSNumberishTime> bindingsCurrentTime() const;
+    virtual std::optional<CSSNumberishTime> bindingsCurrentTime() const { return currentTime(); };
     virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<CSSNumberishTime>&);
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }


### PR DESCRIPTION
#### 12b70e251e35902a59d671d4170e9d38841f87df
<pre>
[EWS macOS] imported/w3c/web-platform-tests/web-animations/timing-model/timelines/document-timelines.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=280528">https://bugs.webkit.org/show_bug.cgi?id=280528</a>
<a href="https://rdar.apple.com/136843486">rdar://136843486</a>

Reviewed by Antti Koivisto.

Ensure that when a CSSNumberishTime is converted automatically to an API-facing type,
either `double` or `CSSNumberish`, we go through the `secondsToWebAnimationsAPITime`
utility to round the time value per <a href="https://drafts.csswg.org/web-animations-1/#precision-of-time-values.">https://drafts.csswg.org/web-animations-1/#precision-of-time-values.</a>

This allows us to remove some bindings-specific code as well, which is how this bug
surfaced in the first place with 284168@main.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::bindingsCurrentTime const): Deleted.
(WebCore::AnimationPlaybackEvent::bindingsTimelineTime const): Deleted.
* Source/WebCore/animation/AnimationPlaybackEvent.h:
* Source/WebCore/animation/AnimationPlaybackEvent.idl:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::operator double const):
(WebCore::CSSNumberishTime::operator CSSNumberish const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::bindingsStartTime const): Deleted.
(WebCore::WebAnimation::bindingsCurrentTime const): Deleted.
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::bindingsStartTime const):
(WebCore::WebAnimation::bindingsCurrentTime const):

Canonical link: <a href="https://commits.webkit.org/284448@main">https://commits.webkit.org/284448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/313751905f4af4cac9520225048e9fb07cc9b56b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55212 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13675 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35690 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16931 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62878 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/old-content-has-scrollbars.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62784 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4419 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10598 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44621 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->