### PR TITLE
Crash in GraphicsContext::drawImageBuffer

### DIFF
--- a/LayoutTests/fast/canvas/canvas-layer-drawing-no-source-image-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-layer-drawing-no-source-image-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/fast/canvas/canvas-layer-drawing-no-source-image.html
+++ b/LayoutTests/fast/canvas/canvas-layer-drawing-no-source-image.html
@@ -1,0 +1,34 @@
+<p>This test passes if it doesn't crash.</p>
+<style>
+body {
+    -webkit-box-reflect: right -1px;
+    filter: brightness();
+}
+.class2 { 
+    motion-path: path("M 65535 73 H 45 V 1 H 7 L 1 1");
+    padding-top: 1vmax;
+    margin-top: 21vmin;
+    font-family: "Lucida Grande";
+    zoom: 55%;
+    -webkit-filter: opacity(0.5);
+}
+</style><script>
+if (testRunner)
+    testRunner.dumpAsText();
+
+function eventhandler1() {
+    htmlvar00047.height = "0";
+    window.resizeTo(5,1);
+    htmlvar00046.setAttribute("class", "class2");
+    htmlvar00043.scrollIntoViewIfNeeded();
+}
+</script>
+<marquee id="col">
+<dir id="htmlvar00005"<li id="htmlvar00007" style="animation-duration: initial; -webkit-padding-after: 2147483648px" ")\&quot;ej-eLL$L?">
+<style id="htmlvar00013" onload="eventhandler1()"></style>
+<h1 id="htmlvar00015" contenteditable=="-1">
+<ul id="htmlvar00024">
+</marquee>
+<hr id="htmlvar00043" title<h6 id=/h6>
+<label id="htmlvar00046">
+<iframe id="htmlvar00047" heighttruespeed="false">Nfhv_[N7O92

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
@@ -83,8 +83,8 @@ void ImageBufferContextSwitcher::endClipAndDrawSourceImage(GraphicsContext& dest
 void ImageBufferContextSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace)
 {
     if (!m_filter) {
-        ASSERT(m_sourceImage);
-        destinationContext.drawImageBuffer(*m_sourceImage, m_sourceImageRect, { destinationContext.compositeOperation(), destinationContext.blendMode() });
+        if (m_sourceImage)
+            destinationContext.drawImageBuffer(*m_sourceImage, m_sourceImageRect, { destinationContext.compositeOperation(), destinationContext.blendMode() });
         return;
     }
 


### PR DESCRIPTION
#### 94f6264db37e061dcdbe45285687161e74e5a8be
<pre>
Crash in GraphicsContext::drawImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=277034">https://bugs.webkit.org/show_bug.cgi?id=277034</a>
<a href="https://rdar.apple.com/132434375">rdar://132434375</a>

Reviewed by Darin Adler and Ryosuke Niwa.

In the scenario thata sourceImageRect is too big so the m_sourceImage can&apos;t be allocated we need to handle it safely to prevent a crash.

* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp:
(WebCore::ImageBufferContextSwitcher::endDrawSourceImage):

Canonical link: <a href="https://commits.webkit.org/284812@main">https://commits.webkit.org/284812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/963326daf45de90d65b254f096343b28cd7eba88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21586 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14369 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17843 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5256 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/543 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->