### PR TITLE
[WTF] Add LibraryHash::compute

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2496,6 +2496,8 @@ protected:
 
     bool isUpToDate(Decoder& decoder) const
     {
+        if (!computeJSCBytecodeCacheVersion())
+            return false;
         if (m_cacheVersion != computeJSCBytecodeCacheVersion())
             return false;
         if (m_bootSessionUUID.decode(decoder) != bootSessionUUIDString())

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -886,6 +886,8 @@
 		E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BE09A724A5854D009DF2B4 /* ICUHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BE09A624A58545009DF2B4 /* ICUHelpers.cpp */; };
 		E3DA37E7287AD1A10066808F /* StringCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DA37E6287AD1A10066808F /* StringCommon.cpp */; };
+		E3FFF1632CACF8A400636764 /* LibraryHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3FFF1622CACF8A400636764 /* LibraryHash.cpp */; };
+		E3FFF1642CACF8A400636764 /* LibraryHash.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FFF1612CACF8A400636764 /* LibraryHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD371A96245500536DF6 /* WorkQueue.cpp */; };
 		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */; };
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
@@ -1900,6 +1902,8 @@
 		E3E64F0B22813428001E55B4 /* Nonmovable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Nonmovable.h; sourceTree = "<group>"; };
 		E3E8162F2764799300BAA45B /* RefCountedFixedVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RefCountedFixedVector.h; sourceTree = "<group>"; };
 		E3FD6D6627A1F6AD00935000 /* GenericHashKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GenericHashKey.h; sourceTree = "<group>"; };
+		E3FFF1612CACF8A400636764 /* LibraryHash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibraryHash.h; sourceTree = "<group>"; };
+		E3FFF1622CACF8A400636764 /* LibraryHash.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LibraryHash.cpp; sourceTree = "<group>"; };
 		E419F2E623AB9E2300B26129 /* VectorHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VectorHash.h; sourceTree = "<group>"; };
 		E4A0AD371A96245500536DF6 /* WorkQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkQueue.cpp; sourceTree = "<group>"; };
 		E4A0AD381A96245500536DF6 /* WorkQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkQueue.h; sourceTree = "<group>"; };
@@ -2321,6 +2325,8 @@
 				E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */,
 				E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */,
 				539EB0621D55284200C82EF7 /* LEBDecoder.h */,
+				E3FFF1622CACF8A400636764 /* LibraryHash.cpp */,
+				E3FFF1612CACF8A400636764 /* LibraryHash.h */,
 				337B2D6826546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.cpp */,
 				337B2D6926546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.h */,
 				A70DA0831799F04D00529A9B /* ListDump.h */,
@@ -3425,6 +3431,7 @@
 				E32AB5022B5CE35D00B9FAAE /* LazyUniqueRef.h in Headers */,
 				DDF307D327C086DF006A526F /* LChar.h in Headers */,
 				DD3DC88927A4BF8E007E5B61 /* LEBDecoder.h in Headers */,
+				E3FFF1642CACF8A400636764 /* LibraryHash.h in Headers */,
 				6311592628989A55006A9A12 /* LibraryPathDiagnostics.h in Headers */,
 				DD3DC8B427A4BF8E007E5B61 /* LikelyDenseUnsignedIntegerSet.h in Headers */,
 				DDF307D527C086DF006A526F /* LineEnding.h in Headers */,
@@ -4174,6 +4181,7 @@
 				C2BCFC401F61D13000C9222C /* Language.cpp in Sources */,
 				C2BCFC421F61D61600C9222C /* LanguageCF.cpp in Sources */,
 				1C503BE623AAE0AE0072E66B /* LanguageCocoa.mm in Sources */,
