### PR TITLE
Swift Implementation for underlying Queue::writeBuffer

### DIFF
--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -213,8 +213,6 @@ protected:
     }
 };
 
-} // namespace WTF
-
 template<typename T>
 inline void retainRefCounted(T* obj)
 {
@@ -230,5 +228,9 @@ inline void releaseRefCounted(T* obj)
     static_assert(std::derived_from<T, WTF::RefCounted<T>>);
     static_cast<WTF::RefCounted<T>*>(obj)->deref();
 }
+
+} // namespace WTF
+
+
 
 using WTF::RefCounted;

--- a/Source/WTF/wtf/RetainReleaseSwift.h
+++ b/Source/WTF/wtf/RetainReleaseSwift.h
@@ -29,6 +29,14 @@
 #include <swift/bridging>
 #endif
 
-#if !HAVE(SWIFT_CPP_INTEROP) && !defined(SWIFT_SHARED_REFERENCE) // FIXME: rdar://136787800
+#if !HAVE(SWIFT_CPP_INTEROP)
+
+#ifndef SWIFT_SHARED_REFERENCE // FIXME: rdar://136787800
 #define SWIFT_SHARED_REFERENCE(__retain, __release)
+#endif
+
+#ifndef SWIFT_RETURNS_INDEPENDENT_VALUE // FIXME: rdar://136787800
+#define SWIFT_RETURNS_INDEPENDENT_VALUE
+#endif
+
 #endif

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -154,8 +154,6 @@ protected:
     ThreadSafeRefCounted() = default;
 };
 
-} // namespace WTF
-
 template<typename T>
 inline void retainThreadSafeRefCounted(T* obj)
 {
@@ -171,5 +169,7 @@ inline void releaseThreadSafeRefCounted(T* obj)
     static_assert(std::derived_from<T, WTF::ThreadSafeRefCounted<T>>);
     static_cast<WTF::ThreadSafeRefCounted<T>*>(obj)->deref();
 }
+
+} // namespace WTF
 
 using WTF::ThreadSafeRefCounted;

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -179,6 +179,23 @@ private:
 };
 
 template<typename T>
+inline void retainThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr(T* obj)
+{
+    RELEASE_ASSERT(obj != nullptr);
+    static_assert(std::derived_from<T, ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<T>>);
+    static_cast<ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<T>*>(obj)->ref();
+}
+
+template<typename T>
+inline void releaseThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr(T* obj)
+{
+    RELEASE_ASSERT(obj != nullptr);
+    static_assert(std::derived_from<T, ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<T>>);
+    static_cast<ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<T>*>(obj)->deref();
+}
+
+
+template<typename T>
 class ThreadSafeWeakPtr {
 public:
     ThreadSafeWeakPtr() = default;

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		941C1EE52CA328F7004D4220 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941C1EE42CA328EE004D4220 /* Queue.swift */; };
 		941C1EE62CA33255004D4220 /* Queue.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACA9C273A426D0095F8D5 /* Queue.h */; };
 		941C1EE72CA46829004D4220 /* Instance.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACAA0273A426D0095F8D5 /* Instance.h */; };
+		941C64B72CAB4A0700A63214 /* Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACA9B273A426D0095F8D5 /* Device.h */; };
 		9478714A2C98CECB003DB695 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947871492C98CEC6003DB695 /* Buffer.swift */; };
 		9478714C2C98D31A003DB695 /* WebGPUSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 9478714B2C98D314003DB695 /* WebGPUSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94CC0FE62CA203B300CB3264 /* WebGPUSwiftInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 94CC0FE52CA203AB00CB3264 /* WebGPUSwiftInternal.h */; };
@@ -890,6 +891,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CEBD7E72716AFBA00A5254D /* WebGPU.h in Headers */,
+				941C64B72CAB4A0700A63214 /* Device.h in Headers */,
 				0D30F93929F1FAC50055D9F1 /* ExternalTexture.h in Headers */,
 				941C1EE72CA46829004D4220 /* Instance.h in Headers */,
 				0D509DCD29CAB6EC00546D84 /* MetalSPI.h in Headers */,

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -157,10 +157,10 @@ private:
 
 inline void retainBuffer(WebGPU::Buffer* obj)
 {
-    retainRefCounted(obj);
+    WTF::retainRefCounted(obj);
 }
 
 inline void releaseBuffer(WebGPU::Buffer* obj)
 {
-    releaseRefCounted(obj);
+    WTF::releaseRefCounted(obj);
 }

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -36,6 +36,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Function.h>
 #import <wtf/Ref.h>
+#import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/Vector.h>
@@ -241,6 +242,16 @@ private:
 #if HAVE(COREVIDEO_METAL_SUPPORT)
     RetainPtr<CVMetalTextureCacheRef> m_coreVideoTextureCache;
 #endif
-};
+} SWIFT_SHARED_REFERENCE(retainDevice, releaseDevice);
 
 } // namespace WebGPU
+
+inline void retainDevice(WebGPU::Device* obj)
+{
+    WTF::retainThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr(obj);
+}
+
+inline void releaseDevice(WebGPU::Device* obj)
+{
+    WTF::releaseThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr(obj);
+}

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -77,7 +77,7 @@ public:
     void makeInvalid();
     void setCommittedSignalEvent(id<MTLSharedEvent>, size_t frameIndex);
 
-    const Device& device() const;
+    const Device& device() const SWIFT_RETURNS_INDEPENDENT_VALUE;
     void clearTextureIfNeeded(const WGPUImageCopyTexture&, NSUInteger);
     id<MTLCommandBuffer> commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
     void commitMTLCommandBuffer(id<MTLCommandBuffer>);
