### PR TITLE
Adopt more smart pointers in GPUProcess/graphics (part 1)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -46,7 +46,7 @@ RemoteBindGroup::RemoteBindGroup(WebCore::WebGPU::BindGroup& bindGroup, WebGPU::
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteBindGroup::~RemoteBindGroup() = default;
@@ -59,17 +59,27 @@ void RemoteBindGroup::destruct()
 void RemoteBindGroup::updateExternalTextures(WebGPUIdentifier externalTextureIdentifier)
 {
     if (auto externalTexture = protectedObjectHeap()->convertExternalTextureFromBacking(externalTextureIdentifier); externalTexture.get())
-        m_backing->updateExternalTextures(*externalTexture.get());
+        protectedBacking()->updateExternalTextures(*externalTexture.get());
 }
 
 void RemoteBindGroup::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteBindGroup::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::BindGroup> RemoteBindGroup::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteBindGroup::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -74,7 +74,10 @@ private:
     RemoteBindGroup& operator=(RemoteBindGroup&&) = delete;
 
     WebCore::WebGPU::BindGroup& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::BindGroup> protectedBacking();
+
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -45,7 +45,7 @@ RemoteBindGroupLayout::RemoteBindGroupLayout(WebCore::WebGPU::BindGroupLayout& b
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteBindGroupLayout::~RemoteBindGroupLayout() = default;
@@ -57,12 +57,17 @@ void RemoteBindGroupLayout::destruct()
 
 void RemoteBindGroupLayout::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteBindGroupLayout::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemoteBindGroupLayout::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -75,6 +75,8 @@ private:
 
     WebCore::WebGPU::BindGroupLayout& backing() { return m_backing; }
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -45,29 +45,39 @@ RemoteQuerySet::RemoteQuerySet(WebCore::WebGPU::QuerySet& querySet, WebGPU::Obje
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteQuerySet::~RemoteQuerySet() = default;
 
 void RemoteQuerySet::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteQuerySet::destroy()
 {
-    m_backing->destroy();
+    protectedBacking()->destroy();
 }
 
 void RemoteQuerySet::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteQuerySet::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::QuerySet> RemoteQuerySet::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteQuerySet::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -74,6 +74,9 @@ private:
     RemoteQuerySet& operator=(RemoteQuerySet&&) = delete;
 
     WebCore::WebGPU::QuerySet& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::QuerySet> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -56,7 +56,7 @@ RemoteRenderPassEncoder::~RemoteRenderPassEncoder() = default;
 
 void RemoteRenderPassEncoder::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    protectedObjectHeap()->removeObject(m_identifier);
 }
 
 void RemoteRenderPassEncoder::stopListeningForIPC()
@@ -66,43 +66,43 @@ void RemoteRenderPassEncoder::stopListeningForIPC()
 
 void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
-    auto convertedRenderPipeline = m_objectHeap->convertRenderPipelineFromBacking(renderPipeline);
+    auto convertedRenderPipeline = protectedObjectHeap()->convertRenderPipelineFromBacking(renderPipeline);
     ASSERT(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
 
-    m_backing->setPipeline(*convertedRenderPipeline);
+    protectedBacking()->setPipeline(*convertedRenderPipeline);
 }
 
 void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
+    auto convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
 
-    m_backing->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
+    protectedBacking()->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
 }
 
 void RemoteRenderPassEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
+    RefPtr convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer).get();
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
 
-    m_backing->setVertexBuffer(slot, convertedBuffer.get(), offset, size);
+    protectedBacking()->setVertexBuffer(slot, convertedBuffer.get(), offset, size);
 }
 
 void RemoteRenderPassEncoder::unsetVertexBuffer(WebCore::WebGPU::Index32 slot, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    m_backing->setVertexBuffer(slot, nullptr, offset, size);
+    protectedBacking()->setVertexBuffer(slot, nullptr, offset, size);
 }
 
 void RemoteRenderPassEncoder::draw(WebCore::WebGPU::Size32 vertexCount, std::optional<WebCore::WebGPU::Size32> instanceCount,
     std::optional<WebCore::WebGPU::Size32> firstVertex, std::optional<WebCore::WebGPU::Size32> firstInstance)
 {
-    m_backing->draw(vertexCount, instanceCount, firstVertex, firstInstance);
+    protectedBacking()->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
 void RemoteRenderPassEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount,
@@ -111,90 +111,90 @@ void RemoteRenderPassEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount,
     std::optional<WebCore::WebGPU::SignedOffset32> baseVertex,
     std::optional<WebCore::WebGPU::Size32> firstInstance)
 {
-    m_backing->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+    protectedBacking()->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }
 
 void RemoteRenderPassEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    m_backing->drawIndirect(*convertedIndirectBuffer, indirectOffset);
