### PR TITLE
Adopt more smart pointers in GPUProcess/graphics (part 2)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
@@ -45,24 +45,29 @@ RemoteCommandBuffer::RemoteCommandBuffer(WebCore::WebGPU::CommandBuffer& command
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteCommandBuffer::~RemoteCommandBuffer() = default;
 
 void RemoteCommandBuffer::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteCommandBuffer::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteCommandBuffer::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemoteCommandBuffer::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -74,6 +74,7 @@ private:
     RemoteCommandBuffer& operator=(RemoteCommandBuffer&&) = delete;
 
     WebCore::WebGPU::CommandBuffer& backing() { return m_backing; }
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -47,33 +47,43 @@ RemoteComputePipeline::RemoteComputePipeline(WebCore::WebGPU::ComputePipeline& c
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteComputePipeline::~RemoteComputePipeline() = default;
 
 void RemoteComputePipeline::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    protectedObjectHeap()->removeObject(m_identifier);
 }
 
 void RemoteComputePipeline::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteComputePipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
     // "A new GPUBindGroupLayout wrapper is returned each time"
     Ref objectHeap = m_objectHeap.get();
-    auto bindGroupLayout = m_backing->getBindGroupLayout(index);
+    auto bindGroupLayout = protectedBacking()->getBindGroupLayout(index);
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteComputePipeline::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::ComputePipeline> RemoteComputePipeline::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteComputePipeline::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -74,6 +74,10 @@ private:
     RemoteComputePipeline& operator=(RemoteComputePipeline&&) = delete;
 
     WebCore::WebGPU::ComputePipeline& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::ComputePipeline> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
@@ -45,34 +45,44 @@ RemoteExternalTexture::RemoteExternalTexture(WebCore::WebGPU::ExternalTexture& e
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteExternalTexture::~RemoteExternalTexture() = default;
 
 void RemoteExternalTexture::destroy()
 {
-    m_backing->destroy();
+    protectedBacking()->destroy();
 }
 
 void RemoteExternalTexture::undestroy()
 {
-    m_backing->undestroy();
+    protectedBacking()->undestroy();
 }
 
 void RemoteExternalTexture::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteExternalTexture::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteExternalTexture::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::ExternalTexture> RemoteExternalTexture::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteExternalTexture::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -74,6 +74,9 @@ private:
     RemoteExternalTexture& operator=(RemoteExternalTexture&&) = delete;
 
     WebCore::WebGPU::ExternalTexture& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::ExternalTexture> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -75,30 +75,37 @@ void RemoteTexture::stopListeningForIPC()
 void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor>& descriptor, WebGPUIdentifier identifier)
 {
     std::optional<WebCore::WebGPU::TextureViewDescriptor> convertedDescriptor;
+    Ref objectHeap = m_objectHeap.get();
+
     if (descriptor) {
-        auto resultDescriptor = m_objectHeap->convertFromBacking(*descriptor);
+        auto resultDescriptor = objectHeap->convertFromBacking(*descriptor);
         MESSAGE_CHECK(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
     }
-    auto textureView = m_backing->createView(convertedDescriptor);
+    auto textureView = protectedBacking()->createView(convertedDescriptor);
     MESSAGE_CHECK(textureView);
-    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), m_gpu, identifier);
-    m_objectHeap->addObject(identifier, remoteTextureView);
+    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), Ref { m_gpu.get() }, identifier);
+    objectHeap->addObject(identifier, remoteTextureView);
 }
 
 void RemoteTexture::destroy()
 {
-    m_backing->destroy();
+    protectedBacking()->destroy();
 }
 
 void RemoteTexture::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteTexture::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::Texture> RemoteTexture::protectedBacking()
+{
+    return m_backing;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -78,6 +78,7 @@ private:
     RemoteTexture& operator=(RemoteTexture&&) = delete;
 
     WebCore::WebGPU::Texture& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::Texture> protectedBacking();
 
     RefPtr<IPC::Connection> connection() const;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
@@ -81,7 +81,7 @@ RefPtr<IPC::Connection> RemoteXRProjectionLayer::connection() const
 
 void RemoteXRProjectionLayer::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -54,8 +54,10 @@ RemoteTextureProxy::~RemoteTextureProxy()
 RefPtr<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& descriptor)
 {
     std::optional<TextureViewDescriptor> convertedDescriptor;
+    Ref convertToBackingContext = m_convertToBackingContext;
+
     if (descriptor) {
-        convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
+        convertedDescriptor = convertToBackingContext->convertToBacking(*descriptor);
         if (!convertedDescriptor)
             return nullptr;
     }
@@ -65,7 +67,7 @@ RefPtr<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::o
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteTextureViewProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteTextureViewProxy::create(*this, convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }


### PR DESCRIPTION
#### f66e2c40cc0621e5282e4c5b25ae9c245cab952d
<pre>
Adopt more smart pointers in GPUProcess/graphics (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280661">https://bugs.webkit.org/show_bug.cgi?id=280661</a>
<a href="https://rdar.apple.com/137023471">rdar://137023471</a>

Reviewed by Chris Dumez and Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::endPrepareForDisplay):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp:
(WebKit::RemoteCommandBuffer::RemoteCommandBuffer):
(WebKit::RemoteCommandBuffer::destruct):
(WebKit::RemoteCommandBuffer::stopListeningForIPC):
(WebKit::RemoteCommandBuffer::setLabel):
(WebKit::RemoteCommandBuffer::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::RemoteComputePipeline):
(WebKit::RemoteComputePipeline::destruct):
(WebKit::RemoteComputePipeline::stopListeningForIPC):
(WebKit::RemoteComputePipeline::getBindGroupLayout):
(WebKit::RemoteComputePipeline::setLabel):
(WebKit::RemoteComputePipeline::protectedBacking):
(WebKit::RemoteComputePipeline::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp:
(WebKit::RemoteExternalTexture::RemoteExternalTexture):
(WebKit::RemoteExternalTexture::destroy):
(WebKit::RemoteExternalTexture::undestroy):
(WebKit::RemoteExternalTexture::destruct):
(WebKit::RemoteExternalTexture::stopListeningForIPC):
(WebKit::RemoteExternalTexture::setLabel):
(WebKit::RemoteExternalTexture::protectedBacking):
(WebKit::RemoteExternalTexture::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::createView):
(WebKit::RemoteTexture::destroy):
(WebKit::RemoteTexture::destruct):
(WebKit::RemoteTexture::setLabel):
(WebKit::RemoteTexture::protectedBacking):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp:
(WebKit::RemoteTextureView::RemoteTextureView):
(WebKit::RemoteTextureView::destruct):
(WebKit::RemoteTextureView::stopListeningForIPC):
(WebKit::RemoteTextureView::setLabel):
(WebKit::RemoteTextureView::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp:
(WebKit::RemoteXRProjectionLayer::destruct):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::didPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::close):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::createView):

Canonical link: <a href="https://commits.webkit.org/284621@main">https://commits.webkit.org/284621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c902ef239c28d207443095d6c6f9d0d36e2ac083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21099 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55505 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13982 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35985 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41617 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17331 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63199 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 61 flakes 179 failures; Uploaded test results; 52 flakes 124 failures; Compiled WebKit; 41 flakes 82 failures; Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11155 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4758 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45145 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->