### PR TITLE
[Navigation] Fix cross-document navigations in subframes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7519,6 +7519,7 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/ [ Sk
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace.html [ Failure ]
+imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-srcdoc-navigation.html [ Failure ]
 
 # General flakes, almost exclusively on mac-wk2-stress.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate.html [ Pass Timeout Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate event for history.back() - cross-document assert_true: expected true got false
+PASS navigate event for history.back() - cross-document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child-expected.txt
@@ -1,4 +1,6 @@
 
 
-FAIL navigation.traverseTo() can navigate 3 frames of different types with correct navigate event cancelable values assert_equals: expected 2 but got 1
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT navigation.traverseTo() can navigate 3 frames of different types with correct navigate event cancelable values Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-top-cancels-cross-document-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-top-cancels-cross-document-child-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate.traverseTo() cancelled by top frame cancels cross-document iframe assert_equals: expected 2 but got 1
+PASS navigate.traverseTo() cancelled by top frame cancels cross-document iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-push-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-push-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after push assert_equals: expected 2 but got 1
+PASS navigation.activation after push
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-same-document-then-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-same-document-then-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation same-document then cross-document assert_equals: expected 3 but got 1
+PASS navigation.activation same-document then cross-document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blank-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blank-navigation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entries() after navigation to about:blank assert_equals: expected 2 but got 1
+PASS entries() after navigation to about:blank
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.entries() behavior after forward-pruning due to cross-document navs assert_array_equals: lengths differ, expected array ["", "?fork"] length 2, got ["?fork"] length 1
+PASS navigation.entries() behavior after forward-pruning due to cross-document navs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entries() after navigation to a javascript: URL assert_equals: expected 2 but got 1
+FAIL entries() after navigation to a javascript: URL assert_equals: expected 2 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.entries() behavior when multiple windows navigate. assert_equals: expected 2 but got 1
+PASS navigation.entries() behavior when multiple windows navigate.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-srcdoc-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-srcdoc-navigation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entries() after setting a srcdoc attribute assert_equals: expected 2 but got 1
+FAIL entries() after setting a srcdoc attribute assert_not_equals: got disallowed value "8ad74782-f402-4540-a51a-ee9b0d6d3f35"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
@@ -1,4 +1,3 @@
+FAIL: Timed out waiting for notifyDone to be called
 
-
-FAIL The url of a document is censored by a no-referrer policy dynamically promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'i.contentWindow.navigation.activation.from.url')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The url of a document with no-referrer referrer meta tag is censored in NavigationHistoryEntry assert_equals: expected 3 but got 1
+FAIL The url of a document with no-referrer referrer meta tag is censored in NavigationHistoryEntry assert_equals: expected (object) null but got (string) "http://localhost:8800/navigation-api/navigation-history-entry/resources/no-referrer-meta.html"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The url of a document with no-referrer referrer policy is censored in NavigationHistoryEntry assert_equals: expected 3 but got 1
+FAIL The url of a document with no-referrer referrer policy is censored in NavigationHistoryEntry assert_equals: expected (object) null but got (string) "http://localhost:8800/navigation-api/navigation-history-entry/resources/no-referrer.html"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() to the current URL with history: 'push' and allow it to go cross document assert_equals: expected 2 but got 1
+PASS navigate() to the current URL with history: 'push' and allow it to go cross document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-already-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-already-detached-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL back() in a detached window assert_equals: expected 2 but got 1
+PASS back() in a detached window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-before-navigate-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-before-navigate-event-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL traverseTo() promise rejections when detaching an iframe before onnavigate (cross-document) assert_equals: expected 2 but got 1
+PASS traverseTo() promise rejections when detaching an iframe before onnavigate (cross-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL A sandboxed iframe cannot navigate its parent via its own navigation object by using back() assert_throws_dom: function "() => { throw committedReason; }" threw object "InvalidStateError: Cannot go back" that is not a DOMException SecurityError: property "code" is equal to 11, expected 18
+FAIL A sandboxed iframe cannot navigate its parent via its own navigation object by using back() assert_unreached: committed must not fulfill Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL A sandboxed iframe cannot navigate its sibling via its own navigation object by using back() assert_throws_dom: function "() => { throw committedReason; }" threw object "InvalidStateError: Cannot go back" that is not a DOMException SecurityError: property "code" is equal to 11, expected 18
+FAIL A sandboxed iframe cannot navigate its sibling via its own navigation object by using back() assert_unreached: committed must not fulfill Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() still works for a non-current cross-document entry assert_equals: expected 2 but got 1
+PASS entry.getState() still works for a non-current cross-document entry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-undefined-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-undefined-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Default behavior for entry.getState() for a non-current cross-document entry assert_equals: expected 2 but got 1
+PASS Default behavior for entry.getState() for a non-current cross-document entry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-location-api-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after cross-document location API navigation assert_equals: expected 2 but got 1
+PASS entry.getState() behavior after cross-document location API navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after cross-document location API navigation assert_equals: expected 2 but got 1
+PASS entry.getState() behavior after cross-document location API navigation
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7246,7 +7246,7 @@ webkit.org/b/275963 [ x86_64 ] imported/w3c/web-platform-tests/svg/import/metada
 webkit.org/b/275963 [ x86_64 ] svg/W3C-SVG-1.1/metadata-example-01-b.svg [ Failure ]
 webkit.org/b/275963 [ x86_64 ] svg/custom/use-on-symbol-inside-pattern.svg [ Failure ]
 
-webkit.org/b/275962 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored.html [ Failure ]
+webkit.org/b/275962 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored.html [ Timeout ]
 
 # rdar://130594018 (REGRESSION (278344@main?): [ iOS 18 Release ] 2 http/tests/xmlhttprequest/* layout tests are constantly failing.)
 [ Release ] http/tests/xmlhttprequest/resetting-timeout-to-zero.html [ Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2371,7 +2371,7 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-l
 
 webkit.org/b/275713 fast/text/international/system-language/declarative-language.html [ Failure ]
 
-webkit.org/b/275962 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored.html [ Failure ]
+webkit.org/b/275962 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored.html [ Timeout ]
 
 # rdar://124307254 ([ Sequoia+ ]: Bad rendering of EmojiImage)
 [ Sequoia+ ] fast/css/font-fallback-private-use-area-apple-logo-exception.html [ ImageOnlyFailure ]

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -54,7 +54,9 @@ Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(ScriptExecutionContex
 {
     Ref historyItem = other.m_associatedHistoryItem;
     RefPtr state = historyItem->navigationAPIStateObject();
-    return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), other.m_urlString, WTFMove(state), other.m_key, other.m_id));
+    if (!state)
+        state = other.m_state;
+    return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), other.m_urlString, WTFMove(state), other.m_associatedHistoryItem->uuidIdentifier(), other.m_id));
 }
 
 ScriptExecutionContext* NavigationHistoryEntry::scriptExecutionContext() const


### PR DESCRIPTION
#### 61ed07908d96469ff94ac923699ce5cd53cb58a0
<pre>
[Navigation] Fix cross-document navigations in subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=280750">https://bugs.webkit.org/show_bug.cgi?id=280750</a>

Reviewed by Alex Christensen.

Fix cross-document navigations done on subframes, we need extra logic to not lose the NavigationHistoryEntry bookkeeping done in the previous window.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-top-cancels-cross-document-child-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-push-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-same-document-then-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-blank-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-javascript-url-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-srcdoc-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-already-detached-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-before-navigate-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-parent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-back-sibling-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-undefined-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-location-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/page/Navigation.cpp:
(WebCore::getEntryIndexOfHistoryItem):
(WebCore::Navigation::initializeForNewWindow):
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::create):

Canonical link: <a href="https://commits.webkit.org/284785@main">https://commits.webkit.org/284785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21dc0d3ebfbe3ee97553a888f9c3142a564eb27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17794 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63523 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11564 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5205 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45712 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->