### PR TITLE
[JSC] Rebaseline Intl implementation based on lowest dependency ICU 70

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -42,16 +42,12 @@
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
-#if HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
 #include <unicode/uformattedvalue.h>
 #ifdef U_HIDE_DRAFT_API
 #undef U_HIDE_DRAFT_API
 #endif
-#endif // HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
 #include <unicode/udateintervalformat.h>
-#if HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
 #define U_HIDE_DRAFT_API 1
-#endif // HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
 
 namespace JSC {
 
@@ -1445,8 +1441,6 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     return m_dateIntervalFormat.get();
 }
 
-#if HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
-
 static std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>> formattedValueFromDateRange(UDateIntervalFormat& dateIntervalFormat, UDateFormat& dateFormat, double startDate, double endDate, UErrorCode& status)
 {
     auto result = std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>>(udtitvfmt_openResult(&status));
@@ -1525,8 +1519,6 @@ static bool dateFieldsPracticallyEqual(const UFormattedValue* formattedValue, UE
     return !hasSpan;
 }
 
-#endif // HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
-
 JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double startDate, double endDate)
 {
     ASSERT(m_dateFormat);
@@ -1545,7 +1537,6 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
     auto* dateIntervalFormat = createDateIntervalFormatIfNecessary(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-#if HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
     UErrorCode status = U_ZERO_ERROR;
     auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_dateFormat, startDate, endDate, status);
     if (U_FAILURE(status)) {
@@ -1583,17 +1574,6 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
 
     return jsString(vm, String(WTFMove(buffer)));
-#else
-    Vector<UChar, 32> buffer;
-    auto status = callBufferProducingFunction(udtitvfmt_format, dateIntervalFormat, startDate, endDate, buffer, nullptr);
-    if (U_FAILURE(status)) {
-        throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
-    }
-    replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
-
-    return jsString(vm, String(WTFMove(buffer)));
-#endif
 }
 
 JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, double startDate, double endDate)
@@ -1603,7 +1583,6 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-#if HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
     // http://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-partitiondatetimerangepattern
     startDate = timeClip(startDate);
     endDate = timeClip(endDate);
@@ -1807,12 +1786,6 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     }
 
     return parts;
-#else
-    UNUSED_PARAM(startDate);
-    UNUSED_PARAM(endDate);
-    throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-    return { };
-#endif
 }
 
 

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -32,12 +32,6 @@
 
 struct UDateIntervalFormat;
 
