### PR TITLE
REGRESSION(284269@main) [WPE] Copy 'inspector.gresource' in generate bundle step

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -766,6 +766,9 @@ class BundleCreator(object):
         if needs_to_create_wpe_backend_symlink:
             self._ensure_wpe_backend_symlink()
 
+        if self._platform == 'wpe':
+            self._bundler.copy(os.path.join(self._buildpath, 'WebInspectorUI', 'DerivedSources', 'inspector.gresource'))
+
         # Now copy data files to share dir (only needed when bunding all for MiniBrowser).
         # We assume that the system uses standard paths at /usr/share and /etc for this resources
         # Every path should be checked and if some one is not found, then it will raise an error.

--- a/Tools/Scripts/webkitpy/binary_bundling/bundle.py
+++ b/Tools/Scripts/webkitpy/binary_bundling/bundle.py
@@ -49,6 +49,9 @@ class BinaryBundler:
     def set_use_sys_lib_directory(self, should_use_sys_lib_directory):
         self._should_use_sys_lib_directory = should_use_sys_lib_directory
 
+    def copy(self, orig_file):
+        shutil.copy(orig_file, self._destination_dir)
+
     def copy_and_maybe_strip_patchelf(self, orig_file, type='bin', strip=True, patchelf_removerpath=True, patchelf_nodefaultlib=False, patchelf_setinterpreter_relativepath=None, object_final_destination_dir=None):
         """ This does the following:
             1. Copies the binary/lib (object)


### PR DESCRIPTION
#### 26028203feef4ee170ca49a711a0c2170442f1fc
<pre>
REGRESSION(284269@main) [WPE] Copy &apos;inspector.gresource&apos; in generate bundle step
<a href="https://bugs.webkit.org/show_bug.cgi?id=280512">https://bugs.webkit.org/show_bug.cgi?id=280512</a>

Reviewed by Adrian Perez de Castro.

After 284269@main, the &apos;generate-bundle&apos; script is failing because it
tries to copy the &apos;InspectorResource&apos; library which no longer exists for WPE.

Instead, the script should copy the &apos;inspector.gresource&apos; file.

* Tools/Scripts/generate-bundle:
(BundleCreator._create_bundle):
* Tools/Scripts/webkitpy/binary_bundling/bundle.py:
(BinaryBundler.copy):

Canonical link: <a href="https://commits.webkit.org/284551@main">https://commits.webkit.org/284551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e84e3d240bfad2f954af758a25bf1500f4c64de2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55323 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13785 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72658 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44681 "Found 1 new test failure: editing/input/ios/typing-with-inline-predictions.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35802 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69101 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17512 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62986 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62903 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4552 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10651 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->