### PR TITLE
[JSC] Implement SetterThatIgnoresPrototypeProperties() as specified in Iterator helpers proposal

### DIFF
--- a/JSTests/stress/iterator-prototype-constructor-setter.js
+++ b/JSTests/stress/iterator-prototype-constructor-setter.js
@@ -17,3 +17,50 @@ function assertThrows(expectedError, f) {
 assertThrows(TypeError, function () {
     Iterator.prototype.constructor = {};
 });
+
+var setter = Object.getOwnPropertyDescriptor(Iterator.prototype, "constructor").set;
+
+assertThrows(TypeError, function () {
+    setter.call(10);
+});
+
+assertThrows(TypeError, function () {
+    setter.call(Object.preventExtensions({}));
+});
+
+class MyError extends Error {}
+
+assertThrows(MyError, function () {
+    setter.call({ set constructor(v) { throw v; } }, new MyError);
+});
+
+var logs = [];
+var loggingHandler = {
+    getOwnPropertyDescriptor(target, key) {
+        logs.push(`getOwnPropertyDescriptor key: ${String(key)}`);
+        return Reflect.getOwnPropertyDescriptor(target, key);
+    },
+    set(target, key, value, receiver) {
+        logs.push(`set key: ${String(key)}, value: ${value}`);
+        return Reflect.set(target, key, value, receiver);
+    },
+    defineProperty(target, key, desc) {
+        logs.push(`defineProperty key: ${String(key)}, desc: ${JSON.stringify(desc)}`);
+        return Reflect.defineProperty(target, key, desc);
+    },
+};
+
+var proxyWithProperty = new Proxy({ constructor: 1 }, loggingHandler);
+setter.call(proxyWithProperty, 2);
+assert(logs[0], "getOwnPropertyDescriptor key: constructor");
+assert(logs[1], "set key: constructor, value: 2");
+assert(logs[2], "getOwnPropertyDescriptor key: constructor");
+assert(logs[3], `defineProperty key: constructor, desc: {"value":2}`);
+assert(logs.length, 4);
+
+logs = [];
+var proxyWithoutProperty = new Proxy({}, loggingHandler);
+setter.call(proxyWithoutProperty, 3);
+assert(logs[0], "getOwnPropertyDescriptor key: constructor");
+assert(logs[1], `defineProperty key: constructor, desc: {"value":3,"writable":true,"enumerable":true,"configurable":true}`);
+assert(logs.length, 2);

--- a/JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js
+++ b/JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js
@@ -17,3 +17,50 @@ function assertThrows(expectedError, f) {
 assertThrows(TypeError, function () {
     Iterator.prototype[Symbol.toStringTag] = "foo";
 });
+
+var setter = Object.getOwnPropertyDescriptor(Iterator.prototype, Symbol.toStringTag).set;
+
+assertThrows(TypeError, function () {
+    setter.call("foo");
+});
+
+assertThrows(TypeError, function () {
+    setter.call(Object.preventExtensions({}));
+});
+
+class MyError extends Error {}
+
+assertThrows(MyError, function () {
+    setter.call({ set [Symbol.toStringTag](v) { throw v; } }, new MyError);
+});
+
+var logs = [];
+var loggingHandler = {
+    getOwnPropertyDescriptor(target, key) {
+        logs.push(`getOwnPropertyDescriptor key: ${String(key)}`);
+        return Reflect.getOwnPropertyDescriptor(target, key);
+    },
+    set(target, key, value, receiver) {
+        logs.push(`set key: ${String(key)}, value: ${value}`);
+        return Reflect.set(target, key, value, receiver);
+    },
+    defineProperty(target, key, desc) {
+        logs.push(`defineProperty key: ${String(key)}, desc: ${JSON.stringify(desc)}`);
+        return Reflect.defineProperty(target, key, desc);
+    },
+};
+
+var proxyWithProperty = new Proxy({ [Symbol.toStringTag]: 1 }, loggingHandler);
+setter.call(proxyWithProperty, 2);
+assert(logs[0], "getOwnPropertyDescriptor key: Symbol(Symbol.toStringTag)");
+assert(logs[1], "set key: Symbol(Symbol.toStringTag), value: 2");
+assert(logs[2], "getOwnPropertyDescriptor key: Symbol(Symbol.toStringTag)");
+assert(logs[3], `defineProperty key: Symbol(Symbol.toStringTag), desc: {"value":2}`);
+assert(logs.length, 4);
+
+logs = [];
+var proxyWithoutProperty = new Proxy({}, loggingHandler);
+setter.call(proxyWithoutProperty, 3);
+assert(logs[0], "getOwnPropertyDescriptor key: Symbol(Symbol.toStringTag)");
+assert(logs[1], `defineProperty key: Symbol(Symbol.toStringTag), desc: {"value":3,"writable":true,"enumerable":true,"configurable":true}`);
+assert(logs.length, 2);

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -103,22 +103,8 @@ JSC_DEFINE_CUSTOM_GETTER(iteratorProtoConstructorGetter, (JSGlobalObject* global
 // https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-constructor
 JSC_DEFINE_CUSTOM_SETTER(iteratorProtoConstructorSetter, (JSGlobalObject* globalObject, EncodedJSValue encodedThisValue, EncodedJSValue value, PropertyName propertyName))
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-
-    if (!thisValue.isObject())
-        return throwVMTypeError(globalObject, scope, "Iterator.prototype.constructor setter expected |this| to be an object."_s);
-
-    JSObject* thisObject = thisValue.toObject(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (thisObject == globalObject->iteratorPrototype())
-        return throwVMTypeError(globalObject, scope, "Iterator.prototype.constructor setter cannot be applied to Iterator.prototype."_s);
-
-    thisObject->putDirect(vm, propertyName, JSValue::decode(value), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-
+    bool shouldThrow = true;
+    setterThatIgnoresPrototypeProperties(globalObject, JSValue::decode(encodedThisValue), globalObject->iteratorPrototype(), propertyName, JSValue::decode(value), shouldThrow);
     return JSValue::encode(jsUndefined());
 }
 
@@ -132,22 +118,8 @@ JSC_DEFINE_CUSTOM_GETTER(iteratorProtoToStringTagGetter, (JSGlobalObject* global
 // https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-@@tostringtag
 JSC_DEFINE_CUSTOM_SETTER(iteratorProtoToStringTagSetter, (JSGlobalObject* globalObject, EncodedJSValue encodedThisValue, EncodedJSValue value, PropertyName propertyName))
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-
-    if (!thisValue.isObject())
-        return throwVMTypeError(globalObject, scope, "Iterator.prototype[Symbol.toStringTag] setter expected |this| to be an object."_s);
-
-    JSObject* thisObject = thisValue.toObject(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (thisObject == globalObject->iteratorPrototype())
-        return throwVMTypeError(globalObject, scope, "Iterator.prototype[Symbol.toStringTag] setter cannot be applied to Iterator.prototype."_s);
-
-    thisObject->putDirect(vm, propertyName, JSValue::decode(value), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-
+    bool shouldThrow = true;
+    setterThatIgnoresPrototypeProperties(globalObject, JSValue::decode(encodedThisValue), globalObject->iteratorPrototype(), propertyName, JSValue::decode(value), shouldThrow);
     return JSValue::encode(jsUndefined());
 }
 

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1750,6 +1750,8 @@ bool validateAndApplyPropertyDescriptor(JSGlobalObject*, JSObject*, PropertyName
 JS_EXPORT_PRIVATE NEVER_INLINE bool ordinarySetSlow(JSGlobalObject*, JSObject*, PropertyName, JSValue, JSValue receiver, bool shouldThrow);
 JS_EXPORT_PRIVATE NEVER_INLINE bool ordinarySetWithOwnDescriptor(JSGlobalObject*, JSObject*, PropertyName, JSValue, JSValue receiver, PropertyDescriptor&& ownDescriptor, bool shouldThrow);
 
+bool setterThatIgnoresPrototypeProperties(JSGlobalObject*, JSValue thisValue, JSObject* homeObject, PropertyName, JSValue, bool shouldThrow);
+
 // Helper for defining native functions, if you're not using a static hash table.
 // Use this macro from within finishCreation() methods in prototypes. This assumes
 // you've defined variables called globalObject, globalObject, and vm, and they


### PR DESCRIPTION
#### a3e7b8f85e8fb9444ed717f3d494052adacddfef
<pre>
[JSC] Implement SetterThatIgnoresPrototypeProperties() as specified in Iterator helpers proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=280705">https://bugs.webkit.org/show_bug.cgi?id=280705</a>
&lt;<a href="https://rdar.apple.com/problem/137078675">rdar://problem/137078675</a>&gt;

Reviewed by Yusuke Suzuki.

Unfortunately, putDirect() is not enough to implement SetterThatIgnoresPrototypeProperties() [1]:
  * if the property is absent, and object is non-extensible, a TypeError should be thrown;
  * if the property is present, its descriptor should not be overwritten (like putDirect() does),
    and the setter, if present, should be invoked.

Also, SetterThatIgnoresPrototypeProperties() should invoke non-ordinary [[GetOwnProperty]], [[Set]],
and [[DefineOwnProperty]] methods because it can be called on any object, including a ProxyObject.

[1]: <a href="https://tc39.es/proposal-iterator-helpers/#sec-SetterThatIgnoresPrototypeProperties">https://tc39.es/proposal-iterator-helpers/#sec-SetterThatIgnoresPrototypeProperties</a> (steps 3-5)

* JSTests/stress/iterator-prototype-constructor-setter.js:
* JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js:
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_SETTER):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::setterThatIgnoresPrototypeProperties):
* Source/JavaScriptCore/runtime/JSObject.h:

Canonical link: <a href="https://commits.webkit.org/284737@main">https://commits.webkit.org/284737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adfadb6a773e237ce4f5ec538b2a7bb74a7541b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/70368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/49774 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/23133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21546 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/57574 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/21386 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21546 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/73434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/57574 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/23133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/57574 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/23133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19907 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/63489 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/57574 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/23133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/69615 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/14594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/21386 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/76176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/14636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/23133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/23133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/91398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10767 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/45576 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/343 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/91398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47927 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46392 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->