### PR TITLE
[JS3] Make wasm-cli reuse regular cli runner

### DIFF
--- a/PerformanceTests/JetStream3/wasm-cli.js
+++ b/PerformanceTests/JetStream3/wasm-cli.js
@@ -21,25 +21,20 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ */
 
-const isInBrowser = false;
-console = {
-    log: () => { }
-}
+testList = [
+  "HashSet-wasm",
+  "tsf-wasm",
+  "quicksort-wasm",
+  "gcc-loops-wasm",
+  "richards-wasm",
+  "tfjs-wasm",
+  "tfjs-wasm-simd",
+  "argon2-wasm",
+  "argon2-wasm-simd",
+  "8bitbench-wasm",
+];
 
-testList = ["HashSet-wasm", "tsf-wasm", "quicksort-wasm", "gcc-loops-wasm", "richards-wasm", "tfjs-wasm", "argon2-wasm", "argon2-wasm-simd"];
-
-RAMification = false;
-
-load("./JetStreamDriver.js");
-
-async function runJetStream() {
-    try {
-        await JetStream.initialize();
-        JetStream.start();
-    } catch (e) {
-        throw e;
-    }
-}
-runJetStream();
+// Re-use the full CLI runner, just with the subset of Wasm line items above.
+load("./cli.js");


### PR DESCRIPTION
#### e1f1cca094b8d9b13ef54ec55e191e2f6660dd25
<pre>
[JS3] Make wasm-cli reuse regular cli runner
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1f1cca094b8d9b13ef54ec55e191e2f6660dd25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20859 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55459 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 24 flakes 77 failures; Uploaded test results; 13 flakes 63 failures; Compiled WebKit (warnings); 5 flakes 58 failures; Passed layout tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13930 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41547 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63149 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63079 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11088 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4702 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45054 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->