-#if !defined(HAVE_ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
-#if U_ICU_VERSION_MAJOR_NUM >= 64
-#define HAVE_ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS 1
-#endif
-#endif
-
 namespace JSC {
 
 enum class RelevantExtensionKey : uint8_t;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -56,6 +56,7 @@ const ClassInfo IntlDateTimeFormatPrototype::s_info = { "Intl.DateTimeFormat"_s,
 @begin dateTimeFormatPrototypeTable
   format                intlDateTimeFormatPrototypeGetterFormat              DontEnum|ReadOnly|CustomAccessor
   formatRange           intlDateTimeFormatPrototypeFuncFormatRange           DontEnum|Function 2
+  formatRangeToParts    intlDateTimeFormatPrototypeFuncFormatRangeToParts    DontEnum|Function 2
   formatToParts         intlDateTimeFormatPrototypeFuncFormatToParts         DontEnum|Function 1
   resolvedOptions       intlDateTimeFormatPrototypeFuncResolvedOptions       DontEnum|Function 0
 @end
@@ -82,12 +83,7 @@ void IntlDateTimeFormatPrototype::finishCreation(VM& vm, JSGlobalObject* globalO
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-#if HAVE(ICU_U_DATE_INTERVAL_FORMAT_FORMAT_RANGE_TO_PARTS)
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("formatRangeToParts"_s, intlDateTimeFormatPrototypeFuncFormatRangeToParts, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-#else
     UNUSED_PARAM(globalObject);
-    UNUSED_PARAM(&intlDateTimeFormatPrototypeFuncFormatRangeToParts);
-#endif
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -36,21 +36,14 @@
 // While UListFormatter APIs are draft in ICU 67, they are stable in ICU 68 with the same function signatures.
 // So we can assume that these signatures of draft APIs are stable.
 // If UListFormatter is available, UNumberFormatter is also available.
-#if HAVE(ICU_U_LIST_FORMATTER)
 #ifdef U_HIDE_DRAFT_API
 #undef U_HIDE_DRAFT_API
-#endif
 #endif
 #include <unicode/ulistformatter.h>
 #include <unicode/unumberformatter.h>
 #include <unicode/ures.h>
-#if HAVE(ICU_U_LIST_FORMATTER)
 #define U_HIDE_DRAFT_API 1
-#endif
-
-#if HAVE(ICU_U_LIST_FORMATTER)
 #include <unicode/uformattedvalue.h>
-#endif
 
 namespace JSC {
 namespace IntlDurationFormatInternal {
@@ -245,7 +238,6 @@ void IntlDurationFormat::initializeDurationFormat(JSGlobalObject* globalObject, 
     m_fractionalDigits = intlNumberOption(globalObject, options, vm.propertyNames->fractionalDigits, 0, 9, fractionalDigitsUndefinedValue);
     RETURN_IF_EXCEPTION(scope, void());
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     {
         auto toUListFormatterWidth = [](Style style) {
             // 6. Let listStyle be durationFormat.[[Style]].
@@ -272,14 +264,7 @@ void IntlDurationFormat::initializeDurationFormat(JSGlobalObject* globalObject, 
             return;
         }
     }
-#else
-    UNUSED_PARAM(IntlDurationFormatInternal::verbose);
-    throwTypeError(globalObject, scope, "Failed to initialize Intl.DurationFormat since this feature is not supported in the linked ICU version"_s);
-    return;
-#endif
 }
-
-#if HAVE(ICU_U_LIST_FORMATTER)
 
 static String retrieveSeparator(const CString& locale, const String& numberingSystem)
 {
@@ -540,15 +525,12 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
     return elements;
 }
 
-#endif
-
 // https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.format
 JSValue IntlDurationFormat::format(JSGlobalObject* globalObject, ISO8601::Duration duration) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     auto elements = collectElements(globalObject, this, WTFMove(duration));
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -584,10 +566,6 @@ JSValue IntlDurationFormat::format(JSGlobalObject* globalObject, ISO8601::Durati
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
 
     return jsString(vm, String(WTFMove(result)));
-#else
-    UNUSED_PARAM(duration);
-    return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
-#endif
 }
 
 // https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.formatToParts
@@ -596,7 +574,6 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     auto elements = collectElements(globalObject, this, WTFMove(duration));
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -749,10 +726,6 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
     }
 
     return parts;
-#else
-    UNUSED_PARAM(duration);
-    return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
-#endif
 }
 
 // https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.resolvedOptions

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -101,9 +101,7 @@ private:
     static ASCIILiteral unitStyleString(UnitStyle);
     static ASCIILiteral displayString(Display);
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     std::unique_ptr<UListFormatter, UListFormatterDeleter> m_listFormat;
-#endif
     String m_locale;
     String m_numberingSystem;
     CString m_dataLocaleWithExtensions;

--- a/Source/JavaScriptCore/runtime/IntlListFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.cpp
@@ -33,19 +33,12 @@
 
 // While UListFormatter APIs are draft in ICU 67, they are stable in ICU 68 with the same function signatures.
 // So we can assume that these signatures of draft APIs are stable.
-#if HAVE(ICU_U_LIST_FORMATTER)
 #ifdef U_HIDE_DRAFT_API
 #undef U_HIDE_DRAFT_API
 #endif
-#endif
 #include <unicode/ulistformatter.h>
-#if HAVE(ICU_U_LIST_FORMATTER)
 #define U_HIDE_DRAFT_API 1
-#endif
-
-#if HAVE(ICU_U_LIST_FORMATTER)
 #include <unicode/uformattedvalue.h>
-#endif
 
 namespace JSC {
 
@@ -112,7 +105,6 @@ void IntlListFormat::initializeListFormat(JSGlobalObject* globalObject, JSValue 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "long"_s, Style::Long }, { "short"_s, Style::Short }, { "narrow"_s, Style::Narrow } }, "style must be either \"long\", \"short\", or \"narrow\""_s, Style::Long);
     RETURN_IF_EXCEPTION(scope, void());
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     auto toUListFormatterType = [](Type type) {
         switch (type) {
         case Type::Conjunction:
@@ -143,13 +135,8 @@ void IntlListFormat::initializeListFormat(JSGlobalObject* globalObject, JSValue 
         throwTypeError(globalObject, scope, "failed to initialize ListFormat"_s);
         return;
     }
-#else
-    throwTypeError(globalObject, scope, "Failed to initialize Intl.ListFormat since this feature is not supported in the linked ICU version"_s);
-    return;
-#endif
 }
 
-#if HAVE(ICU_U_LIST_FORMATTER)
 static Vector<String, 4> stringListFromIterable(JSGlobalObject* globalObject, JSValue iterable)
 {
     Vector<String, 4> result;
@@ -169,7 +156,6 @@ static Vector<String, 4> stringListFromIterable(JSGlobalObject* globalObject, JS
     });
     return result;
 }
-#endif
 
 // https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.format
 JSValue IntlListFormat::format(JSGlobalObject* globalObject, JSValue list) const
@@ -177,7 +163,6 @@ JSValue IntlListFormat::format(JSGlobalObject* globalObject, JSValue list) const
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     auto stringList = stringListFromIterable(globalObject, list);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -189,10 +174,6 @@ JSValue IntlListFormat::format(JSGlobalObject* globalObject, JSValue list) const
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
 
     return jsString(vm, String(WTFMove(result)));
-#else
-    UNUSED_PARAM(list);
-    return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
-#endif
 }
 
 // https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.formatToParts
@@ -201,7 +182,6 @@ JSValue IntlListFormat::formatToParts(JSGlobalObject* globalObject, JSValue list
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-#if HAVE(ICU_U_LIST_FORMATTER)
     auto stringList = stringListFromIterable(globalObject, list);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -287,10 +267,6 @@ JSValue IntlListFormat::formatToParts(JSGlobalObject* globalObject, JSValue list
     }
 
     return parts;
-#else
-    UNUSED_PARAM(list);
-    return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
-#endif
 }
 
 // https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.resolvedOptions

--- a/Source/JavaScriptCore/runtime/IntlListFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.h
@@ -28,12 +28,6 @@
 #include "JSObject.h"
 #include <wtf/unicode/icu/ICUHelpers.h>
 
-#if !defined(HAVE_ICU_U_LIST_FORMATTER)
-#if U_ICU_VERSION_MAJOR_NUM >= 67 || (U_ICU_VERSION_MAJOR_NUM >= 66 && USE(APPLE_INTERNAL_SDK))
-#define HAVE_ICU_U_LIST_FORMATTER 1
-#endif
-#endif
-
 struct UListFormatter;
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -34,25 +34,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
-#if !defined(HAVE_ICU_U_NUMBER_FORMATTER)
-// UNUM_COMPACT_FIELD and UNUM_MEASURE_UNIT_FIELD are available after ICU 64.
-#if U_ICU_VERSION_MAJOR_NUM >= 64
-#define HAVE_ICU_U_NUMBER_FORMATTER 1
-#endif
-#endif
-
-#if !defined(HAVE_ICU_U_NUMBER_RANGE_FORMATTER)
-#if U_ICU_VERSION_MAJOR_NUM >= 68
-#define HAVE_ICU_U_NUMBER_RANGE_FORMATTER 1
-#endif
-#endif
-
-#if !defined(HAVE_ICU_U_NUMBER_RANGE_FORMATTER_FORMAT_RANGE_TO_PARTS)
-#if U_ICU_VERSION_MAJOR_NUM >= 69
-#define HAVE_ICU_U_NUMBER_RANGE_FORMATTER_FORMAT_RANGE_TO_PARTS 1
-#endif
-#endif
-
 struct UFormattedValue;
 struct UNumberFormatter;
 struct UNumberRangeFormatter;
@@ -70,17 +51,13 @@ enum class IntlNotation : uint8_t { Standard, Scientific, Engineering, Compact }
 template<typename IntlType> void setNumberFormatDigitOptions(JSGlobalObject*, IntlType*, JSObject*, unsigned minimumFractionDigitsDefault, unsigned maximumFractionDigitsDefault, IntlNotation);
 template<typename IntlType> void appendNumberFormatDigitOptionsToSkeleton(IntlType*, StringBuilder&);
 
-#if HAVE(ICU_U_NUMBER_FORMATTER)
 struct UNumberFormatterDeleter {
     JS_EXPORT_PRIVATE void operator()(UNumberFormatter*);
 };
-#endif
 
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
 struct UNumberRangeFormatterDeleter {
     JS_EXPORT_PRIVATE void operator()(UNumberRangeFormatter*);
 };
-#endif
 
 class IntlMathematicalValue {
     WTF_MAKE_TZONE_ALLOCATED(IntlMathematicalValue);
@@ -182,20 +159,14 @@ public:
     JSValue format(JSGlobalObject*, double) const;
     JSValue format(JSGlobalObject*, IntlMathematicalValue&&) const;
     JSValue formatToParts(JSGlobalObject*, double, JSString* sourceType = nullptr) const;
-#if HAVE(ICU_U_NUMBER_FORMATTER)
     JSValue formatToParts(JSGlobalObject*, IntlMathematicalValue&&, JSString* sourceType = nullptr) const;
-#endif
     JSObject* resolvedOptions(JSGlobalObject*) const;
 
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
     JSValue formatRange(JSGlobalObject*, double, double) const;
     JSValue formatRange(JSGlobalObject*, IntlMathematicalValue&&, IntlMathematicalValue&&) const;
-#endif
 
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER_FORMAT_RANGE_TO_PARTS)
     JSValue formatRangeToParts(JSGlobalObject*, double, double) const;
     JSValue formatRangeToParts(JSGlobalObject*, IntlMathematicalValue&&, IntlMathematicalValue&&) const;
-#endif
 
     JSBoundFunction* boundFormat() const { return m_boundFormat.get(); }
     void setBoundFormat(VM&, JSBoundFunction*);
@@ -241,14 +212,8 @@ private:
     static JSValue useGroupingValue(VM&, UseGrouping);
 
     WriteBarrier<JSBoundFunction> m_boundFormat;
-#if HAVE(ICU_U_NUMBER_FORMATTER)
     std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter> m_numberFormatter;
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
     std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter> m_numberRangeFormatter;
-#endif
-#else
-    std::unique_ptr<UNumberFormat, ICUDeleter<unum_close>> m_numberFormat;
-#endif
 
     String m_locale;
     String m_numberingSystem;

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
@@ -35,17 +35,11 @@
 namespace JSC {
 
 static JSC_DECLARE_CUSTOM_GETTER(intlNumberFormatPrototypeGetterFormat);
+static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRange);
+static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRangeToParts);
 static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatToParts);
 static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatPrototypeFuncResolvedOptions);
 static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatFuncFormat);