+    protectedBacking()->drawIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteRenderPassEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    m_backing->drawIndexedIndirect(*convertedIndirectBuffer, indirectOffset);
+    protectedBacking()->drawIndexedIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteRenderPassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebGPUIdentifier bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
-    auto convertedBindGroup = m_objectHeap->convertBindGroupFromBacking(bindGroup);
+    auto convertedBindGroup = protectedObjectHeap()->convertBindGroupFromBacking(bindGroup);
     if (!convertedBindGroup)
         return;
 
-    m_backing->setBindGroup(index, *convertedBindGroup, WTFMove(dynamicOffsets));
+    protectedBacking()->setBindGroup(index, *convertedBindGroup, WTFMove(dynamicOffsets));
 }
 
 void RemoteRenderPassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    m_backing->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
 }
 
 void RemoteRenderPassEncoder::popDebugGroup()
 {
-    m_backing->popDebugGroup();
+    protectedBacking()->popDebugGroup();
 }
 
 void RemoteRenderPassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    m_backing->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
 }
 
 void RemoteRenderPassEncoder::setViewport(float x, float y,
     float width, float height,
     float minDepth, float maxDepth)
 {
-    m_backing->setViewport(x, y, width, height, minDepth, maxDepth);
+    protectedBacking()->setViewport(x, y, width, height, minDepth, maxDepth);
 }
 
 void RemoteRenderPassEncoder::setScissorRect(WebCore::WebGPU::IntegerCoordinate x, WebCore::WebGPU::IntegerCoordinate y,
     WebCore::WebGPU::IntegerCoordinate width, WebCore::WebGPU::IntegerCoordinate height)
 {
-    m_backing->setScissorRect(x, y, width, height);
+    protectedBacking()->setScissorRect(x, y, width, height);
 }
 
 void RemoteRenderPassEncoder::setBlendConstant(WebGPU::Color color)
 {
-    auto convertedColor = m_objectHeap->convertFromBacking(color);
+    auto convertedColor = protectedObjectHeap()->convertFromBacking(color);
     ASSERT(convertedColor);
     if (!convertedColor)
         return;
 
-    m_backing->setBlendConstant(*convertedColor);
+    protectedBacking()->setBlendConstant(*convertedColor);
 }
 
 void RemoteRenderPassEncoder::setStencilReference(WebCore::WebGPU::StencilValue stencilValue)
 {
-    m_backing->setStencilReference(stencilValue);
+    protectedBacking()->setStencilReference(stencilValue);
 }
 
 void RemoteRenderPassEncoder::beginOcclusionQuery(WebCore::WebGPU::Size32 queryIndex)
 {
-    m_backing->beginOcclusionQuery(queryIndex);
+    protectedBacking()->beginOcclusionQuery(queryIndex);
 }
 
 void RemoteRenderPassEncoder::endOcclusionQuery()
 {
-    m_backing->endOcclusionQuery();
+    protectedBacking()->endOcclusionQuery();
 }
 
 void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBundles)
@@ -208,17 +208,27 @@ void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBu
             return;
         convertedBundles.append(*convertedBundle);
     }
-    m_backing->executeBundles(WTFMove(convertedBundles));
+    protectedBacking()->executeBundles(WTFMove(convertedBundles));
 }
 
 void RemoteRenderPassEncoder::end()
 {
-    m_backing->end();
+    protectedBacking()->end();
 }
 
 void RemoteRenderPassEncoder::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::RenderPassEncoder> RemoteRenderPassEncoder::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<WebGPU::ObjectHeap> RemoteRenderPassEncoder::protectedObjectHeap() const
