### PR TITLE
[CoordinatedGraphics] Simplify and cleanup CoordinatedBackingStore

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -111,7 +111,7 @@ void updateBackingStore(TextureMapperLayer& layer,
     auto& backingStore = *compositionState.backingStore;
 
     layer.setBackingStore(&backingStore);
-    backingStore.setSize(layer.size());
+    backingStore.resize(layer.size());
 
     for (auto& tile : update.tilesToCreate)
         backingStore.createTile(tile.tileID, tile.scale);
@@ -383,7 +383,7 @@ void CoordinatedGraphicsScene::updateSceneState()
     }
 
     for (auto& backingStore : backingStoresWithPendingBuffers)
-        backingStore->commitTileOperations(*m_textureMapper);
+        backingStore->swapBuffers(*m_textureMapper);
 
     for (auto& proxy : proxiesForSwapping)
         proxy->swapBuffer();


### PR DESCRIPTION
#### f5a16430e711f3a6d11d5e8a2141aea8273bcbdd
<pre>
[CoordinatedGraphics] Simplify and cleanup CoordinatedBackingStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=280748">https://bugs.webkit.org/show_bug.cgi?id=280748</a>

Reviewed by Miguel Gomez.

Remove the pending size, since all tile operations are now done at the
same time and rename commitTileOperations as swapBuffers.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStoreTile::swapBuffers):
(WebCore::CoordinatedBackingStore::createTile):
(WebCore::CoordinatedBackingStore::removeTile):
(WebCore::CoordinatedBackingStore::updateTile):
(WebCore::CoordinatedBackingStore::resize):
(WebCore::CoordinatedBackingStore::swapBuffers):
(WebCore::CoordinatedBackingStore::removeAllTiles): Deleted.
(WebCore::CoordinatedBackingStore::setSize): Deleted.
(WebCore::CoordinatedBackingStore::commitTileOperations): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
(WebCore::CoordinatedBackingStoreTile::CoordinatedBackingStoreTile): Deleted.
(WebCore::CoordinatedBackingStoreTile::scale const): Deleted.
(WebCore::CoordinatedBackingStore::create): Deleted.
(WebCore::CoordinatedBackingStore::CoordinatedBackingStore): Deleted.
(WebCore::CoordinatedBackingStore::rect const): Deleted.
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::updateBackingStore):
(WebKit::CoordinatedGraphicsScene::updateSceneState):

Canonical link: <a href="https://commits.webkit.org/284605@main">https://commits.webkit.org/284605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3c993298e57ae4f5092cd6284635e17e07947d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13908 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35919 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69331 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19357 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63129 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63058 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4677 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10685 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45026 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46100 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->