### PR TITLE
RE-BASELINE: fast/text/font-weights-zh.html

### DIFF
--- a/LayoutTests/platform/ios/fast/text/font-weights-zh-expected.txt
+++ b/LayoutTests/platform/ios/fast/text/font-weights-zh-expected.txt
@@ -55,20 +55,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 267x19
           text run at (0,0) width 267: "Font: Heiti SC Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,438) size 784x23
-        RenderText {#text} at (0,0) size 147x23
-          text run at (0,0) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,0) size 144x23
+          text run at (0,0) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,461) size 784x20
         RenderText {#text} at (0,0) size 267x19
           text run at (0,0) width 267: "Font: Heiti SC Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,481) size 784x23
-        RenderText {#text} at (0,0) size 147x23
-          text run at (0,0) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,0) size 144x23
+          text run at (0,0) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,504) size 784x20
         RenderText {#text} at (0,0) size 267x19
           text run at (0,0) width 267: "Font: Heiti SC Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,524) size 784x23
-        RenderText {#text} at (0,0) size 147x23
-          text run at (0,0) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,0) size 144x23
+          text run at (0,0) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,547) size 784x20
         RenderText {#text} at (0,0) size 321x19
           text run at (0,0) width 321: "Font: STHeitiSC-Light Weight: 100 Style: normal"
@@ -217,20 +217,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 253x19
           text run at (0,0) width 253: "Font: Heiti SC Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,1599) size 784x23
-        RenderText {#text} at (0,0) size 147x23
-          text run at (0,0) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,0) size 144x23
+          text run at (0,0) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,1622) size 784x20
         RenderText {#text} at (0,0) size 253x19
           text run at (0,0) width 253: "Font: Heiti SC Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,1642) size 784x23
-        RenderText {#text} at (0,0) size 147x23
-          text run at (0,0) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,0) size 144x23
+          text run at (0,0) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,1665) size 784x20
         RenderText {#text} at (0,0) size 253x19
           text run at (0,0) width 253: "Font: Heiti SC Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,1685) size 784x23
-        RenderText {#text} at (0,0) size 147x23
-          text run at (0,0) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,0) size 144x23
+          text run at (0,0) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,1708) size 784x20
         RenderText {#text} at (0,0) size 308x19
           text run at (0,0) width 308: "Font: STHeitiSC-Light Weight: 100 Style: italic"
@@ -379,20 +379,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 277x19
           text run at (0,0) width 277: "Font: Songti SC Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,2760) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,2783) size 784x20
         RenderText {#text} at (0,0) size 277x19
           text run at (0,0) width 277: "Font: Songti SC Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,2803) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,2826) size 784x20
         RenderText {#text} at (0,0) size 277x19
           text run at (0,0) width 277: "Font: Songti SC Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,2846) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,2869) size 784x20
         RenderText {#text} at (0,0) size 353x19
           text run at (0,0) width 353: "Font: STSongti-SC-Regular Weight: 100 Style: normal"
@@ -433,20 +433,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 353x19
           text run at (0,0) width 353: "Font: STSongti-SC-Regular Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,3147) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3170) size 784x20
         RenderText {#text} at (0,0) size 353x19
           text run at (0,0) width 353: "Font: STSongti-SC-Regular Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,3190) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3213) size 784x20
         RenderText {#text} at (0,0) size 353x19
           text run at (0,0) width 353: "Font: STSongti-SC-Regular Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,3233) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3256) size 784x20
         RenderText {#text} at (0,0) size 337x19
           text run at (0,0) width 337: "Font: STSongti-SC-Light Weight: 100 Style: normal"
@@ -487,20 +487,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 337x19
           text run at (0,0) width 337: "Font: STSongti-SC-Light Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,3534) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3557) size 784x20
         RenderText {#text} at (0,0) size 337x19
           text run at (0,0) width 337: "Font: STSongti-SC-Light Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,3577) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3600) size 784x20
         RenderText {#text} at (0,0) size 337x19
           text run at (0,0) width 337: "Font: STSongti-SC-Light Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,3620) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3643) size 784x20
         RenderText {#text} at (0,0) size 333x19
           text run at (0,0) width 333: "Font: STSongti-SC-Bold Weight: 100 Style: normal"
@@ -541,20 +541,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 333x19
           text run at (0,0) width 333: "Font: STSongti-SC-Bold Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,3921) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3944) size 784x20
         RenderText {#text} at (0,0) size 333x19
           text run at (0,0) width 333: "Font: STSongti-SC-Bold Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,3964) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,3987) size 784x20
         RenderText {#text} at (0,0) size 333x19
           text run at (0,0) width 333: "Font: STSongti-SC-Bold Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,4007) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4030) size 784x20
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Black Weight: 100 Style: normal"
@@ -595,20 +595,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Black Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,4308) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4331) size 784x20
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Black Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,4351) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4374) size 784x20
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Black Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,4394) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4417) size 784x20
         RenderText {#text} at (0,0) size 263x19
           text run at (0,0) width 263: "Font: Songti SC Weight: 100 Style: italic"
@@ -649,20 +649,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 263x19
           text run at (0,0) width 263: "Font: Songti SC Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,4695) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4718) size 784x20
         RenderText {#text} at (0,0) size 263x19
           text run at (0,0) width 263: "Font: Songti SC Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,4738) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4761) size 784x20
         RenderText {#text} at (0,0) size 263x19
           text run at (0,0) width 263: "Font: Songti SC Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,4781) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,4804) size 784x20
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Regular Weight: 100 Style: italic"
@@ -703,20 +703,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Regular Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,5082) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5105) size 784x20
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Regular Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,5125) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5148) size 784x20
         RenderText {#text} at (0,0) size 339x19
           text run at (0,0) width 339: "Font: STSongti-SC-Regular Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,5168) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5191) size 784x20
         RenderText {#text} at (0,0) size 323x19
           text run at (0,0) width 323: "Font: STSongti-SC-Light Weight: 100 Style: italic"
@@ -757,20 +757,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 323x19
           text run at (0,0) width 323: "Font: STSongti-SC-Light Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,5469) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5492) size 784x20
         RenderText {#text} at (0,0) size 323x19
           text run at (0,0) width 323: "Font: STSongti-SC-Light Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,5512) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5535) size 784x20
         RenderText {#text} at (0,0) size 323x19
           text run at (0,0) width 323: "Font: STSongti-SC-Light Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,5555) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5578) size 784x20
         RenderText {#text} at (0,0) size 320x19
           text run at (0,0) width 320: "Font: STSongti-SC-Bold Weight: 100 Style: italic"
@@ -811,20 +811,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 320x19
           text run at (0,0) width 320: "Font: STSongti-SC-Bold Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,5856) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5879) size 784x20
         RenderText {#text} at (0,0) size 320x19
           text run at (0,0) width 320: "Font: STSongti-SC-Bold Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,5899) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5922) size 784x20
         RenderText {#text} at (0,0) size 320x19
           text run at (0,0) width 320: "Font: STSongti-SC-Bold Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,5942) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,5965) size 784x20
         RenderText {#text} at (0,0) size 326x19
           text run at (0,0) width 326: "Font: STSongti-SC-Black Weight: 100 Style: italic"
@@ -865,20 +865,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 326x19
           text run at (0,0) width 326: "Font: STSongti-SC-Black Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,6243) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,6266) size 784x20
         RenderText {#text} at (0,0) size 326x19
           text run at (0,0) width 326: "Font: STSongti-SC-Black Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,6286) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,6309) size 784x20
         RenderText {#text} at (0,0) size 326x19
           text run at (0,0) width 326: "Font: STSongti-SC-Black Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,6329) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,6352) size 784x20
         RenderText {#text} at (0,0) size 392x19
           text run at (0,0) width 392: "Font: Hiragino Kaku Gothic ProN Weight: 100 Style: normal"
@@ -1675,20 +1675,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 412x19
           text run at (0,0) width 412: "Font: AppleSDGothicNeo-ExtraBold Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,12156) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,12179) size 784x20
         RenderText {#text} at (0,0) size 412x19
           text run at (0,0) width 412: "Font: AppleSDGothicNeo-ExtraBold Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,12199) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,12222) size 784x20
         RenderText {#text} at (0,0) size 412x19
           text run at (0,0) width 412: "Font: AppleSDGothicNeo-ExtraBold Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,12242) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,12265) size 784x20
         RenderText {#text} at (0,0) size 388x19
           text run at (0,0) width 388: "Font: AppleSDGothicNeo-Heavy Weight: 100 Style: normal"
@@ -1729,20 +1729,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 388x19
           text run at (0,0) width 388: "Font: AppleSDGothicNeo-Heavy Weight: 700 Style: normal"
       RenderBlock {DIV} at (0,12543) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,12566) size 784x20
         RenderText {#text} at (0,0) size 388x19
           text run at (0,0) width 388: "Font: AppleSDGothicNeo-Heavy Weight: 800 Style: normal"
       RenderBlock {DIV} at (0,12586) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,12609) size 784x20
         RenderText {#text} at (0,0) size 388x19
           text run at (0,0) width 388: "Font: AppleSDGothicNeo-Heavy Weight: 900 Style: normal"
       RenderBlock {DIV} at (0,12629) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,12652) size 784x20
         RenderText {#text} at (0,0) size 340x19
           text run at (0,0) width 340: "Font: Apple SD Gothic Neo Weight: 100 Style: italic"
@@ -2215,20 +2215,20 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 399x19
           text run at (0,0) width 399: "Font: AppleSDGothicNeo-ExtraBold Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,16026) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,16049) size 784x20
         RenderText {#text} at (0,0) size 399x19
           text run at (0,0) width 399: "Font: AppleSDGothicNeo-ExtraBold Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,16069) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,16092) size 784x20
         RenderText {#text} at (0,0) size 399x19
           text run at (0,0) width 399: "Font: AppleSDGothicNeo-ExtraBold Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,16112) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,16135) size 784x20
         RenderText {#text} at (0,0) size 375x19
           text run at (0,0) width 375: "Font: AppleSDGothicNeo-Heavy Weight: 100 Style: italic"
@@ -2269,17 +2269,17 @@ layer at (0,0) size 800x16538
         RenderText {#text} at (0,0) size 375x19
           text run at (0,0) width 375: "Font: AppleSDGothicNeo-Heavy Weight: 700 Style: italic"
       RenderBlock {DIV} at (0,16413) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,16436) size 784x20
         RenderText {#text} at (0,0) size 375x19
           text run at (0,0) width 375: "Font: AppleSDGothicNeo-Heavy Weight: 800 Style: italic"
       RenderBlock {DIV} at (0,16456) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
       RenderBlock {DIV} at (0,16479) size 784x20
         RenderText {#text} at (0,0) size 375x19
           text run at (0,0) width 375: "Font: AppleSDGothicNeo-Heavy Weight: 900 Style: italic"
       RenderBlock {DIV} at (0,16499) size 784x23
-        RenderText {#text} at (0,2) size 147x19
-          text run at (0,2) width 147: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"
+        RenderText {#text} at (0,2) size 144x19
+          text run at (0,2) width 144: "\x{679C}\x{57CE}\x{7684}\x{7F8E}\x{8B7D}\x{3002}\x{4E2D}\x{56FD}\x{53E4}"


### PR DESCRIPTION
#### 67985011db6bd5af5d0039c25d547a664425c28c
<pre>
RE-BASELINE: fast/text/font-weights-zh.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=280656">https://bugs.webkit.org/show_bug.cgi?id=280656</a>
<a href="https://rdar.apple.com/133995468">rdar://133995468</a>

Reviewed by Brent Fulgham.

Rebaseline needed due to font update, similarly to <a href="https://commits.webkit.org/281032@main">https://commits.webkit.org/281032@main</a>

* LayoutTests/platform/ios/fast/text/font-weights-zh-expected.txt:

Canonical link: <a href="https://commits.webkit.org/284482@main">https://commits.webkit.org/284482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ee92cc695266e60944ed130b096415561ade559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20562 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13752 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75348 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17036 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62874 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15439 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4523 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->