### PR TITLE
[iOS] Selection is unnecessarily clipped in overflow scrolling areas when SelectionHonorsOverflowScrolling is enabled

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -133,6 +133,8 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
 #if PLATFORM(IOS_FAMILY)
         if (editorState.visualData->selectionClipRect != IntRect())
             ts.dumpProperty("selectionClipRect", editorState.visualData->selectionClipRect);
+        if (editorState.visualData->editableRootBounds != IntRect())
+            ts.dumpProperty("editableRootBounds", editorState.visualData->editableRootBounds);
         if (editorState.visualData->caretRectAtEnd != IntRect())
             ts.dumpProperty("caretRectAtEnd", editorState.visualData->caretRectAtEnd);
         if (!editorState.visualData->selectionGeometries.isEmpty())
@@ -163,6 +165,7 @@ void EditorState::clipOwnedRectExtentsToNumericLimits()
     auto sanitizeVisualData = [](auto& visualData) {
 #if PLATFORM(IOS_FAMILY)
         visualData.selectionClipRect = visualData.selectionClipRect.toRectWithExtentsClippedToNumericLimits();
+        visualData.editableRootBounds = visualData.editableRootBounds.toRectWithExtentsClippedToNumericLimits();
         visualData.caretRectAtEnd = visualData.caretRectAtEnd.toRectWithExtentsClippedToNumericLimits();
         visualData.markedTextCaretRectAtStart = visualData.markedTextCaretRectAtStart.toRectWithExtentsClippedToNumericLimits();
         visualData.markedTextCaretRectAtEnd = visualData.markedTextCaretRectAtEnd.toRectWithExtentsClippedToNumericLimits();

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -148,6 +148,7 @@ struct EditorState {
 #endif
 #if PLATFORM(IOS_FAMILY)
         WebCore::IntRect selectionClipRect;
+        WebCore::IntRect editableRootBounds;
         WebCore::IntRect caretRectAtEnd;
         Vector<WebCore::SelectionGeometry> selectionGeometries;
         Vector<WebCore::SelectionGeometry> markedTextRects;

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -119,6 +119,7 @@ struct WebKit::EditorState {
 #endif
 #if PLATFORM(IOS_FAMILY)
     WebCore::IntRect selectionClipRect;
+    WebCore::IntRect editableRootBounds;
     WebCore::IntRect caretRectAtEnd;
     Vector<WebCore::SelectionGeometry> selectionGeometries;
     Vector<WebCore::SelectionGeometry> markedTextRects;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3311,9 +3311,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return shouldAcknowledgeTap(_singleTapGestureRecognizer.get());
 
     if (gestureRecognizer == _keyboardDismissalGestureRecognizer) {
+        auto tapIsInEditableRoot = [&] {
+            auto& state = _page->editorState();
+            return state.hasVisualData() && state.visualData->editableRootBounds.contains(WebCore::roundedIntPoint(point));
+        };
         return self._hasFocusedElement
             && !self.hasHiddenContentEditable
-            && !CGRectContainsPoint(self.selectionClipRect, point)
+            && !tapIsInEditableRoot()
             && shouldAcknowledgeTap(_keyboardDismissalGestureRecognizer.get());
     }
 
@@ -8866,7 +8870,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
             editableRootIsTransparentOrFullyClipped = YES;
 
         if (self._hasFocusedElement) {
-            auto elementArea = visualData.selectionClipRect.area<RecordOverflow>();
+            auto elementArea = visualData.editableRootBounds.area<RecordOverflow>();
             if (!elementArea.hasOverflowed() && elementArea < minimumFocusedElementAreaForSuppressingSelectionAssistant)
                 focusedElementIsTooSmall = YES;
         }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -665,12 +665,15 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
         }();
     }
 
-    RefPtr editableRootOrFormControl = enclosingTextFormControl(selection.start()) ?: selection.rootEditableElement();
-    if (editableRootOrFormControl)
+    if (RefPtr editableRootOrFormControl = enclosingTextFormControl(selection.start()) ?: selection.rootEditableElement()) {
         postLayoutData.editableRootIsTransparentOrFullyClipped = result.isContentEditable && isTransparentOrFullyClipped(*editableRootOrFormControl);
+#if PLATFORM(IOS_FAMILY)
+        result.visualData->editableRootBounds = rootViewInteractionBounds(Ref { *editableRootOrFormControl });
+#endif
+    }
 
 #if PLATFORM(IOS_FAMILY)
-    computeSelectionClipRect(result, selection, editableRootOrFormControl.get());
+    computeSelectionClipRectAndEnclosingScroller(result, selection, result.visualData->editableRootBounds);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1870,7 +1870,7 @@ private:
     void clearSelectionAfterTapIfNeeded();
     void scheduleLayoutViewportHeightExpansionUpdate();
     void scheduleEditorStateUpdateAfterAnimationIfNeeded(const WebCore::Element&);
-    void computeSelectionClipRect(EditorState&, const WebCore::VisibleSelection&, const WebCore::Element* editableRootOrFormControl) const;
+    void computeSelectionClipRectAndEnclosingScroller(EditorState&, const WebCore::VisibleSelection&, const WebCore::IntRect& editableRootBounds) const;
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)