+				E3FFF1632CACF8A400636764 /* LibraryHash.cpp in Sources */,
 				6311592728989A55006A9A12 /* LibraryPathDiagnostics.mm in Sources */,
 				337B2D6A26546EB300DDFD3D /* LikelyDenseUnsignedIntegerSet.cpp in Sources */,
 				C2BCFC551F621F3F00C9222C /* LineEnding.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -141,6 +141,7 @@ set(WTF_PUBLIC_HEADERS
     Language.h
     LazyRef.h
     LazyUniqueRef.h
+    LibraryHash.h
     LikelyDenseUnsignedIntegerSet.h
     ListDump.h
     ListHashSet.h
@@ -530,6 +531,7 @@ set(WTF_SOURCES
     Int128.cpp
     JSONValues.cpp
     Language.cpp
+    LibraryHash.cpp
     LikelyDenseUnsignedIntegerSet.cpp
     Lock.cpp
     LockedPrintStream.cpp

--- a/Source/WTF/wtf/LibraryHash.cpp
+++ b/Source/WTF/wtf/LibraryHash.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/LibraryHash.h>
+
+#include <wtf/DataLog.h>
+#include <wtf/HexNumber.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/SuperFastHash.h>
+
+#if OS(DARWIN)
+#include <dlfcn.h>
+#include <mach-o/dyld.h>
+#include <uuid/uuid.h>
+#include <wtf/spi/darwin/dyldSPI.h>
+#elif OS(WINDOWS)
+#include <windows.h>
+#elif OS(UNIX)
+#include <dlfcn.h>
+#include <link.h>
+
+/* Define ElfW for compatibility with Linux, prefer __ElfN() in FreeBSD code */
+#if !defined(ElfW)
+#define ElfW(x) __ElfN(x)
+#endif
+
+#if !defined(NT_GNU_BUILD_ID)
+#define NT_GNU_BUILD_ID 3
+#endif
+
+#endif
+
+namespace WTF {
+
+std::optional<unsigned> LibraryHash::compute(void* function)
+{
+    static constexpr bool verbose = false;
+    UNUSED_VARIABLE(verbose);
+
+#if OS(DARWIN)
+    uuid_t uuid;
+    if (const mach_header* header = dyld_image_header_containing_address(function); header && _dyld_get_image_uuid(header, uuid)) {
+        uuid_string_t uuidString = { };
+        uuid_unparse(uuid, uuidString);
+        unsigned hash = SuperFastHash::computeHash(uuidString);
+        dataLogLnIf(verbose, "UUID of JavaScriptCore.framework:", uuidString);
+        return hash;
+    }
+    return std::nullopt;
+#elif OS(WINDOWS)
+    // https://deplinenoise.wordpress.com/2013/06/14/getting-your-pdb-name-from-a-running-executable-windows/
+    struct PdbInfo {
+        uint32_t signature;
+        uint8_t guid[16];
+        uint32_t age;
+    };
+
+    HMODULE hModule = nullptr;
+    if (BOOL result = GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, reinterpret_cast<char*>(function), &hModule); !result)
+        return std::nullopt;
+
+    uintptr_t baseAddress = std::bit_cast<uintptr_t>(hModule);
+
+    // This is where the MZ...blah header lives (the DOS header)
+    auto* dos = std::bit_cast<IMAGE_DOS_HEADER*>(baseAddress);
+
+    // We want the PE header.
+    auto* file = std::bit_cast<IMAGE_FILE_HEADER*>(baseAddress + dos->e_lfanew + 4);
+
+    if (file->SizeOfOptionalHeader == 0)
+        return std::nullopt;
+
+    // Straight after that is the optional header (which technically is optional, but in practice always there.)
+    auto* opt = std::bit_cast<IMAGE_OPTIONAL_HEADER*>(std::bit_cast<uintptr_t>(file) + sizeof(IMAGE_FILE_HEADER));
+
+    if (opt->NumberOfRvaAndSizes <= IMAGE_DIRECTORY_ENTRY_DEBUG)
+        return std::nullopt;
+
+    // Grab the debug data directory which has an indirection to its data
+    auto* dir = &opt->DataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG];
+
+    if (dir->Size == 0)
+        return std::nullopt;
+
+    // Convert that data to the right type.
+    auto* debugDirectory = std::bit_cast<IMAGE_DEBUG_DIRECTORY*>(baseAddress + dir->VirtualAddress);
+
+    if (debugDirectory->Type != IMAGE_DEBUG_TYPE_CODEVIEW)
+        return std::nullopt;
+
+    auto* info = std::bit_cast<PdbInfo*>(baseAddress + debugDirectory->AddressOfRawData);
+
+    // 'R' 'S' 'D' 'S'
+    if (info->signature != 0x53445352)
+        return std::nullopt;
+
+    return SuperFastHash::computeHash(std::span<const uint8_t> { info->guid, 16U });
+#elif OS(UNIX)
+    Dl_info info { };
+    if (!dladdr(function, &info))
+        return std::nullopt;
+
+    if (!info.dli_fbase)
+        return std::nullopt;
+
+    struct DLParam {
+        void* start { nullptr };
+        std::span<const uint8_t> description;
+    };
+
+    DLParam param { };
+    param.start = info.dli_fbase;
+    if (!dl_iterate_phdr(static_cast<int(*)(struct dl_phdr_info*, size_t, void*)>(
+        [](struct dl_phdr_info* info, size_t, void* priv) -> int {
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Unix port
+            auto* data = static_cast<DLParam*>(priv);
+            void* start = nullptr;
+            for (unsigned i = 0; i < info->dlpi_phnum; ++i) {
+                if (info->dlpi_phdr[i].p_type == PT_LOAD) {
+                    start = std::bit_cast<void*>(static_cast<uintptr_t>(info->dlpi_addr + info->dlpi_phdr[i].p_vaddr));
+                    break;
+                }
+            }
+
+            if (start != data->start)
+                return 0;
+
+            for (unsigned i = 0; i < info->dlpi_phnum; ++i) {
+                if (info->dlpi_phdr[i].p_type != PT_NOTE)
+                    continue;
+
+                // https://refspecs.linuxbase.org/elf/gabi4+/ch5.pheader.html#note_section
+                using NoteHeader = ElfW(Nhdr);
+
+                auto* payload = std::bit_cast<uint8_t*>(static_cast<uintptr_t>(info->dlpi_addr + info->dlpi_phdr[i].p_vaddr));
+                size_t length = info->dlpi_phdr[i].p_filesz;
+                for (size_t index = 0; index < length;) {
+                    auto* cursor  = payload + index;
+                    if ((index + sizeof(NoteHeader)) > length)
+                        return 0;
+
+                    auto* note = std::bit_cast<NoteHeader*>(cursor);
+                    size_t size = sizeof(NoteHeader) + roundUpToMultipleOf<4>(note->n_namesz) + roundUpToMultipleOf<4>(note->n_descsz);
+                    if ((index + size) > length)
+                        return 0;
+
+                    auto* name = cursor + sizeof(NoteHeader);
+                    auto* description = cursor + sizeof(NoteHeader) + roundUpToMultipleOf<4>(note->n_namesz);
+
+                    if (note->n_type == NT_GNU_BUILD_ID && note->n_descsz != 0 && note->n_namesz == 4 && memcmp(name, "GNU", 4) == 0) {
+                        // Found build-id note.
+                        data->description = std::span { description, note->n_descsz };
+                        return 1;
+                    }
+
+                    index += size;
+                }
+            }
+            return 0;
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        }), &param))
+        return std::nullopt;
+
+    if (param.description.empty()) {
+        WTFReportBacktrace();
+        WTFCrash();
+        return std::nullopt;
+    }
+
+    if constexpr (verbose) {
+        for (uint8_t value : param.description)
+            dataLog(hex(value));
+        dataLogLn("");
+    }
+
+    return SuperFastHash::computeHash(param.description);
+#else
+    return std::nullopt;
+#endif
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/LibraryHash.h
+++ b/Source/WTF/wtf/LibraryHash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "JSCBytecodeCacheVersion.h"
+#pragma once
 
