### PR TITLE
[WPE][Debug] ASSERTION FAILED: canSafelyBeUsed()

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1519,7 +1519,7 @@ public:
     void getTextFragmentMatch(CompletionHandler<void(const String&)>&&);
 
 #if USE(WPE_RENDERER)
-    int hostFileDescriptor() const { return m_hostFileDescriptor.value(); }
+    UnixFileDescriptor hostFileDescriptor() const { return m_hostFileDescriptor.duplicate(); }
 #endif
 
     void updateCurrentModifierState(OptionSet<WebCore::PlatformEvent::Modifier> modifiers);

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -46,6 +46,7 @@ std::unique_ptr<AcceleratedSurfaceLibWPE> AcceleratedSurfaceLibWPE::create(WebPa
 
 AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE(WebPage& webPage, Client& client)
     : AcceleratedSurface(webPage, client)
+    , m_hostFD(webPage.hostFileDescriptor())
 {
 }
 
@@ -56,7 +57,7 @@ AcceleratedSurfaceLibWPE::~AcceleratedSurfaceLibWPE()
 
 void AcceleratedSurfaceLibWPE::initialize()
 {
-    m_backend = wpe_renderer_backend_egl_target_create(dupCloseOnExec(m_webPage->hostFileDescriptor()));
+    m_backend = wpe_renderer_backend_egl_target_create(m_hostFD.release());
     static struct wpe_renderer_backend_egl_target_client s_client = {
         // frame_complete
         [](void* data)

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -29,6 +29,7 @@
 
 #include "AcceleratedSurface.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 struct wpe_renderer_backend_egl_target;
 
@@ -63,6 +64,7 @@ public:
 private:
     AcceleratedSurfaceLibWPE(WebPage&, Client&);
 
+    UnixFileDescriptor m_hostFD;
     struct wpe_renderer_backend_egl_target* m_backend { nullptr };
 };
 


### PR DESCRIPTION
#### 4d33c93bc32ae08a7958a1c59d59f13a06d18e39
<pre>
[WPE][Debug] ASSERTION FAILED: canSafelyBeUsed()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280617">https://bugs.webkit.org/show_bug.cgi?id=280617</a>

Reviewed by Chris Dumez.

Save the host file descriptor on AcceleratedSurfaceLibWPE constructor
that is called in the main thread. In initialize(), called from the
compositor thread when the GL context is created, we can release the
file descriptor passing the ownership to the backend.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE):
(WebKit::AcceleratedSurfaceLibWPE::initialize):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/284554@main">https://commits.webkit.org/284554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efe286cf34f792d235059a7f530a2ef9f6ec9d03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41519 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75619 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17240 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63056 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11061 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4675 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10652 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->