### PR TITLE
check-webkit-style: file path based skip rules don't work as expected in the diff mode with Windows Python

### DIFF
--- a/Tools/Scripts/webkitpy/style/patchreader.py
+++ b/Tools/Scripts/webkitpy/style/patchreader.py
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import os
 import re
 
 from webkitcorepy import string_utils
@@ -67,6 +68,7 @@ class PatchReader(object):
         call_only_once = True
 
         for path, diff_file in patch_files.items():
+            path = path.replace('/', os.sep)
             line_numbers = diff_file.added_or_modified_line_numbers()
             _log.debug('Found %s new or modified lines in: %s' % (len(line_numbers), path))
 

--- a/Tools/Scripts/webkitpy/style/patchreader_unittest.py
+++ b/Tools/Scripts/webkitpy/style/patchreader_unittest.py
@@ -29,6 +29,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os.path
 import unittest
 
 from webkitpy.common.system.filesystem_mock import MockFileSystem
@@ -72,15 +73,15 @@ class PatchReaderTest(unittest.TestCase):
 
     def test_check_patch(self):
         # The modified line_numbers array for this patch is: [2].
-        self._call_check_patch("""diff --git a/__init__.py b/__init__.py
+        self._call_check_patch("""diff --git a/xyz/__init__.py b/xyz/__init__.py
 index ef65bee..e3db70e 100644
---- a/__init__.py
-+++ b/__init__.py
+--- a/xyz/__init__.py
++++ b/xyz/__init__.py
 @@ -1,1 +1,2 @@
  # Required for Python to search this directory for module files
 +# New line
 """)
-        self._assert_checked([("__init__.py", [2])], 0)
+        self._assert_checked([(os.path.join("xyz", "__init__.py"), [2])], 0)
 
     def test_check_patch_with_deletion(self):
         self._call_check_patch("""Index: __init__.py


### PR DESCRIPTION
#### 3cd22d8b906980450a3d3082e4aaaf93a729955b
<pre>
check-webkit-style: file path based skip rules don&apos;t work as expected in the diff mode with Windows Python
<a href="https://bugs.webkit.org/show_bug.cgi?id=280662">https://bugs.webkit.org/show_bug.cgi?id=280662</a>

Reviewed by Jonathan Bedard.

check-webkit-style has two modes, the diff mode and the file mode. The
diff mode checks only the content inside specified diff files. The
file mode checks the entire content of specified files.

check-webkit-style has a lot of file path based skip rules.
&lt;<a href="https://github.com/WebKit/WebKit/blob/524c5c896dca0d3f5363b0d9cb95558ab3678f06/Tools/Scripts/webkitpy/style/checker.py#L466-L531">https://github.com/WebKit/WebKit/blob/524c5c896dca0d3f5363b0d9cb95558ab3678f06/Tools/Scripts/webkitpy/style/checker.py#L466-L531</a>&gt;
&lt;<a href="https://commits.webkit.org/167707@main">https://commits.webkit.org/167707@main</a>&gt; started to use os.path.join
and os.path.sep for them to use OS-specific path separators.

The file path based skip rules didn&apos;t work as expected in the diff
mode on Windows Python because file paths retrived from diff files
were Unix paths.

Convert the Unix path separators to OS-specific path separators.

* Tools/Scripts/webkitpy/style/patchreader.py:
(PatchReader.check):
* Tools/Scripts/webkitpy/style/patchreader_unittest.py:
(PatchReaderTest.test_check_patch):

Canonical link: <a href="https://commits.webkit.org/284512@main">https://commits.webkit.org/284512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dd45ccc738e4dd4faeac4d2958f8e4cd312e893

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55314 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13775 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35793 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69092 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17492 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75378 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68829 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62980 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62896 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10920 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4538 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10627 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44787 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->