### PR TITLE
[WPE] WPE Platform: add a connect method to WPEDisplayDRM to use a custom device file

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -231,7 +231,7 @@ static std::unique_ptr<WPE::DRM::Plane> choosePlaneForCrtc(int fd, WPE::DRM::Pla
     return nullptr;
 }
 
-static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
+static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* deviceName, GError** error)
 {
     RefPtr<struct udev> udev = adoptRef(udev_new());
     if (!udev) {
@@ -240,19 +240,28 @@ static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
     }
 
     auto session = WPE::DRM::Session::create();
-    auto displayDevice = findDevice(udev.get(), session->seatID());
-    if (displayDevice.isNull()) {
-        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "No suitable DRM device found");
-        return FALSE;
+    DisplayDevice displayDevice;
+    if (!deviceName) {
+        displayDevice = findDevice(udev.get(), session->seatID());
+        if (displayDevice.isNull()) {
+            g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "No suitable DRM device found");
+            return FALSE;
+        }
+    } else {
+        int fd = open(deviceName, O_RDWR | O_CLOEXEC);
+        if (fd < 0) {
+            g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Failed to open DRM device");
+            return FALSE;
+        }
+        WTF::UnixFileDescriptor unixFd(fd, WTF::UnixFileDescriptor::Adopt);
+        displayDevice = { deviceName, WTFMove(unixFd) };
     }
-
     auto fd = WTFMove(displayDevice.fd);
     if (drmSetMaster(fd.value()) == -1) {
         g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Failed to become DRM master");
         return FALSE;
     }
 
-    auto displayDRM = WPE_DISPLAY_DRM(display);
     if (!wpeDisplayDRMInitializeCapabilities(displayDRM, fd.value(), error))
         return FALSE;
 
@@ -303,6 +312,11 @@ static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
         displayDRM->priv->cursor = makeUnique<WPE::DRM::Cursor>(WTFMove(cursorPlane), device, displayDRM->priv->cursorWidth, displayDRM->priv->cursorHeight);
 
     return TRUE;
+}
+
+static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
+{
+    return wpeDisplayDRMSetup(WPE_DISPLAY_DRM(display), nullptr, error);
 }
 
 static WPEView* wpeDisplayDRMCreateView(WPEDisplay* display)
@@ -411,6 +425,23 @@ const WPE::DRM::Seat& wpeDisplayDRMGetSeat(WPEDisplayDRM* display)
 WPEDisplay* wpe_display_drm_new(void)
 {
     return WPE_DISPLAY(g_object_new(WPE_TYPE_DISPLAY_DRM, nullptr));
+}
+
+/**
+ * wpe_display_drm_connect:
+ * @display: a #WPEDisplayDRM
+ * @name: (nullable): the name of the DRM device to connect to, or %NULL
+ * @error: return location for error or %NULL to ignore
+ *
+ * Connect to the DRM device named @name. If @name is %NULL it
+ * connects to the default device.
+ *
+ * Returns: %TRUE if connection succeeded, or %FALSE in case of error.
+ */
+gboolean wpe_display_drm_connect(WPEDisplayDRM* display, const char* name, GError** error)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY_DRM(display), FALSE);
+    return wpeDisplayDRMSetup(display, name, error);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
@@ -41,6 +41,9 @@ G_BEGIN_DECLS
 WPE_API G_DECLARE_FINAL_TYPE (WPEDisplayDRM, wpe_display_drm, WPE, DISPLAY_DRM, WPEDisplay)
 
 WPE_API WPEDisplay         *wpe_display_drm_new                (void);
+WPE_API gboolean            wpe_display_drm_connect            (WPEDisplayDRM *display,
+                                                                const char    *name,
+                                                                GError       **error);
 WPE_API struct gbm_device  *wpe_display_drm_get_device         (WPEDisplayDRM *display);
 WPE_API gboolean            wpe_display_drm_supports_atomic    (WPEDisplayDRM *display);
 WPE_API gboolean            wpe_display_drm_supports_modifiers (WPEDisplayDRM *display);


### PR DESCRIPTION
#### f98baf30b97d9a1b2abedcf66839b950a959bb50
<pre>
[WPE] WPE Platform: add a connect method to WPEDisplayDRM to use a custom device file
<a href="https://bugs.webkit.org/show_bug.cgi?id=265654">https://bugs.webkit.org/show_bug.cgi?id=265654</a>

Reviewed by Carlos Garcia Campos.

Adding a wpe_display_drm_connect() to the DRM platform&apos;s API, so that
the DRM device to connect to may be specified by the device name.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMSetup): a setup function to be called by the two functions
below
(wpeDisplayDRMConnect):
(wpe_display_drm_connect):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h:

Canonical link: <a href="https://commits.webkit.org/285545@main">https://commits.webkit.org/285545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29dec7bd6c70a9f363147bc1823c59a935e25547

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23974 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/57376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15822 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43977 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22491 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78827 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17170 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62777 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/65105 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13370 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests running") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7039 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11232 "Built successfully and passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48147 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2940 "Built successfully") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->