### PR TITLE
Fix uninitialized value warnings reported by GCC 14

### DIFF
--- a/Source/WTF/wtf/SingleThreadIntegralWrapper.h
+++ b/Source/WTF/wtf/SingleThreadIntegralWrapper.h
@@ -40,7 +40,10 @@ public:
     SingleThreadIntegralWrapper& operator++();
     SingleThreadIntegralWrapper& operator--();
 
+// https://bugs.webkit.org/show_bug.cgi?id=280710
+IGNORE_GCC_WARNINGS_BEGIN("uninitialized")
     IntegralType valueWithoutThreadCheck() const { return m_value; }
+IGNORE_GCC_WARNINGS_END
 
 private:
 #if ASSERT_ENABLED && !USE(WEB_THREAD)

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2800,7 +2800,7 @@ sub GenerateDictionaryImplementationContent
         $result .= "    }\n";
 
         # 2. Let dict be an empty dictionary value of type D; every dictionary member is initially considered to be not present.
-        $result .= "    $className result;\n";
+        $result .= "    $className result { };\n";
 
         # 3. Let dictionaries be a list consisting of D and all of D’s inherited dictionaries, in order from least to most derived.
         #

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
@@ -61,7 +61,7 @@ template<> ConversionResult<IDLDictionary<ExposedToWorkerAndWindow::Dict>> conve
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    ExposedToWorkerAndWindow::Dict result;
+    ExposedToWorkerAndWindow::Dict result { };
     JSValue objValue;
     if (isNullOrUndefined)
         objValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -103,7 +103,7 @@ template<> ConversionResult<IDLDictionary<TestCallbackInterface::Dictionary>> co
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestCallbackInterface::Dictionary result;
+    TestCallbackInterface::Dictionary result { };
     JSValue optionalMemberValue;
     if (isNullOrUndefined)
         optionalMemberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary.cpp
@@ -45,7 +45,7 @@ template<> ConversionResult<IDLDictionary<TestDerivedDictionary>> convertDiction
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestDerivedDictionary result;
+    TestDerivedDictionary result { };
     JSValue boolMemberValue;
     if (isNullOrUndefined)
         boolMemberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary2.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary2.cpp
@@ -45,7 +45,7 @@ template<> ConversionResult<IDLDictionary<TestDerivedDictionary2>> convertDictio
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestDerivedDictionary2 result;
+    TestDerivedDictionary2 result { };
     JSValue boolMemberValue;
     if (isNullOrUndefined)
         boolMemberValue = jsUndefined();
@@ -141,7 +141,7 @@ template<> ConversionResult<IDLDictionary<TestDerivedDictionary2::Dictionary>> c
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestDerivedDictionary2::Dictionary result;
+    TestDerivedDictionary2::Dictionary result { };
     JSValue boolMemberValue;
     if (isNullOrUndefined)
         boolMemberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionary.cpp
@@ -38,7 +38,7 @@ template<> ConversionResult<IDLDictionary<TestDictionary>> convertDictionary<Tes
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestDictionary result;
+    TestDictionary result { };
     JSValue memberValue;
     if (isNullOrUndefined)
         memberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryNoToNative.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryNoToNative.cpp
@@ -55,7 +55,7 @@ template<> ConversionResult<IDLDictionary<TestDictionaryNoToNative::GenerateKeyw
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestDictionaryNoToNative::GenerateKeyword result;
+    TestDictionaryNoToNative::GenerateKeyword result { };
     JSValue memberValue;
     if (isNullOrUndefined)
         memberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryWithOnlyConditionalMembers.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryWithOnlyConditionalMembers.cpp
@@ -43,7 +43,7 @@ template<> ConversionResult<IDLDictionary<TestDictionaryWithOnlyConditionalMembe
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestDictionaryWithOnlyConditionalMembers result;
+    TestDictionaryWithOnlyConditionalMembers result { };
 #if ENABLE(TEST_CONDITIONAL)
     JSValue conditionalMemberValue;
     if (isNullOrUndefined)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEmptyDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEmptyDictionary.cpp
