### PR TITLE
[TZone] Annotate more subclasses found during bench testing

### DIFF
--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -40,10 +40,13 @@
 #include <wtf/RunLoop.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadedScrollingTree);
 
 ThreadedScrollingTree::ThreadedScrollingTree(AsyncScrollingCoordinator& scrollingCoordinator)
     : m_scrollingCoordinator(&scrollingCoordinator)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -33,6 +33,7 @@
 #include <wtf/Condition.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,6 +44,7 @@ class AsyncScrollingCoordinator;
 // to the correct scrolling tree nodes or dispatching events back to the ScrollingCoordinator
 // object on the main thread if they can't be handled on the scrolling thread for various reasons.
 class ThreadedScrollingTree : public ScrollingTree {
+    WTF_MAKE_TZONE_ALLOCATED(ThreadedScrollingTree);
 public:
     virtual ~ThreadedScrollingTree();
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -31,6 +31,7 @@
 #include "MediaSessionHelperIOS.h"
 #include "MediaSessionManagerCocoa.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WebMediaSessionHelper;
 
@@ -47,6 +48,7 @@ class MediaSessionManageriOS
     : public MediaSessionManagerCocoa
     , public MediaSessionHelperClient
     , public AudioSessionInterruptionObserver {
+    WTF_MAKE_TZONE_ALLOCATED(MediaSessionManageriOS);
 public:
     virtual ~MediaSessionManageriOS();
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -39,8 +39,11 @@
 #import <wtf/MainThread.h>
 #import <wtf/RAMSize.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManageriOS);
 
 std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::create()
 {

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -236,6 +236,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMParser);
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WebMParserTrackData, WebMParser::TrackData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WebMParserVideoTrackData, WebMParser::VideoTrackData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WebMParserAudioTrackData, WebMParser::AudioTrackData);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceBufferParserWebM);
 
 // FIXME: Remove this once kCMVideoCodecType_VP9 is added to CMFormatDescription.h

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -210,6 +210,7 @@ public:
     };
 
     class VideoTrackData : public TrackData {
+        WTF_MAKE_TZONE_ALLOCATED(VideoTrackData);
     public:
         static auto create(CodecType codecType, const webm::TrackEntry& trackEntry, WebMParser& parser) -> UniqueRef<VideoTrackData>
         {
@@ -238,6 +239,7 @@ public:
     };
 
     class AudioTrackData : public TrackData {
+        WTF_MAKE_TZONE_ALLOCATED(AudioTrackData);
     public:
         static auto create(CodecType codecType, const webm::TrackEntry& trackEntry, WebMParser& parser) -> UniqueRef<AudioTrackData>
         {

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "APIDictionary.h"
-#include <wtf/TZoneMallocInlines.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace IPC {
@@ -37,9 +37,10 @@ class Decoder;
 namespace WebKit {
 
 class RemoteObjectInvocation {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteObjectInvocation);
 public:
     struct ReplyInfo {
-        WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteObjectInvocation);
+        WTF_MAKE_TZONE_ALLOCATED(ReplyInfo);
     public:
         ReplyInfo(uint64_t replyID, String&& blockSignature)
             : replyID(replyID)

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.mm
@@ -25,8 +25,12 @@
 
 #import "config.h"
 #import "RemoteObjectInvocation.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteObjectInvocation);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RemoteObjectInvocationReplyInfo, RemoteObjectInvocation::ReplyInfo);
 
 RemoteObjectInvocation::RemoteObjectInvocation() = default;
 

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -30,6 +30,7 @@
 #import "APIFullscreenClient.h"
 #import "WKWebView.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @protocol _WKFullscreenDelegate;
@@ -37,6 +38,7 @@
 namespace WebKit {
 
 class FullscreenClient final : public API::FullscreenClient {
+    WTF_MAKE_TZONE_ALLOCATED(FullscreenClient);
 public:
     explicit FullscreenClient(WKWebView *);
     ~FullscreenClient() { };

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -28,8 +28,11 @@
 
 #import "WKWebViewInternal.h"
 #import "_WKFullscreenDelegate.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FullscreenClient);
 
 FullscreenClient::FullscreenClient(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -99,6 +99,7 @@ public:
 
 private:
     class NavigationClient final : public API::NavigationClient {
+        WTF_MAKE_TZONE_ALLOCATED(NavigationClient);
     public:
         explicit NavigationClient(NavigationState&);
         ~NavigationClient();
@@ -165,6 +166,7 @@ private:
     };
     
     class HistoryClient final : public API::HistoryClient {
+        WTF_MAKE_TZONE_ALLOCATED(HistoryClient);
     public:
         explicit HistoryClient(NavigationState&);
         ~HistoryClient();

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -122,6 +122,8 @@ static WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>& navigationStates()
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationState);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NavigationStateHistoryClient, NavigationState::HistoryClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NavigationStateNavigationClient, NavigationState::NavigationClient);
 
 NavigationState::NavigationState(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -92,6 +92,7 @@ private:
 #endif
 
     class UIClient : public API::UIClient, public CanMakeWeakPtr<UIClient> {
+        WTF_MAKE_TZONE_ALLOCATED(UIClient);
     public:
         explicit UIClient(UIDelegate&);
         ~UIClient();

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -86,6 +86,8 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UIDelegate);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(UIDelegateUIClient, UIDelegate::UIClient);
+
 
 UIDelegate::UIDelegate(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "RemoteScrollingTree.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 
@@ -40,6 +41,9 @@
 #include <WebCore/ScrollingTreeStickyNodeCocoa.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteScrollingTree);
+
 using namespace WebCore;
 
 RemoteScrollingTree::RemoteScrollingTree(RemoteScrollingCoordinatorProxy& scrollingCoordinator)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -31,6 +31,7 @@
 #include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingTree.h>
 #include <WebCore/WheelEventTestMonitor.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -42,6 +43,7 @@ namespace WebKit {
 class RemoteScrollingCoordinatorProxy;
 
 class RemoteScrollingTree : public WebCore::ScrollingTree {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingTree);
 public:
     static Ref<RemoteScrollingTree> create(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTree();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)
 
 #include "RemoteScrollingCoordinatorProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS UIScrollView;
 OBJC_CLASS WKBaseScrollView;
@@ -42,6 +43,7 @@ class RemoteLayerTreeDrawingAreaProxyIOS;
 class RemoteLayerTreeNode;
 
 class RemoteScrollingCoordinatorProxyIOS final : public RemoteScrollingCoordinatorProxy {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxyIOS);
 public:
     explicit RemoteScrollingCoordinatorProxyIOS(WebPageProxy&);
     ~RemoteScrollingCoordinatorProxyIOS() = default;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -52,8 +52,12 @@
 #import <WebCore/ScrollingTreePluginScrollingNode.h>
 #import <WebCore/ScrollingTreePositionedNode.h>
 #import <tuple>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteScrollingCoordinatorProxyIOS);
+
 using namespace WebCore;
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, webPageProxy().legacyMainFrameProcess().connection())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -33,8 +33,12 @@
 #include "ScrollingTreeOverflowScrollingNodeIOS.h"
 #include "ScrollingTreePluginScrollingNodeIOS.h"
 #include <WebCore/ScrollingTreeFixedNodeCocoa.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteScrollingTreeIOS);
+
 using namespace WebCore;
 
 Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorProxy& scrollingCoordinator)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
@@ -28,12 +28,14 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
 
 #include "RemoteScrollingTree.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RemoteScrollingCoordinatorProxy;
 
 class RemoteScrollingTreeIOS final : public RemoteScrollingTree {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingTreeIOS);
 public:
     explicit RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTreeIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -29,6 +29,7 @@
 
 #include "RemoteLayerTreeEventDispatcher.h"
 #include "RemoteScrollingCoordinatorProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class RemoteScrollingCoordinatorProxyMac;
@@ -46,6 +47,7 @@ class RemoteLayerTreeEventDispatcher;
 #endif
 
 class RemoteScrollingCoordinatorProxyMac final : public RemoteScrollingCoordinatorProxy {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxyMac);
 public:
     explicit RemoteScrollingCoordinatorProxyMac(WebPageProxy&);
     ~RemoteScrollingCoordinatorProxyMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -44,8 +44,12 @@
 #import <WebCore/ScrollingTreePluginScrollingNode.h>
 #import <WebCore/ScrollingTreePositionedNode.h>
 #import <WebCore/WheelEventDeltaFilter.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteScrollingCoordinatorProxyMac);
+
 using namespace WebCore;
 
 RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac(WebPageProxy& webPageProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -32,6 +32,7 @@
 #include "RemoteScrollingCoordinator.h"
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingTree.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class PlatformMouseEvent;
@@ -42,6 +43,7 @@ namespace WebKit {
 class RemoteScrollingCoordinatorProxy;
 
 class RemoteScrollingTreeMac final : public RemoteScrollingTree {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingTreeMac);
 public:
     explicit RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTreeMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -43,9 +43,13 @@
 #import <WebCore/ScrollingTreePositionedNode.h>
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteScrollingTreeMac);
+
 using namespace WebCore;
 
 Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorProxy& scrollingCoordinator)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -56,8 +56,11 @@
 #include <WebCore/UserAgent.h>
 #include <WebCore/WorkerFetchResult.h>
 #include <WebCore/WorkerInitializationData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSharedWorkerContextManagerConnection);
 
 WebSharedWorkerContextManagerConnection::WebSharedWorkerContextManagerConnection(Ref<IPC::Connection>&& connectionToNetworkProcess, WebCore::RegistrableDomain&& registrableDomain, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, const WebPreferencesStore& preferencesStore, RemoteWorkerInitializationData&& initializationData)
     : m_connectionToNetworkProcess(WTFMove(connectionToNetworkProcess))

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
@@ -34,6 +34,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/SharedWorkerContextManager.h>
 #include <WebCore/SharedWorkerIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct ClientOrigin;
@@ -48,6 +49,7 @@ class WebUserContentController;
 struct RemoteWorkerInitializationData;
 
 class WebSharedWorkerContextManagerConnection final : public WebCore::SharedWorkerContextManager::Connection, public IPC::MessageReceiver {
+    WTF_MAKE_TZONE_ALLOCATED(WebSharedWorkerContextManagerConnection);
 public:
     WebSharedWorkerContextManagerConnection(Ref<IPC::Connection>&&, WebCore::RegistrableDomain&&, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, RemoteWorkerInitializationData&&);
     ~WebSharedWorkerContextManagerConnection();


### PR DESCRIPTION
#### b70def597077e3a18dcb0050eb4d260e0cfba518
<pre>
[TZone] Annotate more subclasses found during bench testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=280691">https://bugs.webkit.org/show_bug.cgi?id=280691</a>
<a href="https://rdar.apple.com/137065725">rdar://137065725</a>

Reviewed by Yijia Huang.

Added annotations in derived classes that didn&apos;t have any existing allocation annotations.
These classes were found while doing some testing.
Also fixed the existing nested annotation (ReplyInfo) in RemoteObjectInvocation.h and added one for
the enclosing class RemoteObjectInvocation.

* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.mm:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h:

Canonical link: <a href="https://commits.webkit.org/284525@main">https://commits.webkit.org/284525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bed491d57f498441ad3d49dfc1765de779d0da7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22480 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72793 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41446 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17919 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13709 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/69405 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60217 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15482 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/11018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44931 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->