### PR DESCRIPTION
#### 8c423827078839d00eabdd9f4a0266d1a2112a79
<pre>
[iOS] Selection is unnecessarily clipped in overflow scrolling areas when SelectionHonorsOverflowScrolling is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280702">https://bugs.webkit.org/show_bug.cgi?id=280702</a>

Reviewed by Abrar Rahman Protyasha.

Continue to refactor UIKit-based text selection rendering on iOS. This patch avoids propagating
`selectionClipRect` to the UI process, in the case where clipping can be entirely handled by an
enclosing platform scroll view. Notably, we still need to compute and send a `selectionClipRect` in
the case where the selection is inside of a single line text field which is scrollable in the inline
direction, but doesn&apos;t correspond to a native scroll view.

See below for more details.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::operator&lt;&lt;):
(WebKit::EditorState::clipOwnedRectExtentsToNumericLimits):
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Add a separate member that represents the bounds of the editable root which contains the selection.
Currently, there are a couple of places in `WKContentViewInteraction` that use `selectionClipRect`
interchangeably with the bounds of the root editable container. `SelectionHonorsOverflowScrolling`
breaks this assumption, because the selection clip rect is now empty in an unscrollable text field.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizerShouldBegin:]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):

See above comment.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):

Refactor this to compute and pass in `editableRootBounds` separately, when computing the selection
clip rect. Also rename `computeSelectionClipRect` to `computeSelectionClipRectAndEnclosingScroller`
to reflect its new responsibilities.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::enclosingScroller):
(WebKit::forEachEnclosingScroller):

Refactor this code so that we&apos;re able to walk up the render tree by `container()`, and visit
scrollable areas until we find one with a corresponding scrolling node, instead of stopping at the
first scrollable area (which may not have a scrolling node ID). This allows us to detect the case
where the selection&apos;s immediate scrollable container does not map to a node in the scrolling tree,
but there&apos;s another enclosing scroller wherein the selection should be parented. In this case, we
want to still install the selection views inside of the enclosing scroll view, but we still need to
set a selection clip rect that clamps the selection to the immediate scrollable area (for instance,
a text field with enough content to require scrolling).

(WebKit::WebPage::computeSelectionClipRectAndEnclosingScroller const):
(WebKit::WebPage::computeSelectionClipRect const): Deleted.

Canonical link: <a href="https://commits.webkit.org/284533@main">https://commits.webkit.org/284533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69531a5daf795e6224da683d1a1119c73f4c942c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20878 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20729 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13850 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60135 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41442 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17170 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62990 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11013 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4606 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44924 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->