@@ -39,7 +39,7 @@ template<> ConversionResult<IDLDictionary<TestEmptyDictionary>> convertDictionar
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestEmptyDictionary result;
+    TestEmptyDictionary result { };
     return result;
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -60,7 +60,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestEventConstructor::Init result;
+    TestEventConstructor::Init result { };
     JSValue bubblesValue;
     if (isNullOrUndefined)
         bubblesValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary.cpp
@@ -45,7 +45,7 @@ template<> ConversionResult<IDLDictionary<TestInheritedDictionary>> convertDicti
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestInheritedDictionary result;
+    TestInheritedDictionary result { };
     JSValue boolMemberValue;
     if (isNullOrUndefined)
         boolMemberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary2.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary2.cpp
@@ -43,7 +43,7 @@ template<> ConversionResult<IDLDictionary<TestInheritedDictionary2>> convertDict
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestInheritedDictionary2 result;
+    TestInheritedDictionary2 result { };
     JSValue boolMemberValue;
     if (isNullOrUndefined)
         boolMemberValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -549,7 +549,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::Dictionary result;
+    TestObj::Dictionary result { };
     JSValue annotatedTypeInSequenceMemberValue;
     if (isNullOrUndefined)
         annotatedTypeInSequenceMemberValue = jsUndefined();
@@ -1309,7 +1309,7 @@ template<> ConversionResult<IDLDictionary<TestObj::DictionaryThatShouldNotTolera
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::DictionaryThatShouldNotTolerateNull result;
+    TestObj::DictionaryThatShouldNotTolerateNull result { };
     JSValue booleanWithoutDefaultValue;
     if (isNullOrUndefined)
         booleanWithoutDefaultValue = jsUndefined();
@@ -1381,7 +1381,7 @@ template<> ConversionResult<IDLDictionary<TestObj::DictionaryThatShouldTolerateN
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::DictionaryThatShouldTolerateNull result;
+    TestObj::DictionaryThatShouldTolerateNull result { };
     JSValue booleanWithoutDefaultValue;
     if (isNullOrUndefined)
         booleanWithoutDefaultValue = jsUndefined();
@@ -1421,7 +1421,7 @@ template<> ConversionResult<IDLDictionary<AlternateDictionaryName>> convertDicti
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    AlternateDictionaryName result;
+    AlternateDictionaryName result { };
     JSValue booleanWithoutDefaultValue;
     if (isNullOrUndefined)
         booleanWithoutDefaultValue = jsUndefined();
@@ -1461,7 +1461,7 @@ template<> ConversionResult<IDLDictionary<TestObj::ParentDictionary>> convertDic
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::ParentDictionary result;
+    TestObj::ParentDictionary result { };
     JSValue parentMember1Value;
     if (isNullOrUndefined)
         parentMember1Value = jsUndefined();
@@ -1501,7 +1501,7 @@ template<> ConversionResult<IDLDictionary<TestObj::ChildDictionary>> convertDict
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::ChildDictionary result;
+    TestObj::ChildDictionary result { };
     JSValue parentMember1Value;
     if (isNullOrUndefined)
         parentMember1Value = jsUndefined();
@@ -1569,7 +1569,7 @@ template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryA>> conv
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::ConditionalDictionaryA result;
+    TestObj::ConditionalDictionaryA result { };
     JSValue stringWithoutDefaultValue;
     if (isNullOrUndefined)
         stringWithoutDefaultValue = jsUndefined();
@@ -1600,7 +1600,7 @@ template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryB>> conv
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::ConditionalDictionaryB result;
+    TestObj::ConditionalDictionaryB result { };
     JSValue stringWithoutDefaultValue;
     if (isNullOrUndefined)
         stringWithoutDefaultValue = jsUndefined();
@@ -1631,7 +1631,7 @@ template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryC>> conv
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::ConditionalDictionaryC result;
+    TestObj::ConditionalDictionaryC result { };
     JSValue stringWithoutDefaultValue;
     if (isNullOrUndefined)
         stringWithoutDefaultValue = jsUndefined();
