### PR TITLE
[Static Analyzer CI] Rename scripts and processes from smart pointer to safer CPP

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -262,7 +262,7 @@
                   "workernames": ["bot611"]
                   },
                   {
-                    "name": "Apple-Sonoma-Smart-Pointer-Static-Analyzer-Build", "factory": "SmartPointerStaticAnalyzerFactory",
+                    "name": "Apple-Sonoma-Safer-CPP-Checks", "factory": "SaferCPPStaticAnalyzerFactory",
                     "platform": "mac-sonoma", "configuration": "release", "architectures": ["arm64"],
                     "workernames": ["bot600"]
                   },
@@ -804,7 +804,7 @@
                   "builderNames": ["Apple-Sequoia-Debug-WK2-Site-Isolation-Tree-Tests"]
                   },                  
                   { "type": "PlatformSpecificScheduler", "platform": "mac-sonoma", "branch": "main", "treeStableTimer": 45.0,
-                  "builderNames": ["Apple-Sonoma-Release-Build", "Apple-Sonoma-Debug-Build","Apple-Sonoma-Smart-Pointer-Static-Analyzer-Build"]
+                  "builderNames": ["Apple-Sonoma-Release-Build", "Apple-Sonoma-Debug-Build","Apple-Sonoma-Safer-CPP-Checks"]
                   },
                   { "type": "Triggerable", "name": "sonoma-release-tests-wk1",
                   "builderNames": ["Apple-Sonoma-Release-WK1-Tests"]

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -283,11 +283,11 @@ class DownloadAndPerfTestFactory(Factory):
             self.addStep(RunBenchmarkTests(timeout=2000))
 
 
-class SmartPointerStaticAnalyzerFactory(Factory):
+class SaferCPPStaticAnalyzerFactory(Factory):
     def __init__(self, platform, configuration, architectures, additionalArguments=None, device_model=None, **kwargs):
         Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model, **kwargs)
         self.addStep(PrintClangVersion())
-        self.addStep(ScanBuildSmartPointer())
+        self.addStep(ScanBuild())
 
 
 class CrossTargetDownloadAndPerfTestFactory(DownloadAndPerfTestFactory):

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -604,7 +604,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'trigger'
         ],
-        'Apple-Sonoma-Smart-Pointer-Static-Analyzer-Build': [
+        'Apple-Sonoma-Safer-CPP-Checks': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -615,7 +615,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'print-clang-version',
-            'scan-build-smart-pointer'
+            'scan-build'
         ],
         'Apple-Ventura-Release-WK1-Tests': [
             'configure-build',

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -295,7 +295,7 @@
     },
     {
       "name": "macOS-Safer-CPP-Checks-EWS", "shortname": "mac-safer-cpp", "icon": "buildOnly",
-      "factory": "SmartPointerStaticAnalyzerFactory", "platform": "mac-sonoma",
+      "factory": "SaferCPPStaticAnalyzerFactory", "platform": "mac-sonoma",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews237", "ews246", "ews247", "ews248", "ews249", "ews250"]
     },

--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -56,7 +56,7 @@ class Events(service.BuildbotService):
         'run-layout-tests-without-change', 'layout-tests-repeat-failures-without-change',
         'run-layout-tests-in-stress-mode', 'run-layout-tests-in-guard-malloc-stress-mode',
         'run-api-tests', 'run-api-tests-without-change', 're-run-api-tests',
-        'scan-build-smart-pointer', 'parse-static-analyzer-results', 'find-unexpected-smart-pointer-results',
+        'scan-build', 'parse-static-analyzer-results', 'find-unexpected-results',
         'jscore-test', 'jscore-test-without-change',
         'add-reviewer-to-commit-message', 'commit-patch', 'push-commit-to-webkit-repo', 'canonicalize-commit',
         'build-webkit-org-unit-tests', 'buildbot-check-config', 'buildbot-check-config-for-build-webkit', 'buildbot-check-config-for-ews',

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -32,7 +32,7 @@ from .steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Cano
                     MapBranchAlias, RemoveAndAddLabels, RetrievePRDataFromLabel, RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                     RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests,
                     RunWebKitPyTests, RunWebKitTests, RunWebKitTestsRedTree, RunWebKitTestsInStressMode, RunWebKitTestsInStressGuardmallocMode,
