### PR TITLE
Adopt more smart pointers in GPUProcess/webrtc

### DIFF
--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -82,6 +82,8 @@ private:
     WorkQueue& workQueue() const { return m_queue; }
     Ref<WorkQueue> protectedWorkQueue() const { return m_queue; }
 
+    Ref<IPC::Connection> protectedConnection() const { return m_connection; }
+
     // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -196,7 +196,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::reset()
         return;
 
     m_canReset = false;
-    m_connection->send(Messages::GPUProcessConnection::ResetAudioMediaStreamTrackRendererInternalUnit { m_identifier }, 0);
+    Ref { m_connection }->send(Messages::GPUProcessConnection::ResetAudioMediaStreamTrackRendererInternalUnit { m_identifier }, 0);
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::setShouldRegisterAsSpeakerSamplesProducer(bool value)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -65,7 +65,7 @@ RemoteMediaRecorder::RemoteMediaRecorder(GPUConnectionToWebProcess& gpuConnectio
 
 RemoteMediaRecorder::~RemoteMediaRecorder()
 {
-    m_writer->close();
+    protectedWriter()->close();
 }
 
 RefPtr<IPC::Connection> RemoteMediaRecorder::connection() const
@@ -96,37 +96,37 @@ void RemoteMediaRecorder::audioSamplesAvailable(MediaTime time, uint64_t numberO
     m_audioBufferList->setSampleCount(numberOfFrames);
     m_ringBuffer->fetch(m_audioBufferList->list(), numberOfFrames, time.timeValue());
 
-    m_writer->appendAudioSampleBuffer(*m_audioBufferList, *m_description, time, numberOfFrames);
+    protectedWriter()->appendAudioSampleBuffer(*m_audioBufferList, *m_description, time, numberOfFrames);
 }
 
 void RemoteMediaRecorder::videoFrameAvailable(SharedVideoFrame&& sharedVideoFrame)
 {
     if (auto frame = m_sharedVideoFrameReader.read(WTFMove(sharedVideoFrame)))
-        m_writer->appendVideoFrame(*frame);
+        protectedWriter()->appendVideoFrame(*frame);
 }
 
 void RemoteMediaRecorder::fetchData(CompletionHandler<void(std::span<const uint8_t>, double)>&& completionHandler)
 {
-    m_writer->fetchData([completionHandler = WTFMove(completionHandler)](auto&& data, auto timeCode) mutable {
+    protectedWriter()->fetchData([completionHandler = WTFMove(completionHandler)](auto&& data, auto timeCode) mutable {
         completionHandler(data ? data->makeContiguous()->span() : std::span<const uint8_t> { }, timeCode);
     });
 }
 
 void RemoteMediaRecorder::stopRecording(CompletionHandler<void()>&& completionHandler)
 {
-    m_writer->stopRecording();
+    protectedWriter()->stopRecording();
     completionHandler();
 }
 
 void RemoteMediaRecorder::pause(CompletionHandler<void()>&& completionHandler)
 {
-    m_writer->pause();
+    protectedWriter()->pause();
     completionHandler();
 }
 
 void RemoteMediaRecorder::resume(CompletionHandler<void()>&& completionHandler)
 {
-    m_writer->resume();
+    protectedWriter()->resume();
     completionHandler();
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -72,12 +72,12 @@ void RemoteSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size
 #else
     UNUSED_PARAM(canShowWhileLocked);
 #endif
-    m_sampleBufferDisplayLayer->initialize(hideRootLayer, size, shouldMaintainAspectRatio, [this, weakThis = WeakPtr { *this }, contextOptions, callback = WTFMove(callback)](bool didSucceed) mutable {
+    protectedSampleBufferDisplayLayer()->initialize(hideRootLayer, size, shouldMaintainAspectRatio, [this, weakThis = WeakPtr { *this }, contextOptions, callback = WTFMove(callback)](bool didSucceed) mutable {
         if (!weakThis || !didSucceed)
             return callback({ });
 
         m_layerHostingContext = LayerHostingContext::createForExternalHostingProcess(contextOptions);
-        m_layerHostingContext->setRootLayer(m_sampleBufferDisplayLayer->rootLayer());
+        m_layerHostingContext->setRootLayer(protectedSampleBufferDisplayLayer()->rootLayer());
         callback(m_layerHostingContext->contextID());
     });
 }
@@ -100,7 +100,7 @@ CGRect RemoteSampleBufferDisplayLayer::bounds() const
 
 void RemoteSampleBufferDisplayLayer::updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)
 {
-    m_sampleBufferDisplayLayer->updateDisplayMode(hideDisplayLayer, hideRootLayer);
+    protectedSampleBufferDisplayLayer()->updateDisplayMode(hideDisplayLayer, hideRootLayer);
 }
 
 void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std::optional<WTF::MachSendRight>&& fence)
@@ -108,17 +108,17 @@ void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std:
     if (fence && fence->sendRight())
         m_layerHostingContext->setFencePort(fence->sendRight());
 
-    m_sampleBufferDisplayLayer->updateBoundsAndPosition(bounds, { });
+    protectedSampleBufferDisplayLayer()->updateBoundsAndPosition(bounds, { });
 }
 
 void RemoteSampleBufferDisplayLayer::flush()
 {
-    m_sampleBufferDisplayLayer->flush();
+    protectedSampleBufferDisplayLayer()->flush();
 }
 
 void RemoteSampleBufferDisplayLayer::flushAndRemoveImage()
 {
-    m_sampleBufferDisplayLayer->flushAndRemoveImage();
+    protectedSampleBufferDisplayLayer()->flushAndRemoveImage();
 }
 
 void RemoteSampleBufferDisplayLayer::play()
@@ -134,12 +134,12 @@ void RemoteSampleBufferDisplayLayer::pause()
 void RemoteSampleBufferDisplayLayer::enqueueVideoFrame(SharedVideoFrame&& frame)
 {
     if (auto videoFrame = m_sharedVideoFrameReader.read(WTFMove(frame)))
-        m_sampleBufferDisplayLayer->enqueueVideoFrame(*videoFrame);
+        protectedSampleBufferDisplayLayer()->enqueueVideoFrame(*videoFrame);
 }
 
 void RemoteSampleBufferDisplayLayer::clearVideoFrames()
 {
-    m_sampleBufferDisplayLayer->clearVideoFrames();
+    protectedSampleBufferDisplayLayer()->clearVideoFrames();
 }
 
 IPC::Connection* RemoteSampleBufferDisplayLayer::messageSenderConnection() const
@@ -164,7 +164,7 @@ void RemoteSampleBufferDisplayLayer::setSharedVideoFrameMemory(SharedMemory::Han
 
 void RemoteSampleBufferDisplayLayer::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)
 {
-    m_sampleBufferDisplayLayer->setShouldMaintainAspectRatio(shouldMaintainAspectRatio);
+    protectedSampleBufferDisplayLayer()->setShouldMaintainAspectRatio(shouldMaintainAspectRatio);
 }
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -68,7 +68,7 @@ void RemoteSampleBufferDisplayLayerManager::close()
     Ref ipcConnection = connection->protectedConnection();
     ipcConnection->removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName());
     ipcConnection->removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName());