@@ -1660,7 +1660,7 @@ template<> ConversionResult<IDLDictionary<TestObj::PromisePair>> convertDictiona
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestObj::PromisePair result;
+    TestObj::PromisePair result { };
     JSValue promise1Value;
     if (isNullOrUndefined)
         promise1Value = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -64,7 +64,7 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    TestPromiseRejectionEvent::Init result;
+    TestPromiseRejectionEvent::Init result { };
     JSValue bubblesValue;
     if (isNullOrUndefined)
         bubblesValue = jsUndefined();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -57,7 +57,7 @@ template<> ConversionResult<IDLDictionary<DictionaryImplName>> convertDictionary
         throwTypeError(&lexicalGlobalObject, throwScope);
         return ConversionResultException { };
     }
-    DictionaryImplName result;
+    DictionaryImplName result { };
     JSValue boolMemberValue;
     if (isNullOrUndefined)
         boolMemberValue = jsUndefined();


### PR DESCRIPTION
#### 02e0216272b7da88f6ee7ec8af9c4317fdeb75b4
<pre>
Fix uninitialized value warnings reported by GCC 14
<a href="https://bugs.webkit.org/show_bug.cgi?id=280710">https://bugs.webkit.org/show_bug.cgi?id=280710</a>

Reviewed by NOBODY (OOPS!).

We have an actual uninitialized value bug in CodeGeneratorJS.pm.

Then I can&apos;t see anything wrong in SingleThreadIntegralWrapper or the
code that calls it. This probably requires a GCC bug report.

* Source/WTF/wtf/SingleThreadIntegralWrapper.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateDictionaryImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp:
(WebCore::convertDictionary&lt;ExposedToWorkerAndWindow::Dict&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::convertDictionary&lt;TestCallbackInterface::Dictionary&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary.cpp:
(WebCore::convertDictionary&lt;TestDerivedDictionary&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary2.cpp:
(WebCore::convertDictionary&lt;TestDerivedDictionary2&gt;):
(WebCore::convertDictionary&lt;TestDerivedDictionary2::Dictionary&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionary.cpp:
(WebCore::convertDictionary&lt;TestDictionary&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryNoToNative.cpp:
(WebCore::convertDictionary&lt;TestDictionaryNoToNative::GenerateKeyword&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryWithOnlyConditionalMembers.cpp:
(WebCore::convertDictionary&lt;TestDictionaryWithOnlyConditionalMembers&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestEmptyDictionary.cpp:
(WebCore::convertDictionary&lt;TestEmptyDictionary&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp:
(WebCore::convertDictionary&lt;TestEventConstructor::Init&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary.cpp:
(WebCore::convertDictionary&lt;TestInheritedDictionary&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary2.cpp:
(WebCore::convertDictionary&lt;TestInheritedDictionary2&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::convertDictionary&lt;TestObj::Dictionary&gt;):
(WebCore::convertDictionary&lt;TestObj::DictionaryThatShouldNotTolerateNull&gt;):
(WebCore::convertDictionary&lt;TestObj::DictionaryThatShouldTolerateNull&gt;):
(WebCore::convertDictionary&lt;AlternateDictionaryName&gt;):
(WebCore::convertDictionary&lt;TestObj::ParentDictionary&gt;):
(WebCore::convertDictionary&lt;TestObj::ChildDictionary&gt;):
(WebCore::convertDictionary&lt;TestObj::ConditionalDictionaryA&gt;):
(WebCore::convertDictionary&lt;TestObj::ConditionalDictionaryB&gt;):
(WebCore::convertDictionary&lt;TestObj::ConditionalDictionaryC&gt;):
(WebCore::convertDictionary&lt;TestObj::PromisePair&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp:
(WebCore::convertDictionary&lt;TestPromiseRejectionEvent::Init&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
(WebCore::convertDictionary&lt;DictionaryImplName&gt;):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e0216272b7da88f6ee7ec8af9c4317fdeb75b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20199 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63781 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76469 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69908 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63697 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63632 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5327 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91690 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/637 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19992 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46942 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->