### PR TITLE
[Writing Tools] Enable Writing Tools tests for some testing configurations

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -58,6 +58,10 @@
 
 #import <pal/cocoa/WritingToolsUISoftLink.h>
 
+#if PLATFORM(VISION)
+asm(".linker_option \"-framework\", \"WritingTools\"");
+#endif
+
 #if PLATFORM(MAC)
 
 @interface NSMenu (Extras)
@@ -126,6 +130,16 @@
 
 @end
 #endif
+
+@interface WKWebViewConfiguration (Staging_135210076)
+
+#if PLATFORM(IOS_FAMILY)
+@property (nonatomic) UIWritingToolsBehavior writingToolsBehavior;
+#else
+@property (nonatomic) NSWritingToolsBehavior writingToolsBehavior;
+#endif
+
+@end
 
 #if PLATFORM(IOS_FAMILY)
 using PlatformTextPlaceholder = UITextPlaceholder;
@@ -3041,8 +3055,10 @@ TEST(WritingTools, SuggestedTextIsSelectedAfterSmartReply)
 
 #if PLATFORM(MAC)
         id<NSTextInputClient_Async> contentView = (id<NSTextInputClient_Async>)webView.get();
-#else
+#elif USE(BROWSERENGINEKIT)
         id<BETextInput> contentView = [webView asyncTextInput];
+#else
+        id<UIWKInteractionViewProtocol> contentView = [webView textInputContentView];
 #endif
 
         [contentView insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(PlatformTextPlaceholder *placeholder) {


### PR DESCRIPTION
#### 855b274febc5b5b46a320801d300b16d958c51b4
<pre>
[Writing Tools] Enable Writing Tools tests for some testing configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=280658">https://bugs.webkit.org/show_bug.cgi?id=280658</a>
<a href="https://rdar.apple.com/135210076">rdar://135210076</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:

Canonical link: <a href="https://commits.webkit.org/284541@main">https://commits.webkit.org/284541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e74e89ebff9d6a9fd90c3880bf4b2d5cbb38d610

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56869 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20677 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55371 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35850 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69177 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63038 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62954 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4566 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44872 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45946 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47210 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->