-    m_queue->dispatch([this, protectedThis = Ref { *this }] {
+    protectedQueue()->dispatch([this, protectedThis = Ref { *this }] {
         Locker lock(m_layersLock);
         callOnMainRunLoop([layers = WTFMove(m_layers)] { });
     });
@@ -98,7 +98,7 @@ void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayer
             return;
         }
         layer->initialize(hideRootLayer, size, shouldMaintainAspectRatio, canShowWhileLocked, [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier, layer = Ref { *layer }](auto layerId) mutable {
-            m_queue->dispatch([this, protectedThis = WTFMove(protectedThis), callback = WTFMove(callback), identifier, layer = WTFMove(layer), layerId = WTFMove(layerId)]() mutable {
+            protectedQueue()->dispatch([this, protectedThis = WTFMove(protectedThis), callback = WTFMove(callback), identifier, layer = WTFMove(layer), layerId = WTFMove(layerId)]() mutable {
                 Locker lock(m_layersLock);
                 ASSERT(!m_layers.contains(identifier));
                 m_layers.add(identifier, WTFMove(layer));
@@ -111,7 +111,7 @@ void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayer
 void RemoteSampleBufferDisplayLayerManager::releaseLayer(SampleBufferDisplayLayerIdentifier identifier)
 {
     callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier]() mutable {
-        m_queue->dispatch([this, protectedThis = WTFMove(protectedThis), identifier] {
+        protectedQueue()->dispatch([this, protectedThis = WTFMove(protectedThis), identifier] {
             Locker lock(m_layersLock);
             ASSERT(m_layers.contains(identifier));
             callOnMainRunLoop([layer = m_layers.take(identifier)] { });

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
@@ -36,6 +36,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
+#include <wtf/WorkQueue.h>
 
 namespace IPC {
 class Decoder;
@@ -78,6 +79,8 @@ private:
     using LayerCreationCallback = CompletionHandler<void(std::optional<LayerHostingContextID>)>&&;
     void createLayer(SampleBufferDisplayLayerIdentifier, bool hideRootLayer, WebCore::IntSize, bool shouldMaintainAspectRatio, bool canShowWhileLocked, LayerCreationCallback);
     void releaseLayer(SampleBufferDisplayLayerIdentifier);
+
+    Ref<WorkQueue> protectedQueue() const { return m_queue; }
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     Ref<IPC::Connection> m_connection;


### PR DESCRIPTION
#### 0acb006bca65fc3b800382f2b36d3cb1eefa47c0
<pre>
Adopt more smart pointers in GPUProcess/webrtc
<a href="https://bugs.webkit.org/show_bug.cgi?id=280652">https://bugs.webkit.org/show_bug.cgi?id=280652</a>
<a href="https://rdar.apple.com/137007140">rdar://137007140</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::stopListeningForIPC):
(WebKit::LibWebRTCCodecsProxy::initialize):
(WebKit::LibWebRTCCodecsProxy::releaseDecoder):
(WebKit::LibWebRTCCodecsProxy::releaseEncoder):
(WebKit::LibWebRTCCodecsProxy::encodeFrame):
(WebKit::LibWebRTCCodecsProxy::notifyEncoderResult):
(WebKit::LibWebRTCCodecsProxy::notifyDecoderResult):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::reset):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::~RemoteMediaRecorder):
(WebKit::RemoteMediaRecorder::audioSamplesAvailable):
(WebKit::RemoteMediaRecorder::videoFrameAvailable):
(WebKit::RemoteMediaRecorder::fetchData):
(WebKit::RemoteMediaRecorder::stopRecording):
(WebKit::RemoteMediaRecorder::pause):
(WebKit::RemoteMediaRecorder::resume):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
(WebKit::RemoteSampleBufferDisplayLayer::initialize):
(WebKit::RemoteSampleBufferDisplayLayer::updateDisplayMode):
(WebKit::RemoteSampleBufferDisplayLayer::updateBoundsAndPosition):
(WebKit::RemoteSampleBufferDisplayLayer::flush):
(WebKit::RemoteSampleBufferDisplayLayer::flushAndRemoveImage):
(WebKit::RemoteSampleBufferDisplayLayer::enqueueVideoFrame):
(WebKit::RemoteSampleBufferDisplayLayer::clearVideoFrames):
(WebKit::RemoteSampleBufferDisplayLayer::setShouldMaintainAspectRatio):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp:
(WebKit::RemoteSampleBufferDisplayLayerManager::close):
(WebKit::RemoteSampleBufferDisplayLayerManager::createLayer):
(WebKit::RemoteSampleBufferDisplayLayerManager::releaseLayer):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h:

Canonical link: <a href="https://commits.webkit.org/284506@main">https://commits.webkit.org/284506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fa30060a74822990d0a9cf35306a150f15c8594

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20700 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55288 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41300 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19077 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62954 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62866 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4518 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44746 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45820 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->