-                    ScanBuildSmartPointer, SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateClang, UpdateWorkingDirectory, UpdatePullRequest,
+                    ScanBuild, SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateClang, UpdateWorkingDirectory, UpdatePullRequest,
                     ValidateCommitMessage, ValidateChange, ValidateCommitterAndReviewer, WaitForCrashCollection,
                     InstallBuiltProduct, ValidateRemote, ValidateSquashed, GITHUB_PROJECTS)
 
@@ -97,7 +97,7 @@ class WatchListFactory(factory.BuildFactory):
         self.addStep(ApplyWatchList())
 
 
-class SmartPointerStaticAnalyzerFactory(factory.BuildFactory):
+class SaferCPPStaticAnalyzerFactory(factory.BuildFactory):
     findModifiedLayoutTests = False
 
     def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, **kwargs):
@@ -118,7 +118,7 @@ class SmartPointerStaticAnalyzerFactory(factory.BuildFactory):
         self.addStep(UpdateClang())
         self.addStep(CheckOutPullRequest())
         self.addStep(KillOldProcesses())
-        self.addStep(ScanBuildSmartPointer())
+        self.addStep(ScanBuild())
 
 
 class BindingsFactory(Factory):

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -310,7 +310,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'update-clang',
             'checkout-pull-request',
             'kill-old-processes',
