### PR TITLE
[GTK][WPE] Clicking 'Run Benchmark' button on MotionMark 1.3(.1) developer.html asserts with threaded CPU rendering

### DIFF
--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -38,7 +38,7 @@ ControlPart::ControlPart(StyleAppearance type)
 
 ControlFactory& ControlPart::controlFactory() const
 {
-    return m_controlFactory ? *m_controlFactory : ControlFactory::shared();
+    return m_overrideControlFactory ? *m_overrideControlFactory : ControlFactory::shared();
 }
 
 PlatformControl* ControlPart::platformControl() const

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -44,7 +44,7 @@ public:
     StyleAppearance type() const { return m_type; }
 
     WEBCORE_EXPORT ControlFactory& controlFactory() const;
-    void setControlFactory(ControlFactory& controlFactory) { m_controlFactory = &controlFactory; }
+    void setOverrideControlFactory(ControlFactory* controlFactory) { m_overrideControlFactory = controlFactory; }
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&);
@@ -60,6 +60,7 @@ protected:
 
     mutable std::unique_ptr<PlatformControl> m_platformControl;
     RefPtr<ControlFactory> m_controlFactory;
+    ControlFactory* m_overrideControlFactory { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -852,8 +852,9 @@ DrawControlPart::DrawControlPart(ControlPart& part, const FloatRoundedRect& bord
 
 void DrawControlPart::apply(GraphicsContext& context, ControlFactory& controlFactory) const
 {
-    m_part->setControlFactory(controlFactory);
+    m_part->setOverrideControlFactory(&controlFactory);
     context.drawControlPart(m_part, m_borderRect, m_deviceScaleFactor, m_style);
+    m_part->setOverrideControlFactory(nullptr);
 }
 
 void DrawControlPart::dump(TextStream& ts, OptionSet<AsTextFlag>) const


### PR DESCRIPTION
#### 0405c02b6c3eed1cb46e79fee8ac50fced5296d1
<pre>
[GTK][WPE] Clicking &apos;Run Benchmark&apos; button on MotionMark 1.3(.1) developer.html asserts with threaded CPU rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=280629">https://bugs.webkit.org/show_bug.cgi?id=280629</a>

Reviewed by Said Abou-Hallawa.

If a DisplayList is recorded in the Gtk/WPE ports, a ControlFactory is
created on the main thread (ControlFactory::shared()) that is used for
drawing control parts (such as a ToggleButtonPart).

In the threaded CPU rendering mode, we replay such a DisplayList in a
secondary thread. However, we cannot use the same ControlFactory, but
need to allocate a per-thread ControlFactory, since the
ControlFactory::shared() is MainThreadNeverDestroyed, and thus only
allows accesses from the main thread.

The ControlFactory we pass to the display list replaying mechanism, is
then stored in RefPtr&lt;ControlFactory&gt; in ControlPart -- in our case a
ControlFactory from the secondary thread is now stored in ControlPart.
Upon render tree destruction (tearDownRenderers()) we end up trying to
deref() a worker-thread owned ControlFactory, from the main thread,
which fires an assertion, since ControlFactory is not thread-safe.

Fix that, by only overriding the ControlFactory temporarily, when
handling a DrawControlPart display list item, and immediately reset it
again after usage, to avoid that situation.

Covered by existing tests.

* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::controlFactory const):
* Source/WebCore/platform/graphics/controls/ControlPart.h:
(WebCore::ControlPart::setOverrideControlFactory):
(WebCore::ControlPart::setControlFactory): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawControlPart::apply const):

Canonical link: <a href="https://commits.webkit.org/284485@main">https://commits.webkit.org/284485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e41bbee8e3ab9d496f4e6349112a7d68ccff9f10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20596 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13780 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44674 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35797 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69096 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41340 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63275 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75382 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13569 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13609 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/60146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10925 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44791 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45865 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->