### PR TITLE
Fix bugs in IPInt metadata generation and execution

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-call-add13.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-call-add13.js
@@ -1,0 +1,61 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $add (export "add") (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.add)
+        (local.get 2)
+        (i32.add)
+        (local.get 3)
+        (i32.add)
+        (local.get 4)
+        (i32.add)
+        (local.get 5)
+        (i32.add)
+        (local.get 6)
+        (i32.add)
+        (local.get 7)
+        (i32.add)
+        (local.get 8)
+        (i32.add)
+        (local.get 9)
+        (i32.add)
+        (local.get 10)
+        (i32.add)
+        (local.get 11)
+        (i32.add)
+        (local.get 12)
+        (i32.add)
+        (return)
+    )
+    (func (export "test") (param i32) (result i32)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (local.get 0)
+        (call $add)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test, add } = instance.exports
+    assert.eq(add(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 13);
+    assert.eq(test(1), 13)
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -692,10 +692,14 @@ extern "C" void ipint_catch_all_entry();
     m(0x09, mint_fa1) \
     m(0x0a, mint_fa2) \
     m(0x0b, mint_fa3) \
-    m(0x0c, mint_stackzero) \
-    m(0x0d, mint_stackeight) \
-    m(0x0e, mint_gap) \
-    m(0x0f, mint_call) \
+    m(0x0c, mint_fa4) \
+    m(0x0d, mint_fa5) \
+    m(0x0e, mint_fa6) \
+    m(0x0f, mint_fa7) \
+    m(0x10, mint_stackzero) \
+    m(0x11, mint_stackeight) \
+    m(0x12, mint_gap) \
+    m(0x13, mint_call) \
 
 #define FOR_EACH_IPINT_MINT_RETURN_OPCODE(m) \
     m(0x00, mint_r0) \
@@ -710,8 +714,12 @@ extern "C" void ipint_catch_all_entry();
     m(0x09, mint_fr1) \
     m(0x0a, mint_fr2) \
     m(0x0b, mint_fr3) \
-    m(0x0c, mint_stack) \
-    m(0x0d, mint_end) \
+    m(0x0c, mint_fr4) \
+    m(0x0d, mint_fr5) \
+    m(0x0e, mint_fr6) \
+    m(0x0f, mint_fr7) \
+    m(0x10, mint_stack) \
+    m(0x11, mint_end) \
 
 #define FOR_EACH_IPINT_UINT_OPCODE(m) \
     m(0x00, uint_r0) \

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -993,6 +993,18 @@ mintAlign(_fa2)
 mintAlign(_fa3)
     break
 
+mintAlign(_fa4)
+    break
+
+mintAlign(_fa5)
+    break
+
+mintAlign(_fa6)
+    break
+
+mintAlign(_fa7)
+    break
+
 mintAlign(_stackzero)
     break
 
@@ -1040,6 +1052,18 @@ mintAlign(_fr2)
     break
 
 mintAlign(_fr3)
+    break
+
+mintAlign(_fr4)
+    break
+
+mintAlign(_fr5)
+    break
+
+mintAlign(_fr6)
+    break
+
+mintAlign(_fr7)
     break
 
 mintAlign(_stack)

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -888,6 +888,11 @@ end)
 # This is the interpreted analogue to WasmBinding.cpp:wasmToWasm
 op(wasm_to_wasm_wrapper_entry, macro()
     loadp (Callee - PrologueStackPointerDelta)[sp], ws0
+    loadp [ws0], ws0
+
+if JSVALUE64
+    andp ~(constexpr JSValue::NativeCalleeTag), ws0
+end
 
     loadi Wasm::Callee::m_index[ws0], ws1
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -169,11 +169,11 @@ struct TableCopyMetadata {
 
 enum class CallArgumentBytecode : uint8_t { // (mINT)
     ArgumentGPR = 0x0, // 0x00 - 0x07: push into a0, a1, ...
-    ArgumentFPR = 0x8, // 0x08 - 0x0b: push into fa0, fa1, ...
-    ArgumentStackAligned = 0xc, // 0x0c: pop stack value, push onto stack[0]
-    ArgumentStackUnaligned = 0xd, // 0x0d: pop stack value, add another 16B for params, push onto stack[8]
-    StackAlign = 0xe, // 0x0e: add another 16B for params
-    End = 0xf // 0x0f: stop
+    ArgumentFPR = 0x8, // 0x08 - 0x0f: push into fa0, fa1, ...
+    ArgumentStackAligned = 0x10, // 0x10: pop stack value, push onto stack[0]
+    ArgumentStackUnaligned = 0x11, // 0x11: pop stack value, add another 16B for params, push onto stack[8]
+    StackAlign = 0x12, // 0x12: add another 16B for params
+    End = 0x13 // 0x13: stop
 };
 
 struct CallMetadata {
@@ -193,9 +193,9 @@ struct CallIndirectMetadata {
 
 enum class CallResultBytecode : uint8_t { // (mINT)
     ResultGPR = 0x0, // 0x00 - 0x07: r0 - r7
-    ResultFPR = 0x8, // 0x08 - 0x0b: fr0 - fr3
-    ResultStack = 0xc, // 0x0c: stack
-    End = 0xd // 0x0d: end
+    ResultFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
+    ResultStack = 0x10, // 0x0c: stack
+    End = 0x11 // 0x0d: end
 };
 
 struct callReturnMetadata {

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -239,6 +239,12 @@ def ipint_reenable_all_breakpoints(debugger, command, exec_ctx, result, internal
         brk.enabled = True
 
 
+def ipint_continue_on_all_breakpoints(debugger, command, exec_ctx, result, internal_dict):
+    for brk in breakpoints:
+        brk.enabled = True
+        brk.SetAutoContinue(True)
+
+
 def set_breakpoints(debugger, command, exe_ctx, result, internal_dict):
     print("Initializing internal breakpoints...", file=result)
     target = debugger.GetTargetAtIndex(0)
@@ -259,5 +265,6 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand('command script add -f debug_ipint.ipint_break_at ipint_break_at')
     debugger.HandleCommand('command script add -f debug_ipint.ipint_disable_all_breakpoints ipint_disable_all_breakpoints')
     debugger.HandleCommand('command script add -f debug_ipint.ipint_reenable_all_breakpoints ipint_reenable_all_breakpoints')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_continue_on_all_breakpoints ipint_autocontinue')
     debugger.HandleCommand('command script add -f debug_ipint.set_breakpoints set_breakpoints')
     print("IPInt debugger ready")


### PR DESCRIPTION
#### b7b59d4334fc96b77893d2fc4e498bd593ba9d66
<pre>
Fix bugs in IPInt metadata generation and execution
<a href="https://bugs.webkit.org/show_bug.cgi?id=280711">https://bugs.webkit.org/show_bug.cgi?id=280711</a>
<a href="https://rdar.apple.com/137081917">rdar://137081917</a>

Reviewed by Yusuke Suzuki.

This patch goes through and resolves a wide variety of edge cases in IPInt exposed by the spec tests, stress tests, and JetStream2.
JetStream2.0 now runs with IPInt enabled, and we pass all core spec tests besides the new exception spec.

* JSTests/wasm/ipint-tests/ipint-test-call-add13.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.add.export.string_appeared_here.param.i32.i32.i32.i32.i32.i32.i32.i32.i32.i32.i32.i32.i32.result.i32.local.0.local.1.i32.add.local.2.i32.add.local.3.i32.add.local.4.i32.add.local.5.i32.add.local.6.i32.add.local.7.i32.add.local.8.i32.add.local.9.i32.add.local.10.i32.add.local.11.i32.add.local.12.i32.add.return.func.export.string_appeared_here.param.i32.result.i32.local.0.local.0.local.0.local.0.local.0.local.0.local.0.local.0.local.0.local.0.local.0.local.0.local.0.call.add.return.async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::tryToResolveBranchTarget):
(JSC::Wasm::IPIntGenerator::coalesceControlFlow):
(JSC::Wasm::IPIntGenerator::addBlock):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElse):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addBranch):
(JSC::Wasm::IPIntGenerator::addSwitch):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::doWasmCall):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/284564@main">https://commits.webkit.org/284564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f800ae8263cf743ce1d49eff8e6772372413de6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20898 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19275 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62856 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75538 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/68986 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62998 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15506 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4616 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90768 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44944 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16116 "Found 2 new JSC binary failures: testapi, testb3, Found 100 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/instanceof-operator.js.layout ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->