### PR TITLE
Stop using class-level JS_EXPORT_PRIVATE for `JavaScriptCore/inspector` directory

### DIFF
--- a/Source/JavaScriptCore/inspector/AsyncStackTrace.h
+++ b/Source/JavaScriptCore/inspector/AsyncStackTrace.h
@@ -34,7 +34,7 @@ namespace Inspector {
 class ScriptCallFrame;
 class ScriptCallStack;
 
-class JS_EXPORT_PRIVATE AsyncStackTrace : public RefCounted<AsyncStackTrace> {
+class AsyncStackTrace : public RefCounted<AsyncStackTrace> {
 public:
     enum class State : uint8_t {
         Pending,
@@ -48,9 +48,9 @@ public:
     bool isPending() const;
     bool isLocked() const;
 
-    const ScriptCallFrame& at(size_t) const;
-    size_t size() const;
-    bool topCallFrameIsBoundary() const;
+    JS_EXPORT_PRIVATE const ScriptCallFrame& at(size_t) const;
+    JS_EXPORT_PRIVATE size_t size() const;
+    JS_EXPORT_PRIVATE bool topCallFrameIsBoundary() const;
     bool truncated() const { return m_truncated; }
 
     const RefPtr<AsyncStackTrace>& parentStackTrace() const { return m_parent; }
@@ -61,7 +61,7 @@ public:
 
     Ref<Protocol::Console::StackTrace> buildInspectorObject() const;
 
-    ~AsyncStackTrace();
+    JS_EXPORT_PRIVATE ~AsyncStackTrace();
 
 private:
     AsyncStackTrace(Ref<ScriptCallStack>&&, bool, RefPtr<AsyncStackTrace>);

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.h
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.h
@@ -52,17 +52,17 @@ class InjectedScriptManager;
 class ScriptArguments;
 class ScriptCallStack;
 
-class JS_EXPORT_PRIVATE ConsoleMessage {
+class ConsoleMessage {
     WTF_MAKE_NONCOPYABLE(ConsoleMessage);
     WTF_MAKE_TZONE_ALLOCATED(ConsoleMessage);
 public:
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, unsigned long requestIdentifier = 0, WallTime timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, const String& url, unsigned line, unsigned column, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    JS_EXPORT_PRIVATE ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    JS_EXPORT_PRIVATE ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, const String& url, unsigned line, unsigned column, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    JS_EXPORT_PRIVATE ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, WallTime timestamp = { });
     ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, WallTime timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, Vector<JSONLogValue>&&, JSC::JSGlobalObject*, unsigned long requestIdentifier = 0, WallTime timestamp = { });
-    ~ConsoleMessage();
+    JS_EXPORT_PRIVATE ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    JS_EXPORT_PRIVATE ConsoleMessage(MessageSource, MessageType, MessageLevel, Vector<JSONLogValue>&&, JSC::JSGlobalObject*, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    JS_EXPORT_PRIVATE ~ConsoleMessage();
 
     void addToFrontend(ConsoleFrontendDispatcher&, InjectedScriptManager&, bool generatePreview);
     void updateRepeatCountInConsole(ConsoleFrontendDispatcher&);
@@ -76,7 +76,7 @@ public:
     unsigned column() const { return m_column; }
     WallTime timestamp() const { return m_timestamp; }
 
-    JSC::JSGlobalObject* globalObject() const;
+    JS_EXPORT_PRIVATE JSC::JSGlobalObject* globalObject() const;
 
     void incrementCount() { ++m_repeatCount; }
 
@@ -85,9 +85,9 @@ public:
 
     bool isEqual(ConsoleMessage* msg) const;
 
-    void clear();
+    JS_EXPORT_PRIVATE void clear();
 
-    String toString() const;
+    JS_EXPORT_PRIVATE String toString() const;
 
 private:
     void autogenerateMetadata(JSC::JSGlobalObject* = nullptr);

--- a/Source/JavaScriptCore/inspector/IdentifiersFactory.h
+++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.h
@@ -29,10 +29,10 @@
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE IdentifiersFactory {
+class IdentifiersFactory {
 public:
-    static String createIdentifier();
-    static String requestId(unsigned long identifier);
+    JS_EXPORT_PRIVATE static String createIdentifier();
+    JS_EXPORT_PRIVATE static String requestId(unsigned long identifier);
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
@@ -46,6 +46,10 @@ InjectedScript::InjectedScript()
 {
 }
 
+InjectedScript::InjectedScript(const InjectedScript&) = default;
+
+InjectedScript& InjectedScript::operator=(const InjectedScript&) = default;
+
 InjectedScript::InjectedScript(JSC::JSGlobalObject* globalObject, JSC::JSObject* injectedScriptObject, InspectorEnvironment* environment)
     : InjectedScriptBase("InjectedScript"_s, globalObject, injectedScriptObject, environment)
 {

--- a/Source/JavaScriptCore/inspector/InjectedScript.h
+++ b/Source/JavaScriptCore/inspector/InjectedScript.h
@@ -45,11 +45,14 @@ namespace Inspector {
 class InjectedScriptModule;
 class InspectorEnvironment;
 
-class JS_EXPORT_PRIVATE InjectedScript final : public InjectedScriptBase {
+class InjectedScript final : public InjectedScriptBase {
 public:
-    InjectedScript();
+    JS_EXPORT_PRIVATE InjectedScript();
+    JS_EXPORT_PRIVATE InjectedScript(const InjectedScript&);
     InjectedScript(JSC::JSGlobalObject*, JSC::JSObject*, InspectorEnvironment*);
-    ~InjectedScript() final;
+    JS_EXPORT_PRIVATE ~InjectedScript() final;
+
+    JS_EXPORT_PRIVATE InjectedScript& operator=(const InjectedScript&);
 
     struct ExecuteOptions {
         String objectGroup;
@@ -75,19 +78,19 @@ public:
     void saveResult(Protocol::ErrorString&, const String& callArgumentJSON, std::optional<int>& savedResultIndex);
 
     Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> wrapCallFrames(JSC::JSValue) const;
-    RefPtr<Protocol::Runtime::RemoteObject> wrapObject(JSC::JSValue, const String& groupName, bool generatePreview = false) const;
+    JS_EXPORT_PRIVATE RefPtr<Protocol::Runtime::RemoteObject> wrapObject(JSC::JSValue, const String& groupName, bool generatePreview = false) const;
     RefPtr<Protocol::Runtime::RemoteObject> wrapJSONString(const String& json, const String& groupName, bool generatePreview = false) const;
     RefPtr<Protocol::Runtime::RemoteObject> wrapTable(JSC::JSValue table, JSC::JSValue columns) const;
     RefPtr<Protocol::Runtime::ObjectPreview> previewValue(JSC::JSValue) const;
 
-    void setEventValue(JSC::JSValue);
-    void clearEventValue();
+    JS_EXPORT_PRIVATE void setEventValue(JSC::JSValue);
+    JS_EXPORT_PRIVATE void clearEventValue();
 
     void setExceptionValue(JSC::JSValue);
     void clearExceptionValue();
 
-    JSC::JSValue findObjectById(const String& objectId) const;
-    void inspectObject(JSC::JSValue);
+    JS_EXPORT_PRIVATE JSC::JSValue findObjectById(const String& objectId) const;
+    JS_EXPORT_PRIVATE void inspectObject(JSC::JSValue);
     void releaseObject(const String& objectId);
     void releaseObjectGroup(const String& objectGroup);
 

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -105,6 +105,10 @@ RefPtr<JSON::Value> toInspectorValue(JSC::JSGlobalObject* globalObject, JSC::JSV
     return jsToInspectorValue(globalObject, value, JSON::Value::maxDepth);
 }
 
+InjectedScriptBase::InjectedScriptBase(const InjectedScriptBase&) = default;
+
+InjectedScriptBase& InjectedScriptBase::operator=(const InjectedScriptBase&) = default;
+
 InjectedScriptBase::InjectedScriptBase(const String& name)
     : m_name(name)
 {

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.h
@@ -51,9 +51,12 @@ using AsyncCallCallback = WTF::Function<void(Protocol::ErrorString&, RefPtr<Prot
 
 JS_EXPORT_PRIVATE RefPtr<JSON::Value> toInspectorValue(JSC::JSGlobalObject*, JSC::JSValue);
 
-class JS_EXPORT_PRIVATE InjectedScriptBase {
+class InjectedScriptBase {
 public:
-    virtual ~InjectedScriptBase();
+    JS_EXPORT_PRIVATE InjectedScriptBase(const InjectedScriptBase&);
+    JS_EXPORT_PRIVATE virtual ~InjectedScriptBase();
+
+    JS_EXPORT_PRIVATE InjectedScriptBase& operator=(const InjectedScriptBase&);
 
     const String& name() const { return m_name; }
     bool hasNoValue() const { return !m_injectedScriptObject.get(); }

--- a/Source/JavaScriptCore/inspector/InjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptHost.cpp
@@ -34,6 +34,8 @@ namespace Inspector {
 
 using namespace JSC;
 
+InjectedScriptHost::InjectedScriptHost() = default;
+
 InjectedScriptHost::~InjectedScriptHost() = default;
 
 JSValue InjectedScriptHost::wrapper(JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/inspector/InjectedScriptHost.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptHost.h
@@ -31,10 +31,11 @@
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE InjectedScriptHost : public RefCounted<InjectedScriptHost> {
+class InjectedScriptHost : public RefCounted<InjectedScriptHost> {
 public:
     static Ref<InjectedScriptHost> create() { return adoptRef(*new InjectedScriptHost); }
-    virtual ~InjectedScriptHost();
+    JS_EXPORT_PRIVATE InjectedScriptHost();
+    JS_EXPORT_PRIVATE virtual ~InjectedScriptHost();
 
     virtual JSC::JSValue subtype(JSC::JSGlobalObject*, JSC::JSValue) { return JSC::jsUndefined(); }
     virtual JSC::JSValue getInternalProperties(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue) { return { }; }

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -47,24 +47,24 @@ namespace Inspector {
 
 class InjectedScriptHost;
 
-class JS_EXPORT_PRIVATE InjectedScriptManager {
+class InjectedScriptManager {
     WTF_MAKE_NONCOPYABLE(InjectedScriptManager);
     WTF_MAKE_TZONE_ALLOCATED(InjectedScriptManager);
 public:
-    InjectedScriptManager(InspectorEnvironment&, Ref<InjectedScriptHost>&&);
-    virtual ~InjectedScriptManager();
+    JS_EXPORT_PRIVATE InjectedScriptManager(InspectorEnvironment&, Ref<InjectedScriptHost>&&);
+    JS_EXPORT_PRIVATE virtual ~InjectedScriptManager();
 
-    virtual void connect();
-    virtual void disconnect();
-    virtual void discardInjectedScripts();
+    JS_EXPORT_PRIVATE virtual void connect();
+    JS_EXPORT_PRIVATE virtual void disconnect();
+    JS_EXPORT_PRIVATE virtual void discardInjectedScripts();
 
     InjectedScriptHost& injectedScriptHost();
     InspectorEnvironment& inspectorEnvironment() const { return m_environment; }
 
-    InjectedScript injectedScriptFor(JSC::JSGlobalObject*);
-    InjectedScript injectedScriptForId(int);
-    int injectedScriptIdFor(JSC::JSGlobalObject*);
-    InjectedScript injectedScriptForObjectId(const String& objectId);
+    JS_EXPORT_PRIVATE InjectedScript injectedScriptFor(JSC::JSGlobalObject*);
+    JS_EXPORT_PRIVATE InjectedScript injectedScriptForId(int);
+    JS_EXPORT_PRIVATE int injectedScriptIdFor(JSC::JSGlobalObject*);
+    JS_EXPORT_PRIVATE InjectedScript injectedScriptForObjectId(const String& objectId);
     void releaseObjectGroup(const String& objectGroup);
     void clearEventValue();
     void clearExceptionValue();

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.h
@@ -43,9 +43,9 @@ namespace Inspector {
 class InjectedScript;
 class InjectedScriptManager;
 
-class JS_EXPORT_PRIVATE InjectedScriptModule : public InjectedScriptBase {
+class InjectedScriptModule : public InjectedScriptBase {
 public:
-    ~InjectedScriptModule() override;
+    JS_EXPORT_PRIVATE ~InjectedScriptModule() override;
     virtual JSC::JSFunction* injectModuleFunction(JSC::JSGlobalObject*) const = 0;
     virtual JSC::JSValue host(InjectedScriptManager*, JSC::JSGlobalObject*) const = 0;
 
@@ -53,9 +53,9 @@ protected:
     // Do not expose constructor in the child classes as well. Instead provide
     // a static factory method that would create a new instance of the class
     // and call its ensureInjected() method immediately.
-    explicit InjectedScriptModule(const String& name);
+    JS_EXPORT_PRIVATE explicit InjectedScriptModule(const String& name);
     void ensureInjected(InjectedScriptManager*, JSC::JSGlobalObject*);
-    void ensureInjected(InjectedScriptManager*, const InjectedScript&);
+    JS_EXPORT_PRIVATE void ensureInjected(InjectedScriptManager*, const InjectedScript&);
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/InspectorAgentRegistry.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentRegistry.h
@@ -37,16 +37,16 @@ class InspectorAgentBase;
 
 enum class DisconnectReason;
 
-class JS_EXPORT_PRIVATE AgentRegistry {
+class AgentRegistry {
 public:
-    AgentRegistry();
-    ~AgentRegistry();
+    JS_EXPORT_PRIVATE AgentRegistry();
+    JS_EXPORT_PRIVATE ~AgentRegistry();
 
-    void append(std::unique_ptr<InspectorAgentBase>);
+    JS_EXPORT_PRIVATE void append(std::unique_ptr<InspectorAgentBase>);
 
-    void didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*);
-    void willDestroyFrontendAndBackend(DisconnectReason);
-    void discardValues();
+    JS_EXPORT_PRIVATE void didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*);
+    JS_EXPORT_PRIVATE void willDestroyFrontendAndBackend(DisconnectReason);
+    JS_EXPORT_PRIVATE void discardValues();
 
 private:
     // These are declared here to avoid MSVC from trying to create default iplementations which would

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
@@ -40,29 +40,29 @@ class BackendDispatcher;
 
 typedef String ErrorString;
 
-class JS_EXPORT_PRIVATE SupplementalBackendDispatcher : public RefCounted<SupplementalBackendDispatcher> {
+class SupplementalBackendDispatcher : public RefCounted<SupplementalBackendDispatcher> {
 public:
-    SupplementalBackendDispatcher(BackendDispatcher&);
-    virtual ~SupplementalBackendDispatcher();
+    JS_EXPORT_PRIVATE SupplementalBackendDispatcher(BackendDispatcher&);
+    JS_EXPORT_PRIVATE virtual ~SupplementalBackendDispatcher();
     virtual void dispatch(long requestId, const String& method, Ref<JSON::Object>&& message) = 0;
 protected:
     Ref<BackendDispatcher> m_backendDispatcher;
 };
 
-class JS_EXPORT_PRIVATE BackendDispatcher : public RefCounted<BackendDispatcher> {
+class BackendDispatcher : public RefCounted<BackendDispatcher> {
 public:
-    static Ref<BackendDispatcher> create(Ref<FrontendRouter>&&);
+    JS_EXPORT_PRIVATE static Ref<BackendDispatcher> create(Ref<FrontendRouter>&&);
 
-    class JS_EXPORT_PRIVATE CallbackBase : public RefCounted<CallbackBase> {
+    class CallbackBase : public RefCounted<CallbackBase> {
     public:
-        CallbackBase(Ref<BackendDispatcher>&&, long requestId);
+        JS_EXPORT_PRIVATE CallbackBase(Ref<BackendDispatcher>&&, long requestId);
         virtual ~CallbackBase() { }
 
-        bool isActive() const;
+        JS_EXPORT_PRIVATE bool isActive() const;
         void disable() { m_alreadySent = true; }
 
-        void sendSuccess(Ref<JSON::Object>&&);
-        void sendFailure(const ErrorString&);
+        JS_EXPORT_PRIVATE void sendSuccess(Ref<JSON::Object>&&);
+        JS_EXPORT_PRIVATE void sendFailure(const ErrorString&);
 
     private:
         Ref<BackendDispatcher> m_backendDispatcher;
@@ -83,8 +83,8 @@ public:
         ServerError
     };
 
-    void registerDispatcherForDomain(const String& domain, SupplementalBackendDispatcher*);
-    void dispatch(const String& message);
+    JS_EXPORT_PRIVATE void registerDispatcherForDomain(const String& domain, SupplementalBackendDispatcher*);
+    JS_EXPORT_PRIVATE void dispatch(const String& message);
 
     // Note that 'unused' is a workaround so the compiler can pick the right sendResponse based on arity.
     // When <http://webkit.org/b/179847> is fixed or this class is renamed for the JSON::Object case,
@@ -92,19 +92,19 @@ public:
     void sendResponse(long requestId, RefPtr<JSON::Object>&& result);
     void sendResponse(long requestId, RefPtr<JSON::Object>&& result, bool unused);
     void sendResponse(long requestId, Ref<JSON::Object>&& result);
-    void sendResponse(long requestId, Ref<JSON::Object>&& result, bool unused);
+    JS_EXPORT_PRIVATE void sendResponse(long requestId, Ref<JSON::Object>&& result, bool unused);
     void sendPendingErrors();
 
-    void reportProtocolError(CommonErrorCode, const String& errorMessage);
+    JS_EXPORT_PRIVATE void reportProtocolError(CommonErrorCode, const String& errorMessage);
     void reportProtocolError(std::optional<long> relatedRequestId, CommonErrorCode, const String& errorMessage);
 
-    std::optional<bool> getBoolean(JSON::Object*, const String& name, bool required);
-    std::optional<int> getInteger(JSON::Object*, const String& name, bool required);
-    std::optional<double> getDouble(JSON::Object*, const String& name, bool required);
-    String getString(JSON::Object*, const String& name, bool required);
-    RefPtr<JSON::Value> getValue(JSON::Object*, const String& name, bool required);
-    RefPtr<JSON::Object> getObject(JSON::Object*, const String& name, bool required);
-    RefPtr<JSON::Array> getArray(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE std::optional<bool> getBoolean(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE std::optional<int> getInteger(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE std::optional<double> getDouble(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE String getString(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE RefPtr<JSON::Value> getValue(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE RefPtr<JSON::Object> getObject(JSON::Object*, const String& name, bool required);
+    JS_EXPORT_PRIVATE RefPtr<JSON::Array> getArray(JSON::Object*, const String& name, bool required);
 
 private:
     BackendDispatcher(Ref<FrontendRouter>&&);

--- a/Source/JavaScriptCore/inspector/InspectorFrontendRouter.h
+++ b/Source/JavaScriptCore/inspector/InspectorFrontendRouter.h
@@ -33,21 +33,21 @@ namespace Inspector {
 
 class FrontendChannel;
 
-class JS_EXPORT_PRIVATE FrontendRouter : public RefCounted<FrontendRouter> {
+class FrontendRouter : public RefCounted<FrontendRouter> {
 public:
-    static Ref<FrontendRouter> create();
+    JS_EXPORT_PRIVATE static Ref<FrontendRouter> create();
 
     bool hasFrontends() const { return !m_connections.isEmpty(); }
-    bool hasLocalFrontend() const;
-    bool hasRemoteFrontend() const;
+    JS_EXPORT_PRIVATE bool hasLocalFrontend() const;
+    JS_EXPORT_PRIVATE bool hasRemoteFrontend() const;
 
     unsigned frontendCount() const { return m_connections.size(); }
 
-    void connectFrontend(FrontendChannel&);
-    void disconnectFrontend(FrontendChannel&);
-    void disconnectAllFrontends();
+    JS_EXPORT_PRIVATE void connectFrontend(FrontendChannel&);
+    JS_EXPORT_PRIVATE void disconnectFrontend(FrontendChannel&);
+    JS_EXPORT_PRIVATE void disconnectAllFrontends();
 
-    void sendEvent(const String& message) const;
+    JS_EXPORT_PRIVATE void sendEvent(const String& message) const;
     void sendResponse(const String& message) const;
 
 private:

--- a/Source/JavaScriptCore/inspector/InspectorTarget.h
+++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
@@ -48,7 +48,7 @@ enum class InspectorTargetType : uint8_t {
     ServiceWorker,
 };
 
-class JS_EXPORT_PRIVATE InspectorTarget : public CanMakeWeakPtr<InspectorTarget> {
+class InspectorTarget : public CanMakeWeakPtr<InspectorTarget> {
 public:
     virtual ~InspectorTarget() = default;
 
@@ -59,8 +59,8 @@ public:
     virtual bool isProvisional() const { return false; }
     bool isPaused() const { return m_isPaused; }
     void pause();
-    void resume();
-    void setResumeCallback(WTF::Function<void()>&&);
+    JS_EXPORT_PRIVATE void resume();
+    JS_EXPORT_PRIVATE void setResumeCallback(WTF::Function<void()>&&);
 
     // Connection management.
     virtual void connect(FrontendChannel::ConnectionType) = 0;

--- a/Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.h
+++ b/Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.h
@@ -32,11 +32,11 @@
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE PerGlobalObjectWrapperWorld {
+class PerGlobalObjectWrapperWorld {
 public:
-    JSC::JSValue getWrapper(JSC::JSGlobalObject*);
-    void addWrapper(JSC::JSGlobalObject*, JSC::JSObject*);
-    void clearAllWrappers();
+    JS_EXPORT_PRIVATE JSC::JSValue getWrapper(JSC::JSGlobalObject*);
+    JS_EXPORT_PRIVATE void addWrapper(JSC::JSGlobalObject*, JSC::JSObject*);
+    JS_EXPORT_PRIVATE void clearAllWrappers();
 
 private:
     HashMap<JSC::JSGlobalObject*, JSC::Strong<JSC::JSObject>> m_wrappers;

--- a/Source/JavaScriptCore/inspector/ScriptArguments.h
+++ b/Source/JavaScriptCore/inspector/ScriptArguments.h
@@ -44,18 +44,18 @@ class JSGlobalObject;
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE ScriptArguments : public RefCounted<ScriptArguments> {
+class ScriptArguments : public RefCounted<ScriptArguments> {
 public:
-    static Ref<ScriptArguments> create(JSC::JSGlobalObject*, Vector<JSC::Strong<JSC::Unknown>>&& arguments);
-    ~ScriptArguments();
+    JS_EXPORT_PRIVATE static Ref<ScriptArguments> create(JSC::JSGlobalObject*, Vector<JSC::Strong<JSC::Unknown>>&& arguments);
+    JS_EXPORT_PRIVATE ~ScriptArguments();
 
-    JSC::JSValue argumentAt(size_t) const;
+    JS_EXPORT_PRIVATE JSC::JSValue argumentAt(size_t) const;
     size_t argumentCount() const { return m_arguments.size(); }
 
-    JSC::JSGlobalObject* globalObject() const;
+    JS_EXPORT_PRIVATE JSC::JSGlobalObject* globalObject() const;
 
-    bool getFirstArgumentAsString(String& result) const;
-    Vector<String> getArgumentsAsStrings() const;
+    JS_EXPORT_PRIVATE bool getFirstArgumentAsString(String& result) const;
+    JS_EXPORT_PRIVATE Vector<String> getArgumentsAsStrings() const;
     bool isEqual(const ScriptArguments&) const;
 
     static String truncateStringForConsoleMessage(const String& message)

--- a/Source/JavaScriptCore/inspector/ScriptCallFrame.h
+++ b/Source/JavaScriptCore/inspector/ScriptCallFrame.h
@@ -39,13 +39,13 @@
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE ScriptCallFrame  {
+class ScriptCallFrame  {
 public:
     using LineColumn = JSC::LineColumn;
 
     ScriptCallFrame(const String& functionName, const String& scriptName, JSC::SourceID, LineColumn);
     ScriptCallFrame(const String& functionName, const String& scriptName, const String& preRedirectURL, JSC::SourceID, LineColumn);
-    ~ScriptCallFrame();
+    JS_EXPORT_PRIVATE ~ScriptCallFrame();
 
     const String& functionName() const { return m_functionName; }
     const String& sourceURL() const { return m_scriptName; }
@@ -54,7 +54,7 @@ public:
     unsigned columnNumber() const { return m_lineColumn.column; }
     JSC::SourceID sourceID() const { return m_sourceID; }
 
-    bool isEqual(const ScriptCallFrame&) const;
+    JS_EXPORT_PRIVATE bool isEqual(const ScriptCallFrame&) const;
     bool isNative() const;
 
     bool operator==(const ScriptCallFrame& other) const { return isEqual(other); }

--- a/Source/JavaScriptCore/inspector/ScriptCallStack.h
+++ b/Source/JavaScriptCore/inspector/ScriptCallStack.h
@@ -41,30 +41,30 @@ namespace Inspector {
 
 class AsyncStackTrace;
 
-class JS_EXPORT_PRIVATE ScriptCallStack : public RefCounted<ScriptCallStack> {
+class ScriptCallStack : public RefCounted<ScriptCallStack> {
 public:
     static constexpr size_t maxCallStackSizeToCapture = 200;
     
     static Ref<ScriptCallStack> create();
     static Ref<ScriptCallStack> create(Vector<ScriptCallFrame>&&, bool truncated = false, AsyncStackTrace* parentStackTrace = nullptr);
 
-    ~ScriptCallStack();
+    JS_EXPORT_PRIVATE ~ScriptCallStack();
 
-    const ScriptCallFrame& at(size_t) const;
-    size_t size() const;
+    JS_EXPORT_PRIVATE const ScriptCallFrame& at(size_t) const;
+    JS_EXPORT_PRIVATE size_t size() const;
     bool truncated() const { return m_truncated; }
 
     const RefPtr<AsyncStackTrace>& parentStackTrace() const { return m_parentStackTrace; }
     void removeParentStackTrace();
 
-    const ScriptCallFrame* firstNonNativeCallFrame() const;
+    JS_EXPORT_PRIVATE const ScriptCallFrame* firstNonNativeCallFrame() const;
 
     void append(const ScriptCallFrame&);
 
-    bool isEqual(ScriptCallStack*) const;
+    JS_EXPORT_PRIVATE bool isEqual(ScriptCallStack*) const;
 
     Ref<JSON::ArrayOf<Protocol::Console::CallFrame>> buildInspectorArray() const;
-    Ref<Protocol::Console::StackTrace> buildInspectorObject() const;
+    JS_EXPORT_PRIVATE Ref<Protocol::Console::StackTrace> buildInspectorObject() const;
 
 private:
     ScriptCallStack();

--- a/Source/JavaScriptCore/inspector/ScriptFunctionCall.h
+++ b/Source/JavaScriptCore/inspector/ScriptFunctionCall.h
@@ -48,7 +48,7 @@ class JSValue;
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE ScriptCallArgumentHandler {
+class ScriptCallArgumentHandler {
 public:
     ScriptCallArgumentHandler(JSC::JSGlobalObject* globalObject) : m_globalObject(globalObject) { }
 
@@ -59,7 +59,7 @@ public:
     void appendArgument(long long);
     void appendArgument(unsigned int);
     void appendArgument(uint64_t);
-    void appendArgument(int);
+    JS_EXPORT_PRIVATE void appendArgument(int);
     void appendArgument(bool);
 
 protected:
@@ -73,11 +73,11 @@ private:
     void* operator new[](size_t) { ASSERT_NOT_REACHED(); return reinterpret_cast<void*>(0xbadbeef); }
 };
 
-class JS_EXPORT_PRIVATE ScriptFunctionCall : public ScriptCallArgumentHandler {
+class ScriptFunctionCall : public ScriptCallArgumentHandler {
 public:
     typedef JSC::JSValue (*ScriptFunctionCallHandler)(JSC::JSGlobalObject*, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>&);
-    ScriptFunctionCall(JSC::JSGlobalObject*, JSC::JSObject* thisObject, const String& name, ScriptFunctionCallHandler = nullptr);
-    Expected<JSC::JSValue, NakedPtr<JSC::Exception>> call();
+    JS_EXPORT_PRIVATE ScriptFunctionCall(JSC::JSGlobalObject*, JSC::JSObject* thisObject, const String& name, ScriptFunctionCallHandler = nullptr);
+    JS_EXPORT_PRIVATE Expected<JSC::JSValue, NakedPtr<JSC::Exception>> call();
 
 protected:
     ScriptFunctionCallHandler m_callHandler;

--- a/Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.cpp
@@ -32,6 +32,7 @@
 
 namespace Inspector {
 
+RemoteAutomationTarget::RemoteAutomationTarget() = default;
 RemoteAutomationTarget::~RemoteAutomationTarget() = default;
 
 void RemoteAutomationTarget::setIsPaired(bool paired)

--- a/Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.h
@@ -34,12 +34,13 @@ namespace Inspector {
 
 class FrontendChannel;
 
-class JS_EXPORT_PRIVATE RemoteAutomationTarget : public RemoteControllableTarget {
+class RemoteAutomationTarget : public RemoteControllableTarget {
 public:
-    ~RemoteAutomationTarget() override;
+    JS_EXPORT_PRIVATE RemoteAutomationTarget();
+    JS_EXPORT_PRIVATE ~RemoteAutomationTarget() override;
 
     bool isPaired() const { return m_paired; }
-    void setIsPaired(bool);
+    JS_EXPORT_PRIVATE void setIsPaired(bool);
 
     bool isPendingTermination() const { return m_pendingTermination; }
     void setIsPendingTermination() { m_pendingTermination = true; }

--- a/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.cpp
@@ -32,6 +32,8 @@
 
 namespace Inspector {
 
+RemoteControllableTarget::RemoteControllableTarget() = default;
+
 RemoteControllableTarget::~RemoteControllableTarget()
 {
     RemoteInspector::singleton().unregisterTarget(this);

--- a/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
@@ -41,12 +41,13 @@ class FrontendChannel;
 
 using TargetID = unsigned;
 
-class JS_EXPORT_PRIVATE RemoteControllableTarget {
+class RemoteControllableTarget {
 public:
-    virtual ~RemoteControllableTarget();
+    JS_EXPORT_PRIVATE RemoteControllableTarget();
+    JS_EXPORT_PRIVATE virtual ~RemoteControllableTarget();
 
-    void init();
-    void update();
+    JS_EXPORT_PRIVATE void init();
+    JS_EXPORT_PRIVATE void update();
 
     virtual void connect(FrontendChannel&, bool isAutomaticConnection = false, bool immediatelyPause = false) = 0;
     virtual void disconnect(FrontendChannel&) = 0;

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
@@ -38,6 +38,10 @@
 
 namespace Inspector {
 
+RemoteInspectionTarget::RemoteInspectionTarget() = default;
+
+RemoteInspectionTarget::~RemoteInspectionTarget() = default;
+
 bool RemoteInspectionTarget::remoteControlAllowed() const
 {
     return allowsInspectionByPolicy() || hasLocalDebugger();

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -38,10 +38,12 @@ namespace Inspector {
 
 class FrontendChannel;
 
-class JS_EXPORT_PRIVATE RemoteInspectionTarget : public RemoteControllableTarget {
+class RemoteInspectionTarget : public RemoteControllableTarget {
 public:
-    bool inspectable() const;
-    void setInspectable(bool);
+    JS_EXPORT_PRIVATE RemoteInspectionTarget();
+    JS_EXPORT_PRIVATE ~RemoteInspectionTarget() override;
+    JS_EXPORT_PRIVATE bool inspectable() const;
+    JS_EXPORT_PRIVATE void setInspectable(bool);
 
     bool allowsInspectionByPolicy() const;
 
@@ -58,14 +60,14 @@ public:
     virtual void setIndicating(bool) { } // Default is to do nothing.
 
     virtual bool automaticInspectionAllowed() const { return false; }
-    virtual void pauseWaitingForAutomaticInspection();
-    virtual void unpauseForInitializedInspector();
+    JS_EXPORT_PRIVATE virtual void pauseWaitingForAutomaticInspection();
+    JS_EXPORT_PRIVATE virtual void unpauseForInitializedInspector();
 
     // RemoteControllableTarget overrides.
-    bool remoteControlAllowed() const final;
+    JS_EXPORT_PRIVATE bool remoteControlAllowed() const final;
 
     std::optional<ProcessID> presentingApplicationPID() const { return m_presentingApplicationPID; }
-    void setPresentingApplicationPID(std::optional<ProcessID>&&);
+    JS_EXPORT_PRIVATE void setPresentingApplicationPID(std::optional<ProcessID>&&);
 
 private:
     enum class Inspectable : uint8_t {

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -261,9 +261,8 @@ void RemoteInspector::updateHasActiveDebugSession()
     // Legacy iOS WebKit 1 had a notification. This will need to be smarter with WebKit2.
 }
 
-RemoteInspector::Client::~Client()
-{
-}
+RemoteInspector::Client::Client() = default;
+RemoteInspector::Client::~Client() = default;
 
 } // namespace Inspector
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -71,7 +71,7 @@ class RemoteControllableTarget;
 class RemoteInspectionTarget;
 class RemoteInspectorClient;
 
-class JS_EXPORT_PRIVATE RemoteInspector final
+class RemoteInspector final
 #if PLATFORM(COCOA)
     : public RemoteInspectorXPCConnection::Client
 #elif USE(INSPECTOR_SOCKET_SERVER)
@@ -79,7 +79,7 @@ class JS_EXPORT_PRIVATE RemoteInspector final
 #endif
 {
 public:
-    class JS_EXPORT_PRIVATE Client {
+    class Client {
     public:
         struct Capabilities {
             bool remoteAutomationAllowed : 1;
@@ -108,7 +108,8 @@ public:
 #endif
         };
 
-        virtual ~Client();
+        JS_EXPORT_PRIVATE Client();
+        JS_EXPORT_PRIVATE virtual ~Client();
         virtual bool remoteAutomationAllowed() const = 0;
         virtual String browserName() const { return { }; }
         virtual String browserVersion() const { return { }; }
@@ -120,14 +121,14 @@ public:
     };
 
 #if PLATFORM(COCOA)
-    static void setNeedMachSandboxExtension(bool needExtension) { needMachSandboxExtension = needExtension; }
+    JS_EXPORT_PRIVATE static void setNeedMachSandboxExtension(bool needExtension);
 #endif
 #if USE(GLIB)
-    static void setInspectorServerAddress(CString&& address) { s_inspectorServerAddress = WTFMove(address); }
-    static const CString& inspectorServerAddress() { return s_inspectorServerAddress; }
+    JS_EXPORT_PRIVATE static void setInspectorServerAddress(CString&&);
+    JS_EXPORT_PRIVATE static const CString& inspectorServerAddress();
 #endif
-    static void startDisabled();
-    static RemoteInspector& singleton();
+    JS_EXPORT_PRIVATE static void startDisabled();
+    JS_EXPORT_PRIVATE static RemoteInspector& singleton();
     friend class LazyNeverDestroyed<RemoteInspector>;
 
     virtual ~RemoteInspector();
@@ -138,8 +139,8 @@ public:
     void sendMessageToRemote(TargetID, const String& message);
 
     RemoteInspector::Client* client() const { return m_client; }
-    void setClient(RemoteInspector::Client*);
-    void clientCapabilitiesDidChange();
+    JS_EXPORT_PRIVATE void setClient(RemoteInspector::Client*);
+    JS_EXPORT_PRIVATE void clientCapabilitiesDidChange();
     std::optional<RemoteInspector::Client::Capabilities> clientCapabilities() const { return m_clientCapabilities; }
 
     void setupFailed(TargetID);
@@ -150,20 +151,20 @@ public:
     bool enabled() const { return m_enabled; }
     bool hasActiveDebugSession() const { return m_hasActiveDebugSession; }
 
-    void start();
-    void stop();
+    JS_EXPORT_PRIVATE void start();
+    JS_EXPORT_PRIVATE void stop();
 
 #if PLATFORM(COCOA)
     bool hasParentProcessInformation() const { return m_parentProcessIdentifier != 0; }
     ProcessID parentProcessIdentifier() const { return m_parentProcessIdentifier; }
     RetainPtr<CFDataRef> parentProcessAuditData() const { return m_parentProcessAuditData; }
-    void setParentProcessInformation(ProcessID, RetainPtr<CFDataRef> auditData);
+    JS_EXPORT_PRIVATE void setParentProcessInformation(ProcessID, RetainPtr<CFDataRef> auditData);
     std::optional<audit_token_t> parentProcessAuditToken();
 
     void setUsePerTargetPresentingApplicationPIDs(bool usePerTargetPresentingApplicationPIDs) { m_usePerTargetPresentingApplicationPIDs = usePerTargetPresentingApplicationPIDs; }
 
     bool isSimulatingCustomerInstall() const { return m_simulateCustomerInstall; }
-    void connectToWebInspector();
+    JS_EXPORT_PRIVATE void connectToWebInspector();
 #endif
 
     void updateTargetListing(TargetID);

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -854,6 +854,11 @@ void RemoteInspector::receivedPingSuccessMessage()
     m_shouldReconnectToRelayOnFailure = false;
 }
 
+void RemoteInspector::setNeedMachSandboxExtension(bool needExtension)
+{
+    needMachSandboxExtension = needExtension;
+}
+
 } // namespace Inspector
 
 #endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -320,6 +320,16 @@ void RemoteInspector::requestAutomationSession(const char* sessionID, const Clie
     updateClientCapabilities();
 }
 
+void RemoteInspector::setInspectorServerAddress(CString&& address)
+{
+    s_inspectorServerAddress = WTFMove(address);
+}
+
+const CString& RemoteInspector::inspectorServerAddress()
+{
+    return s_inspectorServerAddress;
+}
+
 } // namespace Inspector
 
 #endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.h
@@ -39,15 +39,15 @@ namespace Inspector {
 
 class MessageParser;
 
-class JS_EXPORT_PRIVATE RemoteInspectorConnectionClient : public RemoteInspectorSocketEndpoint::Client {
+class RemoteInspectorConnectionClient : public RemoteInspectorSocketEndpoint::Client {
 public:
-    ~RemoteInspectorConnectionClient() override;
+    JS_EXPORT_PRIVATE ~RemoteInspectorConnectionClient() override;
 
-    std::optional<ConnectionID> connectInet(const char* serverAddr, uint16_t serverPort);
+    JS_EXPORT_PRIVATE std::optional<ConnectionID> connectInet(const char* serverAddr, uint16_t serverPort);
     std::optional<ConnectionID> createClient(PlatformSocketType);
-    void send(ConnectionID, std::span<const uint8_t>);
+    JS_EXPORT_PRIVATE void send(ConnectionID, std::span<const uint8_t>);
 
-    void didReceive(RemoteInspectorSocketEndpoint&, ConnectionID, Vector<uint8_t>&&) final;
+    JS_EXPORT_PRIVATE void didReceive(RemoteInspectorSocketEndpoint&, ConnectionID, Vector<uint8_t>&&) final;
 
     struct Event {
         String methodName;
@@ -61,7 +61,7 @@ public:
     virtual HashMap<String, CallHandler>& dispatchMap() = 0;
 
 protected:
-    std::optional<Vector<Ref<JSON::Object>>> parseTargetListJSON(const String&);
+    JS_EXPORT_PRIVATE std::optional<Vector<Ref<JSON::Object>>> parseTargetListJSON(const String&);
 
     static std::optional<Event> extractEvent(ConnectionID, Vector<uint8_t>&&);
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.h
@@ -38,7 +38,7 @@
 
 namespace Inspector {
 
-class JS_EXPORT_PRIVATE RemoteInspectorSocketEndpoint {
+class RemoteInspectorSocketEndpoint {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     class Client {
@@ -64,23 +64,23 @@ public:
         virtual void didChangeStatus(RemoteInspectorSocketEndpoint&, ConnectionID, Status) = 0;
     };
 
-    static RemoteInspectorSocketEndpoint& singleton();
+    JS_EXPORT_PRIVATE static RemoteInspectorSocketEndpoint& singleton();
 
     RemoteInspectorSocketEndpoint();
-    ~RemoteInspectorSocketEndpoint();
+    JS_EXPORT_PRIVATE ~RemoteInspectorSocketEndpoint();
 
     std::optional<ConnectionID> connectInet(const char* serverAddr, uint16_t serverPort, Client&);
-    std::optional<ConnectionID> listenInet(const char* address, uint16_t port, Listener&);
+    JS_EXPORT_PRIVATE std::optional<ConnectionID> listenInet(const char* address, uint16_t port, Listener&);
     void invalidateClient(Client&);
     void invalidateListener(Listener&);
 
-    void send(ConnectionID, std::span<const uint8_t>);
+    JS_EXPORT_PRIVATE void send(ConnectionID, std::span<const uint8_t>);
 
-    std::optional<ConnectionID> createClient(PlatformSocketType, Client&);
+    JS_EXPORT_PRIVATE std::optional<ConnectionID> createClient(PlatformSocketType, Client&);
 
     std::optional<uint16_t> getPort(ConnectionID) const;
 
-    void disconnect(ConnectionID);
+    JS_EXPORT_PRIVATE void disconnect(ConnectionID);
 
 protected:
     struct BaseConnection {


### PR DESCRIPTION
#### 28b90713af7c0d5887a894cc63d2e5f32541cf29
<pre>
Stop using class-level JS_EXPORT_PRIVATE for `JavaScriptCore/inspector` directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=280719">https://bugs.webkit.org/show_bug.cgi?id=280719</a>

Reviewed by Yusuke Suzuki.

Method-level JS_EXPORT_PRIVATE is preferable to class-level
JS_EXPORT_PRIVATE. Converted classes under `JavaScriptCore/inspector`
directory except `JavaScriptCore/inspector/agents` directory. Classes
under `agents` directory has a problem which should be resovled
separately.

* Source/JavaScriptCore/inspector/AsyncStackTrace.h:
* Source/JavaScriptCore/inspector/ConsoleMessage.h:
(Inspector::ConsoleMessage::ConsoleMessage):
* Source/JavaScriptCore/inspector/IdentifiersFactory.h:
* Source/JavaScriptCore/inspector/InjectedScript.h:
* Source/JavaScriptCore/inspector/InjectedScriptBase.h:
* Source/JavaScriptCore/inspector/InjectedScriptHost.cpp:
* Source/JavaScriptCore/inspector/InjectedScriptHost.h:
* Source/JavaScriptCore/inspector/InjectedScriptManager.h:
* Source/JavaScriptCore/inspector/InjectedScriptModule.h:
* Source/JavaScriptCore/inspector/InspectorAgentRegistry.h:
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h:
* Source/JavaScriptCore/inspector/InspectorFrontendRouter.h:
* Source/JavaScriptCore/inspector/InspectorTarget.h:
* Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.h:
* Source/JavaScriptCore/inspector/ScriptArguments.h:
* Source/JavaScriptCore/inspector/ScriptCallFrame.h:
* Source/JavaScriptCore/inspector/ScriptCallStack.h:
* Source/JavaScriptCore/inspector/ScriptFunctionCall.h:
* Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.cpp:
* Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
* Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.cpp:
* Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp:
* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::setNeedMachSandboxExtension):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::setInspectorServerAddress):
(Inspector::RemoteInspector::inspectorServerAddress):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.h:
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.h:

Canonical link: <a href="https://commits.webkit.org/284744@main">https://commits.webkit.org/284744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8897396ba4f2ad8ceb07c7a7851d950e7eb165b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21310 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55631 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14113 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19679 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63263 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75948 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69390 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63341 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63279 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4920 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91172 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19870 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->