### PR TITLE
Adopt more smart pointers in GPUProcess/graphics (part 4)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -115,7 +115,7 @@ void RemoteImageBuffer::putPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer, We
 {
     assertIsCurrent(workQueue());
     WebCore::IntRect srcRect(srcPoint, srcSize);
-    m_imageBuffer->putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
+    imageBuffer()->putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
 }
 
 void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveResolution, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
@@ -148,11 +148,12 @@ void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, Complet
 {
     assertIsCurrent(workQueue());
     std::optional<WebCore::ShareableBitmap::Handle> handle = [&]() -> std::optional<WebCore::ShareableBitmap::Handle> {
-        auto image = m_imageBuffer->filteredNativeImage(filter);
+        Ref imageBuffer = m_imageBuffer;
+        auto image = imageBuffer->filteredNativeImage(filter);
         if (!image)
             return std::nullopt;
         auto imageSize = image->size();
-        auto bitmap = WebCore::ShareableBitmap::create({ imageSize, m_imageBuffer->colorSpace() });
+        auto bitmap = WebCore::ShareableBitmap::create({ imageSize, imageBuffer->colorSpace() });
         if (!bitmap)
             return std::nullopt;
         auto handle = bitmap->createHandle();
@@ -170,25 +171,25 @@ void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, Complet
 void RemoteImageBuffer::convertToLuminanceMask()
 {
     assertIsCurrent(workQueue());
-    m_imageBuffer->convertToLuminanceMask();
+    imageBuffer()->convertToLuminanceMask();
 }
 
 void RemoteImageBuffer::transformToColorSpace(const WebCore::DestinationColorSpace& colorSpace)
 {
     assertIsCurrent(workQueue());
-    m_imageBuffer->transformToColorSpace(colorSpace);
+    imageBuffer()->transformToColorSpace(colorSpace);
 }
 
 void RemoteImageBuffer::flushContext()
 {
     assertIsCurrent(workQueue());
-    m_imageBuffer->flushDrawingContext();
+    imageBuffer()->flushDrawingContext();
 }
 
 void RemoteImageBuffer::flushContextSync(CompletionHandler<void()>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    m_imageBuffer->flushDrawingContext();
+    imageBuffer()->flushDrawingContext();
     completionHandler();
 }
 
@@ -196,7 +197,7 @@ void RemoteImageBuffer::flushContextSync(CompletionHandler<void()>&& completionH
 void RemoteImageBuffer::dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    auto displayList = m_imageBuffer->dynamicContentScalingDisplayList();
+    auto displayList = imageBuffer()->dynamicContentScalingDisplayList();
     completionHandler({ WTFMove(displayList) });
 }
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -48,7 +48,7 @@ RemoteComputePassEncoder::RemoteComputePassEncoder(WebCore::WebGPU::ComputePassE
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteComputePassEncoder::~RemoteComputePassEncoder() = default;
@@ -60,7 +60,7 @@ void RemoteComputePassEncoder::destruct()
 
 void RemoteComputePassEncoder::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteComputePassEncoder::setPipeline(WebGPUIdentifier computePipeline)
@@ -70,12 +70,12 @@ void RemoteComputePassEncoder::setPipeline(WebGPUIdentifier computePipeline)
     if (!convertedComputePipeline)
         return;
 
-    m_backing->setPipeline(*convertedComputePipeline);
+    protectedBacking()->setPipeline(*convertedComputePipeline);
 }
 
 void RemoteComputePassEncoder::dispatch(WebCore::WebGPU::Size32 workgroupCountX, WebCore::WebGPU::Size32 workgroupCountY, WebCore::WebGPU::Size32 workgroupCountZ)
 {
-    m_backing->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
+    protectedBacking()->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
 }
 
 void RemoteComputePassEncoder::dispatchIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
@@ -85,12 +85,12 @@ void RemoteComputePassEncoder::dispatchIndirect(WebGPUIdentifier indirectBuffer,
     if (!convertedIndirectBuffer)
         return;
 
-    m_backing->dispatchIndirect(*convertedIndirectBuffer, indirectOffset);
+    protectedBacking()->dispatchIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteComputePassEncoder::end()
 {
-    m_backing->end();
+    protectedBacking()->end();
 }
 
 void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebGPUIdentifier bindGroup,
@@ -101,27 +101,42 @@ void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebG
     if (!convertedBindGroup)
         return;
 
-    m_backing->setBindGroup(index, *convertedBindGroup, WTFMove(offsets));
+    protectedBacking()->setBindGroup(index, *convertedBindGroup, WTFMove(offsets));
 }
 
 void RemoteComputePassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    m_backing->pushDebugGroup(WTFMove(groupLabel));
+    protectedBacking()->pushDebugGroup(WTFMove(groupLabel));
 }
 
 void RemoteComputePassEncoder::popDebugGroup()
 {
-    m_backing->popDebugGroup();
+    protectedBacking()->popDebugGroup();
 }
 
 void RemoteComputePassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    m_backing->insertDebugMarker(WTFMove(markerLabel));
+    protectedBacking()->insertDebugMarker(WTFMove(markerLabel));
 }
 
 void RemoteComputePassEncoder::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::ComputePassEncoder> RemoteComputePassEncoder::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteComputePassEncoder::protectedStreamConnection() const
