### PR TITLE
[WebGPU] 284345@main results in pipeline overrides failing to be computed in some sites

### DIFF
--- a/Source/WebGPU/WGSL/CompilationScope.cpp
+++ b/Source/WebGPU/WGSL/CompilationScope.cpp
@@ -33,12 +33,14 @@ namespace WGSL {
 CompilationScope::CompilationScope(ShaderModule& shaderModule)
     : m_shaderModule(shaderModule)
     , m_builderState(shaderModule.astBuilder().saveCurrentState())
+    , m_replacementsSize(shaderModule.currentReplacementSize())
 {
 }
 
 CompilationScope::CompilationScope(CompilationScope&& other)
     : m_shaderModule(other.m_shaderModule)
     , m_builderState(other.m_builderState)
+    , m_replacementsSize(other.m_replacementsSize)
 {
     other.m_invalidated = true;
 }
@@ -47,7 +49,7 @@ CompilationScope::~CompilationScope()
 {
     if (m_invalidated)
         return;
-    m_shaderModule.revertReplacements();
+    m_shaderModule.revertReplacements(m_replacementsSize);
     m_shaderModule.astBuilder().restore(WTFMove(m_builderState));
 }
 

--- a/Source/WebGPU/WGSL/CompilationScope.h
+++ b/Source/WebGPU/WGSL/CompilationScope.h
@@ -41,6 +41,7 @@ private:
     bool m_invalidated { false };
     ShaderModule& m_shaderModule;
     AST::Builder::State m_builderState;
+    size_t m_replacementsSize;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -79,6 +79,7 @@ std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const
     RUN_PASS(buildCallGraph, shaderModule);
     CHECK_PASS(validateIO, shaderModule);
     CHECK_PASS(validateVisibility, shaderModule);
+    RUN_PASS(mangleNames, shaderModule);
 
     Vector<Warning> warnings { };
     return std::variant<SuccessfulCheck, FailedCheck>(std::in_place_type<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));
@@ -104,7 +105,6 @@ inline std::variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule
 
         HashMap<String, Reflection::EntryPointInformation> entryPoints;
 
-        RUN_PASS(mangleNames, shaderModule);
         RUN_PASS(insertBoundsChecks, shaderModule);
         RUN_PASS(rewritePointers, shaderModule);
         RUN_PASS(rewriteEntryPoints, shaderModule, pipelineLayouts);

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -251,11 +251,18 @@ public:
         vector.clear();
     }
 
-    void revertReplacements()
+    size_t currentReplacementSize() const
     {
-        for (int i = m_replacements.size() - 1; i >= 0; --i)
+        return m_replacements.size();
+    }
+
+    void revertReplacements(size_t limit)
+    {
+        if (m_replacements.size() == limit)
+            return;
+        for (size_t i = m_replacements.size() - 1; i >= limit; --i)
             m_replacements[i]();
-        m_replacements.clear();
+        m_replacements.shrinkCapacity(limit);
     }
 
     OptionSet<Extension>& enabledExtensions() { return m_enabledExtensions; }

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -55,9 +55,9 @@ class ShaderModule : public WGPUShaderModuleImpl, public RefCounted<ShaderModule
 
     using CheckResult = std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck, std::monostate>;
 public:
