### PR TITLE
JSDOMPromiseDeferred.h:307:20: "error: use 'template' keyword to treat 'resolve' as a dependent template name" with some Clang versions

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -304,7 +304,7 @@ public:
 
     void resolve(typename IDLType::ParameterType value)
     {
-        m_promise->resolve<IDLType>(std::forward<typename IDLType::ParameterType>(value));
+        m_promise->template resolve<IDLType>(std::forward<typename IDLType::ParameterType>(value));
     }
 
     template<typename U>


### PR DESCRIPTION
#### 01c06ea002c2b91b1025709161885049b5a296c7
<pre>
JSDOMPromiseDeferred.h:307:20: &quot;error: use &apos;template&apos; keyword to treat &apos;resolve&apos; as a dependent template name&quot; with some Clang versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=280744">https://bugs.webkit.org/show_bug.cgi?id=280744</a>
<a href="https://rdar.apple.com/136932730">rdar://136932730</a>

Reviewed by Darin Adler.

In some Clang versions, we get the following error diagnostic:

```
JSDOMPromiseDeferred.h:307:20: error: use &apos;template&apos; keyword to treat &apos;resolve&apos; as a dependent template name
  307 |         m_promise-&gt;resolve&lt;IDLType&gt;(std::forward&lt;typename IDLType::ParameterType&gt;(value));
      |                    ^
      |                    template
```

This is a valid error because `m_promise` is indeed a member template
specialization and the `resolve()` call explicitly depends on a template
parameter.

We fix this by prepending the `resolve()` call with keyword `template`.

c.f. ISO C++23 13.3.3.4.

* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DOMPromiseDeferred::resolve):

Canonical link: <a href="https://commits.webkit.org/284560@main">https://commits.webkit.org/284560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24d7ecf141d19cd806a50b0907aafa3e4dfd33f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75618 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17239 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63126 "Found 1 new test failure: compositing/shared-backing/overlap-after-end-sharing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63055 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4674 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10655 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45023 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->