### PR TITLE
[Static Analyzer CI] Add steps to download cmake and ninja on worker

### DIFF
--- a/Tools/CISupport/Shared/download-and-install-build-tools
+++ b/Tools/CISupport/Shared/download-and-install-build-tools
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+import subprocess
+import argparse
+import sys
+
+CMAKE_VERSION = '3.30.4'
+NINJA_VERSION = '1.12.1'
+CMAKE_DOWNLOAD_URL = f'https://github.com/Kitware/CMake/releases/download/v{CMAKE_VERSION}/cmake-{CMAKE_VERSION}-macos-universal.dmg'
+NINJA_DOWNLOAD_URL = f'https://github.com/ninja-build/ninja/releases/download/v{NINJA_VERSION}/ninja-mac.zip'
+
+
+def parser():
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('package', default='', choices=['cmake', 'ninja'], help='')
+    return parser.parse_args()
+
+
+def run(command):
+    try:
+        subprocess.run(command)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f'{e.output}')
+        sys.exit()
+
+
+def print_version(package):
+    try:
+        log = subprocess.check_output(f'{package} --version', shell=True, text=True)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f'{e.output}')
+        return -1
+    print(f'{log}')
+    version_re = re.compile(r'\d+.\d+.\d+', re.MULTILINE)
+    match = version_re.search(log).group(0)
+    return match
+
+
+def download_and_install(package):
+    if package == 'cmake':
+        run(['mkdir', '/tmp/cmake'])
+        print('Mounting to /tmp/cmake...')
+        run(['hdiutil', 'attach', CMAKE_DOWNLOAD_URL, '-nobrowse', '-mountpoint', '/tmp/cmake'])
+        print('Moving CMake.app to Applications...')
+        run(['ditto', '/tmp/cmake/CMake.app', '/Applications/CMake.app'])
+        print('Detaching and removing /tmp/cmake...')
+        run(['hdiutil', 'detach', '/tmp/cmake'])
+        run(['rm', '-rf', '/tmp/cmake'])
+    elif package == 'ninja':
+        print('Downloading ninja.zip...')
+        run(['curl', NINJA_DOWNLOAD_URL, '-L', '-o', 'ninja.zip'])
+        run(['rm', 'ninja'])
+        run(['unzip', 'ninja.zip'])
+        print('ninja executable created!')
+        run(['rm', 'ninja.zip'])
+    version = print_version(package)
+    if version == -1:
+        return -1
+    return 0
+
+
+def main():
+    args = parser()
+    package = args.package
+    version = print_version(package)
+    if package == 'ninja' and version == NINJA_VERSION:
+        print(f'ninja is already up to date... skipping download and installation.')
+        return 0
+    elif package == 'cmake' and version == CMAKE_VERSION:
+        print(f'cmake is already up to date... skipping download and installation.')
+        return 0
+    return download_and_install(package)
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -27,7 +27,7 @@ from buildbot.steps import trigger
 from .steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Canonicalize,
                     CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                     CheckStatusOnEWSQueues, CheckStyle, CleanGitRepo, CleanDerivedSources, CompileJSC, CompileWebKit, ConfigureBuild, DetermineLabelOwner,
-                    DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests, GetTestExpectationsBaseline, GetUpdatedTestExpectations, GitHub,
+                    DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests, GetTestExpectationsBaseline, GetUpdatedTestExpectations, GitHub, InstallCMake, InstallNinja,
                     InstallGtkDependencies, InstallHooks, InstallWpeDependencies, InstallWinDependencies, KillOldProcesses, PrintClangVersion, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
                     MapBranchAlias, RemoveAndAddLabels, RetrievePRDataFromLabel, RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                     RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests,
@@ -111,6 +111,8 @@ class SmartPointerStaticAnalyzerFactory(factory.BuildFactory):
         self.addStep(CheckOutSource())
         self.addStep(FetchBranches())
         self.addStep(ShowIdentifier())
+        self.addStep(InstallCMake())
+        self.addStep(InstallNinja())
         self.addStep(PrintClangVersion())
         self.addStep(CheckOutPullRequest())
         self.addStep(KillOldProcesses())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -303,6 +303,8 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'checkout-source',
             'fetch-branch-references',
             'show-identifier',
+            'install-cmake',
+            'install-ninja',
             'print-clang-version',
             'checkout-pull-request',
             'kill-old-processes',


### PR DESCRIPTION
#### 1a9cbdc6175fb64a2e4fcb420c1970ca01f9a2af
<pre>
[Static Analyzer CI] Add steps to download cmake and ninja on worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=280722">https://bugs.webkit.org/show_bug.cgi?id=280722</a>
<a href="https://rdar.apple.com/137073482">rdar://137073482</a>

Reviewed by Jonathan Bedard.

In order to build clang, we need to install cmake and ninja. This commit introduces a script
that downloads the corresponding package and installs it on the worker in a specified directory.

The InstallClang and InstallNinja steps are added to the factory and should only need to be run
on a bot the very first time it is running this particular queue.

* Tools/CISupport/ews-build/factories.py:
(SmartPointerStaticAnalyzerFactory.__init__):
* Tools/CISupport/ews-build/steps.py:
(InstallCMake):
(InstallCMake.__init__):
(InstallCMake.run):
(InstallCMake.evaluateCommand):
(InstallCMake.getResultSummary):
(InstallNinja):
(InstallNinja.__init__):
(InstallNinja.run):
(InstallNinja.evaluateCommand):
(InstallNinja.getResultSummary):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/284572@main">https://commits.webkit.org/284572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c7b133d4cddd9a5a85e1c1cdfea51e16a26f1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22639 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20895 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/41574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18055 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/14111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/69564 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60352 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/11114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45090 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46164 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->