### PR TITLE
Adopt more smart pointers in GPUProcess/graphics (part 3)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -84,7 +84,7 @@ void RemoteCommandEncoder::beginRenderPass(const WebGPU::RenderPassDescriptor& d
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto renderPassEncoder = m_backing->beginRenderPass(*convertedDescriptor);
+    auto renderPassEncoder = protectedBacking()->beginRenderPass(*convertedDescriptor);
     MESSAGE_CHECK(renderPassEncoder);
     auto remoteRenderPassEncoder = RemoteRenderPassEncoder::create(*renderPassEncoder, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteRenderPassEncoder);
@@ -100,7 +100,7 @@ void RemoteCommandEncoder::beginComputePass(const std::optional<WebGPU::ComputeP
         convertedDescriptor = WTFMove(resultDescriptor);
     }
 
-    auto computePassEncoder = m_backing->beginComputePass(convertedDescriptor);
+    auto computePassEncoder = protectedBacking()->beginComputePass(convertedDescriptor);
     MESSAGE_CHECK(computePassEncoder);
     auto computeRenderPassEncoder = RemoteComputePassEncoder::create(*computePassEncoder, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, computeRenderPassEncoder);
@@ -121,7 +121,7 @@ void RemoteCommandEncoder::copyBufferToBuffer(
     if (!convertedSource || !convertedDestination)
         return;
 
-    m_backing->copyBufferToBuffer(*convertedSource, sourceOffset, *convertedDestination, destinationOffset, size);
+    protectedBacking()->copyBufferToBuffer(*convertedSource, sourceOffset, *convertedDestination, destinationOffset, size);
 }
 
 void RemoteCommandEncoder::copyBufferToTexture(
@@ -138,7 +138,7 @@ void RemoteCommandEncoder::copyBufferToTexture(
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
 
-    m_backing->copyBufferToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
+    protectedBacking()->copyBufferToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
 }
 
 void RemoteCommandEncoder::copyTextureToBuffer(
@@ -155,7 +155,7 @@ void RemoteCommandEncoder::copyTextureToBuffer(
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
 
-    m_backing->copyTextureToBuffer(*convertedSource, *convertedDestination, *convertedCopySize);
+    protectedBacking()->copyTextureToBuffer(*convertedSource, *convertedDestination, *convertedCopySize);
 }
 
 void RemoteCommandEncoder::copyTextureToTexture(
@@ -172,7 +172,7 @@ void RemoteCommandEncoder::copyTextureToTexture(
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
 
-    m_backing->copyTextureToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
+    protectedBacking()->copyTextureToTexture(*convertedSource, *convertedDestination, *convertedCopySize);
 }
 
 void RemoteCommandEncoder::clearBuffer(
@@ -185,22 +185,22 @@ void RemoteCommandEncoder::clearBuffer(
     if (!convertedBuffer)
         return;
 
-    m_backing->clearBuffer(*convertedBuffer, offset, size);
+    protectedBacking()->clearBuffer(*convertedBuffer, offset, size);
 }
 
 void RemoteCommandEncoder::pushDebugGroup(String&& groupLabel)
 {
-    m_backing->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
 }
 
 void RemoteCommandEncoder::popDebugGroup()
 {
-    m_backing->popDebugGroup();
+    protectedBacking()->popDebugGroup();
 }
 
 void RemoteCommandEncoder::insertDebugMarker(String&& markerLabel)
 {
-    m_backing->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
 }
 
 void RemoteCommandEncoder::writeTimestamp(WebGPUIdentifier querySet, WebCore::WebGPU::Size32 queryIndex)
@@ -210,7 +210,7 @@ void RemoteCommandEncoder::writeTimestamp(WebGPUIdentifier querySet, WebCore::We
     if (!convertedQuerySet)
         return;
 
-    m_backing->writeTimestamp(*convertedQuerySet, queryIndex);
+    protectedBacking()->writeTimestamp(*convertedQuerySet, queryIndex);
 }
 
 void RemoteCommandEncoder::resolveQuerySet(
@@ -228,7 +228,7 @@ void RemoteCommandEncoder::resolveQuerySet(
     if (!convertedQuerySet || !convertedDestination)
         return;
 
-    m_backing->resolveQuerySet(*convertedQuerySet, firstQuery, queryCount, *convertedDestination, destinationOffset);
+    protectedBacking()->resolveQuerySet(*convertedQuerySet, firstQuery, queryCount, *convertedDestination, destinationOffset);
 }
 
 void RemoteCommandEncoder::finish(const WebGPU::CommandBufferDescriptor& descriptor, WebGPUIdentifier identifier)
@@ -237,7 +237,7 @@ void RemoteCommandEncoder::finish(const WebGPU::CommandBufferDescriptor& descrip
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto commandBuffer = m_backing->finish(*convertedDescriptor);
+    auto commandBuffer = protectedBacking()->finish(*convertedDescriptor);
     MESSAGE_CHECK(commandBuffer);
     auto remoteCommandBuffer = RemoteCommandBuffer::create(*commandBuffer, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteCommandBuffer);
@@ -245,7 +245,12 @@ void RemoteCommandEncoder::finish(const WebGPU::CommandBufferDescriptor& descrip
 
 void RemoteCommandEncoder::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::CommandEncoder> RemoteCommandEncoder::protectedBacking()
+{
+    return m_backing;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -84,6 +84,8 @@ private:
     RemoteCommandEncoder& operator=(RemoteCommandEncoder&&) = delete;
 
     WebCore::WebGPU::CommandEncoder& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::CommandEncoder> protectedBacking();
+
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -49,7 +49,7 @@ RemoteCompositorIntegration::RemoteCompositorIntegration(WebCore::WebGPU::Compos
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteCompositorIntegration::~RemoteCompositorIntegration() = default;
@@ -70,7 +70,7 @@ void RemoteCompositorIntegration::destruct()
 void RemoteCompositorIntegration::paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex, CompletionHandler<void()>&& completionHandler)
 {
     UNUSED_PARAM(imageBufferIdentifier);
-    m_backing->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTFMove(completionHandler)] (WebCore::NativeImage* image) mutable {
+    protectedBacking()->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTFMove(completionHandler)] (WebCore::NativeImage* image) mutable {
         if (image && gpu.ptr())
             gpu->paintNativeImageToImageBuffer(*image, imageBufferIdentifier);
         completionHandler();
@@ -79,7 +79,7 @@ void RemoteCompositorIntegration::paintCompositedResultsToCanvas(WebCore::Render
 
 void RemoteCompositorIntegration::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
 }
 
 #if PLATFORM(COCOA)
@@ -88,15 +88,25 @@ void RemoteCompositorIntegration::recreateRenderBuffers(int width, int height, W
     auto convertedDevice = protectedObjectHeap()->convertDeviceFromBacking(deviceIdentifier);
     MESSAGE_CHECK_COMPLETION(convertedDevice, callback({ }));
 
-    callback(m_backing->recreateRenderBuffers(width, height, WTFMove(destinationColorSpace), alphaMode, textureFormat, *convertedDevice));
+    callback(protectedBacking()->recreateRenderBuffers(width, height, WTFMove(destinationColorSpace), alphaMode, textureFormat, *convertedDevice));
 }
 #endif
 
 void RemoteCompositorIntegration::prepareForDisplay(CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_backing->prepareForDisplay([completionHandler = WTFMove(completionHandler)]() mutable {
+    protectedBacking()->prepareForDisplay([completionHandler = WTFMove(completionHandler)]() mutable {
         completionHandler(true);
     });
+}
+
+Ref<WebCore::WebGPU::CompositorIntegration> RemoteCompositorIntegration::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteCompositorIntegration::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -90,6 +90,10 @@ private:
     RemoteCompositorIntegration& operator=(RemoteCompositorIntegration&&) = delete;
 
     WebCore::WebGPU::CompositorIntegration& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::CompositorIntegration> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -87,6 +87,9 @@ private:
     RemoteQueue& operator=(RemoteQueue&&) = delete;
 
     WebCore::WebGPU::Queue& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::Queue> protectedBacking();
+
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
@@ -45,24 +45,29 @@ RemoteTextureView::RemoteTextureView(WebCore::WebGPU::TextureView& textureView, 
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteTextureView::~RemoteTextureView() = default;
 
 void RemoteTextureView::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteTextureView::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteTextureView::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemoteTextureView::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -74,6 +74,7 @@ private:
     RemoteTextureView& operator=(RemoteTextureView&&) = delete;
 
     WebCore::WebGPU::TextureView& backing() { return m_backing; }
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -119,6 +119,8 @@ private:
 
     void setLabelInternal(const String&) final;
 
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const;
+
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -70,7 +70,7 @@ void RemoteCompositorIntegrationProxy::prepareForDisplay(CompletionHandler<void(
     auto sendResult = sendSync(Messages::RemoteCompositorIntegration::PrepareForDisplay());
     UNUSED_VARIABLE(sendResult);
 
-    m_presentationContext->present();
+    RefPtr { m_presentationContext }->present();
 
     completionHandler();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -52,7 +52,7 @@ RemoteQueueProxy::~RemoteQueueProxy()
 void RemoteQueueProxy::submit(Vector<std::reference_wrapper<WebCore::WebGPU::CommandBuffer>>&& commandBuffers)
 {
     auto convertedCommandBuffers = WTF::compactMap(commandBuffers, [&](auto& commandBuffer) -> std::optional<WebGPUIdentifier> {
-        auto convertedCommandBuffer = m_convertToBackingContext->convertToBacking(commandBuffer);
+        auto convertedCommandBuffer = protectedConvertToBackingContext()->convertToBacking(commandBuffer);
         return convertedCommandBuffer;
     });
 
@@ -75,7 +75,7 @@ void RemoteQueueProxy::writeBuffer(
     WebCore::WebGPU::Size64 dataOffset,
     std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
+    auto convertedBuffer = protectedConvertToBackingContext()->convertToBacking(buffer);
 
     auto sharedMemory = WebCore::SharedMemory::copySpan(source.subspan(dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset))));
     std::optional<WebCore::SharedMemoryHandle> handle;
@@ -93,11 +93,12 @@ void RemoteQueueProxy::writeTexture(
     const WebCore::WebGPU::ImageDataLayout& dataLayout,
     const WebCore::WebGPU::Extent3D& size)
 {
-    auto convertedDestination = m_convertToBackingContext->convertToBacking(destination);
+    Ref convertToBackingContext = m_convertToBackingContext;
+    auto convertedDestination = convertToBackingContext->convertToBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedDataLayout = m_convertToBackingContext->convertToBacking(dataLayout);
+    auto convertedDataLayout = convertToBackingContext->convertToBacking(dataLayout);
     ASSERT(convertedDataLayout);
-    auto convertedSize = m_convertToBackingContext->convertToBacking(size);
+    auto convertedSize = convertToBackingContext->convertToBacking(size);
     ASSERT(convertedSize);
     if (!convertedDestination || !convertedDataLayout || !convertedSize)
         return;
@@ -136,11 +137,12 @@ void RemoteQueueProxy::copyExternalImageToTexture(
     const WebCore::WebGPU::ImageCopyTextureTagged& destination,
     const WebCore::WebGPU::Extent3D& copySize)
 {
-    auto convertedSource = m_convertToBackingContext->convertToBacking(source);
+    Ref convertToBackingContext = m_convertToBackingContext;
+    auto convertedSource = convertToBackingContext->convertToBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_convertToBackingContext->convertToBacking(destination);
+    auto convertedDestination = convertToBackingContext->convertToBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedCopySize = m_convertToBackingContext->convertToBacking(copySize);
+    auto convertedCopySize = convertToBackingContext->convertToBacking(copySize);
     ASSERT(convertedCopySize);
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
@@ -153,6 +155,11 @@ void RemoteQueueProxy::setLabelInternal(const String& label)
 {
     auto sendResult = send(Messages::RemoteQueue::SetLabel(label));
     UNUSED_VARIABLE(sendResult);
+}
+
+Ref<ConvertToBackingContext> RemoteQueueProxy::protectedConvertToBackingContext() const
+{
+    return m_convertToBackingContext;
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -60,6 +60,8 @@ private:
     RemoteQueueProxy& operator=(RemoteQueueProxy&&) = delete;
 
     WebGPUIdentifier backing() const { return m_backing; }
+
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const;
     
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)


### PR DESCRIPTION
#### 9827a6f785a6f929421ff4c909dfad3ac63e3c1f
<pre>
Adopt more smart pointers in GPUProcess/graphics (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280694">https://bugs.webkit.org/show_bug.cgi?id=280694</a>
<a href="https://rdar.apple.com/137069460">rdar://137069460</a>

Reviewed by Chris Dumez and Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::beginRenderPass):
(WebKit::RemoteCommandEncoder::beginComputePass):
(WebKit::RemoteCommandEncoder::copyBufferToBuffer):
(WebKit::RemoteCommandEncoder::copyBufferToTexture):
(WebKit::RemoteCommandEncoder::copyTextureToBuffer):
(WebKit::RemoteCommandEncoder::copyTextureToTexture):
(WebKit::RemoteCommandEncoder::clearBuffer):
(WebKit::RemoteCommandEncoder::pushDebugGroup):
(WebKit::RemoteCommandEncoder::popDebugGroup):
(WebKit::RemoteCommandEncoder::insertDebugMarker):
(WebKit::RemoteCommandEncoder::writeTimestamp):
(WebKit::RemoteCommandEncoder::resolveQuerySet):
(WebKit::RemoteCommandEncoder::finish):
(WebKit::RemoteCommandEncoder::setLabel):
(WebKit::RemoteCommandEncoder::protectedBacking):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::RemoteCompositorIntegration):
(WebKit::RemoteCompositorIntegration::paintCompositedResultsToCanvas):
(WebKit::RemoteCompositorIntegration::stopListeningForIPC):
(WebKit::RemoteCompositorIntegration::recreateRenderBuffers):
(WebKit::RemoteCompositorIntegration::prepareForDisplay):
(WebKit::RemoteCompositorIntegration::protectedBacking):
(WebKit::RemoteCompositorIntegration::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::destruct):
(WebKit::RemoteQueue::submit):
(WebKit::RemoteQueue::onSubmittedWorkDone):
(WebKit::RemoteQueue::writeBuffer):
(WebKit::RemoteQueue::writeTexture):
(WebKit::RemoteQueue::copyExternalImageToTexture):
(WebKit::RemoteQueue::setLabel):
(WebKit::RemoteQueue::protectedBacking):
(WebKit::RemoteQueue::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp:
(WebKit::RemoteTextureView::RemoteTextureView):
(WebKit::RemoteTextureView::destruct):
(WebKit::RemoteTextureView::stopListeningForIPC):
(WebKit::RemoteTextureView::setLabel):
(WebKit::RemoteTextureView::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::beginRenderPass):
(WebKit::WebGPU::RemoteCommandEncoderProxy::beginComputePass):
(WebKit::WebGPU::RemoteCommandEncoderProxy::copyBufferToBuffer):
(WebKit::WebGPU::RemoteCommandEncoderProxy::copyBufferToTexture):
(WebKit::WebGPU::RemoteCommandEncoderProxy::copyTextureToBuffer):
(WebKit::WebGPU::RemoteCommandEncoderProxy::copyTextureToTexture):
(WebKit::WebGPU::RemoteCommandEncoderProxy::clearBuffer):
(WebKit::WebGPU::RemoteCommandEncoderProxy::writeTimestamp):
(WebKit::WebGPU::RemoteCommandEncoderProxy::resolveQuerySet):
(WebKit::WebGPU::RemoteCommandEncoderProxy::finish):
(WebKit::WebGPU::RemoteCommandEncoderProxy::protectedConvertToBackingContext const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::submit):
(WebKit::WebGPU::RemoteQueueProxy::writeBuffer):
(WebKit::WebGPU::RemoteQueueProxy::writeTexture):
(WebKit::WebGPU::RemoteQueueProxy::copyExternalImageToTexture):
(WebKit::WebGPU::RemoteQueueProxy::protectedConvertToBackingContext const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:

Canonical link: <a href="https://commits.webkit.org/284542@main">https://commits.webkit.org/284542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9441c8e99482039174191d33aeefcd3d05ea46b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20837 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55376 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13830 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41409 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63345 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17882 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 14 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75477 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63046 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4575 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44883 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45957 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47221 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->