### PR TITLE
Adopt more smart pointers in GPUProcess/media (part 1)

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -57,12 +57,12 @@ RemoteCDMInstanceProxy::RemoteCDMInstanceProxy(RemoteCDMProxy& cdm, Ref<CDMInsta
     , m_logIdentifier(cdm.logIdentifier())
 #endif
 {
-    m_instance->setClient(*this);
+    protectedInstance()->setClient(*this);
 }
 
 RemoteCDMInstanceProxy::~RemoteCDMInstanceProxy()
 {
-    m_instance->clearClient();
+    protectedInstance()->clearClient();
 }
 
 void RemoteCDMInstanceProxy::unrequestedInitializationDataReceived(const String& type, Ref<SharedBuffer>&& initData)
@@ -83,12 +83,12 @@ void RemoteCDMInstanceProxy::unrequestedInitializationDataReceived(const String&
 
 void RemoteCDMInstanceProxy::initializeWithConfiguration(const WebCore::CDMKeySystemConfiguration& configuration, AllowDistinctiveIdentifiers allowDistinctiveIdentifiers, AllowPersistentState allowPersistentState, CompletionHandler<void(SuccessValue)>&& completion)
 {
-    m_instance->initializeWithConfiguration(configuration, allowDistinctiveIdentifiers, allowPersistentState, WTFMove(completion));
+    protectedInstance()->initializeWithConfiguration(configuration, allowDistinctiveIdentifiers, allowPersistentState, WTFMove(completion));
 }
 
 void RemoteCDMInstanceProxy::setServerCertificate(Ref<SharedBuffer>&& certificate, CompletionHandler<void(SuccessValue)>&& completion)
 {
-    m_instance->setServerCertificate(WTFMove(certificate), WTFMove(completion));
+    protectedInstance()->setServerCertificate(WTFMove(certificate), WTFMove(completion));
 }
 
 void RemoteCDMInstanceProxy::setStorageDirectory(const String& directory)
@@ -105,12 +105,12 @@ void RemoteCDMInstanceProxy::setStorageDirectory(const String& directory)
         return;
 
     if (directory.startsWith(mediaKeysStorageDirectory))
-        m_instance->setStorageDirectory(directory);
+        protectedInstance()->setStorageDirectory(directory);
 }
 
 void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHandler<void(const RemoteCDMInstanceSessionIdentifier&)>&& completion)
 {
-    auto privSession = m_instance->createSession();
+    auto privSession = protectedInstance()->createSession();
     if (!privSession || !m_cdm || !m_cdm->factory()) {
         completion({ });
         return;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -97,7 +97,7 @@ RefPtr<MediaPlayer> RemoteLegacyCDMProxy::cdmMediaPlayer(const LegacyCDM*) const
 
 const SharedPreferencesForWebProcess& RemoteLegacyCDMProxy::sharedPreferencesForWebProcess() const
 {
-    return m_factory->sharedPreferencesForWebProcess();
+    return protectedFactory()->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -51,6 +51,8 @@ private:
     friend class RemoteLegacyCDMFactoryProxy;
     RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&&, WebCore::MediaPlayerIdentifier&&, std::unique_ptr<WebCore::LegacyCDM>&&);
 
+    RefPtr<RemoteLegacyCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -68,8 +68,8 @@ void RemoteMediaSourceProxy::setMediaPlayers(RemoteMediaPlayerProxy& remoteMedia
     m_remoteMediaPlayerProxy = remoteMediaPlayerProxy;
     for (auto& sourceBuffer : m_sourceBuffers)
         sourceBuffer->setMediaPlayer(remoteMediaPlayerProxy);
-    if (m_private)
-        m_private->setPlayer(mediaPlayerPrivate);
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->setPlayer(mediaPlayerPrivate);
 }
 
 void RemoteMediaSourceProxy::disconnect()
@@ -128,7 +128,7 @@ void RemoteMediaSourceProxy::addSourceBuffer(const WebCore::ContentType& content
         return;
 
     RefPtr<SourceBufferPrivate> sourceBufferPrivate;
-    MediaSourcePrivate::AddStatus status = m_private->addSourceBuffer(contentType, m_webMParserEnabled, sourceBufferPrivate);
+    MediaSourcePrivate::AddStatus status = mediaSourcePrivate()->addSourceBuffer(contentType, m_webMParserEnabled, sourceBufferPrivate);
 
     std::optional<RemoteSourceBufferIdentifier> remoteSourceIdentifier;
     if (status == MediaSourcePrivate::AddStatus::Ok) {
@@ -144,39 +144,39 @@ void RemoteMediaSourceProxy::addSourceBuffer(const WebCore::ContentType& content
 
 void RemoteMediaSourceProxy::durationChanged(const MediaTime& duration)
 {
-    if (m_private)
-        m_private->durationChanged(duration);
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->durationChanged(duration);
 }
 
 void RemoteMediaSourceProxy::bufferedChanged(WebCore::PlatformTimeRanges&& buffered)
 {
-    if (m_private)
-        m_private->bufferedChanged(WTFMove(buffered));
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->bufferedChanged(WTFMove(buffered));
 }
 
 void RemoteMediaSourceProxy::markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status )
 {
-    if (m_private)
-        m_private->markEndOfStream(status);
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->markEndOfStream(status);
 }
 
 void RemoteMediaSourceProxy::unmarkEndOfStream()
 {
-    if (m_private)
-        m_private->unmarkEndOfStream();
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->unmarkEndOfStream();
 }
 
 
 void RemoteMediaSourceProxy::setMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
 {
-    if (m_private)
-        m_private->setMediaPlayerReadyState(readyState);
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->setMediaPlayerReadyState(readyState);
 }
 
 void RemoteMediaSourceProxy::setTimeFudgeFactor(const MediaTime& fudgeFactor)
 {
-    if (m_private)
-        m_private->setTimeFudgeFactor(fudgeFactor);
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->setTimeFudgeFactor(fudgeFactor);
 }
 
 void RemoteMediaSourceProxy::attached()
@@ -189,7 +189,7 @@ void RemoteMediaSourceProxy::shutdown()
 
     disconnect();
 
-    if (auto* manager = m_manager.get())
+    if (RefPtr manager = m_manager.get())
         manager->invalidateMediaSource(m_identifier);
 }
 
@@ -197,7 +197,7 @@ RefPtr<GPUConnectionToWebProcess> RemoteMediaSourceProxy::connectionToWebProcess
 {
     ASSERT(RunLoop::isMain());
 
-    auto* manager = m_manager.get();
+    RefPtr manager = m_manager.get();
     return manager ? manager->gpuConnectionToWebProcess() : nullptr;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -59,6 +59,8 @@ public:
 private:
     explicit RemoteVideoFrameObjectHeap(Ref<IPC::Connection>&&);
 
+    Ref<IPC::Connection> protectedConnection() const { return m_connection; }
+
     // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
@@ -49,8 +49,10 @@ public:
     ~RemoteVideoFrameObjectHeapProxy() = default;
 
 #if PLATFORM(COCOA)
-    void getVideoFrameBuffer(const RemoteVideoFrameProxy& proxy, bool canUseIOSurface, RemoteVideoFrameObjectHeapProxyProcessor::Callback&& callback) { m_processor->getVideoFrameBuffer(proxy, canUseIOSurface, WTFMove(callback)); }
-    RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame& frame)  { return m_processor->getNativeImage(frame); }
+    Ref<RemoteVideoFrameObjectHeapProxyProcessor> protectedProcessor() { return m_processor; }
+
+    void getVideoFrameBuffer(const RemoteVideoFrameProxy& proxy, bool canUseIOSurface, RemoteVideoFrameObjectHeapProxyProcessor::Callback&& callback) { protectedProcessor()->getVideoFrameBuffer(proxy, canUseIOSurface, WTFMove(callback)); }
+    RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame& frame) { return protectedProcessor()->getNativeImage(frame); }
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -68,7 +68,8 @@ void RemoteVideoFrameObjectHeapProxyProcessor::initialize()
         Locker lock(m_connectionLock);
         connection = m_connection;
     }
-    connection->addWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeapProxyProcessor::messageReceiverName(), m_queue, *this);
+
+    connection->addWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeapProxyProcessor::messageReceiverName(), protectedQueue(), *this);
 }
 
 void RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
