### PR TITLE
[WPE] WPE Platform: Add WPESettings API

### DIFF
--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -31,6 +31,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureDetector.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreen.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPESettings.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
@@ -55,6 +56,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureController.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreen.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPESettings.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wpe-platform.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -59,6 +59,7 @@ struct _WPEDisplayPrivate {
     HashMap<String, bool> extensionsMap;
     GRefPtr<WPEBufferDMABufFormats> preferredDMABufFormats;
     GRefPtr<WPEKeymap> keymap;
+    GRefPtr<WPESettings> settings;
 };
 
 WEBKIT_DEFINE_ABSTRACT_TYPE(WPEDisplay, wpe_display, G_TYPE_OBJECT)
@@ -325,6 +326,25 @@ WPEKeymap* wpe_display_get_keymap(WPEDisplay* display, GError** error)
     }
 
     return wpeDisplayClass->get_keymap(display, error);
+}
+
+/**
+ * wpe_display_get_settings:
+ * @display: a #WPEDisplay
+ *
+ * Get the #WPESettings of @display
+ *
+ * Returns: (transfer none): a #WPESettings
+ */
+WPESettings* wpe_display_get_settings(WPEDisplay* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
+
+    auto* priv = display->priv;
+    if (!priv->settings)
+        priv->settings = adoptGRef(WPE_SETTINGS(g_object_new(WPE_TYPE_SETTINGS, nullptr)));
+
+    return priv->settings.get();
 }
 
 #if USE(LIBDRM)

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -36,6 +36,7 @@
 #include <wpe/WPEInputMethodContext.h>
 #include <wpe/WPEKeymap.h>
 #include <wpe/WPEScreen.h>
+#include <wpe/WPESettings.h>
 #include <wpe/WPEView.h>
 
 G_BEGIN_DECLS
