### PR TITLE
[Win] Stop using -Wno-sign-compare

### DIFF
--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -169,7 +169,7 @@ public:
 
     private:
         static constexpr size_t s_maxKeys = 32;
-        static Atomic<int> s_numberOfKeys;
+        static Atomic<size_t> s_numberOfKeys;
         static std::array<Atomic<DestroyFunction>, s_maxKeys> s_destroyFunctions;
         std::array<void*, s_maxKeys> m_slots { };
     };

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -160,7 +160,7 @@ static String generateTemporaryPath(const Function<bool(const String&)>& action)
 {
     wchar_t tempPath[MAX_PATH];
     int tempPathLength = ::GetTempPathW(std::size(tempPath), tempPath);
-    if (tempPathLength <= 0 || tempPathLength > std::size(tempPath))
+    if (tempPathLength <= 0 || static_cast<size_t>(tempPathLength) >= std::size(tempPath))
         return String();
 
     String proposedPath;

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -288,12 +288,12 @@ Thread& Thread::initializeTLS(Ref<Thread>&& thread)
     return *s_threadHolder.thread;
 }
 
-Atomic<int> Thread::SpecificStorage::s_numberOfKeys;
+Atomic<size_t> Thread::SpecificStorage::s_numberOfKeys;
 std::array<Atomic<Thread::SpecificStorage::DestroyFunction>, Thread::SpecificStorage::s_maxKeys> Thread::SpecificStorage::s_destroyFunctions;
 
 bool Thread::SpecificStorage::allocateKey(int& key, DestroyFunction destroy)
 {
-    int k = s_numberOfKeys.exchangeAdd(1);
+    auto k = s_numberOfKeys.exchangeAdd(1);
     if (k >= s_maxKeys) {
         s_numberOfKeys.exchangeSub(1);
         return false;

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -1643,6 +1643,9 @@ static MFVideoArea MakeArea(float x, float y, DWORD width, DWORD height)
     return area;
 }
 
+// FIXME: Fix the warnings
+IGNORE_CLANG_WARNINGS_BEGIN("sign-compare")
+
 static HRESULT validateVideoArea(const MFVideoArea& area, UINT32 width, UINT32 height)
 {
     float fOffsetX = MFOffsetToFloat(area.OffsetX);
@@ -2937,6 +2940,8 @@ HRESULT MediaPlayerPrivateMediaFoundation::Direct3DPresenter::getSwapChainPresen
 
     return S_OK;
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -614,8 +614,8 @@ Ref<DocumentFragment> fragmentFromCFHTML(Document* doc, const String& cfhtml)
     // obtain baseURL if present
     String srcURLStr("sourceURL:"_s);
     String srcURL;
-    unsigned lineStart = cfhtml.findIgnoringASCIICase(srcURLStr);
-    if (lineStart != -1) {
+    size_t lineStart = cfhtml.findIgnoringASCIICase(srcURLStr);
+    if (lineStart != notFound) {
         unsigned srcEnd = cfhtml.find('\n', lineStart);
         unsigned srcStart = lineStart+srcURLStr.length();
         String rawSrcURL = cfhtml.substring(srcStart, srcEnd-srcStart);

--- a/Source/WebCore/platform/win/WebCoreTextRenderer.cpp
+++ b/Source/WebCore/platform/win/WebCoreTextRenderer.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 static bool isOneLeftToRightRun(const TextRun& run)
 {
-    for (int i = 0; i < run.length(); i++) {
+    for (size_t i = 0; i < run.length(); i++) {
         UCharDirection direction = u_charDirection(run[i]);
         if (direction == U_RIGHT_TO_LEFT || direction > U_OTHER_NEUTRAL)
             return false;

--- a/Source/WebCore/platform/win/WheelEventWin.cpp
+++ b/Source/WebCore/platform/win/WheelEventWin.cpp
@@ -64,7 +64,7 @@ static int horizontalScrollChars()
     return scrollChars;
 }
 
-static int verticalScrollLines()
+static unsigned verticalScrollLines()
 {
     static ULONG scrollLines;
     if (!scrollLines && !SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &scrollLines, 0))
@@ -101,7 +101,7 @@ PlatformWheelEvent::PlatformWheelEvent(HWND hWnd, WPARAM wParam, LPARAM lParam, 
     } else {
         m_deltaX = 0;
         m_deltaY = delta;
-        int verticalMultiplier = verticalScrollLines();
+        unsigned verticalMultiplier = verticalScrollLines();
         m_granularity = (verticalMultiplier == WHEEL_PAGESCROLL) ? ScrollByPageWheelEvent : ScrollByPixelWheelEvent;
         if (m_granularity == ScrollByPixelWheelEvent)
             m_deltaY *= static_cast<float>(verticalMultiplier) * cScrollbarPixelsPerLine;

--- a/Source/WebCore/platform/win/WindowsKeyNames.cpp
+++ b/Source/WebCore/platform/win/WindowsKeyNames.cpp
@@ -468,7 +468,7 @@ String WindowsKeyNames::domCodeFromLParam(LPARAM lParam)
     unsigned extendedScanCode = (lParam >> 16) & 0x1ff;
     const auto* result = std::lower_bound(
         std::begin(cDomCodeMap), std::end(cDomCodeMap), extendedScanCode,
-        [](const auto& entry, int needle) {
+        [](const auto& entry, unsigned needle) {
             return entry.scanCode < needle;
         });
     if (result != std::end(cDomCodeMap) && result->scanCode == extendedScanCode)

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -65,7 +65,7 @@ static int horizontalScrollChars()
     return scrollChars;
 }
 
-static int verticalScrollLines()
+static unsigned verticalScrollLines()
 {
     static ULONG scrollLines;
     if (!scrollLines && !::SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &scrollLines, 0))
@@ -444,7 +444,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(HWND hWnd, UINT message, WPAR
     } else {
         deltaX = 0;
         deltaY = delta;
-        int verticalMultiplier = verticalScrollLines();
+        unsigned verticalMultiplier = verticalScrollLines();
         if (verticalMultiplier == WHEEL_PAGESCROLL)
             granularity = WebWheelEvent::ScrollByPageWheelEvent;
         else {

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -111,7 +111,7 @@ void WebInspectorUIProxy::showSavePanelForSingleFile(HWND parentWindow, Vector<W
         auto content = saveDatas[0].content.utf8();
         auto contentSize = content.length();
         auto bytesWritten = FileSystem::writeToFile(fd, content.span());
-        if (bytesWritten == -1 || bytesWritten != contentSize) {
+        if (bytesWritten == -1 || static_cast<size_t>(bytesWritten) != contentSize) {
             auto message = systemErrorMessage(GetLastError());
             if (message.isEmpty())
                 message = makeString("Error: writeToFile returns "_s, bytesWritten, ", contentLength = "_s, content.length());

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -180,6 +180,9 @@ WebPopupMenuProxyWin::~WebPopupMenuProxyWin()
         m_scrollbar->setParent(0);
 }
 
+// FIXME: Fix the warnings
+IGNORE_CLANG_WARNINGS_BEGIN("sign-compare")
+
 void WebPopupMenuProxyWin::showPopupMenu(const IntRect& rect, TextDirection, double pageScaleFactor, const Vector<WebPopupItem>& items, const PlatformPopupMenuData& data, int32_t selectedIndex)
 {
     m_items = items;
@@ -943,6 +946,8 @@ bool WebPopupMenuProxyWin::setFocusedIndex(int i, bool hotTracking)
 
     return true;
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 int WebPopupMenuProxyWin::visibleItems() const
 {

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -918,7 +918,7 @@ void WebView::windowReceivedMessage(HWND, UINT message, WPARAM wParam, LPARAM)
 static Vector<wchar_t> truncatedString(const String& string)
 {
     // Truncate tooltip texts because multiline mode of tooltip control does word-wrapping very slowly
-    auto maxLength = 1024;
+    size_t maxLength = 1024;
     auto buffer = string.wideCharacters();
     if (buffer.size() > maxLength) {
         buffer[maxLength - 4] = L'.';

--- a/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -39,6 +39,9 @@ using namespace WebCore;
 static const int separatorPadding = 4;
 static const int separatorHeight = 1;
 
+// FIXME: Fix the warnings
+IGNORE_CLANG_WARNINGS_BEGIN("sign-compare")
+
 void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, PlatformPopupMenuData& data)
 {
     float deviceScaleFactor = page()->deviceScaleFactor();
@@ -154,5 +157,7 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
         }
     }
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebKit

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -150,10 +150,7 @@ if (COMPILER_IS_GCC_OR_CLANG)
     # clang-cl.exe impersonates cl.exe so some clang arguments like -fno-rtti are
     # represented using cl.exe's options and should not be passed as flags, so
     # we do not add -fno-rtti or -fno-exceptions for clang-cl
-    if (COMPILER_IS_CLANG_CL)
-        # FIXME: These warnings should be addressed
-        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-sign-compare)
-    else ()
+    if (NOT COMPILER_IS_CLANG_CL)
         WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-exceptions)
         WEBKIT_APPEND_GLOBAL_CXX_FLAGS(-fno-rtti)
         WEBKIT_APPEND_GLOBAL_CXX_FLAGS(-fcoroutines)

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -74,7 +74,7 @@ std::wstring createPEMString(WKProtectionSpaceRef protectionSpace)
 
     std::wstring pems;
 
-    for (auto i = 0; i < WKArrayGetSize(chain.get()); i++) {
+    for (size_t i = 0; i < WKArrayGetSize(chain.get()); i++) {
         auto item = WKArrayGetItemAtIndex(chain.get(), i);
         assert(WKGetTypeID(item) == WKDataGetTypeID());
         auto certificate = static_cast<WKDataRef>(item);


### PR DESCRIPTION
#### 97f65ea03a127c0715ee685e79d1b9ec0591a99e
<pre>
[Win] Stop using -Wno-sign-compare
<a href="https://bugs.webkit.org/show_bug.cgi?id=280654">https://bugs.webkit.org/show_bug.cgi?id=280654</a>

Reviewed by Michael Catanzaro.

Mac and Linux have enabled the compiler warning. Enable it for Windows
port.

Some files still ignore the warning. Will fix them later.

* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::generateTemporaryPath):
* Source/WTF/wtf/win/ThreadingWin.cpp:
(WTF::Thread::SpecificStorage::allocateKey):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::fragmentFromCFHTML):
* Source/WebCore/platform/win/WebCoreTextRenderer.cpp:
(WebCore::isOneLeftToRightRun):
* Source/WebCore/platform/win/WheelEventWin.cpp:
(WebCore::verticalScrollLines):
(WebCore::PlatformWheelEvent::PlatformWheelEvent):
* Source/WebCore/platform/win/WindowsKeyNames.cpp:
(WebCore::WindowsKeyNames::domCodeFromLParam):
* Source/WebKit/Shared/win/WebEventFactory.cpp:
(WebKit::verticalScrollLines):
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::showSavePanelForSingleFile):
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::truncatedString):
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:
* Source/cmake/WebKitCompilerFlags.cmake:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(createPEMString):

Canonical link: <a href="https://commits.webkit.org/284481@main">https://commits.webkit.org/284481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0024ebe486358ba45f909a90765e4819ad47bff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20556 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/13755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19082 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/62663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75342 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68793 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13529 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62870 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10897 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90575 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10615 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44751 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16072 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->