+{
+    return m_streamConnection;
+}
+
+Ref<WebGPU::ObjectHeap> RemoteComputePassEncoder::protectedObjectHeap() const
+{
+    return m_objectHeap.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -75,7 +75,10 @@ private:
     RemoteComputePassEncoder& operator=(RemoteComputePassEncoder&&) = delete;
 
     WebCore::WebGPU::ComputePassEncoder& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
+    Ref<WebCore::WebGPU::ComputePassEncoder> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
@@ -45,24 +45,29 @@ RemotePipelineLayout::RemotePipelineLayout(WebCore::WebGPU::PipelineLayout& pipe
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemotePipelineLayout::~RemotePipelineLayout() = default;
 
 void RemotePipelineLayout::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemotePipelineLayout::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemotePipelineLayout::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemotePipelineLayout::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -74,6 +74,7 @@ private:
     RemotePipelineLayout& operator=(RemotePipelineLayout&&) = delete;
 
     WebCore::WebGPU::PipelineLayout& backing() { return m_backing; }
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -74,6 +74,10 @@ private:
     RemoteRenderPipeline& operator=(RemoteRenderPipeline&&) = delete;
 
     WebCore::WebGPU::RenderPipeline& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::RenderPipeline> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
@@ -59,7 +59,7 @@ RemoteXRView::~RemoteXRView() = default;
 
 void RemoteXRView::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteXRView::stopListeningForIPC()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -397,8 +397,8 @@ RefPtr<ImageBuffer> RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(std::u
 
 RemoteSerializedImageBufferProxy::~RemoteSerializedImageBufferProxy()
 {
-    if (m_connection)
-        m_connection->send(Messages::RemoteSharedResourceCache::ReleaseSerializedImageBuffer(m_renderingResourceIdentifier), 0);
+    if (RefPtr connection = m_connection)
+        connection->send(Messages::RemoteSharedResourceCache::ReleaseSerializedImageBuffer(m_renderingResourceIdentifier), 0);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 9cf1b11b2983b1135d07858f035a2acd6b0fd4dc
<pre>
Adopt more smart pointers in GPUProcess/graphics (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280706">https://bugs.webkit.org/show_bug.cgi?id=280706</a>
<a href="https://rdar.apple.com/137077186">rdar://137077186</a>

Reviewed by Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::putPixelBuffer):
(WebKit::RemoteImageBuffer::filteredNativeImage):
(WebKit::RemoteImageBuffer::convertToLuminanceMask):
(WebKit::RemoteImageBuffer::transformToColorSpace):
(WebKit::RemoteImageBuffer::flushContext):
(WebKit::RemoteImageBuffer::flushContextSync):
(WebKit::RemoteImageBuffer::dynamicContentScalingDisplayList):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::endPrepareForDisplay):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::RemoteComputePassEncoder):
(WebKit::RemoteComputePassEncoder::stopListeningForIPC):
(WebKit::RemoteComputePassEncoder::setPipeline):
(WebKit::RemoteComputePassEncoder::dispatch):
(WebKit::RemoteComputePassEncoder::dispatchIndirect):
(WebKit::RemoteComputePassEncoder::end):
(WebKit::RemoteComputePassEncoder::setBindGroup):
(WebKit::RemoteComputePassEncoder::pushDebugGroup):
(WebKit::RemoteComputePassEncoder::popDebugGroup):
(WebKit::RemoteComputePassEncoder::insertDebugMarker):
(WebKit::RemoteComputePassEncoder::setLabel):
(WebKit::RemoteComputePassEncoder::protectedBacking):
(WebKit::RemoteComputePassEncoder::protectedStreamConnection const):
(WebKit::RemoteComputePassEncoder::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp:
(WebKit::RemotePipelineLayout::RemotePipelineLayout):
(WebKit::RemotePipelineLayout::destruct):
(WebKit::RemotePipelineLayout::stopListeningForIPC):
(WebKit::RemotePipelineLayout::setLabel):
(WebKit::RemotePipelineLayout::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::RemoteRenderPipeline):
(WebKit::RemoteRenderPipeline::destruct):
(WebKit::RemoteRenderPipeline::stopListeningForIPC):
(WebKit::RemoteRenderPipeline::getBindGroupLayout):
(WebKit::RemoteRenderPipeline::setLabel):
(WebKit::RemoteRenderPipeline::protectedBacking):
(WebKit::RemoteRenderPipeline::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp:
(WebKit::RemoteXRView::destruct):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteSerializedImageBufferProxy::~RemoteSerializedImageBufferProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::didPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::close):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed):

Canonical link: <a href="https://commits.webkit.org/284538@main">https://commits.webkit.org/284538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b2052262331aef10382cdb870e059806b149ffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55386 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35866 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41441 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19248 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75511 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15489 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4598 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44917 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->