@@ -88,6 +88,9 @@ public:
     static bool writeWillCompletelyClear(WGPUTextureDimension, uint32_t widthForMetal, uint32_t logicalSizeWidth, uint32_t heightForMetal, uint32_t logicalSizeHeight, uint32_t depthForMetal, uint32_t logicalSizeDepthOrArrayLayers);
     void endEncoding(id<MTLCommandEncoder>, id<MTLCommandBuffer>) const;
 
+    id<MTLBlitCommandEncoder> ensureBlitCommandEncoder();
+    void finalizeBlitCommandEncoder();
+
 private:
     Queue(id<MTLCommandQueue>, Device&);
     Queue(Device&);
@@ -95,8 +98,6 @@ private:
     NSString* errorValidatingSubmit(const Vector<std::reference_wrapper<CommandBuffer>>&) const;
     bool validateWriteBuffer(const Buffer&, uint64_t bufferOffset, size_t) const;
 
-    void ensureBlitCommandEncoder();
-    void finalizeBlitCommandEncoder();
 
     bool isIdle() const;
     bool isSchedulingIdle() const { return m_submittedCommandBufferCount == m_scheduledCommandBufferCount; }
@@ -126,11 +127,11 @@ private:
 
 inline void retainQueue(WebGPU::Queue* obj)
 {
-    retainThreadSafeRefCounted(obj);
+    WTF::retainThreadSafeRefCounted(obj);
 }
 
 inline void releaseQueue(WebGPU::Queue* obj)
 {
-    releaseThreadSafeRefCounted(obj);
+    WTF::releaseThreadSafeRefCounted(obj);
 }
 

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -71,10 +71,10 @@ Queue::~Queue()
         endEncoding(m_blitCommandEncoder, m_commandBuffer);
 }
 
-void Queue::ensureBlitCommandEncoder()
+id<MTLBlitCommandEncoder> Queue::ensureBlitCommandEncoder()
 {
     if (m_blitCommandEncoder && m_blitCommandEncoder == encoderForBuffer(m_commandBuffer))
-        return;
+        return m_blitCommandEncoder;
 
     auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];
     commandBufferDescriptor.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
@@ -82,6 +82,7 @@ void Queue::ensureBlitCommandEncoder()
     m_commandBuffer = blitCommandBuffer;
     m_blitCommandEncoder = [m_commandBuffer blitCommandEncoder];
     setEncoderForBuffer(m_commandBuffer, m_blitCommandEncoder);
+    return m_blitCommandEncoder;
 }
 
 void Queue::finalizeBlitCommandEncoder()
@@ -939,8 +940,7 @@ void Queue::clearTextureViewIfNeeded(TextureView& textureView)
             if (parentTexture.previouslyCleared(parentMipLevel, parentSlice))
                 continue;
 
-            ensureBlitCommandEncoder();
-            CommandEncoder::clearTextureIfNeeded(parentTexture, parentMipLevel, parentSlice, *devicePtr, m_blitCommandEncoder);
+            CommandEncoder::clearTextureIfNeeded(parentTexture, parentMipLevel, parentSlice, *devicePtr, ensureBlitCommandEncoder());
         }
     }
     finalizeBlitCommandEncoder();

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -166,6 +166,7 @@ WGPU_EXPORT void wgpuDeviceClearUncapturedErrorCallback(WGPUDevice device) WGPU_
 
 #if ENABLE(WEBGPU_SWIFT) && defined(__WEBGPU__)
 #include "Buffer.h"
+#include "Device.h"
 #include "Queue.h"
 #endif
 


### PR DESCRIPTION
#### 26880c142f2708a75e519e311edf1b99e9ab208b
<pre>
Swift Implementation for underlying Queue::writeBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=280715">https://bugs.webkit.org/show_bug.cgi?id=280715</a>
<a href="https://rdar.apple.com/136672126">rdar://136672126</a>

Reviewed by Mike Wyrzykowski.

Re-implement Queue::writeBuffer using a Swift implementation.
It is still using some underlying utilities from the C++ implementation
but that can only be moved over once Swift implements the whole class and has ownership
of underlying objects.

Testing:
Manual at desk builds with --webGpuSwift and running the Buffer and Queue tests.
Then Run writeBuffer.html test.

* Source/WTF/wtf/RefCounted.h:
(retainRefCounted): Deleted.
(releaseRefCounted): Deleted.
* Source/WTF/wtf/RetainReleaseSwift.h:
* Source/WTF/wtf/ThreadSafeRefCounted.h:
(retainThreadSafeRefCounted): Deleted.
(releaseThreadSafeRefCounted): Deleted.
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::retainThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr):
(WTF::releaseThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Buffer.h:
(retainBuffer):
(releaseBuffer):
* Source/WebGPU/WebGPU/Device.h:
(retainDevice):
(releaseDevice):
* Source/WebGPU/WebGPU/Queue.h:
(WebGPU::Queue::blitCommandEncoder):
(retainQueue):
(releaseQueue):
* Source/WebGPU/WebGPU/Queue.swift:
(WebGPU.writeBuffer(_:bufferOffset:data:)):
(writeBuffer(_:buffer:offset:data:)): Deleted.
* Source/WebGPU/WebGPU/WebGPUExt.h:

Canonical link: <a href="https://commits.webkit.org/284638@main">https://commits.webkit.org/284638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04059647ae7544b19b8a1027779dee1835feb0a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55476 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13947 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17704 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19405 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62986 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75670 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69116 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63160 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4717 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90898 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45074 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/16148 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->