### PR TITLE
Log message name when message receiver is disabled

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1330,7 +1330,7 @@ def generate_enabled_by_for_receiver(receiver, messages, ignore_invalid_message_
         '        if (%s)\n' % ignore_invalid_message_for_testing,
         '            %s;\n' % return_statement_line,
         '#endif // ENABLE(IPC_TESTING_API)\n',
-        '        ASSERT_NOT_REACHED_WITH_MESSAGE("Message received by a disabled message receiver %s");\n' % receiver.name,
+        '        ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver %s", IPC::description(decoder.messageName()).characters());\n' % ('%s', receiver.name),
         '        %s;\n' % return_statement_line,
         '    }\n',
     ]

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connect
         if (connection.ignoreInvalidMessageForTesting())
             return;
 #endif // ENABLE(IPC_TESTING_API)
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Message received by a disabled message receiver TestWithEnabledByAndConjunction");
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledByAndConjunction", IPC::description(decoder.messageName()).characters());
         return;
     }
     Ref protectedThis { *this };

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connecti
         if (connection.ignoreInvalidMessageForTesting())
             return;
 #endif // ENABLE(IPC_TESTING_API)
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Message received by a disabled message receiver TestWithEnabledByOrConjunction");
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledByOrConjunction", IPC::description(decoder.messageName()).characters());
         return;
     }
     Ref protectedThis { *this };

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Deco
         if (connection.ignoreInvalidMessageForTesting())
             return;
 #endif // ENABLE(IPC_TESTING_API)
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Message received by a disabled message receiver TestWithEnabledIf");
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledIf", IPC::description(decoder.messageName()).characters());
         return;
     }
     Ref protectedThis { *this };


### PR DESCRIPTION
#### f8494dfff1a82d183a801a874664dae9e6600c31
<pre>
Log message name when message receiver is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280660">https://bugs.webkit.org/show_bug.cgi?id=280660</a>
<a href="https://rdar.apple.com/137019182">rdar://137019182</a>

Reviewed by Youenn Fablet.

This will help locate sender function when debugging assertion failure.

* Source/WebKit/Scripts/webkit/messages.py:
(generate_enabled_by_for_receiver):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByAndConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByOrConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):

Canonical link: <a href="https://commits.webkit.org/284492@main">https://commits.webkit.org/284492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19d86ef2fdff476bb4c498518bf98edef94aa871

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20736 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55310 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35789 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69087 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41332 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75373 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62973 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4549 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45856 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->