### PR TITLE
Make `FrameState` reference counted

### DIFF
--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -30,6 +30,77 @@
 
 namespace WebKit {
 
+FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, WebCore::BackForwardItemIdentifier identifier, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction,
+#if PLATFORM(IOS_FAMILY)
+    WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
+#endif
+    const Vector<Ref<FrameState>>& children, const Vector<AtomString>& documentState
+)
+    : urlString(urlString)
+    , originalURLString(originalURLString)
+    , referrer(referrer)
+    , target(target)
+    , frameID(frameID)
+    , stateObjectData(stateObjectData)
+    , documentSequenceNumber(documentSequenceNumber)
+    , itemSequenceNumber(itemSequenceNumber)
+    , scrollPosition(scrollPosition)
+    , shouldRestoreScrollPosition(shouldRestoreScrollPosition)
+    , pageScaleFactor(pageScaleFactor)
+    , httpBody(httpBody)
+    , identifier(identifier)
+    , hasCachedPage(hasCachedPage)
+    , title(title)
+    , shouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy)
+    , sessionStateObject(WTFMove(sessionStateObject))
+    , wasCreatedByJSWithoutUserInteraction(wasCreatedByJSWithoutUserInteraction)
+#if PLATFORM(IOS_FAMILY)
+    , exposedContentRect(exposedContentRect)
+    , unobscuredContentRect(unobscuredContentRect)
+    , minimumLayoutSizeInScrollViewCoordinates(minimumLayoutSizeInScrollViewCoordinates)
+    , contentSize(contentSize)
+    , scaleIsInitial(scaleIsInitial)
+    , obscuredInsets(obscuredInsets)
+#endif
+    , children(children)
+    , m_documentState(documentState)
+{
+}
+
+Ref<FrameState> FrameState::copy()
+{
+    return adoptRef(*new FrameState(
+        urlString,
+        originalURLString,
+        referrer,
+        target,
+        frameID,
+        stateObjectData,
+        documentSequenceNumber,
+        itemSequenceNumber,
+        scrollPosition,
+        shouldRestoreScrollPosition,
+        pageScaleFactor,
+        httpBody,
+        identifier,
+        hasCachedPage,
+        title,
+        shouldOpenExternalURLsPolicy,
+        sessionStateObject.copyRef(),
+        wasCreatedByJSWithoutUserInteraction,
+#if PLATFORM(IOS_FAMILY)
+        exposedContentRect,
+        unobscuredContentRect,
+        minimumLayoutSizeInScrollViewCoordinates,
+        contentSize,
+        scaleIsInitial,
+        obscuredInsets,
+#endif
+        children.map([](auto& child) { return child->copy(); }),
+        m_documentState
+    ));
+}
+
 bool FrameState::validateDocumentState(const Vector<AtomString>& documentState)
 {
     for (auto& stateString : documentState) {
@@ -59,7 +130,7 @@ const FrameState* FrameState::stateForFrameID(WebCore::FrameIdentifier frameID) 
     if (this->frameID == frameID)
         return this;
     for (auto& child : children) {
-        if (auto* state = child.stateForFrameID(frameID))
+        if (auto* state = child->stateForFrameID(frameID))
             return state;
     }
     return nullptr;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -33,6 +33,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/ArgumentCoder.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -62,15 +63,19 @@ struct HTTPBody {
     Vector<Element> elements;
 };
 
-class FrameState {
+class FrameState : public RefCounted<FrameState> {
 public:
+    template<typename... Args>
+    static Ref<FrameState> create(Args&&... args)
+    {
+        return adoptRef(*new FrameState(std::forward<Args>(args)...));
+    }
+
     // These are used to help debug <rdar://problem/48634553>.
     FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
     ~FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
-    FrameState(const FrameState&) = default;
-    FrameState(FrameState&&) = default;
-    FrameState& operator=(const FrameState&) = default;
-    FrameState& operator=(FrameState&&) = default;
+
+    Ref<FrameState> copy();
 
     const Vector<AtomString>& documentState() const { return m_documentState; }
     enum class ShouldValidate : bool { No, Yes };
@@ -113,15 +118,21 @@ public:
     WebCore::FloatBoxExtent obscuredInsets;
 #endif
 
-    Vector<FrameState> children;
+    Vector<Ref<FrameState>> children;
 
 private:
-    friend struct IPC::ArgumentCoder<FrameState, void>;
+    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, WebCore::BackForwardItemIdentifier, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction,
+#if PLATFORM(IOS_FAMILY)
+        WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
+#endif
+        const Vector<Ref<FrameState>>& children, const Vector<AtomString>& documentState
+    );
+
     Vector<AtomString> m_documentState;
 };
 
 struct BackForwardListState {
-    Vector<FrameState> items;
+    Vector<Ref<FrameState>> items;
     std::optional<uint32_t> currentIndex;
 };
 

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -37,7 +37,7 @@ header: "SessionState.h"
     std::optional<WallTime> expectedFileModificationTime;
 };
 
-[CustomHeader, LegacyPopulateFromEmptyConstructor] class WebKit::FrameState {
+[RefCounted, CustomHeader] class WebKit::FrameState {
     String urlString;
     String originalURLString;
     String referrer;
@@ -71,11 +71,11 @@ header: "SessionState.h"
     WebCore::FloatBoxExtent obscuredInsets;
 #endif
 
-    Vector<WebKit::FrameState> children;
-    [Validator='WebKit::FrameState::validateDocumentState(*m_documentState)'] Vector<AtomString> m_documentState;
+    Vector<Ref<WebKit::FrameState>> children;
+    [Validator='WebKit::FrameState::validateDocumentState(*documentState)'] Vector<AtomString> documentState();
 };
 
 [CustomHeader] struct WebKit::BackForwardListState {
-    Vector<WebKit::FrameState> items;
+    Vector<Ref<WebKit::FrameState>> items;
     std::optional<uint32_t> currentIndex;
 };

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -51,25 +51,25 @@ class WebBackForwardCacheEntry;
 
 class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem> {
 public:
-    static Ref<WebBackForwardListItem> create(FrameState&&, WebPageProxyIdentifier);
+    static Ref<WebBackForwardListItem> create(Ref<FrameState>&&, WebPageProxyIdentifier);
     virtual ~WebBackForwardListItem();
 
     static WebBackForwardListItem* itemForID(const WebCore::BackForwardItemIdentifier&);
     static HashMap<WebCore::BackForwardItemIdentifier, WeakRef<WebBackForwardListItem>>& allItems();
 
-    WebCore::BackForwardItemIdentifier itemID() const { return m_mainFrameState.identifier; }
+    WebCore::BackForwardItemIdentifier itemID() const { return m_mainFrameState->identifier; }
     WebPageProxyIdentifier pageID() const { return m_pageID; }
 
     WebCore::ProcessIdentifier lastProcessIdentifier() const { return m_lastProcessIdentifier; }
     void setLastProcessIdentifier(const WebCore::ProcessIdentifier& identifier) { m_lastProcessIdentifier = identifier; }
 
-    void setMainFrameState(FrameState&& mainFrameState) { m_mainFrameState = WTFMove(mainFrameState); }
-    const FrameState& mainFrameState() const { return m_mainFrameState; }
+    void setMainFrameState(Ref<FrameState>&& mainFrameState) { m_mainFrameState = WTFMove(mainFrameState); }
+    FrameState& mainFrameState() const { return m_mainFrameState; }
 
-    const String& originalURL() const { return m_mainFrameState.originalURLString; }
-    const String& url() const { return m_mainFrameState.urlString; }
-    const String& title() const { return m_mainFrameState.title; }
-    bool wasCreatedByJSWithoutUserInteraction() const { return m_mainFrameState.wasCreatedByJSWithoutUserInteraction; }
+    const String& originalURL() const { return m_mainFrameState->originalURLString; }
+    const String& url() const { return m_mainFrameState->urlString; }
+    const String& title() const { return m_mainFrameState->title; }
+    bool wasCreatedByJSWithoutUserInteraction() const { return m_mainFrameState->wasCreatedByJSWithoutUserInteraction; }
 
     const URL& resourceDirectoryURL() const { return m_resourceDirectoryURL; }
     void setResourceDirectoryURL(URL&& url) { m_resourceDirectoryURL = WTFMove(url); }
@@ -104,7 +104,7 @@ public:
 #endif
 
 private:
-    WebBackForwardListItem(FrameState&&, WebPageProxyIdentifier);
+    WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier);
 
     void removeFromBackForwardCache();
 
@@ -114,7 +114,7 @@ private:
 
     RefPtr<WebsiteDataStore> m_dataStoreForWebArchive;
 
-    FrameState m_mainFrameState;
+    Ref<FrameState> m_mainFrameState;
     URL m_resourceDirectoryURL;
     WebPageProxyIdentifier m_pageID;
     WebCore::ProcessIdentifier m_lastProcessIdentifier;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -137,7 +137,7 @@ struct WebPageCreationParameters {
     String userAgent { };
 
     bool itemStatesWereRestoredByAPIRequest { false };
-    Vector<FrameState> itemStates { };
+    Vector<Ref<FrameState>> itemStates { };
 
     VisitedLinkTableIdentifier visitedLinkTableID;
     bool canRunBeforeUnloadConfirmPanel { false };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -64,7 +64,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     String userAgent;
 
     bool itemStatesWereRestoredByAPIRequest;
-    Vector<WebKit::FrameState> itemStates;
+    Vector<Ref<WebKit::FrameState>> itemStates;
 
     WebKit::VisitedLinkTableIdentifier visitedLinkTableID;
     bool canRunBeforeUnloadConfirmPanel;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -353,7 +353,7 @@ static inline void decodeFrameState(GVariant* frameStateVariant, FrameState& fra
         frameState.httpBody = WTFMove(httpBody);
     g_variant_unref(httpBodyVariant);
     while (GRefPtr<GVariant> child = adoptGRef(g_variant_iter_next_value(childrenIter.get()))) {
-        FrameState childFrameState;
+        Ref childFrameState = FrameState::create();
         GRefPtr<GVariant> childVariant = adoptGRef(g_variant_get_variant(child.get()));
         decodeFrameState(childVariant.get(), childFrameState);
         frameState.children.append(WTFMove(childFrameState));
@@ -367,10 +367,10 @@ static inline void decodeBackForwardListItemStateV1(GVariantIter* backForwardLis
     GVariant* frameStateVariant;
     unsigned shouldOpenExternalURLsPolicy;
     while (g_variant_iter_loop(backForwardListStateIter, BACK_FORWARD_LIST_ITEM_FORMAT_STRING_V1, &identifier, &title, &frameStateVariant, &shouldOpenExternalURLsPolicy)) {
-        FrameState mainFrameState;
-        mainFrameState.title = String::fromUTF8(title);
+        Ref mainFrameState = FrameState::create();
+        mainFrameState->title = String::fromUTF8(title);
         decodeFrameState(frameStateVariant, mainFrameState);
-        mainFrameState.shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+        mainFrameState->shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
         backForwardListState.items.append(WTFMove(mainFrameState));
     }
 }
@@ -391,10 +391,10 @@ static inline void decodeBackForwardListItemState(GVariantIter* backForwardListS
     GVariant* frameStateVariant;
     unsigned shouldOpenExternalURLsPolicy;
     while (g_variant_iter_loop(backForwardListStateIter, BACK_FORWARD_LIST_ITEM_FORMAT_STRING_V2, &title, &frameStateVariant, &shouldOpenExternalURLsPolicy)) {
-        FrameState mainFrameState;
-        mainFrameState.title = String::fromUTF8(title);
+        Ref mainFrameState = FrameState::create();
+        mainFrameState->title = String::fromUTF8(title);
         decodeFrameState(frameStateVariant, mainFrameState);
-        mainFrameState.shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+        mainFrameState->shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
         backForwardListState.items.append(WTFMove(mainFrameState));
     }
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -508,7 +508,7 @@ void ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess
     m_page->logDiagnosticMessageWithValueDictionary(message, description, valueDictionary, shouldSample);
 }
 
-void ProvisionalPageProxy::backForwardAddItem(FrameIdentifier targetFrameID, FrameState&& mainFrameState)
+void ProvisionalPageProxy::backForwardAddItem(FrameIdentifier targetFrameID, Ref<FrameState>&& mainFrameState)
 {
     m_page->backForwardAddItemShared(protectedProcess(), targetFrameID, WTFMove(mainFrameState), m_replacedDataStoreForWebArchiveLoad ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -181,7 +181,7 @@ private:
     void startURLSchemeTask(IPC::Connection&, URLSchemeTaskParameters&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void decidePolicyForNavigationActionSync(NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
-    void backForwardAddItem(WebCore::FrameIdentifier, FrameState&&);
+    void backForwardAddItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
     void didDestroyNavigation(WebCore::NavigationIdentifier);
 #if USE(QUICK_LOOK)
     void requestPasswordForQuickLookDocumentInMainFrame(const String& fileName, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -463,24 +463,25 @@ void WebBackForwardList::restoreFromState(BackForwardListState backForwardListSt
 
     // FIXME: Enable restoring resourceDirectoryURL.
     m_entries = WTF::map(WTFMove(backForwardListState.items), [this](auto&& state) {
-        setBackForwardItemIdentifiers(state);
-        return WebBackForwardListItem::create(WTFMove(state), m_page->identifier());
+        Ref stateCopy = state->copy();
+        setBackForwardItemIdentifiers(stateCopy);
+        return WebBackForwardListItem::create(WTFMove(stateCopy), m_page->identifier());
     });
     m_currentIndex = backForwardListState.currentIndex ? std::optional<size_t>(*backForwardListState.currentIndex) : std::nullopt;
 
     LOG(BackForward, "(Back/Forward) WebBackForwardList %p restored from state (has %zu entries)", this, m_entries.size());
 }
 
-Vector<FrameState> WebBackForwardList::filteredItemStates(Function<bool(WebBackForwardListItem&)>&& functor) const
+Vector<Ref<FrameState>> WebBackForwardList::filteredItemStates(Function<bool(WebBackForwardListItem&)>&& functor) const
 {
-    return WTF::compactMap(m_entries, [&](auto& entry) -> std::optional<FrameState> {
+    return WTF::compactMap(m_entries, [&](auto& entry) -> std::optional<Ref<FrameState>> {
         if (functor(entry))
             return entry->mainFrameState();
         return std::nullopt;
     });
 }
 
-Vector<FrameState> WebBackForwardList::itemStates() const
+Vector<Ref<FrameState>> WebBackForwardList::itemStates() const
 {
     return filteredItemStates([](WebBackForwardListItem&) {
         return true;

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -84,8 +84,8 @@ public:
     BackForwardListState backForwardListState(WTF::Function<bool (WebBackForwardListItem&)>&&) const;
     void restoreFromState(BackForwardListState);
 
-    Vector<FrameState> itemStates() const;
-    Vector<FrameState> filteredItemStates(Function<bool(WebBackForwardListItem&)>&&) const;
+    Vector<Ref<FrameState>> itemStates() const;
+    Vector<Ref<FrameState>> filteredItemStates(Function<bool(WebBackForwardListItem&)>&&) const;
 
     void addRootChildFrameItem(Ref<WebBackForwardListItem>&&) const;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9091,15 +9091,15 @@ void WebPageProxy::requestDOMPasteAccess(DOMPasteAccessCategory pasteAccessCateg
 
 // BackForwardList
 
-void WebPageProxy::backForwardAddItem(FrameIdentifier targetFrameID, FrameState&& mainFrameState)
+void WebPageProxy::backForwardAddItem(FrameIdentifier targetFrameID, Ref<FrameState>&& mainFrameState)
 {
     backForwardAddItemShared(protectedLegacyMainFrameProcess(), targetFrameID, WTFMove(mainFrameState), didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-void WebPageProxy::backForwardAddItemShared(Ref<WebProcessProxy>&& process, FrameIdentifier targetFrameID, FrameState&& mainFrameState, LoadedWebArchive loadedWebArchive)
+void WebPageProxy::backForwardAddItemShared(Ref<WebProcessProxy>&& process, FrameIdentifier targetFrameID, Ref<FrameState>&& mainFrameState, LoadedWebArchive loadedWebArchive)
 {
-    URL itemURL { mainFrameState.urlString };
-    URL itemOriginalURL { mainFrameState.originalURLString };
+    URL itemURL { mainFrameState->urlString };
+    URL itemOriginalURL { mainFrameState->originalURLString };
 #if PLATFORM(COCOA)
     if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2053,7 +2053,7 @@ public:
     void startURLSchemeTaskShared(IPC::Connection&, Ref<WebProcessProxy>&&, WebCore::PageIdentifier, URLSchemeTaskParameters&&);
     void loadDataWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::SessionHistoryVisibility);
     void loadRequestWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume);
-    void backForwardAddItemShared(Ref<WebProcessProxy>&&, WebCore::FrameIdentifier, FrameState&&, LoadedWebArchive);
+    void backForwardAddItemShared(Ref<WebProcessProxy>&&, WebCore::FrameIdentifier, Ref<FrameState>&&, LoadedWebArchive);
     void backForwardGoToItemShared(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void decidePolicyForNavigationActionSyncShared(Ref<WebProcessProxy>&&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void didDestroyNavigationShared(Ref<WebProcessProxy>&&, WebCore::NavigationIdentifier);
@@ -2756,7 +2756,7 @@ private:
     std::optional<IPC::AsyncReplyID> willPerformPasteCommand(WebCore::DOMPasteAccessCategory, CompletionHandler<void()>&&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 
     // Back/Forward list management
-    void backForwardAddItem(WebCore::FrameIdentifier, FrameState&&);
+    void backForwardAddItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardListContainsItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(bool)>&&);
     void backForwardItemAtIndex(IPC::Connection&, int32_t index, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -198,7 +198,7 @@ messages -> WebPageProxy {
 #endif
 
     # BackForward messages
-    BackForwardAddItem(WebCore::FrameIdentifier targetFrameID, WebKit::FrameState mainFrameState)
+    BackForwardAddItem(WebCore::FrameIdentifier targetFrameID, Ref<WebKit::FrameState> mainFrameState)
     BackForwardGoToItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardItemAtIndex(int32_t itemIndex) -> (std::optional<WebCore::BackForwardItemIdentifier> itemID) Synchronous
     BackForwardListContainsItem(WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1089,14 +1089,14 @@ bool WebProcessProxy::isAllowedToUpdateBackForwardItem(WebBackForwardListItem& i
     return false;
 }
 
-void WebProcessProxy::updateBackForwardItem(FrameState&& mainFrameState)
+void WebProcessProxy::updateBackForwardItem(Ref<FrameState>&& mainFrameState)
 {
-    RefPtr item = WebBackForwardListItem::itemForID(mainFrameState.identifier);
+    RefPtr item = WebBackForwardListItem::itemForID(mainFrameState->identifier);
     if (!item || !isAllowedToUpdateBackForwardItem(*item))
         return;
 
-    if (!!item->backForwardCacheEntry() != mainFrameState.hasCachedPage) {
-        if (mainFrameState.hasCachedPage)
+    if (!!item->backForwardCacheEntry() != mainFrameState->hasCachedPage) {
+        if (mainFrameState->hasCachedPage)
             protectedProcessPool()->checkedBackForwardCache()->addEntry(*item, coreProcessIdentifier());
         else if (!item->suspendedPage())
             protectedProcessPool()->checkedBackForwardCache()->removeEntry(*item);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -560,7 +560,7 @@ private:
     void platformDestroy();
 
     // IPC message handlers.
-    void updateBackForwardItem(FrameState&&);
+    void updateBackForwardItem(Ref<FrameState>&&);
     void didDestroyFrame(IPC::Connection&, WebCore::FrameIdentifier, WebPageProxyIdentifier);
     void didDestroyUserGestureToken(WebCore::PageIdentifier, uint64_t);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> WebProcessProxy WantsDispatchMessage {
-    UpdateBackForwardItem(WebKit::FrameState mainFrameState)
+    UpdateBackForwardItem(Ref<WebKit::FrameState> mainFrameState)
     DidDestroyFrame(WebCore::FrameIdentifier frameID, WebKit::WebPageProxyIdentifier pageID) 
 
     DidDestroyUserGestureToken(WebCore::PageIdentifier pageID, uint64_t userGestureTokenID) 

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -64,53 +64,53 @@ static HTTPBody toHTTPBody(const FormData& formData)
     return httpBody;
 }
 
-FrameState toFrameState(const HistoryItem& historyItem)
+Ref<FrameState> toFrameState(const HistoryItem& historyItem)
 {
-    FrameState frameState;
+    Ref frameState = FrameState::create();
 
-    frameState.urlString = historyItem.urlString();
-    frameState.originalURLString = historyItem.originalURLString();
-    frameState.referrer = historyItem.referrer();
-    frameState.target = historyItem.target();
-    frameState.frameID = historyItem.frameID();
+    frameState->urlString = historyItem.urlString();
+    frameState->originalURLString = historyItem.originalURLString();
+    frameState->referrer = historyItem.referrer();
+    frameState->target = historyItem.target();
+    frameState->frameID = historyItem.frameID();
 
-    frameState.setDocumentState(historyItem.documentState());
+    frameState->setDocumentState(historyItem.documentState());
     if (RefPtr<SerializedScriptValue> stateObject = historyItem.stateObject())
-        frameState.stateObjectData = stateObject->wireBytes();
+        frameState->stateObjectData = stateObject->wireBytes();
 
-    frameState.documentSequenceNumber = historyItem.documentSequenceNumber();
-    frameState.itemSequenceNumber = historyItem.itemSequenceNumber();
+    frameState->documentSequenceNumber = historyItem.documentSequenceNumber();
+    frameState->itemSequenceNumber = historyItem.itemSequenceNumber();
 
-    frameState.scrollPosition = historyItem.scrollPosition();
-    frameState.shouldRestoreScrollPosition = historyItem.shouldRestoreScrollPosition();
-    frameState.pageScaleFactor = historyItem.pageScaleFactor();
+    frameState->scrollPosition = historyItem.scrollPosition();
+    frameState->shouldRestoreScrollPosition = historyItem.shouldRestoreScrollPosition();
+    frameState->pageScaleFactor = historyItem.pageScaleFactor();
 
     if (FormData* formData = const_cast<HistoryItem&>(historyItem).formData()) {
         HTTPBody httpBody = toHTTPBody(*formData);
         httpBody.contentType = historyItem.formContentType();
 
-        frameState.httpBody = WTFMove(httpBody);
+        frameState->httpBody = WTFMove(httpBody);
     }
 
-    frameState.identifier = historyItem.identifier();
-    frameState.hasCachedPage = historyItem.isInBackForwardCache();
-    frameState.shouldOpenExternalURLsPolicy = historyItem.shouldOpenExternalURLsPolicy();
-    frameState.sessionStateObject = historyItem.stateObject();
-    frameState.wasCreatedByJSWithoutUserInteraction = historyItem.wasCreatedByJSWithoutUserInteraction();
+    frameState->identifier = historyItem.identifier();
+    frameState->hasCachedPage = historyItem.isInBackForwardCache();
+    frameState->shouldOpenExternalURLsPolicy = historyItem.shouldOpenExternalURLsPolicy();
+    frameState->sessionStateObject = historyItem.stateObject();
+    frameState->wasCreatedByJSWithoutUserInteraction = historyItem.wasCreatedByJSWithoutUserInteraction();
 
     static constexpr auto maxTitleLength = 1000u; // Closest power of 10 above the W3C recommendation for Title length.
-    frameState.title = historyItem.title().left(maxTitleLength);
+    frameState->title = historyItem.title().left(maxTitleLength);
 
 #if PLATFORM(IOS_FAMILY)
-    frameState.exposedContentRect = historyItem.exposedContentRect();
-    frameState.unobscuredContentRect = historyItem.unobscuredContentRect();
-    frameState.minimumLayoutSizeInScrollViewCoordinates = historyItem.minimumLayoutSizeInScrollViewCoordinates();
-    frameState.contentSize = historyItem.contentSize();
-    frameState.scaleIsInitial = historyItem.scaleIsInitial();
-    frameState.obscuredInsets = historyItem.obscuredInsets();
+    frameState->exposedContentRect = historyItem.exposedContentRect();
+    frameState->unobscuredContentRect = historyItem.unobscuredContentRect();
+    frameState->minimumLayoutSizeInScrollViewCoordinates = historyItem.minimumLayoutSizeInScrollViewCoordinates();
+    frameState->contentSize = historyItem.contentSize();
+    frameState->scaleIsInitial = historyItem.scaleIsInitial();
+    frameState->obscuredInsets = historyItem.obscuredInsets();
 #endif
 
-    frameState.children = historyItem.children().map([](auto& childHistoryItem) {
+    frameState->children = historyItem.children().map([](auto& childHistoryItem) {
         return toFrameState(childHistoryItem);
     });
 
@@ -174,8 +174,8 @@ static void applyFrameState(HistoryItemClient& client, HistoryItem& historyItem,
     historyItem.setObscuredInsets(frameState.obscuredInsets);
 #endif
 
-    for (const auto& childFrameState : frameState.children) {
-        Ref childHistoryItem = HistoryItem::create(client, childFrameState.urlString, { }, { }, childFrameState.identifier);
+    for (auto& childFrameState : frameState.children) {
+        Ref childHistoryItem = HistoryItem::create(client, childFrameState->urlString, { }, { }, childFrameState->identifier);
         applyFrameState(client, childHistoryItem, childFrameState);
 
         historyItem.addChildItem(WTFMove(childHistoryItem));

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.h
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class FrameState;
 
-FrameState toFrameState(const WebCore::HistoryItem&);
+Ref<FrameState> toFrameState(const WebCore::HistoryItem&);
 Ref<WebCore::HistoryItem> toHistoryItem(WebCore::HistoryItemClient&, const FrameState&);
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3755,7 +3755,7 @@ void WebPage::setNeedsFontAttributes(bool needsFontAttributes)
         scheduleFullEditorStateUpdate();
 }
 
-void WebPage::restoreSessionInternal(const Vector<FrameState>& frameStates, WasRestoredByAPIRequest restoredByAPIRequest, WebBackForwardListProxy::OverwriteExistingItem overwrite)
+void WebPage::restoreSessionInternal(const Vector<Ref<FrameState>>& frameStates, WasRestoredByAPIRequest restoredByAPIRequest, WebBackForwardListProxy::OverwriteExistingItem overwrite)
 {
     // Since we're merely restoring HistoryItems from the UIProcess, there is no need to send HistoryItem update notifications back to the UIProcess.
     // Also, with process-swap on navigation, these updates may actually overwrite important state in the UIProcess such as the scroll position.
@@ -3763,25 +3763,25 @@ void WebPage::restoreSessionInternal(const Vector<FrameState>& frameStates, WasR
     for (const auto& frameState : frameStates) {
         auto historyItem = toHistoryItem(m_historyItemClient, frameState);
         historyItem->setWasRestoredFromSession(restoredByAPIRequest == WasRestoredByAPIRequest::Yes);
-        static_cast<WebBackForwardListProxy&>(corePage()->backForward().client()).addItemFromUIProcess(frameState.identifier, WTFMove(historyItem), m_identifier, overwrite);
+        static_cast<WebBackForwardListProxy&>(corePage()->backForward().client()).addItemFromUIProcess(frameState->identifier, WTFMove(historyItem), m_identifier, overwrite);
     }
 }
 
-void WebPage::restoreSession(const Vector<FrameState>& frameStates)
+void WebPage::restoreSession(const Vector<Ref<FrameState>>& frameStates)
 {
     restoreSessionInternal(frameStates, WasRestoredByAPIRequest::Yes, WebBackForwardListProxy::OverwriteExistingItem::No);
 }
 
-void WebPage::updateBackForwardListForReattach(const Vector<FrameState>& frameStates)
+void WebPage::updateBackForwardListForReattach(const Vector<Ref<FrameState>>& frameStates)
 {
     restoreSessionInternal(frameStates, WasRestoredByAPIRequest::No, WebBackForwardListProxy::OverwriteExistingItem::Yes);
 }
 
-void WebPage::setCurrentHistoryItemForReattach(FrameState&& mainFrameState)
+void WebPage::setCurrentHistoryItemForReattach(Ref<FrameState>&& mainFrameState)
 {
     Ref historyItem = toHistoryItem(m_historyItemClient, mainFrameState);
     auto& historyItemRef = historyItem.get();
-    static_cast<WebBackForwardListProxy&>(corePage()->backForward().client()).addItemFromUIProcess(mainFrameState.identifier, WTFMove(historyItem), m_identifier, WebBackForwardListProxy::OverwriteExistingItem::Yes);
+    static_cast<WebBackForwardListProxy&>(corePage()->backForward().client()).addItemFromUIProcess(mainFrameState->identifier, WTFMove(historyItem), m_identifier, WebBackForwardListProxy::OverwriteExistingItem::Yes);
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(corePage()->mainFrame()))
         localMainFrame->checkedHistory()->setCurrentItem(historyItemRef);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2005,11 +2005,11 @@ private:
     void loadDataInFrame(std::span<const uint8_t>, String&& MIMEType, String&& encodingName, URL&& baseURL, WebCore::FrameIdentifier);
 
     enum class WasRestoredByAPIRequest : bool { No, Yes };
-    void restoreSessionInternal(const Vector<FrameState>&, WasRestoredByAPIRequest, WebBackForwardListProxy::OverwriteExistingItem);
-    void restoreSession(const Vector<FrameState>&);
+    void restoreSessionInternal(const Vector<Ref<FrameState>>&, WasRestoredByAPIRequest, WebBackForwardListProxy::OverwriteExistingItem);
+    void restoreSession(const Vector<Ref<FrameState>>&);
     void didRemoveBackForwardItem(const WebCore::BackForwardItemIdentifier&);
-    void updateBackForwardListForReattach(const Vector<FrameState>&);
-    void setCurrentHistoryItemForReattach(FrameState&&);
+    void updateBackForwardListForReattach(const Vector<Ref<FrameState>>&);
+    void setCurrentHistoryItemForReattach(Ref<FrameState>&&);
 
     void requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -208,9 +208,9 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     StopLoading()
     StopLoadingDueToProcessSwap()
 
-    RestoreSession(Vector<WebKit::FrameState> frameStates)
-    UpdateBackForwardListForReattach(Vector<WebKit::FrameState> frameStates)
-    SetCurrentHistoryItemForReattach(WebKit::FrameState frameState)
+    RestoreSession(Vector<Ref<WebKit::FrameState>> frameStates)
+    UpdateBackForwardListForReattach(Vector<Ref<WebKit::FrameState>> frameStates)
+    SetCurrentHistoryItemForReattach(Ref<WebKit::FrameState> frameState)
 
     DidRemoveBackForwardItem(WebCore::BackForwardItemIdentifier backForwardItemID)
 


### PR DESCRIPTION
#### 61b4008f656685047d66c15d36b7365dcc8b1881
<pre>
Make `FrameState` reference counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280697">https://bugs.webkit.org/show_bug.cgi?id=280697</a>
<a href="https://rdar.apple.com/137069776">rdar://137069776</a>

Reviewed by Alex Christensen.

This will be required for future changes that introduce a UI process-side wrapper for FrameState to
manage back forward state by frame.

* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::create):
(WebKit::FrameState::FrameState):
(WebKit::FrameState::copy):
(WebKit::FrameState::stateForFrameID const):
* Source/WebKit/Shared/SessionState.h:
(WebKit::FrameState::~FrameState):
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::create):
(WebKit::WebBackForwardListItem::WebBackForwardListItem):
(WebKit::WebBackForwardListItem::~WebBackForwardListItem):
(WebKit::childItemWithDocumentSequenceNumber):
(WebKit::childItemWithTarget):
(WebKit::documentTreesAreEqual):
(WebKit::WebBackForwardListItem::itemIsInSameDocument const):
(WebKit::hasSameFrames):
(WebKit::WebBackForwardListItem::itemIsClone):
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::itemID const):
(WebKit::WebBackForwardListItem::setMainFrameState):
(WebKit::WebBackForwardListItem::mainFrameState const):
(WebKit::WebBackForwardListItem::originalURL const):
(WebKit::WebBackForwardListItem::url const):
(WebKit::WebBackForwardListItem::title const):
(WebKit::WebBackForwardListItem::wasCreatedByJSWithoutUserInteraction const):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp:
(decodeFrameState):
(decodeBackForwardListItemStateV1):
(decodeBackForwardListItemState):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::backForwardAddItem):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::restoreFromState):
(WebKit::WebBackForwardList::filteredItemStates const):
(WebKit::WebBackForwardList::itemStates const):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardAddItem):
(WebKit::WebPageProxy::backForwardAddItemShared):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::updateBackForwardItem):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeFrameStateNode):
(WebKit::encodeSessionHistory):
(WebKit::decodeBackForwardTreeNode):
(WebKit::decodeSessionHistoryEntries):
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFrameState):
(WebKit::applyFrameState):
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::restoreSessionInternal):
(WebKit::WebPage::restoreSession):
(WebKit::WebPage::updateBackForwardListForReattach):
(WebKit::WebPage::setCurrentHistoryItemForReattach):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/284567@main">https://commits.webkit.org/284567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eff2bff272f8247165ecbbc731d6e72b25210c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69812 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20970 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55432 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13898 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41513 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63120 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63049 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4671 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10660 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->