### PR TITLE
[Canvas] Adopt smart pointers in WebGLDefaultFramebuffer

### DIFF
--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<WebGLDefaultFramebuffer> WebGLDefaultFramebuffer::create(WebGLRe
 WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& context)
     : m_context(context)
 {
-    auto attributes = m_context.protectedGraphicsContextGL()->contextAttributes();
+    auto attributes = context.protectedGraphicsContextGL()->contextAttributes();
     m_hasStencil = attributes.stencil;
     m_hasDepth = attributes.depth;
     if (!attributes.preserveDrawingBuffer) {
@@ -57,12 +57,12 @@ WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& cont
 
 IntSize WebGLDefaultFramebuffer::size() const
 {
-    return m_context.protectedGraphicsContextGL()->getInternalFramebufferSize();
+    return m_context->protectedGraphicsContextGL()->getInternalFramebufferSize();
 }
 
 void WebGLDefaultFramebuffer::reshape(IntSize size)
 {
-    m_context.protectedGraphicsContextGL()->reshape(size.width(), size.height());
+    m_context->protectedGraphicsContextGL()->reshape(size.width(), size.height());
 }
 
 void WebGLDefaultFramebuffer::markBuffersClear(GCGLbitfield clearBuffers)

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
@@ -53,7 +53,8 @@ public:
 private:
     WebGLDefaultFramebuffer(WebGLRenderingContextBase&);
 
-    WebGLRenderingContextBase& m_context;
+    WeakRef<WebGLRenderingContextBase> m_context;
+
     GCGLbitfield m_unpreservedBuffers { 0 };
     GCGLbitfield m_dirtyBuffers { 0 };
     bool m_hasStencil : 1;


### PR DESCRIPTION
#### 357b0605abb8a5c2dc78cc7d8323dc17e6f37d98
<pre>
[Canvas] Adopt smart pointers in WebGLDefaultFramebuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=280607">https://bugs.webkit.org/show_bug.cgi?id=280607</a>

Reviewed by Chris Dumez.

Use a weak reference for the rendering context to
prevent static analyzer warnings of uncounted members.

* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
(WebCore::WebGLDefaultFramebuffer::WebGLDefaultFramebuffer):
(WebCore::WebGLDefaultFramebuffer::size const):
(WebCore::WebGLDefaultFramebuffer::reshape):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h:

Canonical link: <a href="https://commits.webkit.org/284677@main">https://commits.webkit.org/284677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c62b47b6a731579274b649e63dbdeecf9ac82cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13673 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18951 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75210 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62782 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15557 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4416 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44620 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->