### PR TITLE
[WGSL] Add mechanism to validate override values

### DIFF
--- a/Source/WebGPU/WGSL/CompilationMessage.h
+++ b/Source/WebGPU/WGSL/CompilationMessage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,12 @@ class CompilationMessage {
 public:
     CompilationMessage(String&& message, SourceSpan span)
         : m_message(WTFMove(message))
+        , m_span(span)
+    {
+    }
+
+    CompilationMessage(const String& message, SourceSpan span)
+        : m_message(message)
         , m_span(span)
     {
     }

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1767,8 +1767,14 @@ void TypeChecker::visit(AST::ArrayTypeExpression& array)
                 }
             }
             size = { static_cast<unsigned>(elementCount) };
-        } else
+        } else {
+            m_shaderModule.addOverrideValidation(*array.maybeElementCount(), [&](const ConstantValue& elementCount) -> std::optional<String> {
+                if (elementCount.integerValue() < 1)
+                    return { "array count must be greater than 0"_s };
+                return std::nullopt;
+            });
             size = { array.maybeElementCount() };
+        }
     }
 
     inferred(m_types.arrayType(elementType, size));

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,16 +120,18 @@ inline std::variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule
     return result;
 }
 
-String generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMap<String, ConstantValue>& constantValues)
+std::variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMap<String, ConstantValue>& constantValues)
 {
     PhaseTimes phaseTimes;
     String result;
+    if (auto maybeError = shaderModule.validateOverrides(constantValues))
+        return { *maybeError };
     {
         PhaseTimer phaseTimer("generateMetalCode", phaseTimes);
         result = Metal::generateMetalCode(shaderModule, prepareResult, constantValues);
     }
     logPhaseTimes(phaseTimes);
-    return result;
+    return { result };
 }
 
 std::variant<PrepareResult, Error> prepare(ShaderModule& ast, const HashMap<String, PipelineLayout*>& pipelineLayouts)

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -233,7 +233,7 @@ struct PrepareResult {
 std::variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, PipelineLayout*>&);
 std::variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, PipelineLayout*);
 
-String generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&);
+std::variant<String, Error> generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&);
 
 std::optional<ConstantValue> evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.cpp
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WGSLShaderModule.h"
+
+#include "WGSL.h"
+
+namespace WGSL {
+
+std::optional<Error> ShaderModule::validateOverrides(const HashMap<String, ConstantValue>& constantValues)
+{
+    for (const auto& [expression, validators] : m_overrideValidations) {
+        auto maybeValue = evaluate(*expression, constantValues);
+        if (!maybeValue)
+            return { Error("failed to evaluate override expression"_s, expression->span()) };
+
+        for (const auto& validator : validators) {
+            if (auto maybeError = validator(*maybeValue))
+                return { Error(*maybeError, expression->span()) };
+        }
+
+    }
+    return std::nullopt;
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -270,6 +270,15 @@ public:
     }
     bool hasFeature(const String& featureName) const { return m_configuration.supportedFeatures.contains(featureName); }
 
+    template<typename Validator>
+    void addOverrideValidation(AST::Expression& expression, Validator&& validator)
+    {
+        auto result = m_overrideValidations.add(&expression, Vector<Function<std::optional<String>(const ConstantValue&)>> { });
+        result.iterator->value.append(WTFMove(validator));
+    }
+
+    std::optional<Error> validateOverrides(const HashMap<String, ConstantValue>&);
+
 private:
     String m_source;
     bool m_usesExternalTextures { false };
@@ -306,6 +315,7 @@ private:
     std::optional<CallGraph> m_callGraph;
     Vector<std::function<void()>> m_replacements;
     HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_pipelineOverrideIds;
+    HashMap<const AST::Expression*, Vector<Function<std::optional<String>(const ConstantValue&)>>> m_overrideValidations;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/tests/invalid/override.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/override.wgsl
@@ -1,0 +1,10 @@
+// RUN: %not %metal main 2>&1 | %check
+
+override ll: u32 = 0;
+// CHECK-L: array count must be greater than 0
+var<workgroup> oob: array<u32, ll>;
+
+@compute @workgroup_size(1)
+fn main() {
+    let x = oob[0];
+}

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -160,7 +160,14 @@ static int runWGSL(const CommandLine& options)
 
         constantValues.add(constant.mangledName, *defaultValue);
     }
-    auto msl = WGSL::generate(shaderModule, result, constantValues);
+    auto generationResult = WGSL::generate(shaderModule, result, constantValues);
+
+    if (auto* error = std::get_if<WGSL::Error>(&generationResult)) {
+        dataLogLn(*error);
+        return EXIT_FAILURE;
+    }
+
+    auto& msl = std::get<String>(generationResult);
 
     if (options.dumpASTAtEnd())
         WGSL::AST::dumpAST(shaderModule);

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		97A448A62AE3546700A4E147 /* ASTMustUseAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A448A32AE3546700A4E147 /* ASTMustUseAttribute.h */; };
 		97A448A72AE3546700A4E147 /* ASTDiagnosticAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A448A42AE3546700A4E147 /* ASTDiagnosticAttribute.h */; };
 		97A448A82AE3546700A4E147 /* ASTCallStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A448A52AE3546700A4E147 /* ASTCallStatement.h */; };