-
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
-static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRange);
-#endif
-
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER_FORMAT_RANGE_TO_PARTS)
-static JSC_DECLARE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRangeToParts);
-#endif
 
 }
 
@@ -57,9 +51,11 @@ const ClassInfo IntlNumberFormatPrototype::s_info = { "Intl.NumberFormat"_s, &Ba
 
 /* Source for IntlNumberFormatPrototype.lut.h
 @begin numberFormatPrototypeTable
-  format           intlNumberFormatPrototypeGetterFormat         DontEnum|ReadOnly|CustomAccessor
-  formatToParts    intlNumberFormatPrototypeFuncFormatToParts    DontEnum|Function 1
-  resolvedOptions  intlNumberFormatPrototypeFuncResolvedOptions  DontEnum|Function 0
+  format              intlNumberFormatPrototypeGetterFormat            DontEnum|ReadOnly|CustomAccessor
+  formatRange         intlNumberFormatPrototypeFuncFormatRange         DontEnum|Function 2
+  formatRangeToParts  intlNumberFormatPrototypeFuncFormatRangeToParts  DontEnum|Function 2
+  formatToParts       intlNumberFormatPrototypeFuncFormatToParts       DontEnum|Function 1
+  resolvedOptions     intlNumberFormatPrototypeFuncResolvedOptions     DontEnum|Function 0
 @end
 */
 
@@ -86,12 +82,6 @@ void IntlNumberFormatPrototype::finishCreation(VM& vm, JSGlobalObject* globalObj
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
     UNUSED_PARAM(globalObject);
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("formatRange"_s, intlNumberFormatPrototypeFuncFormatRange, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-#endif
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER_FORMAT_RANGE_TO_PARTS)
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("formatRangeToParts"_s, intlNumberFormatPrototypeFuncFormatRangeToParts, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-#endif
 }
 
 // https://tc39.es/ecma402/#sec-number-format-functions
@@ -144,7 +134,6 @@ JSC_DEFINE_CUSTOM_GETTER(intlNumberFormatPrototypeGetterFormat, (JSGlobalObject*
     return JSValue::encode(boundFormat);
 }
 
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
 JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRange, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -174,7 +163,6 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRange, (JSGlobalObje
 
     RELEASE_AND_RETURN(scope, JSValue::encode(numberFormat->formatRange(globalObject, WTFMove(start), WTFMove(end))));
 }
-#endif
 
 JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatToParts, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
@@ -189,7 +177,6 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatToParts, (JSGlobalOb
     if (UNLIKELY(!numberFormat))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatToParts called on value that's not a NumberFormat"_s));
 
-#if HAVE(ICU_U_NUMBER_FORMATTER)
     auto value = toIntlMathematicalValue(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -197,15 +184,8 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatToParts, (JSGlobalOb
         RELEASE_AND_RETURN(scope, JSValue::encode(numberFormat->formatToParts(globalObject, number.value())));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(numberFormat->formatToParts(globalObject, WTFMove(value))));
-#else
-    double value = callFrame->argument(0).toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(numberFormat->formatToParts(globalObject, value)));
-#endif
 }
 
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER_FORMAT_RANGE_TO_PARTS)
 JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRangeToParts, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -235,7 +215,6 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRangeToParts, (JSGlo
 
     RELEASE_AND_RETURN(scope, JSValue::encode(numberFormat->formatRangeToParts(globalObject, WTFMove(start), WTFMove(end))));
 }
-#endif
 
 JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncResolvedOptions, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -167,6 +167,8 @@ namespace JSC {
   Collator              createCollatorConstructor                    DontEnum|PropertyCallback
   DateTimeFormat        createDateTimeFormatConstructor              DontEnum|PropertyCallback
   DisplayNames          createDisplayNamesConstructor                DontEnum|PropertyCallback
+  DurationFormat        createDurationFormatConstructor              DontEnum|PropertyCallback
+  ListFormat            createListFormatConstructor                  DontEnum|PropertyCallback
   Locale                createLocaleConstructor                      DontEnum|PropertyCallback
   NumberFormat          createNumberFormatConstructor                DontEnum|PropertyCallback
   PluralRules           createPluralRulesConstructor                 DontEnum|PropertyCallback
@@ -254,13 +256,6 @@ void IntlObject::finishCreation(VM& vm, JSGlobalObject*)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
-#if HAVE(ICU_U_LIST_FORMATTER)
-    putDirectWithoutTransition(vm, vm.propertyNames->DurationFormat, createDurationFormatConstructor(vm, this), static_cast<unsigned>(PropertyAttribute::DontEnum));
-    putDirectWithoutTransition(vm, vm.propertyNames->ListFormat, createListFormatConstructor(vm, this), static_cast<unsigned>(PropertyAttribute::DontEnum));
-#else
-    UNUSED_PARAM(&createDurationFormatConstructor);
-    UNUSED_PARAM(&createListFormatConstructor);
-#endif
 }
 
 Structure* IntlObject::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.h
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.h
@@ -69,11 +69,8 @@ public:
 
     void initializePluralRules(JSGlobalObject*, JSValue locales, JSValue options);
     JSValue select(JSGlobalObject*, double value) const;
-    JSObject* resolvedOptions(JSGlobalObject*) const;
-
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
     JSValue selectRange(JSGlobalObject*, double start, double end) const;
-#endif
+    JSObject* resolvedOptions(JSGlobalObject*) const;
 
 private:
     IntlPluralRules(VM&, Structure*);
@@ -85,15 +82,8 @@ private:
     enum class Type : bool { Cardinal, Ordinal };
 
     std::unique_ptr<UPluralRules, UPluralRulesDeleter> m_pluralRules;
-#if HAVE(ICU_U_NUMBER_FORMATTER)
     std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter> m_numberFormatter;
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
     std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter> m_numberRangeFormatter;
-#endif
-#else
-    using UNumberFormatDeleter = ICUDeleter<unum_close>;
-    std::unique_ptr<UNumberFormat, UNumberFormatDeleter> m_numberFormat;
-#endif
 
     String m_locale;
     unsigned m_minimumIntegerDigits { 1 };

--- a/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
@@ -33,9 +33,7 @@
 namespace JSC {
 
 static JSC_DECLARE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect);
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
 static JSC_DECLARE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange);
-#endif
 static JSC_DECLARE_HOST_FUNCTION(intlPluralRulesPrototypeFuncResolvedOptions);
 
 }