-    static Ref<ShaderModule> create(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&& checkResult, HashMap<String, Ref<PipelineLayout>>&& pipelineLayoutHints, HashMap<String, WGSL::Reflection::EntryPointInformation>&& entryPointInformation, id<MTLLibrary> library, NSMutableSet<NSString *> *originalOverrideNames, HashMap<String, String>&& originalFunctionNames, Device& device)
+    static Ref<ShaderModule> create(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&& checkResult, HashMap<String, Ref<PipelineLayout>>&& pipelineLayoutHints, HashMap<String, WGSL::Reflection::EntryPointInformation>&& entryPointInformation, id<MTLLibrary> library, Device& device)
     {
-        return adoptRef(*new ShaderModule(WTFMove(checkResult), WTFMove(pipelineLayoutHints), WTFMove(entryPointInformation), library, originalOverrideNames, WTFMove(originalFunctionNames), device));
+        return adoptRef(*new ShaderModule(WTFMove(checkResult), WTFMove(pipelineLayoutHints), WTFMove(entryPointInformation), library, device));
     }
     static Ref<ShaderModule> createInvalid(Device& device, CheckResult&& checkResult = std::monostate { })
     {
@@ -95,7 +95,6 @@ public:
     using FragmentInputs = VertexOutputs;
     const FragmentOutputs* fragmentReturnTypeForEntryPoint(const String&) const;
     const FragmentInputs* fragmentInputsForEntryPoint(const String&) const;
-    bool hasOverride(const String&) const;
     const VertexStageIn* stageInTypesForEntryPoint(const String&) const;
     const VertexOutputs* vertexReturnTypeForEntryPoint(const String&) const;
     bool usesFrontFacingInInput(const String&) const;
@@ -105,7 +104,7 @@ public:
     bool usesFragDepth(const String&) const;
 
 private:
-    ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&&, HashMap<String, Ref<PipelineLayout>>&&, HashMap<String, WGSL::Reflection::EntryPointInformation>&&, id<MTLLibrary>, NSMutableSet<NSString *> *, HashMap<String, String>&&, Device&);
+    ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&&, HashMap<String, Ref<PipelineLayout>>&&, HashMap<String, WGSL::Reflection::EntryPointInformation>&&, id<MTLLibrary>, Device&);
     ShaderModule(Device&, CheckResult&&);
 
     CheckResult convertCheckResult(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&&);
@@ -132,8 +131,6 @@ private:
     String m_defaultFragmentEntryPoint;
     String m_defaultComputeEntryPoint;
 
-    NSMutableSet<NSString *> *m_originalOverrideNames { nil };
-    const HashMap<String, String> m_originalFunctionNames;
     struct ShaderModuleState {
         bool usesFrontFacingInInput { false };
         bool usesSampleIndexInInput { false };


### PR DESCRIPTION
#### 3e2281f1f1343a8990caa3b49ef98560b09224de
<pre>
[WebGPU] 284345@main results in pipeline overrides failing to be computed in some sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=280739">https://bugs.webkit.org/show_bug.cgi?id=280739</a>
<a href="https://rdar.apple.com/137104174">rdar://137104174</a>

Reviewed by Mike Wyrzykowski.

After we started storing overrides by their mangled name some of the samples were
broken. That was due to trying to resolve the overrides used for the `@workgroup_size`
attribute, which contained unmangled identifiers. To fix this, we run the mangling
pass right after type checking, and from that point on always refer to mangled names.

* Source/WebGPU/WGSL/CompilationScope.cpp:
(WGSL::CompilationScope::CompilationScope):
(WGSL::CompilationScope::~CompilationScope):
* Source/WebGPU/WGSL/CompilationScope.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
(WGSL::prepareImpl):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::currentReplacementSize const):
(WGSL::ShaderModule::revertReplacements):
* Source/WebGPU/WebGPU/ShaderModule.h:
(WebGPU::ShaderModule::create):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):
(WebGPU::handleShaderSuccessOrFailure):
(WebGPU::Device::createShaderModule):
(WebGPU::ShaderModule::ShaderModule):
(WebGPU::ShaderModule::fragmentInputsForEntryPoint const):
(WebGPU::ShaderModule::fragmentReturnTypeForEntryPoint const):
(WebGPU::ShaderModule::vertexReturnTypeForEntryPoint const):
(WebGPU::ShaderModule::stageInTypesForEntryPoint const):
(WebGPU::ShaderModule::entryPointInformation const):
(WebGPU::ShaderModule::hasOverride const): Deleted.

Canonical link: <a href="https://commits.webkit.org/284606@main">https://commits.webkit.org/284606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9120adc5527e3650b6efa8427f05b678434d65ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21037 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13949 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41565 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75679 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63165 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63096 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4723 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45083 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->