### PR TITLE
[CoordinatedGraphics] Tiled backing store is not needed in paintTile()

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
@@ -30,7 +30,6 @@
 #include "CoordinatedGraphicsLayer.h"
 #include "DisplayListRecorderImpl.h"
 #include "GraphicsContextSkia.h"
-#include "TiledBackingStore.h"
 #include <wtf/NumberOfCores.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -52,18 +51,18 @@ std::unique_ptr<SkiaThreadedPaintingPool> SkiaThreadedPaintingPool::create()
     return nullptr;
 }
 
-std::unique_ptr<DisplayList::DisplayList> SkiaThreadedPaintingPool::recordDisplayList(const TiledBackingStore& tiledBackingStore, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect) const
+std::unique_ptr<DisplayList::DisplayList> SkiaThreadedPaintingPool::recordDisplayList(const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect) const
 {
     auto displayList = makeUnique<DisplayList::DisplayList>();
     DisplayList::RecorderImpl recordingContext(*displayList, GraphicsContextState(), FloatRect({ }, dirtyRect.size()), AffineTransform());
-    layer.paintIntoGraphicsContext(recordingContext, tiledBackingStore, dirtyRect);
+    layer.paintIntoGraphicsContext(recordingContext, dirtyRect);
     return displayList;
 }
 
