### PR TITLE
Adopt more smart pointers in GPUProcess/media (part 2)

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<RemoteCDMInstanceSessionProxy> RemoteCDMInstanceSessionProxy::cr
 {
     auto sessionProxy = std::unique_ptr<RemoteCDMInstanceSessionProxy>(new RemoteCDMInstanceSessionProxy(WTFMove(proxy), WTFMove(session), logIdentifier, identifier));
     WeakPtr<WebCore::CDMInstanceSessionClient> client = sessionProxy.get();
-    sessionProxy->m_session->setClient(WTFMove(client));
+    sessionProxy->protectedSession()->setClient(WTFMove(client));
     return sessionProxy;
 }
 
@@ -60,7 +60,7 @@ RemoteCDMInstanceSessionProxy::~RemoteCDMInstanceSessionProxy()
 void RemoteCDMInstanceSessionProxy::setLogIdentifier(uint64_t logIdentifier)
 {
 #if !RELEASE_LOG_DISABLED
-    m_session->setLogIdentifier(logIdentifier);
+    protectedSession()->setLogIdentifier(logIdentifier);
 #else
     UNUSED_PARAM(logIdentifier);
 #endif
@@ -79,7 +79,7 @@ void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGrouping
         return;
     }
 
-    m_session->requestLicense(type, keyGroupingStrategy, initDataType, initData.releaseNonNull(), [completion = WTFMove(completion)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
+    protectedSession()->requestLicense(type, keyGroupingStrategy, initDataType, initData.releaseNonNull(), [completion = WTFMove(completion)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
         completion(WTFMove(message), sessionId, needsIndividualization, succeeded == CDMInstanceSession::Succeeded);
     });
 }
@@ -98,7 +98,7 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
         return;
     }
 