-            'scan-build-smart-pointer'
+            'scan-build'
         ],
         'macOS-Release-WK2-Stress-Tests-EWS': [
             'configure-build',

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -38,7 +38,7 @@ from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQu
                         GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
                         StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory,
                         WinBuildFactory, WinTestsFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory,  visionOSBuildFactory, visionOSEmbeddedBuildFactory, visionOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
-                        macOSWK1Factory, macOSWK2Factory, ServicesFactory, SmartPointerStaticAnalyzerFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
+                        macOSWK1Factory, macOSWK2Factory, ServicesFactory, SaferCPPStaticAnalyzerFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
 
 from .utils import get_custom_suffix
 

--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -30,12 +30,23 @@ PROJECTS = ['WebCore', 'WebKit']
 
 
 def parser():
-    parser = argparse.ArgumentParser(description='Various tools for working on smart pointers')
+    parser = argparse.ArgumentParser(description='Automated tooling for updating safer CPP expectations')
     parser.add_argument(
-        '--update-expectations', '-u',
-        dest='unexpected_results',
+        '--add-expected-failures', '-a',
+        dest='results_to_add',
         default=None,
-        help='Path to unexpected results file following this naming scheme: "[WebKit/WebCore]-unexpected-[passes/failures]". Removes unexpected passes and adds unexpected failures to the expectations files in SmartPointerExpectations.'
+        help='Path to unexpected results file. Adds unexpected failures to the expectations files in SmartPointerExpectations.'
+    )
+    parser.add_argument(
+        '--remove-expected-failures', '-r',
+        dest='results_to_remove',
+        default=None,
+        help='Path to unexpected results file. Removes unexpected failures from the expectations files in SmartPointerExpectations.'
+    )
+    parser.add_argument(
+        '--project', '-p',
+        choices=['WebKit', 'WebCore'],
+        help='Specify which project expectations you want to update.'
     )
     parser.add_argument(
         '--find-expectations', '-f',
@@ -56,7 +67,7 @@ def modify_expectations_for_checker(checker_type, unexpected_contents, project, 
             new_checker_type = line.split()[-1]
             modify_expectations_for_checker(new_checker_type, unexpected_contents, project, type)
         elif line.strip():
-            if type == 'passes':
+            if type == 'remove':
                 expectations.remove(line)
             elif line not in expectations:
                 expectations.append(line)
@@ -65,16 +76,24 @@ def modify_expectations_for_checker(checker_type, unexpected_contents, project, 
     with open(path_to_expectations, 'w') as expectations_file:
         expectations_file.writelines(sorted(expectations))
     print(f'Updated expectations for {checker_type}!')
-    if type == 'passes':
+    if type == 'remove':
         print(f'Removed {prev_len - len(expectations)} fixed files.\n')
     else:
         print(f'Added {len(expectations) - prev_len} files with issues.\n')
 
 
-def update_expectations(unexpected_results):
+def update_expectations(unexpected_results, project, type):
     filename = unexpected_results.split('/')[-1]
-    project, type = filename.split('-')[0], filename.split('-')[-1].removesuffix('.txt')
-    print(f'Modifying unexpected {type} for {project}...\n')
+    if not project:
+        projects = [p for p in ['WebKit', 'WebCore'] if p in filename]
+        if projects:
+            project = projects[0]
+        else:
+            print(f'Could not find a project to update. Please include the project in the filename or pass in the --project argument.')
+            return
+
+    print(f"{'Adding' if type == 'add' else 'Removing'} unexpected failures in {project}...\n")
+
     with open(unexpected_results, 'r') as unexpected_contents:
         for line in unexpected_contents:
             if '=>' in line:
@@ -97,17 +116,23 @@ def is_expected_file(expected_file):
                 expectations = f.read()
                 if line in expectations:
                     if not issues:
-                        print(f'{expected_file} has smart pointer issues:')
+                        print(f'{expected_file} has issues:')
                     issues = True
                     print(f'- {project} {checker}')
     if not issues:
-        print(f'{expected_file} has no known smart pointer issues!')
+        print(f'{expected_file} has no known issues!')
 
 
 def main():
     args = parser()
-    if args.unexpected_results:
-        update_expectations(args.unexpected_results)
+    if args.results_to_add:
+        print('WARNING: Adding expected failures. Please only add expected failures when you fix false negatives in our tools.')
+        user_input = input('Are you sure you want to proceed? [y/N]: ') or 'N'
+        if user_input[0].lower() != 'y':
+            return
+        update_expectations(args.results_to_add, args.project, 'add')
+    if args.results_to_remove:
+        update_expectations(args.results_to_remove, args.project, 'remove')
     if args.expected_file:
         is_expected_file(args.expected_file)
 


### PR DESCRIPTION
#### bc1c19d5d9028c4bed727da393f371de3997f17e
<pre>
[Static Analyzer CI] Rename scripts and processes from smart pointer to safer CPP
<a href="https://bugs.webkit.org/show_bug.cgi?id=280729">https://bugs.webkit.org/show_bug.cgi?id=280729</a>
<a href="https://rdar.apple.com/137096120">rdar://137096120</a>

Reviewed by Ryosuke Niwa and Ryan Haddad.

Reflect the nature of our static analysis better by changing references to smart pointer
to safer cpp or static analysis.

Also updated build summary for build-webkit-org DisplaySaferCPPResults to be more accurate
and useful based on the results. Added unittests for DisplaySaferCPPResults.

* Tools/Scripts/update-safer-cpp-expectations:
    Renamed from Tools/Scripts/smart-pointer-tool.
    Allow the user to pass in any filename if arguments are specified correctly.
(parser): Add arguments for adding and removing failures, specifying project name.
(modify_expectations_for_checker):
(update_expectations):
(is_expected_file):
(main):

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories.py:
(SaferCPPStaticAnalyzerFactory):
(SaferCPPStaticAnalyzerFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/steps.py:
(ScanBuild):
(ScanBuild.run):
(DisplaySaferCPPResults):
(UpdateSaferCPPBaseline):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/events.py:
(Events):
* Tools/CISupport/ews-build/factories.py:
(SaferCPPStaticAnalyzerFactory):
(SaferCPPStaticAnalyzerFactory.__init__):
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/ews-build/loadConfig.py:
* Tools/CISupport/ews-build/steps.py:
(UpdatePullRequest.hideStepIf):
(ScanBuild):
(ScanBuildWithoutChange):
(FindUnexpectedStaticAnalyzerResults.run):
(DisplaySaferCPPResults):
(DisplaySaferCPPResults.getResultSummary):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/284596@main">https://commits.webkit.org/284596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39c5df3f70ec91a419b2ed0ea7d4dec211b0884d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21103 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55507 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13990 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19480 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75745 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63202 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/69623 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60403 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63138 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11157 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4765 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10675 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45149 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->