@@ -49,6 +47,7 @@ const ClassInfo IntlPluralRulesPrototype::s_info = { "Intl.PluralRules"_s, &Base
 /* Source for IntlPluralRulesPrototype.lut.h
 @begin pluralRulesPrototypeTable
   select           intlPluralRulesPrototypeFuncSelect           DontEnum|Function 1
+  selectRange      intlPluralRulesPrototypeFuncSelectRange      DontEnum|Function 2
   resolvedOptions  intlPluralRulesPrototypeFuncResolvedOptions  DontEnum|Function 0
 @end
 */
@@ -76,9 +75,6 @@ void IntlPluralRulesPrototype::finishCreation(VM& vm, JSGlobalObject* globalObje
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
     UNUSED_PARAM(globalObject);
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->selectRange, intlPluralRulesPrototypeFuncSelectRange, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-#endif
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -99,7 +95,6 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect, (JSGlobalObject* gl
     RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->select(globalObject, value)));
 }
 
-#if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
 JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -124,7 +119,6 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObjec
 
     RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->selectRange(globalObject, start, end)));
 }
-#endif
 
 JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncResolvedOptions, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/runtime/IntlWorkaround.cpp
+++ b/Source/JavaScriptCore/runtime/IntlWorkaround.cpp
@@ -26,25 +26,17 @@
 #include "config.h"
 #include "IntlWorkaround.h"
 