-    m_session->updateLicense(sessionId, type, sanitizedResponse.releaseNonNull(), [completion = WTFMove(completion)] (bool sessionClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
+    protectedSession()->updateLicense(sessionId, type, sanitizedResponse.releaseNonNull(), [completion = WTFMove(completion)] (bool sessionClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
         completion(sessionClosed, WTFMove(keyStatuses), WTFMove(expirationTime), WTFMove(message), succeeded == CDMInstanceSession::Succeeded);
     });
 }
@@ -112,26 +112,28 @@ void RemoteCDMInstanceSessionProxy::loadSession(LicenseType type, String session
         return;
     }
 
-    m_session->loadSession(type, *sanitizedSessionId, origin, [completion = WTFMove(completion)] (std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+    protectedSession()->loadSession(type, *sanitizedSessionId, origin, [completion = WTFMove(completion)] (std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
         completion(WTFMove(keyStatuses), WTFMove(expirationTime), WTFMove(message), succeeded == CDMInstanceSession::Succeeded, failure);
     });
 }
 
 void RemoteCDMInstanceSessionProxy::closeSession(const String& sessionId, CloseSessionCallback&& completion)
 {
-    m_session->closeSession(sessionId, [completion = WTFMove(completion)] () mutable { completion(); });
+    protectedSession()->closeSession(sessionId, [completion = WTFMove(completion)] () mutable {
+        completion();
+    });
 }
 
 void RemoteCDMInstanceSessionProxy::removeSessionData(const String& sessionId, LicenseType type, RemoveSessionDataCallback&& completion)
 {
-    m_session->removeSessionData(sessionId, type, [completion = WTFMove(completion)] (CDMInstanceSession::KeyStatusVector&& keyStatuses, RefPtr<SharedBuffer>&& expiredSessionsData, CDMInstanceSession::SuccessValue succeeded) mutable {
+    protectedSession()->removeSessionData(sessionId, type, [completion = WTFMove(completion)] (CDMInstanceSession::KeyStatusVector&& keyStatuses, RefPtr<SharedBuffer>&& expiredSessionsData, CDMInstanceSession::SuccessValue succeeded) mutable {
         completion(WTFMove(keyStatuses), WTFMove(expiredSessionsData), succeeded == CDMInstanceSession::Succeeded);
     });
 }
 
 void RemoteCDMInstanceSessionProxy::storeRecordOfKeyUsage(const String& sessionId)
 {
-    m_session->storeRecordOfKeyUsage(sessionId);
+    protectedSession()->storeRecordOfKeyUsage(sessionId);
 }
 
 void RemoteCDMInstanceSessionProxy::updateKeyStatuses(KeyStatusVector&& keyStatuses)
@@ -139,7 +141,7 @@ void RemoteCDMInstanceSessionProxy::updateKeyStatuses(KeyStatusVector&& keyStatu
     if (!m_cdm)
         return;
 
-    auto* factory = m_cdm->factory();
+    RefPtr factory = m_cdm->factory();
     if (!factory)
         return;
 
@@ -154,7 +156,8 @@ void RemoteCDMInstanceSessionProxy::sendMessage(CDMMessageType type, Ref<SharedB
 {
     if (!m_cdm)
         return;
-    auto* factory = m_cdm->factory();
+
+    RefPtr factory = m_cdm->factory();
     if (!factory)
         return;
 
@@ -170,7 +173,7 @@ void RemoteCDMInstanceSessionProxy::sessionIdChanged(const String& sessionId)
     if (!m_cdm)
         return;
 
-    auto* factory = m_cdm->factory();
+    RefPtr factory = m_cdm->factory();
     if (!factory)
         return;
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -83,6 +83,7 @@ private:
     PlatformDisplayID displayID() final { return m_displayID; }
 
     RefPtr<RemoteCDMProxy> protectedCdm() const;
+    Ref<WebCore::CDMInstanceSession> protectedSession() const { return m_session; }
 
     WeakPtr<RemoteCDMProxy> m_cdm;
     Ref<WebCore::CDMInstanceSession> m_session;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -153,10 +153,11 @@ void RemoteLegacyCDMSessionProxy::cachedKeyForKeyID(String keyId, CachedKeyForKe
 
 void RemoteLegacyCDMSessionProxy::sendMessage(Uint8Array* message, String destinationURL)
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return;
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return;
 
@@ -165,10 +166,11 @@ void RemoteLegacyCDMSessionProxy::sendMessage(Uint8Array* message, String destin
 
 void RemoteLegacyCDMSessionProxy::sendError(MediaKeyErrorCode errorCode, uint32_t systemCode)
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return;
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return;
 
@@ -177,10 +179,11 @@ void RemoteLegacyCDMSessionProxy::sendError(MediaKeyErrorCode errorCode, uint32_
 
 String RemoteLegacyCDMSessionProxy::mediaKeysStorageDirectory() const
 {
-    if (!m_factory)
+    RefPtr factory = m_factory.get();
+    if (!factory)
         return emptyString();
 
-    RefPtr gpuConnectionToWebProcess = m_factory->gpuConnectionToWebProcess();
+    RefPtr gpuConnectionToWebProcess = factory->gpuConnectionToWebProcess();
     if (!gpuConnectionToWebProcess)
         return emptyString();
 
@@ -196,7 +199,7 @@ WTFLogChannel& RemoteLegacyCDMSessionProxy::logChannel() const
 
 const SharedPreferencesForWebProcess& RemoteLegacyCDMSessionProxy::sharedPreferencesForWebProcess() const
 {
-    return m_factory->sharedPreferencesForWebProcess();
+    return protectedFactory()->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -64,6 +64,8 @@ private:
     friend class RemoteLegacyCDMFactoryProxy;
     RemoteLegacyCDMSessionProxy(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
 
+    RefPtr<RemoteLegacyCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -71,16 +71,19 @@ void RemoteMediaResourceManager::stopListeningForIPC()
 void RemoteMediaResourceManager::initializeConnection(IPC::Connection* connection)
 {
     assertIsMainThread();
-    if (m_connection == connection)
+
+    RefPtr protectedConnection = m_connection;
+    if (protectedConnection == connection)
         return;
 
-    if (m_connection)
-        m_connection->removeWorkQueueMessageReceiver(Messages::RemoteMediaResourceManager::messageReceiverName());
+    if (protectedConnection)
+        protectedConnection->removeWorkQueueMessageReceiver(Messages::RemoteMediaResourceManager::messageReceiverName());
 
     m_connection = connection;
+    protectedConnection = m_connection;
 
-    if (m_connection)
-        m_connection->addWorkQueueMessageReceiver(Messages::RemoteMediaResourceManager::messageReceiverName(), RemoteMediaResourceLoader::defaultQueue(), *this);
+    if (protectedConnection)
+        protectedConnection->addWorkQueueMessageReceiver(Messages::RemoteMediaResourceManager::messageReceiverName(), RemoteMediaResourceLoader::defaultQueue(), *this);
 }
 
 void RemoteMediaResourceManager::addMediaResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, RemoteMediaResource& remoteMediaResource)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -71,6 +71,7 @@ private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
 
     RefPtr<IPC::Connection> connection() const;
+    Ref<WebCore::SourceBufferPrivate> protectedSourceBufferPrivate() const { return m_sourceBufferPrivate; }
 
     // SourceBufferPrivateClient
     Ref<WebCore::MediaPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) final;


### PR DESCRIPTION
#### e3c582fa0da7f9cef9234f45e03ccc035f7c33bf
<pre>
Adopt more smart pointers in GPUProcess/media (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280641">https://bugs.webkit.org/show_bug.cgi?id=280641</a>
<a href="https://rdar.apple.com/136999349">rdar://136999349</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::create):
(WebKit::RemoteCDMInstanceSessionProxy::setLogIdentifier):
(WebKit::RemoteCDMInstanceSessionProxy::requestLicense):
(WebKit::RemoteCDMInstanceSessionProxy::updateLicense):
(WebKit::RemoteCDMInstanceSessionProxy::loadSession):
(WebKit::RemoteCDMInstanceSessionProxy::closeSession):
(WebKit::RemoteCDMInstanceSessionProxy::removeSessionData):
(WebKit::RemoteCDMInstanceSessionProxy::storeRecordOfKeyUsage):
(WebKit::RemoteCDMInstanceSessionProxy::updateKeyStatuses):
(WebKit::RemoteCDMInstanceSessionProxy::sendMessage):
(WebKit::RemoteCDMInstanceSessionProxy::sessionIdChanged):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::sendMessage):
(WebKit::RemoteLegacyCDMSessionProxy::sendError):
(WebKit::RemoteLegacyCDMSessionProxy::mediaKeysStorageDirectory const):
(WebKit::RemoteLegacyCDMSessionProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
(WebKit::RemoteLegacyCDMSessionProxy::protectedFactory const):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::initializeConnection):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::RemoteSourceBufferProxy):
(WebKit::RemoteSourceBufferProxy::append):
(WebKit::RemoteSourceBufferProxy::abort):
(WebKit::RemoteSourceBufferProxy::resetParserState):
(WebKit::RemoteSourceBufferProxy::removedFromMediaSource):
(WebKit::RemoteSourceBufferProxy::setMediaSourceEnded):
(WebKit::RemoteSourceBufferProxy::setActive):
(WebKit::RemoteSourceBufferProxy::canSwitchToType):
(WebKit::RemoteSourceBufferProxy::setMode):
(WebKit::RemoteSourceBufferProxy::startChangingType):
(WebKit::RemoteSourceBufferProxy::removeCodedFrames):
(WebKit::RemoteSourceBufferProxy::asyncEvictCodedFrames):
(WebKit::RemoteSourceBufferProxy::addTrackBuffer):
(WebKit::RemoteSourceBufferProxy::resetTrackBuffers):
(WebKit::RemoteSourceBufferProxy::clearTrackBuffers):
(WebKit::RemoteSourceBufferProxy::setAllTrackBuffersNeedRandomAccess):
(WebKit::RemoteSourceBufferProxy::reenqueueMediaIfNeeded):
(WebKit::RemoteSourceBufferProxy::setGroupStartTimestamp):
(WebKit::RemoteSourceBufferProxy::setGroupStartTimestampToEndTimestamp):
(WebKit::RemoteSourceBufferProxy::setShouldGenerateTimestamps):
(WebKit::RemoteSourceBufferProxy::resetTimestampOffsetInTrackBuffers):
(WebKit::RemoteSourceBufferProxy::setTimestampOffset):
(WebKit::RemoteSourceBufferProxy::setAppendWindowStart):
(WebKit::RemoteSourceBufferProxy::setAppendWindowEnd):
(WebKit::RemoteSourceBufferProxy::setMaximumBufferSize):
(WebKit::RemoteSourceBufferProxy::computeSeekTime):
(WebKit::RemoteSourceBufferProxy::seekToTime):
(WebKit::RemoteSourceBufferProxy::updateTrackIds):
(WebKit::RemoteSourceBufferProxy::bufferedSamplesForTrackId):
(WebKit::RemoteSourceBufferProxy::enqueuedSamplesForTrackID):
(WebKit::RemoteSourceBufferProxy::memoryPressure):
(WebKit::RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID):
(WebKit::RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID):
(WebKit::RemoteSourceBufferProxy::detach):
(WebKit::RemoteSourceBufferProxy::attach):
(WebKit::RemoteSourceBufferProxy::createInitializationSegmentInfo):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/284501@main">https://commits.webkit.org/284501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efe3a052d7f2cd9b4ddd938a3f317711f8055598

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20703 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13750 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41307 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62958 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62871 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15468 "Failed to checkout and rebase branch from PR 34467") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4516 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44749 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->