### PR TITLE
AX: need to handle dynamically-created and nested aria-modal dialogs

### DIFF
--- a/LayoutTests/accessibility/mac/dynamic-modal-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-modal-expected.txt
@@ -1,0 +1,18 @@
+This tests nested aria-modal dialogs
+
+Initial focus: show
+Show button reachable: true
+
+Clicking on show button
+
+New focus: dialog_ok
+Show button reachable: false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Show
+
+Inside dialog
+
+OK

--- a/LayoutTests/accessibility/mac/dynamic-modal.html
+++ b/LayoutTests/accessibility/mac/dynamic-modal.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<style>
+  *[role="dialog"] { border: 1px solid black; padding: 1em; margin: 1em; }
+  :focus { outline: 3px solid #ccf; outline-offset: 3px; }
+</style>
+<body>
+
+  <p>
+    <button id="show" autofocus>Show</button>
+  </p>
+
+  <div id="wrapper">
+  </div>
+
+<script>
+document.getElementById("show").addEventListener("click", () => {
+    let dialog = document.createElement('div');
+    dialog.role = "dialog";
+    dialog.id = "dynamic_dialog";
+    dialog.ariaModal = true;
+    dialog.innerHTML = "<h2>Inside dialog</h2><button id='dialog_ok'>OK</button>";
+    document.getElementById("wrapper").appendChild(dialog);
+    setTimeout(() => {
+        document.getElementById("dialog_ok").focus();
+    }, 0);
+});
+
+var testOutput = "This tests nested aria-modal dialogs\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async () => {
+        await waitFor(() => {
+            focus = accessibilityController.focusedElement;
+            return focus && focus.domIdentifier;
+        });
+
+        focus = accessibilityController.focusedElement;
+        testOutput += `Initial focus: ${focus.domIdentifier}\n`;
+
+        show = accessibilityController.accessibleElementById("show");
+        testOutput += `Show button reachable: ${show != null}\n`;
+
+        testOutput += "\nClicking on show button\n\n";
+        document.getElementById("show").click();
+
+        await waitFor(() => {
+            focus = accessibilityController.focusedElement;
+            return focus.domIdentifier != "ok";
+        });
+
+        focus = accessibilityController.focusedElement;
+        testOutput += `New focus: ${focus.domIdentifier}\n`;
+
+        await waitFor(() => {
+            return !accessibilityController.accessibleElementById("show");
+        });
+
+        show = accessibilityController.accessibleElementById("show");
+        testOutput += `Show button reachable: ${show != null}\n`;
+
+        debug(testOutput);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/nested-modal-expected.txt
+++ b/LayoutTests/accessibility/mac/nested-modal-expected.txt
@@ -1,0 +1,23 @@
+This tests nested aria-modal dialogs
+
+Initial focus: showInner
+Before button reachable: false
+ShowInner button reachable: true
+
+Clicking on showInner
+
+New focus: closeInner
+Before button reachable: false
+ShowInner button reachable: false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Before
+
+Outer modal dialog
+
+Show inner dialog
+Inner modal dialog
+
+Close inner dialog

--- a/LayoutTests/accessibility/mac/nested-modal.html
+++ b/LayoutTests/accessibility/mac/nested-modal.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<style>
+  *[role="dialog"] { border: 1px solid black; padding: 1em; margin: 1em; }
+</style>
+<body>
+
+  <p>
+    <button id="before">Before</button>
+  </p>
+
+  <div id="outer" role="dialog" aria-modal="true">
+    <h2>Outer modal dialog</h2>
+    <button id="showInner" autofocus>Show inner dialog</button>
+
+    <div id="inner" role="dialog" aria-modal="true" hidden>
+      <h2>Inner modal dialog</h2>
+      <button id="closeInner">Close inner dialog</button>
+    </div>
+  </div>
+
+<script>
+document.getElementById("showInner").addEventListener("click", () => {
+    document.getElementById("inner").hidden = false;
+    document.getElementById("closeInner").focus();
+});
+
+var testOutput = "This tests nested aria-modal dialogs\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async () => {
+        await waitFor(() => {
+            focus = accessibilityController.focusedElement;
+            return focus && focus.domIdentifier;
+        });
+
+        focus = accessibilityController.focusedElement;
+        testOutput += `Initial focus: ${focus.domIdentifier}\n`;
+
+        before = accessibilityController.accessibleElementById("before");
+        testOutput += `Before button reachable: ${before != null}\n`;
+
+        showInner = accessibilityController.accessibleElementById("showInner");
+        testOutput += `ShowInner button reachable: ${showInner != null}\n`;
+
+        testOutput += "\nClicking on showInner\n\n";
+        document.getElementById("showInner").click();
+
+        await waitFor(() => {
+            focus = accessibilityController.focusedElement;
+            return focus.domIdentifier != "showInner";
+        });
+
+        focus = accessibilityController.focusedElement;
+        testOutput += `New focus: ${focus.domIdentifier}\n`;
+
+        await waitFor(() => {
+            return !accessibilityController.accessibleElementById("showInner");
+        });
+
+        before = accessibilityController.accessibleElementById("before");
+        testOutput += `Before button reachable: ${before != null}\n`;
+
+        showInner = accessibilityController.accessibleElementById("showInner");
+        testOutput += `ShowInner button reachable: ${showInner != null}\n`;
+
+        debug(testOutput);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 77d74fdb4d16d5bcf79cf7a270b7e2dcbaf3799f
<pre>
AX: need to handle dynamically-created and nested aria-modal dialogs
<a href="https://bugs.webkit.org/show_bug.cgi?id=280643">https://bugs.webkit.org/show_bug.cgi?id=280643</a>
<a href="https://rdar.apple.com/137000722">rdar://137000722</a>

Reviewed by Tyler Wilcock.

In isolated tree mode, WebKit wasn&apos;t properly handling the case where
an aria-modal dialog is dynamically created and added to the DOM.  In
addition, WebKit didn&apos;t have any logic to pick the deepest aria-modal
dialog if multiple dialogs are nested. Adding this logic matches
Chrome&apos;s behavior now.  In both cases, the issue was correctly
ignoring everything outside of the dialog while focus is inside.

* LayoutTests/accessibility/mac/dynamic-modal-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-modal.html: Added.
* LayoutTests/accessibility/mac/nested-modal-expected.txt: Added.
* LayoutTests/accessibility/mac/nested-modal.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateCurrentModalNode):
(WebCore::AXObjectCache::handleAttributeChange):

Canonical link: <a href="https://commits.webkit.org/284613@main">https://commits.webkit.org/284613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d330ce3d2e6e5ccc97cf400eabb8f28a1249e75f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20824 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55368 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35847 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19201 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63037 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62970 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4567 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44870 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45944 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47208 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->