-// ICU 69 introduces draft API ubrk_clone and deprecates ubrk_safeClone.
-#if defined(U_HIDE_DRAFT_API)
+#ifdef U_HIDE_DRAFT_API
 #undef U_HIDE_DRAFT_API
 #endif
 #include <unicode/ubrk.h>
-
-#if U_ICU_VERSION_MAJOR_NUM >= 69
-#define HAVE_ICU_UBRK_CLONE 1
-#endif
+#define U_HIDE_DRAFT_API 1
 
 namespace JSC {
 
 UBreakIterator* cloneUBreakIterator(const UBreakIterator* iterator, UErrorCode* status)
 {
-#if HAVE(ICU_UBRK_CLONE)
     return ubrk_clone(iterator, status);
-#else
-    return ubrk_safeClone(iterator, nullptr, nullptr, status);
-#endif
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 31a358087be7e5e70c7a03bdfcf89de35628a2a2
<pre>
[JSC] Rebaseline Intl implementation based on lowest dependency ICU 70
<a href="https://bugs.webkit.org/show_bug.cgi?id=280762">https://bugs.webkit.org/show_bug.cgi?id=280762</a>
<a href="https://rdar.apple.com/137128937">rdar://137128937</a>

Reviewed by Yijia Huang.

Now, Apple and
<a href="https://docs.webkit.org/Ports/WebKitGTK%20and%20WPE%20WebKit/DependenciesPolicy.html">https://docs.webkit.org/Ports/WebKitGTK%20and%20WPE%20WebKit/DependenciesPolicy.html</a>
dependency has ICU 70. This significantly cleans up Intl implementation
and make them maintainable and extendable easily. This patch removes
ifdefs based on ICU 70 requirement.

* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::formatRange):
(JSC::IntlDateTimeFormat::formatRangeToParts):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp:
(JSC::IntlDateTimeFormatPrototype::finishCreation):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::initializeDurationFormat):
(JSC::IntlDurationFormat::format const):
(JSC::IntlDurationFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlDurationFormat.h:
* Source/JavaScriptCore/runtime/IntlListFormat.cpp:
(JSC::IntlListFormat::initializeListFormat):
(JSC::stringListFromIterable):
(JSC::IntlListFormat::format const):
(JSC::IntlListFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlListFormat.h:
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::UNumberFormatterDeleter::operator()):
(JSC::UNumberRangeFormatterDeleter::operator()):
(JSC::partTypeString):
(JSC::IntlNumberFormat::initializeNumberFormat):
(JSC::IntlNumberFormat::format const):
(JSC::IntlNumberFormat::formatRange const):
(JSC::IntlNumberFormat::formatRangeToParts const):
(JSC::IntlNumberFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp:
(JSC::IntlNumberFormatPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::IntlObject::finishCreation):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::initializePluralRules):
(JSC::IntlPluralRules::select const):
(JSC::IntlPluralRules::selectRange const):
* Source/JavaScriptCore/runtime/IntlPluralRules.h:
* Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp:
(JSC::IntlPluralRulesPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlWorkaround.cpp:
(JSC::cloneUBreakIterator):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::OpaqueICUTimeZoneDeleter::operator()):
(JSC::DateCache::calculateLocalTimeOffset):
(JSC::DateCache::defaultTimeZone):
(JSC::DateCache::timeZoneDisplayName):
(JSC::DateCache::timeZoneCacheSlow):
(JSC::toICUTimeZone): Deleted.
(JSC::toOpaqueICUTimeZone): Deleted.

Canonical link: <a href="https://commits.webkit.org/284568@main">https://commits.webkit.org/284568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48a47687fd7b1e6bb2f4c40de9213f08818d7703

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21015 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20866 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13935 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72923 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60250 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/35948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19392 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/62973 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75657 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69103 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17270 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63151 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 78 flakes 115 failures; Uploaded test results") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63081 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/11096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4703 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/90885 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10661 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45061 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/16146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->