### PR TITLE
REGRESSION(284376@main)[WPE]: Build broken with GCC and ARM64

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -523,7 +523,7 @@ void MarkedBlock::Handle::sweep(FreeList* freeList)
 } while (false)
 #endif
 
-#if CPU(ARM64)
+#if CPU(ARM64) && !COMPILER(GCC)
 #define DEFINE_SAVED_VALUE(name, reg, value) \
     volatile register decltype(value) name asm(reg) = value; \
     WTF::opaque(name); \
@@ -531,7 +531,7 @@ void MarkedBlock::Handle::sweep(FreeList* freeList)
 #else
 #define DEFINE_SAVED_VALUE(name, reg, value) \
     decltype(value) name = value; \
-    UNUSED_VARIABLE(name);
+    UNUSED_VARIABLE(reg);
 #endif
 
 #define SAVE_TO_REG(name, value) do { \


### PR DESCRIPTION
#### 964f4b1be9b5c53988d71c1029b2dc27c198cf16
<pre>
REGRESSION(284376@main)[WPE]: Build broken with GCC and ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=280614">https://bugs.webkit.org/show_bug.cgi?id=280614</a>

Reviewed by Michael Catanzaro and Keith Miller.

GCC is failing to build on ARM64 after 284376@main with this error:

 &quot;error: address of explicit register variable ‘savedActualVM’ requested&quot;

And that is because the variables `savedActualVM` and `savedBitfield` are
marked as register storage variables, but is not possible to take the
address of a register variable, which is needed to pass them into the
lambda by reference.

Not sure how Clang deals with this, I guess it automatically decides to
use heap storage for this two variables.
I tried to manually do that for this two variables but then GCC warns with:

 &quot;warning: optimization may eliminate reads and/or writes to register variables [-Wvolatile-register-var]&quot;

due to the conflicting usage of &quot;volatile register&quot; in DEFINE_SAVED_VALUE()
for ARM64, so just fix this by using the version of DEFINE_SAVED_VALUE()
that uses heap variables when the compiler is GCC.

* Source/JavaScriptCore/heap/MarkedBlock.cpp:

Canonical link: <a href="https://commits.webkit.org/284460@main">https://commits.webkit.org/284460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8753d7fc776a82cd86add1944d8190ebc5127283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55226 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18970 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62551 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75229 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68681 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62894 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62800 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4433 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44639 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16050 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->