### PR TITLE
AX: AXTextOperation over multiple ranges is entirely broken

### DIFF
--- a/LayoutTests/accessibility/mac/text-operation/text-operation-capitalize-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-capitalize-expected.txt
@@ -13,9 +13,9 @@ PASS: operationResult[2] === 'E Quick Bro'
 PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: ThE Quick Brown fox jumPs Over the Lazy dog.'
 PASS: operationResult.length === 3
 PASS: operationResult[0] === 'Lazy'
-FAIL: operationResult[1] !== 'Ps Over', was
-FAIL: operationResult[2] !== 'E Quick Bro', was
-FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT3: Th E Quick Bro wn fox jum Ps Over the Lazy dog.', was AXValue: TEXT3: The quick brown fox jumps over the Lazy dog.
+PASS: operationResult[1] === 'Ps Over'
+PASS: operationResult[2] === 'E Quick Bro'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: Th E Quick Bro wn fox jum Ps Over the Lazy dog.'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-lowercase-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-lowercase-expected.txt
@@ -13,9 +13,9 @@ PASS: operationResult[2] === 'e quick bro'
 PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: THe quick broWN FOX JUMps over THE lazy DOG.'
 PASS: operationResult.length === 3
 PASS: operationResult[0] === 'lazy'
-FAIL: operationResult[1] !== 'ps over', was
-FAIL: operationResult[2] !== 'e quick bro', was
-FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT3: TH e quick bro WN FOX JUM ps over THE lazy DOG.', was AXValue: TEXT3: THE QUICK BROWN FOX JUMPS OVER THE lazy DOG.
+PASS: operationResult[1] === 'ps over'
+PASS: operationResult[2] === 'e quick bro'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: TH e quick bro WN FOX JUM ps over THE lazy DOG.'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields-expected.txt
@@ -1,0 +1,18 @@
+Tests that text operations are performed as expected across multiple editable fields.
+
+PASS: operationResult.length === 6
+PASS: operationResult[0] === 'foo'
+PASS: operationResult[1] === 'foo'
+PASS: operationResult[2] === 'foo'
+PASS: operationResult[3] === 'foo'
+PASS: operationResult[4] === 'foo'
+PASS: operationResult[5] === 'foo'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick foo jumps over foo zy dog.'
+PASS: text2.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: The quick foo x jumps ov foo zy dog.'
+PASS: text3.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: The quick brown fox jumps over the foo dog.'
+PASS: text4.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT4: The quick brown fox jumps over foo lazy dog.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <p contenteditable="true" id="text">The quick brown fox jumps over the lazy dog.</p>
+    <p contenteditable="true" id="text2">TEXT2: The quick <span id="target1">brown fo</span>x jumps ov<span id="target2">er the la</span>zy dog.</p>
+    <textarea id="text3">TEXT3: The quick brown fox jumps over the lazy dog.</textarea>
+    <input type="text" id="text4" value="TEXT4: The quick brown fox jumps over the lazy dog.">
+</div>
+
+<script>
+var output = "Tests that text operations are performed as expected across multiple editable fields.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text = accessibilityController.accessibleElementById("text");
+    var text2 = accessibilityController.accessibleElementById("text2");
+    var text3 = accessibilityController.accessibleElementById("text3");
+    var text4 = accessibilityController.accessibleElementById("text4");
+
+    var operationResult;
+    setTimeout(async function() {
+        var markers = [
+            await selectPartialElementTextById("text", 30, 37),
+            await selectPartialElementTextById("text", 9, 20),
+            await selectElementTextById("target2"),
+            await selectElementTextById("target1"),
+            await selectPartialElementTextById("text3", 42, 46),
+            await selectPartialElementTextById("text4", 38, 41),
+        ];
+
+        await waitForNotification(text, "AXValueChanged", async () => {
+            await waitForNotification(text2, "AXValueChanged", async () => {
+                await waitForNotification(text3, "AXValueChanged", async () => {
+                    await waitForNotification(text4, "AXValueChanged", () => {
+                        const webArea = accessibilityController.rootElement.childAtIndex(0);
+                        operationResult = webArea.performTextOperation("TextOperationReplacePreserveCase", markers, "foo", /* smart replace */ true);
+                    });
+                });
+            });
+        });
+
+        output += expect("operationResult.length", "6");
+        output += expect("operationResult[0]", "'foo'");
+        output += expect("operationResult[1]", "'foo'");
+        output += expect("operationResult[2]", "'foo'");
+        output += expect("operationResult[3]", "'foo'");
+        output += expect("operationResult[4]", "'foo'");
+        output += expect("operationResult[5]", "'foo'");
+        output += expect("text.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick foo jumps over foo zy dog.'");
+        output += expect("text2.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT2: The quick foo x jumps ov foo zy dog.'");
+        output += expect("text3.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT3: The quick brown fox jumps over the foo dog.'");
+        output += expect("text4.stringValue.replace(/\\s/g, ' ')", "'AXValue: TEXT4: The quick brown fox jumps over foo lazy dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-at-node-boundary-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-at-node-boundary-expected.txt
@@ -1,0 +1,11 @@
+Tests that text operations are performed as expected at node boundaries.
+
+PASS: operationResult.length === 2
+PASS: operationResult[0] === ' foo '
+PASS: operationResult[1] === ' foo '
+PASS: testContent.stringValue.replace(/\s/g, ' ') === 'AXValue: The quick brown foo  fox jumps over  foo the lazy dog.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-replace-at-node-boundary.html
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-replace-at-node-boundary.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content" contenteditable="true">
+    <p>The quick <em>brown</em><span id="target1"></span> fox jumps over <span id="target2"></span><b>the</b> lazy dog.</p>
+</div>
+
+<script>
+var output = "Tests that text operations are performed as expected at node boundaries.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var testContent = accessibilityController.accessibleElementById("test-content");
+    var operationResult;
+    setTimeout(async function() {
+        var markers = [
+            await selectElementTextById("target2"),
+            await selectElementTextById("target1"),
+        ];
+
+        await waitForNotification(testContent, "AXValueChanged", () => {
+            operationResult = testContent.performTextOperation("TextOperationReplacePreserveCase", markers, " foo ", /* smart replace */ false);
+        });
+
+        output += expect("operationResult.length", "2");
+        output += expect("operationResult[0]", "' foo '");
+        output += expect("operationResult[1]", "' foo '");
+        output += expect("testContent.stringValue.replace(/\\s/g, ' ')", "'AXValue: The quick brown foo  fox jumps over  foo the lazy dog.'");
+
+        document.getElementById("test-content").remove();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace-expected.txt
@@ -13,9 +13,9 @@ PASS: operationResult[2] === '[replaced string]'
 PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: Th[replaced string]wn fox jum[replaced string] the [replaced string] dog.'
 PASS: operationResult.length === 3
 PASS: operationResult[0] === '[replaced string]'
-FAIL: operationResult[1] !== '[replaced string]', was [Replaced string]
-FAIL: operationResult[2] !== '[replaced string]', was [Replaced string]
-FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT4: Th [replaced string] wn fox jum [replaced string] the [replaced string] dog.', was AXValue: TEXT4: The quick brown fox jumps over the [replaced string] dog.
+PASS: operationResult[1] === '[replaced string]'
+PASS: operationResult[2] === '[replaced string]'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT4: Th [replaced string] wn fox jum [replaced string] the [replaced string] dog.'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/text-operation/text-operation-uppercase-expected.txt
+++ b/LayoutTests/accessibility/mac/text-operation/text-operation-uppercase-expected.txt
@@ -13,9 +13,9 @@ PASS: operationResult[2] === 'E QUICK BRO'
 PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT2: ThE QUICK BROwn fox jumPS OVER the LAZY dog.'
 PASS: operationResult.length === 3
 PASS: operationResult[0] === 'LAZY'
-FAIL: operationResult[1] !== 'PS OVER', was
-FAIL: operationResult[2] !== 'E QUICK BRO', was
-FAIL: text.stringValue.replace(/\s/g, ' ') !== 'AXValue: TEXT3: Th E QUICK BRO wn fox jum PS OVER the LAZY dog.', was AXValue: TEXT3: The quick brown fox jumps over the LAZY dog.
+PASS: operationResult[1] === 'PS OVER'
+PASS: operationResult[2] === 'E QUICK BRO'
+PASS: text.stringValue.replace(/\s/g, ' ') === 'AXValue: TEXT3: Th E QUICK BRO wn fox jum PS OVER the LAZY dog.'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1173,11 +1173,16 @@ imported/w3c/web-platform-tests/css/css-view-transitions [ Skip ]
 # AXTextOperation layout tests are not available for WK1.
 accessibility/mac/text-operation/text-operation-capitalize.html [ Skip ]
 accessibility/mac/text-operation/text-operation-lowercase.html [ Skip ]
+accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html [ Skip ]
+accessibility/mac/text-operation/text-operation-replace-at-node-boundary.html [ Skip ]
 accessibility/mac/text-operation/text-operation-replace-preserve-case.html [ Skip ]
 accessibility/mac/text-operation/text-operation-replace.html [ Skip ]
 accessibility/mac/text-operation/text-operation-select.html [ Skip ]
 accessibility/mac/text-operation/text-operation-smart-replace.html [ Skip ]
 accessibility/mac/text-operation/text-operation-uppercase.html [ Skip ]
+
+# Skipping because AXTextMarkerRangeIsValid is not supported on WK1.
+accessibility/mac/dynamic-selection.html [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End features not supported in WebKit1

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -575,12 +575,6 @@ imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Fa
 
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
-# webkit.org/b/278928 AX: AXTextOperation over multiple ranges is entirely broken
-[ Debug ] accessibility/mac/text-operation/text-operation-capitalize.html [ Crash ]
-[ Debug ] accessibility/mac/text-operation/text-operation-lowercase.html [ Crash ]
-[ Debug ] accessibility/mac/text-operation/text-operation-smart-replace.html [ Crash ]
-[ Debug ] accessibility/mac/text-operation/text-operation-uppercase.html [ Crash ]
-
 ### END OF (1) Classified failures with bug reports
 ########################################
 


### PR DESCRIPTION
#### 4b8b62af6ff69eda42b461cbc3c46ec15428ca25
<pre>
AX: AXTextOperation over multiple ranges is entirely broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=278928">https://bugs.webkit.org/show_bug.cgi?id=278928</a>
<a href="https://rdar.apple.com/problem/135021789">rdar://problem/135021789</a>

Reviewed by Tyler Wilcock.

While the AXTextOperation parameterized accessibility attribute provides an API for replacing
multiple ranges of text, in practice it would fail to apply changes after the first replacement in
many cases, especially when using smart replacement.

This was happening because after performing a replacement, in some cases, the remaining SimpleRanges
in `AccessibilityTextOperation` become orphaned as the node they were referring to would no longer
be in the tree. Specifically, this happened whenever the replacement was not performed using
`ReplaceSelectionCommand::performTrivialReplace` but instead followed the longer path in
`ReplaceSelectionCommand::doApply`.

To address this issue, before performing any replacements, we construct character ranges with
respect to their root editable element for all of the provided ranges. The root editable element
seems to be preserved in the tree after performing a replacement using the `ReplaceSelectionCommand`.
Then, we can reconstruct the `SimpleRange` for each replacement, ensuring we always use a valid
SimpleRange.

* LayoutTests/accessibility/mac/text-operation/text-operation-capitalize-expected.txt:
* LayoutTests/accessibility/mac/text-operation/text-operation-lowercase-expected.txt:
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html: Added.

AXTextOperation can be provided text marker ranges from multiple editable fields on a page.
This test ensures that replacements are performed correctly across multiple fields.

* LayoutTests/accessibility/mac/text-operation/text-operation-replace-at-node-boundary-expected.txt: Added.
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-at-node-boundary.html: Added.

Using ReplaceSelectionCommand to perform a replacement over a zero-length range (effectively
an insert) at node boundaries can result in one less whitespace than expected. To resolve
this, AccessibilityObject::performTextOperation now inserts text instead of replacing it when
the selection length is zero.

This test asserts on the correct behavior for that edge case.

* LayoutTests/accessibility/mac/text-operation/text-operation-smart-replace-expected.txt:
* LayoutTests/accessibility/mac/text-operation/text-operation-uppercase-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/accessibility-helper.js:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::textOperationRangeFromRange):
(WebCore::rangeFromTextOperationRange):
(WebCore::AccessibilityObject::performTextOperation):

Canonical link: <a href="https://commits.webkit.org/284801@main">https://commits.webkit.org/284801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48c93518c3c1ebfed6c1789eeb07e5334a2e2719

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14344 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60785 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36336 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63594 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63528 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5211 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/487 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46794 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->