### PR TITLE
[scroll-animations] Implement view-timeline-inset property

### DIFF
--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -28,9 +28,13 @@
 
 #include "AnimationTimelinesController.h"
 #include "CSSNumericFactory.h"
+#include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPrimitiveValueMappings.h"
+#include "CSSPropertyParserConsumer+Timeline.h"
+#include "CSSTokenizer.h"
 #include "CSSUnits.h"
+#include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "CSSViewValue.h"
 #include "Document.h"
@@ -74,13 +78,67 @@ Ref<ViewTimeline> ViewTimeline::createFromCSSValue(Style::BuilderState& builderS
     return adoptRef(*new ViewTimeline(nullAtom(), axis, { startInset, endInset }));
 }
 
-// FIXME: compute offset values from options.
+static std::optional<Length> lengthForInset(std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>> inset)
+{
+    // TODO: Need to test this
+    if (auto* numericInset = std::get_if<RefPtr<CSSNumericValue>>(&inset)) {
+        if (RefPtr insetValue = dynamicDowncast<CSSUnitValue>(*numericInset)) {
+            if (auto length = insetValue->convertTo(CSSUnitType::CSS_PX))
+                return Length(length->value(), LengthType::Fixed);
+            return { };
+        }
+    }
+    ASSERT(std::holds_alternative<RefPtr<CSSKeywordValue>>(inset));
+    return { };
+}
+
+static Length lengthForInsetCSSValue(RefPtr<CSSPrimitiveValue> value)
+{
+    // TODO: Figure out how to make this work when provided calc value
+    if (!value || value->isCalculated())
+        return { };
+    if (value->valueID() == CSSValueAuto)
+        return { };
+    if (value->isPercentage())
+        return Length(value->resolveAsPercentageNoConversionDataRequired(), LengthType::Percent);
+    if (value->isPx())
+        return Length(value->resolveAsLengthNoConversionDataRequired(), LengthType::Fixed);
+
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+static ViewTimelineInsets insetsFromOptions(const std::variant<String, Vector<std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>>> inset, CSSParserContext context)
+{
+    if (auto* insetString = std::get_if<String>(&inset)) {
+        if (insetString->isEmpty())
+            return { };
+        CSSTokenizer tokenizer(*insetString);
+        auto tokenRange = tokenizer.tokenRange();
+        tokenRange.consumeWhitespace();
+        auto consumedInset = CSSPropertyParserHelpers::consumeViewTimelineInsetListItem(tokenRange, context);
+        if (auto insetPair = dynamicDowncast<CSSValuePair>(consumedInset))
+            return { lengthForInsetCSSValue(dynamicDowncast<CSSPrimitiveValue>(insetPair->protectedFirst())), lengthForInsetCSSValue(dynamicDowncast<CSSPrimitiveValue>(insetPair->protectedSecond())) };
+        return { lengthForInsetCSSValue(dynamicDowncast<CSSPrimitiveValue>(consumedInset)), std::nullopt };
+    }
+    auto insetList = std::get<Vector<std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>>>(inset);
+
+    if (!insetList.size())
+        return { };
+    if (insetList.size() == 2)
+        return { lengthForInset(insetList.at(0)), lengthForInset(insetList.at(1)) };
+    return { lengthForInset(insetList.at(0)), std::nullopt };
+}
+
 ViewTimeline::ViewTimeline(ViewTimelineOptions&& options)
     : ScrollTimeline(nullAtom(), options.axis)
     , m_subject(WTFMove(options.subject))
 {
-    if (m_subject)
-        m_subject->protectedDocument()->ensureTimelinesController().addTimeline(*this);
+    if (m_subject) {
+        auto document = m_subject->protectedDocument();
+        document->ensureTimelinesController().addTimeline(*this);
+        m_insets = insetsFromOptions(options.inset, document->cssParserContext());
+    }
 }
 
 ViewTimeline::ViewTimeline(const AtomString& name, ScrollAxis axis, ViewTimelineInsets&& insets)
@@ -182,7 +240,6 @@ ViewTimeline::Data ViewTimeline::computeViewTimelineData() const
     //   cover range
     // - range is the scroll offset corresponding to the end of the cover range minus the scroll offset
     //   corresponding to the start of the cover range
-    // TODO: take into account view-timeline-inset: https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset
     // TODO: take into account animation-range: https://drafts.csswg.org/scroll-animations-1/#animation-range
     // TODO: investigate best way to compute subjectOffset, as offsetTop uses offsetParent(), not the containing scroller
     // TODO: view timeline progress calculation: (currentScrollOffset - coverRangeStart) / (coverRangeEnd - coverRangeStart)
@@ -194,8 +251,11 @@ ViewTimeline::Data ViewTimeline::computeViewTimelineData() const
 
     float subjectSize = axis() == ScrollAxis::Block ? subjectRenderBox->borderBoxRect().height() : subjectRenderBox->borderBoxRect().width();
 
-    auto coverRangeStart = subjectOffset - scrollContainerSize;
-    auto coverRangeEnd = subjectOffset + subjectSize;
+    auto insetStart = m_insets.start.value_or(Length());
+    auto insetEnd = m_insets.end.value_or(insetStart);
+
+    auto coverRangeStart = subjectOffset - scrollContainerSize + insetEnd.value();
+    auto coverRangeEnd = subjectOffset + subjectSize - insetStart.value();
 
     return { currentScrollOffset, coverRangeStart, coverRangeEnd };
 }


### PR DESCRIPTION
#### 653c136096bd0586685b8ec24ff51682e1b6c3d9
<pre>
[scroll-animations] Implement view-timeline-inset property
<a href="https://bugs.webkit.org/show_bug.cgi?id=280655">https://bugs.webkit.org/show_bug.cgi?id=280655</a>
<a href="https://rdar.apple.com/137009069">rdar://137009069</a>

Reviewed by Antoine Quint.

Implement parsing of view timeline inset if set via the ViewTimelineOptions,
and adjust computeViewTimelineData to use insets.

* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::lengthForInset):
(WebCore::insetsFromString):
(WebCore::insetsFromOptions):
(WebCore::ViewTimeline::ViewTimeline):
(WebCore::ViewTimeline::computeViewTimelineData const):
(WebCore::ViewTimeline::currentTime):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/284636@main">https://commits.webkit.org/284636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e984231061b89d325ebba3abc5438da9e9b2eb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21049 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19575 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63287 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63215 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4850 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10696 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->