### PR TITLE
Annotate Geolocation API message endpoints with feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3115,6 +3115,20 @@ GenericCueAPIEnabled:
     WebCore:
       default: false
 
+GeolocationAPIEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "Geolocation API"
+  humanReadableDescription: "Enable Geolocation API"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+  sharedPreferenceForWebProcess: true
+
 GetCoalescedEventsEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/Modules/geolocation/Geolocation.idl
+++ b/Source/WebCore/Modules/geolocation/Geolocation.idl
@@ -26,7 +26,8 @@
 // https://w3c.github.io/geolocation-api/#navigator_interface
 [
     ActiveDOMObject,
-    Conditional=GEOLOCATION, 
+    Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     GenerateIsReachable=ReachableFromNavigator,
     Exposed=Window
 ] interface Geolocation {

--- a/Source/WebCore/Modules/geolocation/GeolocationCoordinates.idl
+++ b/Source/WebCore/Modules/geolocation/GeolocationCoordinates.idl
@@ -27,6 +27,7 @@
 // FIXME: The current standard says this should be annotated with 'SecureContext'.
 [
     Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     Exposed=Window
 ] interface GeolocationCoordinates {
     readonly attribute unrestricted double latitude;

--- a/Source/WebCore/Modules/geolocation/GeolocationPosition.idl
+++ b/Source/WebCore/Modules/geolocation/GeolocationPosition.idl
@@ -27,6 +27,7 @@
 // FIXME: The current standard says this should be annotated with 'SecureContext'.
 [
     Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     Exposed=Window
 ] interface GeolocationPosition {
     readonly attribute GeolocationCoordinates coords;

--- a/Source/WebCore/Modules/geolocation/GeolocationPositionError.idl
+++ b/Source/WebCore/Modules/geolocation/GeolocationPositionError.idl
@@ -26,6 +26,7 @@
 // https://w3c.github.io/geolocation-api/#position_error_interface
 [
     Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     Exposed=Window
 ] interface GeolocationPositionError {
     const unsigned short PERMISSION_DENIED = 1;

--- a/Source/WebCore/Modules/geolocation/Navigator+Geolocation.idl
+++ b/Source/WebCore/Modules/geolocation/Navigator+Geolocation.idl
@@ -20,6 +20,7 @@
 // https://w3c.github.io/geolocation-api/#navigator_interface
 [
     Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     ImplementedBy=NavigatorGeolocation
 ] partial interface Navigator {
     readonly attribute Geolocation geolocation;

--- a/Source/WebCore/Modules/geolocation/PositionCallback.idl
+++ b/Source/WebCore/Modules/geolocation/PositionCallback.idl
@@ -24,5 +24,6 @@
 
 [
     Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     GenerateIsReachable=ImplScriptExecutionContext
 ] callback PositionCallback = undefined (GeolocationPosition? position); // FIXME: This should not be nullable.

--- a/Source/WebCore/Modules/geolocation/PositionErrorCallback.idl
+++ b/Source/WebCore/Modules/geolocation/PositionErrorCallback.idl
@@ -24,5 +24,6 @@
 
 [
     Conditional=GEOLOCATION,
+    EnabledBySetting=GeolocationAPIEnabled,
     GenerateIsReachable=ImplScriptExecutionContext
 ] callback PositionErrorCallback = undefined (GeolocationPositionError error);

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -252,6 +252,10 @@ namespace WebCore {
     macro(GamepadButton) \
     macro(GamepadEvent) \
     macro(GamepadHapticActuator) \
+    macro(Geolocation) \
+    macro(GeolocationCoordinates) \
+    macro(GeolocationPosition) \
+    macro(GeolocationPositionError) \
     macro(HighlightRegistry) \
     macro(Highlight) \
     macro(HTMLAttachmentElement) \

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -92,6 +92,11 @@ void WebGeolocationManagerProxy::webProcessIsGoingAway(WebProcessProxy& proxy)
         stopUpdatingWithProxy(proxy, registrableDomain);
 }
 
+const SharedPreferencesForWebProcess& WebGeolocationManagerProxy::sharedPreferencesForWebProcess(IPC::Connection& connection) const
+{
+    return connectionToWebProcessProxy(connection)->sharedPreferencesForWebProcess();
+}
+
 void WebGeolocationManagerProxy::refWebContextSupplement()
 {
     API::Object::ref();

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
@@ -72,6 +72,7 @@ public:
     using API::Object::deref;
 
     void webProcessIsGoingAway(WebProcessProxy&);
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess(IPC::Connection&) const;
 
 private:
     explicit WebGeolocationManagerProxy(WebProcessPool*);

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in
@@ -20,8 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[SharedPreferencesNeedsConnection]
 messages -> WebGeolocationManagerProxy {
-    StartUpdating(WebCore::RegistrableDomain registrableDomain, WebKit::WebPageProxyIdentifier pageProxyID, String authorizationToken, bool enableHighAccuracy)
-    StopUpdating(WebCore::RegistrableDomain registrableDomain)
-    SetEnableHighAccuracy(WebCore::RegistrableDomain registrableDomain, bool enabled)
+    [EnabledBy=GeolocationAPIEnabled] StartUpdating(WebCore::RegistrableDomain registrableDomain, WebKit::WebPageProxyIdentifier pageProxyID, String authorizationToken, bool enableHighAccuracy)
+    [EnabledBy=GeolocationAPIEnabled] StopUpdating(WebCore::RegistrableDomain registrableDomain)
+    [EnabledBy=GeolocationAPIEnabled] SetEnableHighAccuracy(WebCore::RegistrableDomain registrableDomain, bool enabled)
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -279,8 +279,8 @@ messages -> WebPageProxy {
     ExceededDatabaseQuota(WebCore::FrameIdentifier frameID, String originIdentifier, String databaseName, String databaseDisplayName, uint64_t currentQuota, uint64_t currentOriginUsage, uint64_t currentDatabaseUsage, uint64_t expectedUsage) -> (uint64_t newQuota) Synchronous
 
     # Geolocation messages
-    RequestGeolocationPermissionForFrame(WebKit::GeolocationIdentifier geolocationID, struct WebKit::FrameInfoData frameInfo)
-    RevokeGeolocationAuthorizationToken(String authorizationToken);
+    [EnabledBy=GeolocationAPIEnabled] RequestGeolocationPermissionForFrame(WebKit::GeolocationIdentifier geolocationID, struct WebKit::FrameInfoData frameInfo)
+    [EnabledBy=GeolocationAPIEnabled] RevokeGeolocationAuthorizationToken(String authorizationToken);
 
 #if ENABLE(MEDIA_STREAM)
     # MediaSteam messages


### PR DESCRIPTION
#### ddf215bacf0c0f8dc35c5e26921dd2472acd8aac
<pre>
Annotate Geolocation API message endpoints with feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=280633">https://bugs.webkit.org/show_bug.cgi?id=280633</a>
<a href="https://rdar.apple.com/136993653">rdar://136993653</a>

Reviewed by Ryosuke Niwa.

Add a feature flag for Geolocation API (enabled by default) and annotate message endpoints with it.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/geolocation/Geolocation.idl:
* Source/WebCore/Modules/geolocation/GeolocationCoordinates.idl:
* Source/WebCore/Modules/geolocation/GeolocationPosition.idl:
* Source/WebCore/Modules/geolocation/GeolocationPositionError.idl:
* Source/WebCore/Modules/geolocation/Navigator+Geolocation.idl:
* Source/WebCore/Modules/geolocation/PositionCallback.idl:
* Source/WebCore/Modules/geolocation/PositionErrorCallback.idl:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.h:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/284484@main">https://commits.webkit.org/284484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad9ed852361b821c4cb0f6c6fe2665ffcc3c7793

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41273 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17431 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19032 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62613 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75292 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68743 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62936 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4481 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44701 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16061 "Found 2 new JSC binary failures: testapi, testb3, Found 98 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/instanceof-operator.js.layout ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->