-void SkiaThreadedPaintingPool::postPaintingTask(Ref<Nicosia::Buffer>& buffer, const TiledBackingStore& tiledBackingStore, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect)
+void SkiaThreadedPaintingPool::postPaintingTask(Ref<Nicosia::Buffer>& buffer, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect)
 {
     WTFBeginSignpost(this, RecordTile);
-    auto displayList = recordDisplayList(tiledBackingStore, layer, dirtyRect);
+    auto displayList = recordDisplayList(layer, dirtyRect);
     WTFEndSignpost(this, RecordTile);
 
     buffer->beginPainting();

--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h
@@ -35,7 +35,6 @@ namespace WebCore {
 
 class CoordinatedGraphicsLayer;
 class IntRect;
-class TiledBackingStore;
 
 namespace DisplayList {
 class DisplayList;
@@ -45,15 +44,15 @@ class SkiaThreadedPaintingPool {
     WTF_MAKE_TZONE_ALLOCATED(SkiaThreadedPaintingPool);
     WTF_MAKE_NONCOPYABLE(SkiaThreadedPaintingPool);
 public:
-    SkiaThreadedPaintingPool(unsigned numberOfThreads);
+    explicit SkiaThreadedPaintingPool(unsigned numberOfThreads);
     ~SkiaThreadedPaintingPool() = default;
 
     static std::unique_ptr<SkiaThreadedPaintingPool> create();
 
-    void postPaintingTask(Ref<Nicosia::Buffer>&, const TiledBackingStore&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect);
+    void postPaintingTask(Ref<Nicosia::Buffer>&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect);
 
 private:
-    std::unique_ptr<DisplayList::DisplayList> recordDisplayList(const TiledBackingStore&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect) const;
+    std::unique_ptr<DisplayList::DisplayList> recordDisplayList(const CoordinatedGraphicsLayer&, const IntRect& dirtyRect) const;
     static unsigned numberOfPaintingThreads();
 
     Ref<WorkerPool> m_workerPool;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1070,7 +1070,7 @@ void CoordinatedGraphicsLayer::deviceOrPageScaleFactorChanged()
         m_pendingContentsScaleAdjustment = true;
 }
 
-float CoordinatedGraphicsLayer::effectiveContentsScale()
+float CoordinatedGraphicsLayer::effectiveContentsScale() const
 {
     return selfOrAncestorHaveNonAffineTransforms() ? 1 : deviceScaleFactor() * pageScaleFactor();
 }
@@ -1207,7 +1207,7 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
 
             auto& tileRect = tile.rect();
             auto& dirtyRect = tile.dirtyRect();
-            auto buffer = paintTile(*layerState.mainBackingStore.get(), dirtyRect);
+            auto buffer = paintTile(dirtyRect);
 
             WTFBeginSignpost(this, UpdateTileBackingStore, "rect %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
 
@@ -1236,22 +1236,6 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
     }
 
     finishUpdate();
-}
-
-void CoordinatedGraphicsLayer::paintIntoGraphicsContext(GraphicsContext& context, const TiledBackingStore& tiledBackingStore, const IntRect& dirtyRect) const
-{
-    IntRect initialClip(IntPoint::zero(), dirtyRect.size());
-    context.clip(initialClip);
-
-    if (!contentsOpaque()) {
-        context.setCompositeOperation(CompositeOperator::Copy);
-        context.fillRect(initialClip, Color::transparentBlack);
-        context.setCompositeOperation(CompositeOperator::SourceOver);
-    }
-
-    context.translate(-dirtyRect.x(), -dirtyRect.y());
-    context.scale(tiledBackingStore.contentsScale());
-    paintGraphicsLayerContents(context, tiledBackingStore.mapToContents(dirtyRect));
 }
 
 void CoordinatedGraphicsLayer::purgeBackingStores()
@@ -1431,7 +1415,7 @@ bool CoordinatedGraphicsLayer::selfOrAncestorHasActiveTransformAnimation() const
     return downcast<CoordinatedGraphicsLayer>(*parent()).selfOrAncestorHasActiveTransformAnimation();
 }
 
-bool CoordinatedGraphicsLayer::selfOrAncestorHaveNonAffineTransforms()
+bool CoordinatedGraphicsLayer::selfOrAncestorHaveNonAffineTransforms() const
 {
     if (!m_layerTransform.combined().isAffine())
         return true;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -186,7 +186,9 @@ public:
 
     Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const final;
 
-    void paintIntoGraphicsContext(GraphicsContext&, const TiledBackingStore&, const IntRect& dirtyRect) const;
+#if USE(SKIA)
+    void paintIntoGraphicsContext(GraphicsContext&, const IntRect&) const;
+#endif
 
 private:
     enum class FlushNotification {
@@ -212,16 +214,16 @@ private:
     bool checkPendingStateChanges();
     bool checkContentLayerUpdated();
 
-    Ref<Nicosia::Buffer> paintTile(const TiledBackingStore&, const IntRect& dirtyRect);
+    Ref<Nicosia::Buffer> paintTile(const IntRect& dirtyRect);
 
     void notifyFlushRequired();
 
     bool shouldHaveBackingStore() const;
     bool selfOrAncestorHasActiveTransformAnimation() const;
-    bool selfOrAncestorHaveNonAffineTransforms();
+    bool selfOrAncestorHaveNonAffineTransforms() const;
 
     void setShouldUpdateVisibleRect();
-    float effectiveContentsScale();
+    float effectiveContentsScale() const;
 
     void animationStartedTimerFired();
     void requestPendingTileCreationTimerFired();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
@@ -21,17 +21,21 @@
 #include "CoordinatedGraphicsLayer.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(CAIRO)
+#include "FloatRect.h"
 #include "GraphicsContext.h"
 #include "NicosiaPaintingContext.h"
 #include "NicosiaPaintingEngine.h"
 
 namespace WebCore {
 
-Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const TiledBackingStore& tiledBackingStore, const IntRect& dirtyRect)
+Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& dirtyRect)
 {
-    auto mappedDirtyRect = tiledBackingStore.mapToContents(dirtyRect);
+    auto scale = effectiveContentsScale();
+    FloatRect scaledDirtyRect(dirtyRect);
+    scaledDirtyRect.scale(1 / scale);
+
     auto buffer = Nicosia::UnacceleratedBuffer::create(dirtyRect.size(), contentsOpaque() ? Nicosia::Buffer::NoFlags : Nicosia::Buffer::SupportsAlpha);
-    m_coordinator->paintingEngine().paint(*this, buffer.get(), dirtyRect, mappedDirtyRect, IntRect { { 0, 0 }, dirtyRect.size() }, tiledBackingStore.contentsScale());
+    m_coordinator->paintingEngine().paint(*this, buffer.get(), dirtyRect, enclosingIntRect(scaledDirtyRect), IntRect { { }, dirtyRect.size() }, scale);
     return buffer;
 }
 


### PR DESCRIPTION
#### 58234aa593e4507d3a697a4b5ed2fc00b0e2e5e7
<pre>
[CoordinatedGraphics] Tiled backing store is not needed in paintTile()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280679">https://bugs.webkit.org/show_bug.cgi?id=280679</a>

Reviewed by Nikolas Zimmermann.

The function to map the dirty rect to contents is just scaling the
rectangle, and scale is already available by effectiveContentsScale().
Also make paintIntoGraphicsContext Skia specific, since it&apos;s only used
my Skia, and move it to CoordinatedGraphicsLayerSkia.cpp.

* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp:
(WebCore::SkiaThreadedPaintingPool::recordDisplayList const):
(WebCore::SkiaThreadedPaintingPool::postPaintingTask):
* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::effectiveContentsScale const):
(WebCore::CoordinatedGraphicsLayer::updateContentBuffers):
(WebCore::CoordinatedGraphicsLayer::selfOrAncestorHaveNonAffineTransforms const):
(WebCore::CoordinatedGraphicsLayer::effectiveContentsScale): Deleted.
(WebCore::CoordinatedGraphicsLayer::paintIntoGraphicsContext const): Deleted.
(WebCore::CoordinatedGraphicsLayer::selfOrAncestorHaveNonAffineTransforms): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintIntoGraphicsContext const):
(WebCore::CoordinatedGraphicsLayer::paintTile):

Canonical link: <a href="https://commits.webkit.org/284544@main">https://commits.webkit.org/284544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/607af8be9f8f36b96b5aa4b64edad6ce3384a6a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49200 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22552 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/41506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75598 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/14024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/14059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/60282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10647 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45003 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->