-#include <wtf/LibraryHash.h>
+#include <optional>
 
-namespace JSC {
+namespace WTF {
 
-namespace JSCBytecodeCacheVersionInternal {
-static constexpr bool verbose = false;
-}
+class LibraryHash {
+public:
+    WTF_EXPORT_PRIVATE static std::optional<unsigned> compute(void* function);
+};
 
-uint32_t computeJSCBytecodeCacheVersion()
-{
-    UNUSED_VARIABLE(JSCBytecodeCacheVersionInternal::verbose);
-    static LazyNeverDestroyed<uint32_t> cacheVersion;
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        void* jsFunctionAddr = std::bit_cast<void*>(&computeJSCBytecodeCacheVersion);
-        cacheVersion.construct(LibraryHash::compute(jsFunctionAddr).value_or(0));
-    });
-    return cacheVersion.get();
-}
+} // namespace WTF
 
-} // namespace JSC
+using WTF::LibraryHash;


### PR DESCRIPTION
#### ed84e09e7bebf9cae36fa4ac86bc85fb31b872d0
<pre>
[WTF] Add LibraryHash::compute
<a href="https://bugs.webkit.org/show_bug.cgi?id=280736">https://bugs.webkit.org/show_bug.cgi?id=280736</a>
<a href="https://rdar.apple.com/137103026">rdar://137103026</a>

Reviewed by NOBODY (OOPS!).

This patch extracts how we compute library / framework&apos;s hash value.
And we also add Windows implementation for that. We use this library
hash for cached bytecode&apos;s versioning number.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::GenericCacheEntry::isUpToDate const):
* Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp:
(JSC::computeJSCBytecodeCacheVersion):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/LibraryHash.cpp: Added.
(WTF::LibraryHash::compute):
* Source/WTF/wtf/LibraryHash.h: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed84e09e7bebf9cae36fa4ac86bc85fb31b872d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83695 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34703 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65102 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30254 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33752 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76658 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90145 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82712 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72764 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15723 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2284 "Hash ed84e09e for PR 34557 does not build (failure)") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/12950 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16384 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105129 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10760 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25406 "Found 4813 new JSC stress test failures: airjs-tests.yaml/stress-test.js.bytecode-cache, basic-tests.yaml/stress-test.js.bytecode-cache, cdjs-tests.yaml/main.js.bytecode-cache, cdjs-tests.yaml/motion_test.js.bytecode-cache, cdjs-tests.yaml/red_black_tree_test.js.bytecode-cache, cdjs-tests.yaml/reduce_collision_set_test.js.bytecode-cache, microbenchmarks/Float32Array-matrix-mult.js.bytecode-cache, microbenchmarks/Int16Array-bubble-sort-with-byteLength.js.bytecode-cache, microbenchmarks/Int16Array-bubble-sort.js.bytecode-cache, microbenchmarks/Int16Array-load-int-mul.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->