+		97B4CFCB2CAAF3CD00C87163 /* WGSLShaderModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97B4CFCA2CAAF3CD00C87163 /* WGSLShaderModule.cpp */; };
 		97BCD6AE29D7422B00A82577 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
 		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
@@ -501,6 +502,7 @@
 		97A448A32AE3546700A4E147 /* ASTMustUseAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTMustUseAttribute.h; sourceTree = "<group>"; };
 		97A448A42AE3546700A4E147 /* ASTDiagnosticAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnosticAttribute.h; sourceTree = "<group>"; };
 		97A448A52AE3546700A4E147 /* ASTCallStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTCallStatement.h; sourceTree = "<group>"; };
+		97B4CFCA2CAAF3CD00C87163 /* WGSLShaderModule.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WGSLShaderModule.cpp; sourceTree = "<group>"; };
 		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
 		97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTFloat16Literal.h; sourceTree = "<group>"; };
@@ -737,6 +739,7 @@
 				97099AC42AC49AAB003B41F8 /* WGSLEnums.cpp */,
 				97099AC52AC49AAB003B41F8 /* WGSLEnums.h */,
 				1CA5B4F32A6F28C400E5F297 /* wgslfuzz.cpp */,
+				97B4CFCA2CAAF3CD00C87163 /* WGSLShaderModule.cpp */,
 				9776BE7529957E12002D6D93 /* WGSLShaderModule.h */,
 			);
 			path = WGSL;
@@ -1253,6 +1256,7 @@
 				97DE28482C348D8A00F4DEC3 /* VisibilityValidator.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,
 				97099AC62AC49AAB003B41F8 /* WGSLEnums.cpp in Sources */,
+				97B4CFCB2CAAF3CD00C87163 /* WGSLShaderModule.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -121,7 +121,10 @@ static RefPtr<ShaderModule> earlyCompileShaderModule(Device& device, std::varian
         return nullptr;
     auto& result = std::get<WGSL::PrepareResult>(prepareResult);
     HashMap<String, WGSL::ConstantValue> wgslConstantValues;
-    auto msl = WGSL::generate(shaderModule, result, wgslConstantValues);
+    auto generationResult = WGSL::generate(shaderModule, result, wgslConstantValues);
+    if (std::holds_alternative<WGSL::Error>(generationResult))
+        return nullptr;
+    auto& msl = std::get<String>(generationResult);
     NSError *error = nil;
     auto library = ShaderModule::createLibrary(device.device(), msl, WTFMove(label), &error);
     if (!library)

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -45,8 +45,10 @@ inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const S
     if (auto* maybeError = std::get_if<WGSL::Error>(&prepareResult))
         return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
     HashMap<String, WGSL::ConstantValue> constantValues;
-    auto msl = WGSL::generate(ast, std::get<WGSL::PrepareResult>(prepareResult), constantValues);
-    return { WTFMove(msl) };
+    auto generationResult = WGSL::generate(ast, std::get<WGSL::PrepareResult>(prepareResult), constantValues);
+    if (auto* maybeError = std::get_if<WGSL::Error>(&generationResult))
+        return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
+    return { WTFMove(std::get<String>(generationResult)) };
 }
 
 TEST(WGSLMetalGenerationTests, RedFrag)


### PR DESCRIPTION
#### a9fce285673c6d1720287e2e04e10d3da6615cd5
<pre>
[WGSL] Add mechanism to validate override values
<a href="https://bugs.webkit.org/show_bug.cgi?id=280676">https://bugs.webkit.org/show_bug.cgi?id=280676</a>
<a href="https://rdar.apple.com/136876110">rdar://136876110</a>

Reviewed by Mike Wyrzykowski.

At compile time we validate constant values according to the spec,
as an example in this patch we cover that array sizes must be bigger
than 0. However, when the value can only be computed after overrides
have been provided, we need a way to validate the these values at a
later stage. This patch introduces the mechanism that will be used
for such validations, by storing the necessary validations in the
shader module, and then executing each validation every time the
module is used in a pipeline.

* Source/WebGPU/WGSL/CompilationMessage.h:
(WGSL::CompilationMessage::CompilationMessage):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::generate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/WGSLShaderModule.cpp: Added.
(WGSL::ShaderModule::validateOverrides):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::addOverrideValidation):
* Source/WebGPU/WGSL/tests/invalid/override.wgsl: Added.
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):

Canonical link: <a href="https://commits.webkit.org/284570@main">https://commits.webkit.org/284570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ce966f4edfed57b310d89a22146a14b51d7fc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55331 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13795 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75402 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62914 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15508 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10941 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4562 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44808 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45882 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->