### PR TITLE
[WPE] WPE Platform: add a method to create a new WPEDisplayHeadless using a custom device file

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.h
@@ -38,7 +38,9 @@ G_BEGIN_DECLS
 #define WPE_TYPE_DISPLAY_HEADLESS (wpe_display_headless_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEDisplayHeadless, wpe_display_headless, WPE, DISPLAY_HEADLESS, WPEDisplay)
 
-WPE_API WPEDisplay *wpe_display_headless_new (void);
+WPE_API WPEDisplay *wpe_display_headless_new            (void);
+WPE_API WPEDisplay *wpe_display_headless_new_for_device (const char *name,
+                                                         GError    **error);
 
 G_END_DECLS
 


### PR DESCRIPTION
#### a836ac514c8017e4c663e5d6e8135e103799b429
<pre>
[WPE] WPE Platform: add a method to create a new WPEDisplayHeadless using a custom device file
<a href="https://bugs.webkit.org/show_bug.cgi?id=280701">https://bugs.webkit.org/show_bug.cgi?id=280701</a>

Reviewed by Carlos Garcia Campos.

Add a `wpe_display_headless_new_for_device()` method to the headless
backend in order to create a new display from the specified DRM device.

* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp:
(wpe_display_headless_new_for_device):
* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.h:

Canonical link: <a href="https://commits.webkit.org/284755@main">https://commits.webkit.org/284755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/054b75d16e36eae1cc9d2b40f7539a7a951dbeca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21601 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55806 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14276 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41985 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76231 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63462 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5136 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10782 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/398 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46705 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->