### PR TITLE
[web-animations] Remove CSSNumberishTime::m_source

### DIFF
--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -72,12 +72,10 @@ public:
 
 private:
     enum class Type : uint8_t { Unknown, Time, Percentage };
-    enum class Source : uint8_t { Literal, Number, Milliseconds, Seconds, Percentage };
 
-    CSSNumberishTime(Type, Source, double);
+    CSSNumberishTime(Type, double);
 
     Type m_type { Type::Unknown };
-    Source m_source { Source::Literal };
     double m_value { 0 };
 };
 


### PR DESCRIPTION
#### a4246098d3f64787e32dbfb569641fe2c30b6000
<pre>
[web-animations] Remove CSSNumberishTime::m_source
<a href="https://bugs.webkit.org/show_bug.cgi?id=280771">https://bugs.webkit.org/show_bug.cgi?id=280771</a>
<a href="https://rdar.apple.com/137137691">rdar://137137691</a>

Reviewed by Dean Jackson.

We have `CSSNumberishTime::m_source` for the purpose of serialization,
but it&apos;s not actually needed since times always serialize to a `double` form.

* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::CSSNumberishTime):
(WebCore::CSSNumberishTime::operator+ const):
(WebCore::CSSNumberishTime::operator- const):
(WebCore::CSSNumberishTime::operator* const):
(WebCore::CSSNumberishTime::operator/ const):
(WebCore::CSSNumberishTime::operator CSSNumberish const):
(WebCore::CSSNumberishTime::dump const):
* Source/WebCore/animation/CSSNumberishTime.h:

Canonical link: <a href="https://commits.webkit.org/284598@main">https://commits.webkit.org/284598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad6b090e117836c8097bc6c08c86f67ba36eb0d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55480 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63167 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63099 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4721 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10677 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45086 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->