@@ -90,7 +91,7 @@ void RemoteVideoFrameObjectHeapProxyProcessor::clearCallbacks()
         callbacks = std::exchange(m_callbacks, { });
     }
 
-    m_queue->dispatch([queue = m_queue, callbacks = WTFMove(callbacks)]() mutable {
+    protectedQueue()->dispatch([queue = m_queue, callbacks = WTFMove(callbacks)]() mutable {
         for (auto& callback : callbacks.values())
             callback({ });
     });

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -86,7 +86,8 @@ private:
     void clearCallbacks();
     Callback takeCallback(RemoteVideoFrameIdentifier);
 
-private:
+    Ref<WorkQueue> protectedQueue() const { return m_queue; }
+
     Lock m_connectionLock;
     RefPtr<IPC::Connection> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
     Lock m_callbacksLock;


### PR DESCRIPTION
#### 0edb1455f0f997c444242dfc4d4043ce99fbe7d7
<pre>
Adopt more smart pointers in GPUProcess/media (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280628">https://bugs.webkit.org/show_bug.cgi?id=280628</a>
<a href="https://rdar.apple.com/136985413">rdar://136985413</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::RemoteCDMInstanceProxy):
(WebKit::RemoteCDMInstanceProxy::~RemoteCDMInstanceProxy):
(WebKit::RemoteCDMInstanceProxy::initializeWithConfiguration):
(WebKit::RemoteCDMInstanceProxy::setServerCertificate):
(WebKit::RemoteCDMInstanceProxy::setStorageDirectory):
(WebKit::RemoteCDMInstanceProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
(WebKit::RemoteLegacyCDMProxy::protectedFactory const):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::setMediaPlayers):
(WebKit::RemoteMediaSourceProxy::addSourceBuffer):
(WebKit::RemoteMediaSourceProxy::durationChanged):
(WebKit::RemoteMediaSourceProxy::bufferedChanged):
(WebKit::RemoteMediaSourceProxy::markEndOfStream):
(WebKit::RemoteMediaSourceProxy::unmarkEndOfStream):
(WebKit::RemoteMediaSourceProxy::setMediaPlayerReadyState):
(WebKit::RemoteMediaSourceProxy::setTimeFudgeFactor):
(WebKit::RemoteMediaSourceProxy::shutdown):
(WebKit::RemoteMediaSourceProxy::connectionToWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::create):
(WebKit::RemoteVideoFrameObjectHeap::close):
(WebKit::RemoteVideoFrameObjectHeap::getVideoFrameBuffer):
(WebKit::RemoteVideoFrameObjectHeap::convertFrameBuffer):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h:
(WebKit::RemoteVideoFrameObjectHeapProxy::protectedProcessor):
(WebKit::RemoteVideoFrameObjectHeapProxy::getVideoFrameBuffer):
(WebKit::RemoteVideoFrameObjectHeapProxy::getNativeImage):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::initialize):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::clearCallbacks):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::protectedQueue const):

Canonical link: <a href="https://commits.webkit.org/284509@main">https://commits.webkit.org/284509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8786a3749d44d35b2402063dc016ad61a17ef577

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20702 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71661 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55289 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41302 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19079 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75339 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4519 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44748 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->