### PR TITLE
Stop guessing the content type if there's X-Content-Type-Options: nosniff header.

### DIFF
--- a/LayoutTests/http/tests/workers/service/resources/download-octet-stream.py
+++ b/LayoutTests/http/tests/workers/service/resources/download-octet-stream.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Length: 16\r\n'
+    'X-Content-Type-Options: nosniff\r\n'
+    'Content-Type: application/octet-stream\r\n\r\n'
+
+    '\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f'
+)

--- a/LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https-expected.txt
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https-expected.txt
@@ -1,0 +1,8 @@
+service-worker-download-worker.js has MIME type application/x-javascript
+resources has MIME type text/html
+download-octet-stream.py has MIME type application/octet-stream
+Download started.
+Downloading URL with suggested filename "download-octet-stream.py"
+Download size: 16.
+Download completed.
+

--- a/LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+<script src="resources/sw-test-pre.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.setShouldLogDownloadSize(true);
+  testRunner.waitUntilDownloadFinished();
+  testRunner.setShouldDownloadUndisplayableMIMETypes(true);
+  testRunner.dumpResourceResponseMIMETypes();
+}
+
+async function doTest()
+{
+    await interceptedFrame("resources/service-worker-download-worker.js", "/workers/service/resources/");
+    window.location = "/workers/service/resources/download-octet-stream.py";
+}
+doTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ResourceResponseBase);
 
 bool isScriptAllowedByNosniff(const ResourceResponse& response)
 {
-    if (parseContentTypeOptionsHeader(response.httpHeaderField(HTTPHeaderName::XContentTypeOptions)) != ContentTypeOptionsDisposition::Nosniff)
+    if (!response.isNosniff())
         return true;
     String mimeType = extractMIMETypeFromMediaType(response.httpHeaderField(HTTPHeaderName::ContentType));
     return MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType);
@@ -350,6 +350,11 @@ String ResourceResponseBase::sanitizeSuggestedFilename(const String& suggestedFi
     escapedSuggestedFilename = makeStringByReplacingAll(escapedSuggestedFilename, '"', "\\\""_s);
     response.setHTTPHeaderField(HTTPHeaderName::ContentDisposition, makeString("attachment; filename=\""_s, escapedSuggestedFilename, '"'));
     return response.suggestedFilename();
+}
+
+bool ResourceResponseBase::isNosniff() const
+{
+    return parseContentTypeOptionsHeader(httpHeaderField(HTTPHeaderName::XContentTypeOptions)) == ContentTypeOptionsDisposition::Nosniff;
 }
 
 bool ResourceResponseBase::isSuccessful() const

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -137,6 +137,8 @@ public:
     WEBCORE_EXPORT String suggestedFilename() const;
     WEBCORE_EXPORT static String sanitizeSuggestedFilename(const String&);
 
+    bool isNosniff() const;
+
     WEBCORE_EXPORT void includeCertificateInfo(std::span<const std::byte> = { }) const;
     void setCertificateInfo(CertificateInfo&& info) { m_certificateInfo = WTFMove(info); }
     const std::optional<CertificateInfo>& certificateInfo() const { return m_certificateInfo; };

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -112,7 +112,7 @@ static void processResponse(Ref<Client>&& client, Expected<Ref<FetchResponse>, s
     // In case of main resource and mime type is the default one, we set it to text/html to pass more service worker WPT tests.
     // FIXME: We should refine our MIME type sniffing strategy for synthetic responses.
     if (mode == FetchOptions::Mode::Navigate) {
-        if (resourceResponse.mimeType() == defaultMIMEType()) {
+        if (resourceResponse.mimeType() == defaultMIMEType() && !resourceResponse.isNosniff()) {
             resourceResponse.setMimeType("text/html"_s);
             resourceResponse.setTextEncodingName("UTF-8"_s);
         }


### PR DESCRIPTION
#### 06ef057f2ff284fb423686bf51c418322f11f1d4
<pre>
Stop guessing the content type if there&apos;s X-Content-Type-Options: nosniff header.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280714">https://bugs.webkit.org/show_bug.cgi?id=280714</a>
<a href="https://rdar.apple.com/131857015">rdar://131857015</a>

Reviewed by Chris Dumez.

Respect the site&apos;s policy not to sniff the content. If the server sends the X-Content-Type-Options: nosniff header,
we should not replace the content type to text/html if it is application/octet-stream.

* LayoutTests/http/tests/workers/service/resources/download-octet-stream.py: Added.
* LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https-expected.txt: Added.
* LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html: Added.
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::isScriptAllowedByNosniff):
(WebCore::ResourceResponseBase::isNosniff const):
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::processResponse):

Canonical link: <a href="https://commits.webkit.org/284615@main">https://commits.webkit.org/284615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7abec057d98c9a6961c45052fc334ca7a57963ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22735 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21140 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72099 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20991 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55534 "Found 1 new test failure: http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14012 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17782 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75782 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17362 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63225 "Found 1 new test failure: http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15526 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4790 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46260 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47531 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->