+{
+    return m_objectHeap.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -77,7 +77,9 @@ private:
     RemoteRenderPassEncoder& operator=(RemoteRenderPassEncoder&&) = delete;
 
     WebCore::WebGPU::RenderPassEncoder& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
+    Ref<WebCore::WebGPU::RenderPassEncoder> protectedBacking();
+
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
@@ -45,24 +45,29 @@ RemoteSampler::RemoteSampler(WebCore::WebGPU::Sampler& sampler, WebGPU::ObjectHe
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteSampler::~RemoteSampler() = default;
 
 void RemoteSampler::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteSampler::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteSampler::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemoteSampler::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -74,6 +74,7 @@ private:
     RemoteSampler& operator=(RemoteSampler&&) = delete;
 
     WebCore::WebGPU::Sampler& backing() { return m_backing; }
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
@@ -57,7 +57,7 @@ void RemoteBindGroupProxy::setLabelInternal(const String& label)
 
 void RemoteBindGroupProxy::updateExternalTextures(const WebCore::WebGPU::ExternalTexture& externalTexture)
 {
-    auto sendResult = send(Messages::RemoteBindGroup::UpdateExternalTextures(m_convertToBackingContext->convertToBacking(externalTexture)));
+    auto sendResult = send(Messages::RemoteBindGroup::UpdateExternalTextures(Ref { m_convertToBackingContext }->convertToBacking(externalTexture)));
     UNUSED_VARIABLE(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -51,7 +51,7 @@ RemoteRenderPassEncoderProxy::~RemoteRenderPassEncoderProxy()
 
 void RemoteRenderPassEncoderProxy::setPipeline(const WebCore::WebGPU::RenderPipeline& renderPipeline)
 {
-    auto convertedRenderPipeline = m_convertToBackingContext->convertToBacking(renderPipeline);
+    auto convertedRenderPipeline = protectedConvertToBackingContext()->convertToBacking(renderPipeline);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetPipeline(convertedRenderPipeline));
     UNUSED_VARIABLE(sendResult);
@@ -59,7 +59,7 @@ void RemoteRenderPassEncoderProxy::setPipeline(const WebCore::WebGPU::RenderPipe
 
 void RemoteRenderPassEncoderProxy::setIndexBuffer(const WebCore::WebGPU::Buffer& buffer, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
+    auto convertedBuffer = protectedConvertToBackingContext()->convertToBacking(buffer);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetIndexBuffer(convertedBuffer, indexFormat, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -73,7 +73,7 @@ void RemoteRenderPassEncoderProxy::setVertexBuffer(WebCore::WebGPU::Index32 slot
         return;
     }
 
-    auto convertedBuffer = m_convertToBackingContext->convertToBacking(*buffer);
+    auto convertedBuffer = protectedConvertToBackingContext()->convertToBacking(*buffer);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetVertexBuffer(slot, convertedBuffer, offset, size));
     UNUSED_VARIABLE(sendResult);
@@ -97,7 +97,7 @@ void RemoteRenderPassEncoderProxy::drawIndexed(WebCore::WebGPU::Size32 indexCoun
 
 void RemoteRenderPassEncoderProxy::drawIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protectedConvertToBackingContext()->convertToBacking(indirectBuffer);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::DrawIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -105,7 +105,7 @@ void RemoteRenderPassEncoderProxy::drawIndirect(const WebCore::WebGPU::Buffer& i
 
 void RemoteRenderPassEncoderProxy::drawIndexedIndirect(const WebCore::WebGPU::Buffer& indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_convertToBackingContext->convertToBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protectedConvertToBackingContext()->convertToBacking(indirectBuffer);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::DrawIndexedIndirect(convertedIndirectBuffer, indirectOffset));
     UNUSED_VARIABLE(sendResult);
@@ -114,7 +114,7 @@ void RemoteRenderPassEncoderProxy::drawIndexedIndirect(const WebCore::WebGPU::Bu
 void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, const WebCore::WebGPU::BindGroup& bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
-    auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
+    auto convertedBindGroup = protectedConvertToBackingContext()->convertToBacking(bindGroup);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, dynamicOffsets));
     UNUSED_VARIABLE(sendResult);
@@ -126,7 +126,7 @@ void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, 
     WebCore::WebGPU::Size64 dynamicOffsetsDataStart,
     WebCore::WebGPU::Size32 dynamicOffsetsDataLength)
 {
-    auto convertedBindGroup = m_convertToBackingContext->convertToBacking(bindGroup);
+    auto convertedBindGroup = protectedConvertToBackingContext()->convertToBacking(bindGroup);
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);
@@ -167,7 +167,7 @@ void RemoteRenderPassEncoderProxy::setScissorRect(WebCore::WebGPU::IntegerCoordi
 
 void RemoteRenderPassEncoderProxy::setBlendConstant(WebCore::WebGPU::Color color)
 {
-    auto convertedColor = m_convertToBackingContext->convertToBacking(color);
+    auto convertedColor = protectedConvertToBackingContext()->convertToBacking(color);
     ASSERT(convertedColor);
     if (!convertedColor)
         return;
@@ -197,7 +197,7 @@ void RemoteRenderPassEncoderProxy::endOcclusionQuery()
 void RemoteRenderPassEncoderProxy::executeBundles(Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>>&& renderBundles)
 {
     auto convertedRenderBundles = WTF::compactMap(renderBundles, [&](auto& renderBundle) -> std::optional<WebGPUIdentifier> {
-        return m_convertToBackingContext->convertToBacking(renderBundle);
+        return protectedConvertToBackingContext()->convertToBacking(renderBundle);
     });
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::ExecuteBundles(WTFMove(convertedRenderBundles)));
@@ -214,6 +214,11 @@ void RemoteRenderPassEncoderProxy::setLabelInternal(const String& label)
 {
     auto sendResult = send(Messages::RemoteRenderPassEncoder::SetLabel(label));
     UNUSED_VARIABLE(sendResult);
+}
+
+Ref<ConvertToBackingContext> RemoteRenderPassEncoderProxy::protectedConvertToBackingContext() const
+{
+    return m_convertToBackingContext;
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -60,6 +60,7 @@ private:
     RemoteRenderPassEncoderProxy& operator=(RemoteRenderPassEncoderProxy&&) = delete;
 
     WebGPUIdentifier backing() const { return m_backing; }
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const;
     
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)


### PR DESCRIPTION
#### a234cec946ade67426c0e14e8e5759fe60d4d3be
<pre>
Adopt more smart pointers in GPUProcess/graphics (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280657">https://bugs.webkit.org/show_bug.cgi?id=280657</a>
<a href="https://rdar.apple.com/137016134">rdar://137016134</a>

Reviewed by Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp:
(WebKit::RemoteBindGroup::RemoteBindGroup):
(WebKit::RemoteBindGroup::updateExternalTextures):
(WebKit::RemoteBindGroup::stopListeningForIPC):
(WebKit::RemoteBindGroup::setLabel):
(WebKit::RemoteBindGroup::protectedBacking):
(WebKit::RemoteBindGroup::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp:
(WebKit::RemoteBindGroupLayout::RemoteBindGroupLayout):
(WebKit::RemoteBindGroupLayout::stopListeningForIPC):
(WebKit::RemoteBindGroupLayout::setLabel):
(WebKit::RemoteBindGroupLayout::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp:
(WebKit::RemoteQuerySet::RemoteQuerySet):
(WebKit::RemoteQuerySet::stopListeningForIPC):
(WebKit::RemoteQuerySet::destroy):
(WebKit::RemoteQuerySet::destruct):
(WebKit::RemoteQuerySet::setLabel):
(WebKit::RemoteQuerySet::protectedBacking):
(WebKit::RemoteQuerySet::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::destruct):
(WebKit::RemoteRenderPassEncoder::setPipeline):
(WebKit::RemoteRenderPassEncoder::setIndexBuffer):
(WebKit::RemoteRenderPassEncoder::setVertexBuffer):
(WebKit::RemoteRenderPassEncoder::unsetVertexBuffer):
(WebKit::RemoteRenderPassEncoder::draw):
(WebKit::RemoteRenderPassEncoder::drawIndexed):
(WebKit::RemoteRenderPassEncoder::drawIndirect):
(WebKit::RemoteRenderPassEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderPassEncoder::setBindGroup):
(WebKit::RemoteRenderPassEncoder::pushDebugGroup):
(WebKit::RemoteRenderPassEncoder::popDebugGroup):
(WebKit::RemoteRenderPassEncoder::insertDebugMarker):
(WebKit::RemoteRenderPassEncoder::setViewport):
(WebKit::RemoteRenderPassEncoder::setScissorRect):
(WebKit::RemoteRenderPassEncoder::setBlendConstant):
(WebKit::RemoteRenderPassEncoder::setStencilReference):
(WebKit::RemoteRenderPassEncoder::beginOcclusionQuery):
(WebKit::RemoteRenderPassEncoder::endOcclusionQuery):
(WebKit::RemoteRenderPassEncoder::executeBundles):
(WebKit::RemoteRenderPassEncoder::end):
(WebKit::RemoteRenderPassEncoder::setLabel):
(WebKit::RemoteRenderPassEncoder::protectedBacking):
(WebKit::RemoteRenderPassEncoder::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp:
(WebKit::RemoteSampler::RemoteSampler):
(WebKit::RemoteSampler::destruct):
(WebKit::RemoteSampler::stopListeningForIPC):
(WebKit::RemoteSampler::setLabel):
(WebKit::RemoteSampler::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp:
(WebKit::WebGPU::RemoteBindGroupProxy::updateExternalTextures):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setPipeline):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setIndexBuffer):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setVertexBuffer):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::drawIndirect):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::drawIndexedIndirect):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setBindGroup):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setBlendConstant):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::executeBundles):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::protectedConvertToBackingContext const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:

Canonical link: <a href="https://commits.webkit.org/284498@main">https://commits.webkit.org/284498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33bc453bda606465ddb73f8fea21d9bd344f64b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69681 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/49081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56882 "Build is in progress. Recent messages:") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/20690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72747 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/56882 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/56882 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/56882 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/13663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/20690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/13703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/22432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10620 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/44885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->