### PR TITLE
Adopt more smart pointers for data members

### DIFF
--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -48,8 +48,9 @@ class DateComponents;
 struct DateTimeChooserParameters;
 
 // A super class of date, datetime, datetime-local, month, time, and week types.
-class BaseDateAndTimeInputType : public InputType, private DateTimeChooserClient, private DateTimeEditElementEditControlOwner {
+class BaseDateAndTimeInputType : public InputType, public DateTimeChooserClient, private DateTimeEditElementEditControlOwner {
     WTF_MAKE_TZONE_ALLOCATED(BaseDateAndTimeInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BaseDateAndTimeInputType);
 public:
     bool typeMismatchFor(const String&) const final;
     bool valueMissing(const String&) const final;

--- a/Source/WebCore/html/DateInputType.cpp
+++ b/Source/WebCore/html/DateInputType.cpp
@@ -40,9 +40,12 @@
 #include "InputTypeNames.h"
 #include "PlatformLocale.h"
 #include "StepRange.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DateInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/DateInputType.h
+++ b/Source/WebCore/html/DateInputType.h
@@ -33,10 +33,13 @@
 #if ENABLE(INPUT_TYPE_DATE)
 
 #include "BaseDateAndTimeInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class DateInputType final : public BaseDateAndTimeInputType {
+    WTF_MAKE_TZONE_ALLOCATED(DateInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateInputType);
 public:
     static Ref<DateInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/DateTimeLocalInputType.cpp
+++ b/Source/WebCore/html/DateTimeLocalInputType.cpp
@@ -42,9 +42,12 @@
 #include "InputTypeNames.h"
 #include "PlatformLocale.h"
 #include "StepRange.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DateTimeLocalInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/DateTimeLocalInputType.h
+++ b/Source/WebCore/html/DateTimeLocalInputType.h
@@ -33,10 +33,13 @@
 #if ENABLE(INPUT_TYPE_DATETIMELOCAL)
 
 #include "BaseDateAndTimeInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class DateTimeLocalInputType final : public BaseDateAndTimeInputType {
+    WTF_MAKE_TZONE_ALLOCATED(DateTimeLocalInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeLocalInputType);
 public:
     static Ref<DateTimeLocalInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -44,9 +44,12 @@
 #include <wtf/DateMath.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MonthInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/MonthInputType.h
+++ b/Source/WebCore/html/MonthInputType.h
@@ -33,10 +33,13 @@
 #if ENABLE(INPUT_TYPE_MONTH)
 
 #include "BaseDateAndTimeInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class MonthInputType final : public BaseDateAndTimeInputType {
+    WTF_MAKE_TZONE_ALLOCATED(MonthInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MonthInputType);
 public:
     static Ref<MonthInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -52,6 +52,9 @@ class TextFieldInputType : public InputType, protected SpinButtonOwner, protecte
 #endif
 {
     WTF_MAKE_TZONE_ALLOCATED(TextFieldInputType);
+#if ENABLE(DATALIST_ELEMENT)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextFieldInputType);
+#endif
 public:
     bool valueMissing(const String&) const final;
 

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -43,9 +43,12 @@
 #include "StepRange.h"
 #include <wtf/DateMath.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TimeInputType);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/TimeInputType.h
+++ b/Source/WebCore/html/TimeInputType.h
@@ -33,10 +33,13 @@
 #if ENABLE(INPUT_TYPE_TIME)
 
 #include "BaseDateAndTimeInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class TimeInputType final : public BaseDateAndTimeInputType {
+    WTF_MAKE_TZONE_ALLOCATED(TimeInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TimeInputType);
 public:
     static Ref<TimeInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/WeekInputType.cpp
+++ b/Source/WebCore/html/WeekInputType.cpp
@@ -42,6 +42,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WeekInputType);
+
 using namespace HTMLNames;
 
 static const int weekDefaultStepBase = -259200000; // The first day of 1970-W01.

--- a/Source/WebCore/html/WeekInputType.h
+++ b/Source/WebCore/html/WeekInputType.h
@@ -33,10 +33,13 @@
 #if ENABLE(INPUT_TYPE_WEEK)
 
 #include "BaseDateAndTimeInputType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class WeekInputType final : public BaseDateAndTimeInputType {
+    WTF_MAKE_TZONE_ALLOCATED(WeekInputType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WeekInputType);
 public:
     static Ref<WeekInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/platform/DataListSuggestionsClient.h
+++ b/Source/WebCore/platform/DataListSuggestionsClient.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(DATALIST_ELEMENT)
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -34,7 +35,9 @@ namespace WebCore {
 class IntRect;
 struct DataListSuggestion;
 
-class DataListSuggestionsClient {
+class DataListSuggestionsClient : public CanMakeCheckedPtr<DataListSuggestionsClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DataListSuggestionsClient);
 public:
     virtual ~DataListSuggestionsClient() = default;
 

--- a/Source/WebCore/platform/DateTimeChooserClient.h
+++ b/Source/WebCore/platform/DateTimeChooserClient.h
@@ -32,9 +32,14 @@
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
+#include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
+
 namespace WebCore {
 
-class DateTimeChooserClient {
+class DateTimeChooserClient : public CanMakeCheckedPtr<DateTimeChooserClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeChooserClient);
 public:
     virtual ~DateTimeChooserClient() = default;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -67,6 +67,7 @@ class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 // be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
 class RemoteLayerTreeEventDispatcher : public ThreadSafeRefCounted<RemoteLayerTreeEventDispatcher>, public MomentumEventDispatcher::Client {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeEventDispatcher);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeEventDispatcher);
     friend class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 public:
     static Ref<RemoteLayerTreeEventDispatcher> create(RemoteScrollingCoordinatorProxyMac&, WebCore::PageIdentifier);

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
@@ -48,7 +48,7 @@ using namespace WebCore;
 std::unique_ptr<WebCore::MediaRecorderPrivate> MediaRecorderProvider::createMediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
 {
 #if ENABLE(GPU_PROCESS) && ENABLE(WEB_RTC)
-    auto* page = m_webPage.corePage();
+    RefPtr page = m_webPage->corePage();
     if (page && page->settings().webRTCPlatformCodecsInGPUProcessEnabled())
         return makeUnique<MediaRecorderPrivate>(stream, options);
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.h
@@ -43,7 +43,7 @@ private:
 #endif
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
-    WebPage& m_webPage;
+    WeakRef<WebPage> m_webPage;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -51,13 +51,13 @@ LibWebRTCSocket::LibWebRTCSocket(LibWebRTCSocketFactory& factory, WebCore::Scrip
     , m_remoteAddress(remoteAddress)
     , m_contextIdentifier(contextIdentifier)
 {
-    m_factory.addSocket(*this);
+    m_factory->addSocket(*this);
 }
 
 LibWebRTCSocket::~LibWebRTCSocket()
 {
     Close();
-    m_factory.removeSocket(*this);
+    m_factory->removeSocket(*this);
 }
 
 rtc::SocketAddress LibWebRTCSocket::GetLocalAddress() const
@@ -113,7 +113,7 @@ void LibWebRTCSocket::signalUsedInterface(String&& name)
 
 int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAddress& address, const rtc::PacketOptions& options)
 {
-    RefPtr connection = m_factory.connection();
+    RefPtr connection = m_factory->connection();
     if (!connection)
         return -1;
 
@@ -128,7 +128,7 @@ int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAdd
 
 int LibWebRTCSocket::Close()
 {
-    RefPtr connection = m_factory.connection();
+    RefPtr connection = m_factory->connection();
     if (!connection || m_state == STATE_CLOSED)
         return 0;
 
@@ -155,7 +155,7 @@ int LibWebRTCSocket::SetOption(rtc::Socket::Option option, int value)
 
     m_options[option] = value;
 
-    if (auto* connection = m_factory.connection())
+    if (RefPtr connection = m_factory->connection())
         connection->send(Messages::NetworkRTCProvider::SetSocketOption { identifier(), option, value }, 0);
 
     return 0;
@@ -174,7 +174,7 @@ void LibWebRTCSocket::suspend()
         return;
 
     signalClose(-1);
-    if (auto* connection = m_factory.connection())
+    if (RefPtr connection = m_factory->connection())
         connection->send(Messages::NetworkRTCProvider::CloseSocket { identifier() }, 0);
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -99,7 +99,7 @@ private:
     int GetOption(rtc::Socket::Option, int*) final;
     int SetOption(rtc::Socket::Option, int) final;
 
-    LibWebRTCSocketFactory& m_factory;
+    CheckedRef<LibWebRTCSocketFactory> m_factory;
     Type m_type;
     rtc::SocketAddress m_localAddress;
     rtc::SocketAddress m_remoteAddress;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -32,6 +32,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
@@ -49,7 +50,9 @@ namespace WebKit {
 class LibWebRTCNetwork;
 class LibWebRTCSocket;
 
-class LibWebRTCSocketFactory {
+class LibWebRTCSocketFactory : public CanMakeThreadSafeCheckedPtr<LibWebRTCSocketFactory> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LibWebRTCSocketFactory);
 public:
     LibWebRTCSocketFactory() = default;
 

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
@@ -44,24 +44,23 @@ WebRTCResolver::WebRTCResolver(LibWebRTCSocketFactory& socketFactory, LibWebRTCR
 {
 }
 
+WebRTCResolver::~WebRTCResolver() = default;
+
 void WebRTCResolver::setResolvedAddress(const Vector<RTCNetwork::IPAddress>& addresses)
 {
-    auto& factory = m_socketFactory;
-
     auto rtcAddresses = addresses.map([](auto& address) {
         return address.rtcAddress();
     });
-    WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([&factory, identifier = m_identifier, rtcAddresses = WTFMove(rtcAddresses)] () mutable {
-        if (auto resolver = factory.resolver(identifier))
+    WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([factory = m_socketFactory, identifier = m_identifier, rtcAddresses = WTFMove(rtcAddresses)] () mutable {
+        if (auto resolver = factory->resolver(identifier))
             resolver->setResolvedAddress(WTFMove(rtcAddresses));
     });
 }
 
 void WebRTCResolver::resolvedAddressError(int error)
 {
-    auto& factory = m_socketFactory;
-    WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([&factory, identifier = m_identifier, error]() {
-        if (auto resolver = factory.resolver(identifier))
+    WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([factory = m_socketFactory, identifier = m_identifier, error]() {
+        if (auto resolver = factory->resolver(identifier))
             resolver->setError(error);
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
@@ -29,6 +29,7 @@
 
 #include "LibWebRTCResolverIdentifier.h"
 #include "RTCNetwork.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -41,10 +42,12 @@ namespace WebKit {
 
 class LibWebRTCSocketFactory;
 
-class WebRTCResolver {
+class WebRTCResolver : public CanMakeCheckedPtr<WebRTCResolver> {
     WTF_MAKE_TZONE_ALLOCATED(WebRTCResolver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebRTCResolver);
 public:
     WebRTCResolver(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
+    ~WebRTCResolver();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
@@ -52,7 +55,7 @@ private:
     void setResolvedAddress(const Vector<RTCNetwork::IPAddress>&);
     void resolvedAddressError(int);
 
-    LibWebRTCSocketFactory& m_socketFactory;
+    CheckedRef<LibWebRTCSocketFactory> m_socketFactory;
     LibWebRTCResolverIdentifier m_identifier;
 };
 

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
@@ -48,7 +48,7 @@
 #include <wtf/TZoneMallocInlines.h>
 
 #undef WEBAUTHN_RELEASE_LOG
-#define PAGE_ID (m_webPage.identifier().toUInt64())
+#define PAGE_ID (m_webPage->identifier().toUInt64())
 #define FRAME_ID (webFrame->frameID().object().toUInt64())
 #define WEBAUTHN_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(WebAuthn, "%p - [webPageID=%" PRIu64 ", webFrameID=%" PRIu64 "] WebAuthenticatorCoordinator::" fmt, this, PAGE_ID, FRAME_ID, ##__VA_ARGS__)
 #define WEBAUTHN_RELEASE_LOG_ERROR_NO_FRAME(fmt, ...) RELEASE_LOG_ERROR(WebAuthn, "%p - [webPageID=%" PRIu64 "] WebAuthenticatorCoordinator::" fmt, this, PAGE_ID, ##__VA_ARGS__)
@@ -70,13 +70,18 @@ WebAuthenticatorCoordinator::WebAuthenticatorCoordinator(WebPage& webPage)
 {
 }
 
+Ref<WebPage> WebAuthenticatorCoordinator::protectedPage() const
+{
+    return m_webPage.get();
+}
+
 void WebAuthenticatorCoordinator::makeCredential(const LocalFrame& frame, const PublicKeyCredentialCreationOptions& options, MediationRequirement mediation, RequestCompletionHandler&& handler)
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     if (!webFrame)
         return;
 
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::MakeCredential(webFrame->frameID(), webFrame->info(), options, mediation), WTFMove(handler));
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::MakeCredential(webFrame->frameID(), webFrame->info(), options, mediation), WTFMove(handler));
 }
 
 void WebAuthenticatorCoordinator::getAssertion(const LocalFrame& frame, const PublicKeyCredentialRequestOptions& options, MediationRequirement mediation, const ScopeAndCrossOriginParent& scopeAndCrossOriginParent, RequestCompletionHandler&& handler)
@@ -85,27 +90,27 @@ void WebAuthenticatorCoordinator::getAssertion(const LocalFrame& frame, const Pu
     if (!webFrame)
         return;
 
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetAssertion(webFrame->frameID(), webFrame->info(), options, mediation, scopeAndCrossOriginParent.second), WTFMove(handler));
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetAssertion(webFrame->frameID(), webFrame->info(), options, mediation, scopeAndCrossOriginParent.second), WTFMove(handler));
 }
 
 void WebAuthenticatorCoordinator::isConditionalMediationAvailable(const SecurityOrigin& origin, QueryCompletionHandler&& handler)
 {
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(origin.data()), WTFMove(handler));
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(origin.data()), WTFMove(handler));
 };
 
 void WebAuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable(const SecurityOrigin& origin, QueryCompletionHandler&& handler)
 {
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::IsUserVerifyingPlatformAuthenticatorAvailable(origin.data()), WTFMove(handler));
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::IsUserVerifyingPlatformAuthenticatorAvailable(origin.data()), WTFMove(handler));
 }
 
 void WebAuthenticatorCoordinator::cancel(CompletionHandler<void()>&& handler)
 {
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::Cancel(), WTFMove(handler));
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::Cancel(), WTFMove(handler));
 }
 
 void WebAuthenticatorCoordinator::getClientCapabilities(const SecurityOrigin& origin, CapabilitiesCompletionHandler&& handler)
 {
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetClientCapabilities(origin.data()), WTFMove(handler));
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetClientCapabilities(origin.data()), WTFMove(handler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
@@ -30,6 +30,7 @@
 #include <WebCore/AuthenticatorCoordinatorClient.h>
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -49,7 +50,9 @@ private:
     void getClientCapabilities(const WebCore::SecurityOrigin&, WebCore::CapabilitiesCompletionHandler&&) final;
     void cancel(CompletionHandler<void()>&&) final;
 
-    WebPage& m_webPage;
+    Ref<WebPage> protectedPage() const;
+
+    WeakRef<WebPage> m_webPage;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
@@ -42,6 +42,8 @@ WebDataListSuggestionPicker::WebDataListSuggestionPicker(WebPage& page, WebCore:
 {
 }
 
+WebDataListSuggestionPicker::~WebDataListSuggestionPicker() = default;
+
 void WebDataListSuggestionPicker::handleKeydownWithIdentifier(const String& key)
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::HandleKeydownInDataList(key), m_page.get().identifier());
@@ -49,12 +51,12 @@ void WebDataListSuggestionPicker::handleKeydownWithIdentifier(const String& key)
 
 void WebDataListSuggestionPicker::didSelectOption(const String& selectedOption)
 {
-    m_client.didSelectDataListOption(selectedOption);
+    m_client->didSelectDataListOption(selectedOption);
 }
 
 void WebDataListSuggestionPicker::didCloseSuggestions()
 {
-    m_client.didCloseSuggestions();
+    m_client->didCloseSuggestions();
 }
 
 void WebDataListSuggestionPicker::close()
@@ -64,7 +66,7 @@ void WebDataListSuggestionPicker::close()
 
 void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSuggestionActivationType type)
 {
-    auto suggestions = m_client.suggestions();
+    auto suggestions = m_client->suggestions();
     if (suggestions.isEmpty()) {
         close();
         return;
@@ -72,7 +74,7 @@ void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSug
 
     Ref page { m_page.get() };
 
-    auto elementRectInRootViewCoordinates = m_client.elementRectInRootViewCoordinates();
+    auto elementRectInRootViewCoordinates = m_client->elementRectInRootViewCoordinates();
     if (RefPtr view = page->localMainFrameView()) {
         auto unobscuredRootViewRect = view->contentsToRootView(view->unobscuredContentRect());
         if (!unobscuredRootViewRect.intersects(elementRectInRootViewCoordinates))

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
@@ -28,6 +28,7 @@
 #if ENABLE(DATALIST_ELEMENT)
 
 #include <WebCore/DataListSuggestionPicker.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -50,6 +51,7 @@ class WebPage;
 class WebDataListSuggestionPicker final : public WebCore::DataListSuggestionPicker {
 public:
     WebDataListSuggestionPicker(WebPage&, WebCore::DataListSuggestionsClient&);
+    ~WebDataListSuggestionPicker();
 
     void didSelectOption(const String&);
     void didCloseSuggestions();
@@ -59,7 +61,7 @@ private:
     void displayWithActivationType(WebCore::DataListSuggestionActivationType) final;
     void close() final;
 
-    WebCore::DataListSuggestionsClient& m_client;
+    CheckedRef<WebCore::DataListSuggestionsClient> m_client;
     WeakRef<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
@@ -42,14 +42,16 @@ WebDateTimeChooser::WebDateTimeChooser(WebPage& page, WebCore::DateTimeChooserCl
 {
 }
 
+WebDateTimeChooser::~WebDateTimeChooser() = default;
+
 void WebDateTimeChooser::didChooseDate(StringView date)
 {
-    m_client.didChooseValue(date);
+    m_client->didChooseValue(date);
 }
 
 void WebDateTimeChooser::didEndChooser()
 {
-    m_client.didEndChooser();
+    m_client->didEndChooser();
 }
 
 void WebDateTimeChooser::endChooser()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
@@ -51,6 +51,7 @@ class WebPage;
 class WebDateTimeChooser final : public WebCore::DateTimeChooser {
 public:
     WebDateTimeChooser(WebPage&, WebCore::DateTimeChooserClient&);
+    ~WebDateTimeChooser();
 
     void didChooseDate(StringView);
     void didEndChooser();
@@ -59,7 +60,7 @@ private:
     void endChooser() final;
     void showChooser(const WebCore::DateTimeChooserParameters&) final;
 
-    WebCore::DateTimeChooserClient& m_client;
+    CheckedRef<WebCore::DateTimeChooserClient> m_client;
     WeakRef<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -71,6 +71,10 @@ class EventDispatcher final :
     public MomentumEventDispatcher::Client,
 #endif
     private IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventDispatcher);
+#endif
 public:
     EventDispatcher();
     ~EventDispatcher();

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -193,7 +193,7 @@ void MomentumEventDispatcher::dispatchSyntheticMomentumEvent(WebWheelEvent::Phas
         { },
         WebWheelEvent::MomentumEndType::Unknown);
 
-    m_client.handleSyntheticWheelEvent(*m_currentGesture.pageIdentifier, syntheticEvent, m_lastRubberBandableEdges);
+    m_client->handleSyntheticWheelEvent(*m_currentGesture.pageIdentifier, syntheticEvent, m_lastRubberBandableEdges);
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     m_currentLogState.totalGeneratedOffset += appKitAcceleratedDelta.height();
@@ -241,7 +241,7 @@ void MomentumEventDispatcher::didEndMomentumPhase()
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher ending synthetic momentum phase with total offset %.1f %.1f, duration %f (event offset would have been %.1f %.1f) (tail index %d of %zu)", m_currentGesture.currentOffset.width(), m_currentGesture.currentOffset.height(), (MonotonicTime::now() - m_currentGesture.startTime).seconds(), m_currentGesture.accumulatedEventOffset.width(), m_currentGesture.accumulatedEventOffset.height(), m_currentGesture.currentTailDeltaIndex, m_currentGesture.tailDeltaTable.size());
-    m_client.flushMomentumEventLoggingSoon();
+    m_client->flushMomentumEventLoggingSoon();
 #endif
 
     stopDisplayLink();
@@ -289,7 +289,7 @@ void MomentumEventDispatcher::startDisplayLink()
     }
 
     // FIXME: Switch down to lower-than-full-speed frame rates for the tail end of the curve.
-    m_client.startDisplayDidRefreshCallbacks(displayProperties->displayID);
+    m_client->startDisplayDidRefreshCallbacks(displayProperties->displayID);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher starting display link for display %d", displayProperties->displayID);
 #endif
@@ -306,7 +306,7 @@ void MomentumEventDispatcher::stopDisplayLink()
         return;
     }
 
-    m_client.stopDisplayDidRefreshCallbacks(displayProperties->displayID);
+    m_client->stopDisplayDidRefreshCallbacks(displayProperties->displayID);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher stopping display link for display %d", displayProperties->displayID);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -35,6 +35,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/RectEdges.h>
 #include <memory>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
@@ -52,7 +53,9 @@ class MomentumEventDispatcher {
     WTF_MAKE_NONCOPYABLE(MomentumEventDispatcher);
     WTF_MAKE_TZONE_ALLOCATED(MomentumEventDispatcher);
 public:
-    class Client {
+    class Client : public CanMakeCheckedPtr<Client> {
+        WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
     friend class MomentumEventDispatcher;
     public:
         virtual ~Client() = default;
@@ -177,7 +180,7 @@ private:
 
     mutable Lock m_accelerationCurvesLock;
     HashMap<WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>> m_accelerationCurves WTF_GUARDED_BY_LOCK(m_accelerationCurvesLock);
-    Client& m_client;
+    CheckedRef<Client> m_client;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -65,14 +65,15 @@ static constexpr auto highlightColor = SRGBA<uint8_t> { 255, 228, 56 };
 
 void FindIndicatorOverlayClientIOS::drawRect(PageOverlay& overlay, GraphicsContext& context, const IntRect& dirtyRect)
 {
-    float scaleFactor = m_frame.page()->deviceScaleFactor();
+    Ref frame = m_frame.get();
+    float scaleFactor = frame->page()->deviceScaleFactor();
 
-    if (m_frame.page()->delegatesScaling())
-        scaleFactor *= m_frame.page()->pageScaleFactor();
+    if (frame->page()->delegatesScaling())
+        scaleFactor *= frame->page()->pageScaleFactor();
 
     // If the page scale changed, we need to paint a new TextIndicator.
     if (m_textIndicator->contentImageScaleFactor() != scaleFactor)
-        m_textIndicator = TextIndicator::createWithSelectionInFrame(m_frame, findTextIndicatorOptions(m_frame), TextIndicatorPresentationTransition::None, FloatSize(totalHorizontalMargin, totalVerticalMargin));
+        m_textIndicator = TextIndicator::createWithSelectionInFrame(frame, findTextIndicatorOptions(frame), TextIndicatorPresentationTransition::None, FloatSize(totalHorizontalMargin, totalVerticalMargin));
 
     if (!m_textIndicator)
         return;

--- a/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorOverlayClientIOS.h
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorOverlayClientIOS.h
@@ -49,7 +49,7 @@ private:
     void drawRect(WebCore::PageOverlay&, WebCore::GraphicsContext&, const WebCore::IntRect& dirtyRect) override;
     bool mouseEvent(WebCore::PageOverlay&, const WebCore::PlatformMouseEvent&) override { return false; }
 
-    WebCore::LocalFrame& m_frame;
+    WeakRef<WebCore::LocalFrame> m_frame;
     RefPtr<WebCore::TextIndicator> m_textIndicator;
 };
 


### PR DESCRIPTION
#### 9daa0eabddbdedfbf8b85d551b4a643b3c9e3f30
<pre>
Adopt more smart pointers for data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=280733">https://bugs.webkit.org/show_bug.cgi?id=280733</a>

Reviewed by Youenn Fablet.

* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/platform/DataListSuggestionsClient.h:
* Source/WebCore/platform/DateTimeChooserClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp:
(WebKit::MediaRecorderProvider::createMediaRecorderPrivate):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::LibWebRTCSocket):
(WebKit::LibWebRTCSocket::~LibWebRTCSocket):
(WebKit::LibWebRTCSocket::SendTo):
(WebKit::LibWebRTCSocket::Close):
(WebKit::LibWebRTCSocket::SetOption):
(WebKit::LibWebRTCSocket::suspend):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp:
(WebKit::WebRTCResolver::setResolvedAddress):
(WebKit::WebRTCResolver::resolvedAddressError):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h:
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp:
(WebKit::WebAuthenticatorCoordinator::protectedPage const):
(WebKit::WebAuthenticatorCoordinator::makeCredential):
(WebKit::WebAuthenticatorCoordinator::getAssertion):
(WebKit::WebAuthenticatorCoordinator::isConditionalMediationAvailable):
(WebKit::WebAuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable):
(WebKit::WebAuthenticatorCoordinator::cancel):
(WebKit::WebAuthenticatorCoordinator::getClientCapabilities):
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp:
(WebKit::WebDataListSuggestionPicker::didSelectOption):
(WebKit::WebDataListSuggestionPicker::didCloseSuggestions):
(WebKit::WebDataListSuggestionPicker::displayWithActivationType):
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp:
(WebKit::WebDateTimeChooser::didChooseDate):
(WebKit::WebDateTimeChooser::didEndChooser):
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::dispatchSyntheticMomentumEvent):
(WebKit::MomentumEventDispatcher::didEndMomentumPhase):
(WebKit::MomentumEventDispatcher::startDisplayLink):
(WebKit::MomentumEventDispatcher::stopDisplayLink):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindIndicatorOverlayClientIOS::drawRect):
* Source/WebKit/WebProcess/WebPage/ios/FindIndicatorOverlayClientIOS.h:

Canonical link: <a href="https://commits.webkit.org/284733@main">https://commits.webkit.org/284733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/825537c81c3c7a438fe8849953110118641f4a97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14224 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76165 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63472 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60720 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63409 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5081 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10765 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/332 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->