@@ -104,6 +105,8 @@ WPE_API void                    wpe_display_screen_removed                (WPEDi
 WPE_API const char             *wpe_display_get_drm_device                (WPEDisplay *display);
 WPE_API const char             *wpe_display_get_drm_render_node           (WPEDisplay *display);
 WPE_API gboolean                wpe_display_use_explicit_sync             (WPEDisplay *display);
+
+WPE_API WPESettings            *wpe_display_get_settings                  (WPEDisplay *display);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPESettings.h"
+
+#include <glib.h>
+#include <wpe/WPEDisplay.h>
+#include <wtf/HashMap.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
+
+
+struct SettingEntry {
+    SettingEntry() = default;
+
+    SettingEntry(GRefPtr<GVariant>&& defaultValue, GUniquePtr<GVariantType>&& type)
+        : defaultValue(WTFMove(defaultValue))
+        , type(WTFMove(type))
+    {
+    }
+
+    GRefPtr<GVariant> value() const
+    {
+        return setValue ? setValue : defaultValue;
+    }
+
+    GRefPtr<GVariant> setValue;
+    GRefPtr<GVariant> defaultValue;
+    GUniquePtr<GVariantType> type;
+    bool setByApplication { false };
+};
+
+/**
+ * wpe_settings_error_quark:
+ *
+ * Gets the WPESettings Error Quark.
+ *
+ * Returns: a #GQuark.
+ **/
+G_DEFINE_QUARK(wpe-settings-error-quark, wpe_settings_error)
+
+/**
+ * WPESettings:
+ *
+ * This class stores settings for the WPE platform.
+ *
+ * It is a map of keys to arbitrary values. These keys are registered with [method@WPESettings.register].
+ *
+ * They can be stored and loaded with [method@WPESettings.save_to_keyfile] and [method@WPESettings.load_from_keyfile].
+ *
+ * The [signal@WPESettings::changed] signal is emitted when a setting is changed. You can connect to the detailed signal
+ * to watch a specific key, e.g. `changed::/wpe-platform/fonts/font-hinting`.
+ */
+struct _WPESettingsPrivate {
+    HashMap<CString, SettingEntry> settings;
+};
+
+enum {
+    CHANGED,
+
+    LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0, };
+
+WEBKIT_DEFINE_FINAL_TYPE(WPESettings, wpe_settings, G_TYPE_OBJECT, GObject)
+
+static void wpe_settings_class_init(WPESettingsClass* settingsClass)
+{
+    /**
+     * WPESettings::changed:
+     * @settings: a #WPESettings
+     * @key: the key that changed
+     * @value: the new value
+     *
+     * Emitted when a settings is changed.
+     * It will contain a detail of the specific key that changed.
+     */
+    signals[CHANGED] = g_signal_new(
+        "changed",
+        G_TYPE_FROM_CLASS(G_OBJECT_CLASS(settingsClass)),
+        static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED),
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 2,
+        G_TYPE_STRING,
+        G_TYPE_VARIANT);
+}
+
+static CString makeKeyPath(const char* group, const char* key)
+{
+    char* buffer;
+    size_t length = strlen(group) + strlen(key) + 3;
+
+    CString path = CString::newUninitialized(length - 1, buffer);
+    g_snprintf(buffer, length, "/%s/%s", group, key);
+
+    return path;
+}
+
+/**
+ * wpe_settings_register:
+ * @settings: a #WPESettings
+ * @key: the key to register
+ * @type: the type of the setting
+ * @default_value: (transfer floating): the default value for the setting
+ * @error: return location for a #GError, or %NULL
+ *
+ * Registers a key to be used for settings. This is only intended to be used by platforms and not applications.
+ *
+ * The key must begin with `/wpe-platform/` and not end with `/`. e.g. `/wpe-platform/fonts/hinting`.
+ *
+ * Any floating reference of @default_value will be consumed.
+ *
+ * It is an error to call this function with a key that has already been registered.
+ */
+gboolean wpe_settings_register(WPESettings* settingsObject, const char* key, const GVariantType* type, GVariant* defaultValue, GError** error)
+{
+    g_return_val_if_fail(WPE_IS_SETTINGS(settingsObject), FALSE);
+    g_return_val_if_fail(key && g_str_has_prefix(key, "/wpe-platform/") && !g_str_has_suffix(key, "/"), FALSE);
+    g_return_val_if_fail(defaultValue, FALSE);
+    g_return_val_if_fail(type, FALSE);
+    g_return_val_if_fail(g_variant_type_equal(type, g_variant_get_type(defaultValue)), FALSE);
+
+    if (settingsObject->priv->settings.contains(key)) {
+        g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_ALREADY_REGISTERED, "%s has already been reigstered", key);
+        return FALSE;
+    }
+
+    settingsObject->priv->settings.add(key, SettingEntry(defaultValue, GUniquePtr<GVariantType>(g_variant_type_copy(type))));
+
+    return TRUE;
+}
+
+/**
+ * wpe_settings_load_from_keyfile:
+ * @settings: a #WPESettings
+ * @keyfile: the keyfile to load settings from
+ * @error: return location for a #GError, or %NULL
+ *
+ * Loads settings from a keyfile.
+ *
+ * Only groups named `wpe-platform` or with the prefix `wpe-platform/` will be considered.
+ * All keys under these groups must be registered with [method@WPESettings.register].
+ *
+ * If a value is already set it will be overwritten.
+ *
+ * All keys loaded are expected to be formatted as a GVariant.
+ *
+ * [signal@WPESettings::changed] will be emitted for each key that is loaded with a *new* value.
+ *
+ * Returns: %TRUE if the settings were loaded successfully, %FALSE otherwise.
+ */
+gboolean wpe_settings_load_from_keyfile(WPESettings* settingsObject, GKeyFile* keyFile, GError** error)
+{
+    g_return_val_if_fail(WPE_IS_SETTINGS(settingsObject), FALSE);
+    g_return_val_if_fail(!error || !*error, FALSE);
+    g_return_val_if_fail(keyFile, FALSE);
+
+    GUniquePtr<char*> groups(g_key_file_get_groups(keyFile, nullptr));
+    for (unsigned i = 0; groups.get()[i]; i++) {
+        const char* group = groups.get()[i];
+
+        if (!g_str_has_prefix(group, "wpe-platform/") && strcmp(group, "wpe-platform"))
+            continue;
+
+        GUniquePtr<char*> keys(g_key_file_get_keys(keyFile, group, nullptr, nullptr));
+
+        for (unsigned k = 0; keys.get()[k]; k++) {
+            const char* key = keys.get()[k];
+            GUniquePtr<char> value(g_key_file_get_value(keyFile, group, key, nullptr));
+            if (!value)
+                continue;
+
+            auto path = makeKeyPath(group, key);
+            auto iter = settingsObject->priv->settings.find(path);
+            if (iter == settingsObject->priv->settings.end()) {
+                g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED, "Key %s not registered", path.data());
+                return FALSE;
+            }
+
+            GUniqueOutPtr<GError> innerError;
+            GRefPtr<GVariant> parsedValue = adoptGRef(g_variant_parse(iter->value.type.get(), value.get(), nullptr, nullptr, &innerError.outPtr()));
+            if (!parsedValue) {
+                g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INVALID_VALUE, "Failed to parse value for key %s: %s", path.data(), innerError->message);
+                return FALSE;
+            }
+
+            if (iter->value.setValue && !g_variant_compare(iter->value.setValue.get(), parsedValue.get()))
+                continue;
+
+            iter->value.setValue = WTFMove(parsedValue);
+            g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(path.data()), path.data(), iter->value.setValue.get());
+        }
+    }
+
+    return TRUE;
+}
+
+/**
+ * wpe_settings_save_to_keyfile:
+ * @settings: a #WPESettings
+ * @keyfile: the keyfile to save settings to
+ *
+ * Adds settings to a keyfile. Keys are transformed into group names, for example:
+ * `/wpe-platform/fonts/hinting` will be saved as `hinting` in the group `wpe-platform/fonts`.
+ *
+ * Any existing values in the keyfile will be overwritten.
+ */
+void wpe_settings_save_to_keyfile(WPESettings* settingsObject, GKeyFile* keyFile)
+{
+    g_return_if_fail(WPE_IS_SETTINGS(settingsObject));
+    g_return_if_fail(keyFile);
+
+    for (auto& [key, entry] : settingsObject->priv->settings) {
+        if (!entry.setValue)
+            continue;
+
+        // Transform "/foo/bar/baz" into "foo/bar" and "baz".
+        GUniquePtr<char> keyString(g_strdup(key.data()));
+        auto* keyStart = strrchr(keyString.get(), '/');
+        ASSERT(keyStart && keyStart != keyString.get());
+        *keyStart = '\0';
+        keyStart++;
+
+        const char* group = keyString.get() + 1;
+        // FIXME: Handle empty?
+
+        GUniquePtr<char> variantString(g_variant_print(entry.setValue.get(), FALSE));
+        g_key_file_set_value(keyFile, group, keyStart, variantString.get());
+    }
+}
+
+/**
+ * wpe_settings_set_value:
+ * @settings: a #WPESettings
+ * @key: the key to set
+ * @value: (transfer floating) (nullable): the value to set or %NULL
+ * @source: the source of the settings change
+ * @error: return location for a #GError, or %NULL
+ *
+ * If @source is %WPE_SETTINGS_SOURCE_APPLICATION, then the value will not be overwritten by the platform.
+ * This value should always be %WPE_SETTINGS_SOURCE_PLATFORM for platforms themselves. This can cause this
+ * method to return %TRUE even though no setting changes.
+ *
+ * To set a value @key must have been registered and @value must be of the correct type.
+ *
+ * Any floating reference of @value will be consumed.
+ *
+ * Setting @value to %NULL will reset it to the default.
+ *
+ * On a value being changed it will emit [signal@WPESettings::changed].
+ *
+ * Returns: %FALSE if @error was set, %TRUE otherwise
+ */
+gboolean wpe_settings_set_value(WPESettings* settingsObject, const char* key, GVariant* value, WPESettingsSource source, GError** error)
+{
+    g_return_val_if_fail(WPE_IS_SETTINGS(settingsObject), FALSE);
+    g_return_val_if_fail(!error || !*error, FALSE);
+    g_return_val_if_fail(key && *key == '/', FALSE);
+
+    auto iter = settingsObject->priv->settings.find(key);
+    if (iter == settingsObject->priv->settings.end()) {
+        g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED, "Key %s not registered", key);
+        return FALSE;
+    }
+
+    if (iter->value.setByApplication && source != WPE_SETTINGS_SOURCE_APPLICATION)
+        return TRUE;
+
+    if (!value) {
+        auto previousValue = iter->value.setValue;
+        iter->value.setValue = nullptr;
+        iter->value.setByApplication = source == WPE_SETTINGS_SOURCE_APPLICATION;
+        if (previousValue && g_variant_compare(previousValue.get(), iter->value.defaultValue.get()))
+            g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(key), key, iter->value.value().get());
+        return TRUE;
+    }
+
+    if (!g_variant_type_equal(g_variant_get_type(value), iter->value.type.get())) {
+        g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INCORRECT_TYPE,
+            "Incorrect type (%s) for key %s", g_variant_get_type_string(value), key);
+        return FALSE;
+    }
+
+    auto previousValue = iter->value.value();
+    iter->value.setValue = value;
+    iter->value.setByApplication = source == WPE_SETTINGS_SOURCE_APPLICATION;
+
+    if (g_variant_compare(previousValue.get(), value))
+        g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(key), key, iter->value.value().get());
+
+    return TRUE;
+}
+
+/**
+ * wpe_settings_get_value:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError, or %NULL
+ *
+ * If the key is not registered it will return %NULL and set @error.
+ *
+ * Returns: (transfer none): the value associated with the given key.
+ */
+GVariant* wpe_settings_get_value(WPESettings* settingsObject, const char* key, GError** error)
+{
+    g_return_val_if_fail(WPE_IS_SETTINGS(settingsObject), NULL);
+    g_return_val_if_fail(key && *key == '/', NULL);
+
+    const auto iter = settingsObject->priv->settings.find(key);
+    if (iter == settingsObject->priv->settings.end()) {
+        g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED, "Key %s not registered", key);
+        return nullptr;
+    }
+
+    return iter->value.value().get();
+}
+
+#define g_variant_get_string(str) g_variant_get_string(str, nullptr)
+#define WPE_SETTINGS_HELPER_API(type, name, gvariant_type, retval) \
+    type wpe_settings_get_##name(WPESettings* settings, const char* key, GError** error) \
+    { \
+        GVariant* value = wpe_settings_get_value(settings, key, error); \
+        if (!value) \
+            return retval; \
+        if (!g_variant_type_equal(g_variant_get_type(value), gvariant_type)) { \
+            g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INCORRECT_TYPE, \
+                "Key is type %s, expected %s", g_variant_get_type_string(value), reinterpret_cast<const char*>(gvariant_type)); \
+            return retval; \
+        } \
+        return g_variant_get_##name(value); \
+    } \
+    gboolean wpe_settings_set_##name(WPESettings* settings, const char* key, type value, WPESettingsSource source, GError** error) \
+    { \
+        return wpe_settings_set_value(settings, key, g_variant_new_##name(value), source, error); \
+    }
+
+// Unfortunately the gobject-introspection parser doesn't like comments in macros.
+
+/**
+ * wpe_settings_set_int32:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_int32:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(gint32, int32, G_VARIANT_TYPE_INT32, 0)
+/**
+ * wpe_settings_set_int64:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_int64:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(gint64, int64, G_VARIANT_TYPE_INT64, 0)
+/**
+ * wpe_settings_set_uint32:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_uint32:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(guint32, uint32, G_VARIANT_TYPE_UINT32, 0)
+/**
+ * wpe_settings_set_uint64:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_uint64:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(guint64, uint64, G_VARIANT_TYPE_UINT64, 0)
+/**
+ * wpe_settings_set_boolean:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_boolean:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(gboolean, boolean, G_VARIANT_TYPE_BOOLEAN, FALSE)
+/**
+ * wpe_settings_set_string:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_string:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(const char*, string, G_VARIANT_TYPE_STRING, nullptr)
+/**
+ * wpe_settings_set_double:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @value: the value to set
+ * @source: the source of the settings change
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.set_value] that also validates
+ * the type.
+ */
+/**
+ * wpe_settings_get_double:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @error: return location for a #GError or %NULL
+ *
+ * This is a simple wrapper around [method@WPESettings.get_value] that also validates
+ * the return type.
+ */
+WPE_SETTINGS_HELPER_API(gdouble, double, G_VARIANT_TYPE_DOUBLE, 0.0)
+
+#undef WPE_SETTINGS_HELPER_API
+#undef g_variant_get_string

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+/**
+ * WPESettingsError:
+ * @WPE_SETTINGS_ERROR_INCORRECT_TYPE: Incorrect GVariantType for key
+ * @WPE_SETTINGS_ERROR_NOT_REGISTERED: Key has not been registered
+ * @WPE_SETTINGS_ERROR_ALREADY_REGISTERED: Key has already been registered
+ * @WPE_SETTINGS_ERROR_INVALID_VALUE: Failed to parse a value from a keyfile
+ * 
+ * #WPESettings errors
+ */
+typedef enum {
+    WPE_SETTINGS_ERROR_INCORRECT_TYPE,
+    WPE_SETTINGS_ERROR_NOT_REGISTERED,
+    WPE_SETTINGS_ERROR_ALREADY_REGISTERED,
+    WPE_SETTINGS_ERROR_INVALID_VALUE,
+} WPESettingsError;
+
+#define WPE_SETTINGS_ERROR (wpe_settings_error_quark())
+WPE_API GQuark wpe_settings_error_quark(void);
+
+/**
+ * WPESettingsSource:
+ * @WPE_SETTINGS_SOURCE_PLATFORM: Set by the platform
+ * @WPE_SETTINGS_SOURCE_APPLICATION: Set by the application
+ *
+ * Indicates the source of a settings change.
+ */
+typedef enum {
+    WPE_SETTINGS_SOURCE_PLATFORM,
+    WPE_SETTINGS_SOURCE_APPLICATION,
+} WPESettingsSource;
+
+#define WPE_TYPE_SETTINGS (wpe_settings_get_type())
+WPE_API G_DECLARE_FINAL_TYPE(WPESettings, wpe_settings, WPE, SETTINGS, GObject)
+
+
+WPE_API gboolean      wpe_settings_register                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   const GVariantType *type,
+                                                                   GVariant           *default_value,
+                                                                   GError            **error);
+
+WPE_API gboolean      wpe_settings_load_from_keyfile              (WPESettings        *settings,
+                                                                   GKeyFile           *keyfile,
+                                                                   GError            **error);
+
+WPE_API void         wpe_settings_save_to_keyfile                 (WPESettings        *settings,
+                                                                   GKeyFile           *keyfile);
+
+WPE_API gboolean     wpe_settings_set_value                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GVariant           *value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API GVariant    *wpe_settings_get_value                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API gint32       wpe_settings_get_int32                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API gint64       wpe_settings_get_int64                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API guint32      wpe_settings_get_uint32                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API guint64      wpe_settings_get_uint64                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API const char *wpe_settings_get_string                      (WPESettings        *settings,
+                                                                  const char         *key,
+                                                                  GError            **error);
+
+WPE_API gdouble      wpe_settings_get_double                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_get_boolean                     (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_int32                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   gint32              value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_int64                       (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   gint64              value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_uint32                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   guint32             value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_uint64                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   guint64             value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_string                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   const char         *value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_double                      (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   gdouble             value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+WPE_API gboolean     wpe_settings_set_boolean                     (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   gboolean            value,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
+G_END_DECLS
+

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -32,13 +32,13 @@ import flatpakutils
 from api_test_runner import TestRunner, add_options, get_runner_args
 
 class WPETestRunner(TestRunner):
-    TestRunner.TEST_TARGETS = [ "WPE", "WPEQt", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore" ]
+    TestRunner.TEST_TARGETS = [ "WPE", "WPEPlatform", "WPEQt", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore" ]
 
     def __init__(self, options, tests=[]):
         super(WPETestRunner, self).__init__("wpe", options, tests)
 
     def is_glib_test(self, test_program):
-        return os.path.basename(os.path.dirname(test_program)) in ["WPE"] or os.path.basename(test_program) in ["TestJSC"]
+        return os.path.basename(os.path.dirname(test_program)) in ["WPE", "WPEPlatform"] or os.path.basename(test_program) in ["TestJSC"]
 
     def is_google_test(self, test_program):
         return os.path.basename(test_program) in ["TestWebKit", "TestWTF", "TestWebCore"]

--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestSettings.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "TestMain.h"
+#include <glib.h>
+#include <wpe/WPESettings.h>
+#include <wtf/FileSystem.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+
+static void testSettingsRegistration(Test*, gconstpointer)
+{
+    GRefPtr<WPESettings> settings = adoptGRef(WPE_SETTINGS(g_object_new(WPE_TYPE_SETTINGS, nullptr)));
+    GUniqueOutPtr<GError> error;
+
+    // Cannot set an unregistered key.
+    GRefPtr<GVariant> someValue = g_variant_new_int32(42);
+    gboolean ret = wpe_settings_set_value(settings.get(), "/wpe-platform/non-existing-key", someValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, &error.outPtr());
+    g_assert_false(ret);
+    g_assert_error(error.get(), WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED);
+
+    // Can register new key.
+    g_assert_true(wpe_settings_register(settings.get(), "/wpe-platform/a-new-key", G_VARIANT_TYPE_INT32, someValue.get(), nullptr));
+
+    // Cannot re-register a key.
+    g_assert_false(wpe_settings_register(settings.get(), "/wpe-platform/a-new-key", G_VARIANT_TYPE_INT32, someValue.get(), nullptr));
+
+    // Default values are returned.
+    GVariant* value = wpe_settings_get_value(settings.get(), "/wpe-platform/a-new-key", nullptr);
+    g_assert_cmpvariant(value, someValue.get());
+
+    // Setting a registered key.
+    GRefPtr<GVariant> anotherValue = g_variant_new_int32(10000);
+    ret = wpe_settings_set_value(settings.get(), "/wpe-platform/a-new-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_true(ret);
+
+    // New value is returned.
+    value = wpe_settings_get_value(settings.get(), "/wpe-platform/a-new-key", nullptr);
+    g_assert_cmpvariant(value, anotherValue.get());
+
+    // Setting a value back to default.
+    ret = wpe_settings_set_value(settings.get(), "/wpe-platform/a-new-key", nullptr, WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_assert_true(ret);
+    value = wpe_settings_get_value(settings.get(), "/wpe-platform/a-new-key", nullptr);
+    g_assert_cmpvariant(value, someValue.get());
+
+    // Getting an unreigstered key.
+    value = wpe_settings_get_value(settings.get(), "/wpe-platform/non-existing-key", nullptr);
+    g_assert_null(value);
+
+    // Cannot set a value with a different type.
+    GRefPtr<GVariant> invalidValue = g_variant_new_string("invalid");
+    ret = wpe_settings_set_value(settings.get(), "/wpe-platform/a-new-key", invalidValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, &error.outPtr());
+    g_assert_false(ret);
+    g_assert_error(error.get(), WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INCORRECT_TYPE);
+
+    // Setting an application value overrules the platform value.
+    GVariant* applicationValue = g_variant_new_int32(71902379);
+    ret = wpe_settings_set_value(settings.get(), "/wpe-platform/a-new-key", applicationValue, WPE_SETTINGS_SOURCE_APPLICATION, nullptr);
+    g_assert_true(ret);
+    g_assert_cmpvariant(wpe_settings_get_value(settings.get(), "/wpe-platform/a-new-key", nullptr), applicationValue);
+    ret = wpe_settings_set_value(settings.get(), "/wpe-platform/a-new-key", someValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_assert_true(ret);
+    g_assert_cmpvariant(wpe_settings_get_value(settings.get(), "/wpe-platform/a-new-key", nullptr), applicationValue);
+}
+
+static void testSettingsSaveKeyFiles(Test*, gconstpointer)
+{
+    GRefPtr<WPESettings> settings = adoptGRef(WPE_SETTINGS(g_object_new(WPE_TYPE_SETTINGS, nullptr)));
+
+    GUniquePtr<GKeyFile> keyFile(g_key_file_new());
+    GRefPtr<GVariant> someValue = g_variant_new_int32(42);
+    GRefPtr<GVariant> anotherValue = g_variant_new_int32(10000);
+
+    wpe_settings_register(settings.get(), "/wpe-platform/a-new-key", G_VARIANT_TYPE_INT32, someValue.get(), nullptr);
+
+    // Default setings are not written.
+    wpe_settings_save_to_keyfile(settings.get(), keyFile.get());
+    g_assert_false(g_key_file_has_key(keyFile.get(), "wpe-platform", "a-new-key", nullptr));
+
+    // Non-default is written.
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-new-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    wpe_settings_save_to_keyfile(settings.get(), keyFile.get());
+    g_assert_true(g_key_file_has_key(keyFile.get(), "wpe-platform", "a-new-key", nullptr));
+}
+
+static void testSettingsLoadKeyFiles(Test*, gconstpointer)
+{
+    GRefPtr<WPESettings> settings = adoptGRef(WPE_SETTINGS(g_object_new(WPE_TYPE_SETTINGS, nullptr)));
+
+    GUniquePtr<GKeyFile> keyFile(g_key_file_new());
+    GRefPtr<GVariant> someValue = g_variant_new_int32(42);
+    GRefPtr<GVariant> anotherValue = g_variant_new_int32(10000);
+    GUniqueOutPtr<GError> error;
+    gboolean ret;
+
+    g_key_file_set_integer(keyFile.get(), "wpe-platform", "a-key", 42);
+
+    // Loading a key that has not been registered.
+    ret = wpe_settings_load_from_keyfile(settings.get(), keyFile.get(), &error.outPtr());
+    g_assert_error(error.get(), WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED);
+    g_assert_false(ret);
+
+    // Loading a registered key.
+    ret = wpe_settings_register(settings.get(), "/wpe-platform/a-key", G_VARIANT_TYPE_INT32, someValue.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_true(ret);
+    ret = wpe_settings_load_from_keyfile(settings.get(), keyFile.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_true(ret);
+    g_assert_cmpvariant(wpe_settings_get_value(settings.get(), "/wpe-platform/a-key", nullptr), someValue.get());
+
+    // Loading again overwrites values.
+    g_key_file_set_integer(keyFile.get(), "wpe-platform", "a-key", 10000);
+    ret = wpe_settings_load_from_keyfile(settings.get(), keyFile.get(), nullptr);
+    g_assert_true(ret);
+    g_assert_cmpvariant(wpe_settings_get_value(settings.get(), "/wpe-platform/a-key", nullptr), anotherValue.get());
+
+    // Loading a key with a different type.
+    g_key_file_set_string(keyFile.get(), "wpe-platform", "a-key", "'not-a-number'");
+    ret = wpe_settings_load_from_keyfile(settings.get(), keyFile.get(), &error.outPtr());
+    g_assert_error(error.get(), WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INVALID_VALUE);
+    g_assert_false(ret);
+}
+
+static void testSettingsChangedSignal(Test*, gconstpointer)
+{
+    GRefPtr<WPESettings> settings = adoptGRef(WPE_SETTINGS(g_object_new(WPE_TYPE_SETTINGS, nullptr)));
+    GRefPtr<GVariant> someValue = g_variant_new_int32(42);
+    GRefPtr<GVariant> anotherValue = g_variant_new_int32(10000);
+
+    wpe_settings_register(settings.get(), "/wpe-platform/a-key", G_VARIANT_TYPE_INT32, someValue.get(), nullptr);
+    wpe_settings_register(settings.get(), "/wpe-platform/another-key", G_VARIANT_TYPE_INT32, anotherValue.get(), nullptr);
+
+    // Changing a specific key.
+    int count = 0;
+    int handler = g_signal_connect(settings.get(), "changed::/wpe-platform/a-key", G_CALLBACK(+[](WPESettings*, const char* key, GVariant* value, int* count) {
+        g_assert_cmpstr(key, ==, "/wpe-platform/a-key");
+        g_assert_true(g_variant_type_equal(g_variant_get_type(value), G_VARIANT_TYPE_INT32));
+        g_assert_cmpint(g_variant_get_int32(value), ==, 12345);
+        (*count)++;
+    }), &count);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", g_variant_new_int32(12345), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_signal_handler_disconnect(settings.get(), handler);
+    g_assert_cmpint(count, ==, 1);
+
+    // Changing any key.
+    count = 0;
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", nullptr, WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/another--key", nullptr, WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    handler = g_signal_connect(settings.get(), "changed", G_CALLBACK(+[](WPESettings*, const char* key, GVariant* value, int* count) {
+        g_assert_true(g_str_has_prefix(key, "/wpe-platform/"));
+        g_assert_true(g_variant_type_equal(g_variant_get_type(value), G_VARIANT_TYPE_INT32));
+        (*count)++;
+    }), &count);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", g_variant_new_int32(12345), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/another-key", g_variant_new_int32(12345), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_signal_handler_disconnect(settings.get(), handler);
+    g_assert_cmpint(count, ==, 2);
+
+    // Resetting to default.
+    count = 0;
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    handler = g_signal_connect(settings.get(), "changed", G_CALLBACK(+[](WPESettings*, const char* key, GVariant* value, int* count) {
+        (*count)++;
+    }), &count);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", nullptr, WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_signal_handler_disconnect(settings.get(), handler);
+    g_assert_cmpint(count, ==, 1);
+
+    // Setting to the same value it already was.
+    count = 0;
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    handler = g_signal_connect(settings.get(), "changed", G_CALLBACK(+[](WPESettings*, const char* key, GVariant* value, int* count) {
+        (*count)++;
+    }), &count);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_signal_handler_disconnect(settings.get(), handler);
+    g_assert_cmpint(count, ==, 0);
+
+    // Setting it to a value equal to default.
+    count = 0;
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", nullptr, WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    handler = g_signal_connect(settings.get(), "changed", G_CALLBACK(+[](WPESettings*, const char* key, GVariant* value, int* count) {
+        (*count)++;
+    }), &count);
+    wpe_settings_set_value(settings.get(), "/wpe-platform/a-key", someValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_signal_handler_disconnect(settings.get(), handler);
+    g_assert_cmpint(count, ==, 0);
+
+    // Change on load.
+    count = 0;
+    GUniquePtr<GKeyFile> keyFile(g_key_file_new());
+    g_key_file_set_integer(keyFile.get(), "wpe-platform", "a-key", 12345);
+    handler = g_signal_connect(settings.get(), "changed::/wpe-platform/a-key", G_CALLBACK(+[](WPESettings*, const char* key, GVariant* value, int* count) {
+        g_assert_cmpstr(key, ==, "/wpe-platform/a-key");
+        g_assert_true(g_variant_type_equal(g_variant_get_type(value), G_VARIANT_TYPE_INT32));
+        g_assert_cmpint(g_variant_get_int32(value), ==, 12345);
+        (*count)++;
+    }), &count);
+    wpe_settings_load_from_keyfile(settings.get(), keyFile.get(), nullptr);
+    g_assert_cmpint(count, ==, 1);
+
+    // Unchanged on load
+    wpe_settings_load_from_keyfile(settings.get(), keyFile.get(), nullptr);
+    g_assert_cmpint(count, ==, 1);
+    g_signal_handler_disconnect(settings.get(), handler);
+}
+
+static void testSettingsHelperAPI(Test*, gconstpointer)
+{
+    GRefPtr<WPESettings> settings = adoptGRef(WPE_SETTINGS(g_object_new(WPE_TYPE_SETTINGS, nullptr)));
+
+    wpe_settings_register(settings.get(), "/wpe-platform/a-key", G_VARIANT_TYPE_INT32, g_variant_new_int32(42), nullptr);
+    GUniqueOutPtr<GError> error;
+
+    g_assert_true(wpe_settings_set_int32(settings.get(), "/wpe-platform/a-key", 12345, WPE_SETTINGS_SOURCE_PLATFORM, &error.outPtr()));
+    g_assert_no_error(error.get());
+    g_assert(wpe_settings_get_int32(settings.get(), "/wpe-platform/a-key", &error.outPtr()) == 12345);
+    g_assert_no_error(error.get());
+
+    g_assert_false(wpe_settings_set_string(settings.get(), "/wpe-platform/a-key", "invalid", WPE_SETTINGS_SOURCE_PLATFORM, &error.outPtr()));
+    g_assert_error(error.get(), WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INCORRECT_TYPE);
+}
+
+void beforeAll()
+{
+    Test::add("Settings", "registration", testSettingsRegistration);
+    Test::add("Settings", "save-key-files", testSettingsSaveKeyFiles);
+    Test::add("Settings", "load-key-files", testSettingsLoadKeyFiles);
+    Test::add("Settings", "changed-signal", testSettingsChangedSignal);
+    Test::add("Settings", "helper-api", testSettingsHelperAPI);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -123,6 +123,27 @@ if (COMPILER_IS_GCC_OR_CLANG)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WebKitGLibAPITestsCore -Wno-unused-parameter)
 endif ()
 
+if (ENABLE_WPE_PLATFORM)
+    add_executable(TestWPESettings
+        ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+        ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestSettings.cpp
+    )
+    target_link_libraries(TestWPESettings
+        ${WebKitGLibAPITest_LIBRARIES}
+        WPEPlatform-${WPE_API_VERSION}
+    )
+    target_include_directories(TestWPESettings PRIVATE
+        ${WebKitGLibAPITests_INCLUDE_DIRECTORIES}
+        ${WPEPlatform_DERIVED_SOURCES_DIR}
+        ${WEBKIT_DIR}/WPEPlatform
+    )
+    target_compile_definitions(TestWPESettings PRIVATE ${WebKitGLibAPITests_DEFINITIONS})
+    set_target_properties(TestWPESettings PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TestWebKitAPI/WPEPlatform)
+    if (COMPILER_IS_GCC_OR_CLANG)
+        WEBKIT_ADD_TARGET_CXX_FLAGS(TestWPESettings -Wno-unused-parameter)
+    endif ()
+endif ()
+
 GLIB_COMPILE_RESOURCES(
     OUTPUT        ${TEST_RESOURCES_DIR}/webkitglib-tests-resources.gresource
     RESOURCE_DIRS ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
#### f076fdf8692a441dce2b82f193b8976d4436d424
<pre>
[WPE] WPE Platform: Add WPESettings API
<a href="https://bugs.webkit.org/show_bug.cgi?id=280618">https://bugs.webkit.org/show_bug.cgi?id=280618</a>

Reviewed by Carlos Garcia Campos.

This adds an API to store generic settings similar to GSettings.

Each setting has a known type and default value.

These settings can be saved and loaded from key files.

* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_get_settings):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp: Added.
(SettingEntry::SettingEntry):
(SettingEntry::value const):
(wpe_settings_get_default):
(makeKeyPath):
(wpe_settings_register):
(wpe_settings_load_from_keyfile):
(wpe_settings_save_to_keyfile):
(wpe_settings_set_value):
(wpe_settings_get_value):
* Source/WebKit/WPEPlatform/wpe/WPESettings.h: Added.
* Tools/Scripts/run-wpe-tests:
(WPETestRunner):
(WPETestRunner.is_glib_test):
* Tools/TestWebKitAPI/Tests/WPEPlatform/TestSettings.cpp: Added.
(testSettingsRegistration):
(testSettingsSaveKeyFiles):
(testSettingsLoadKeyFiles):
(testSettingsChangedSignal):
(testSettingsHelperAPI):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/285702@main">https://commits.webkit.org/285702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d881aa2be6ab9f92e38f9c4944545d7d656731a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/61961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16124 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20633 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79287 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/719 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/223 "Found 2 new test failures: http/tests/paymentrequest/ApplePayModifier-automaticReloadPaymentRequest.https.html http/tests/ssl/applepay/ApplePayPaymentDetailsModifier.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65363 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7384 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11333 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3420 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->