### PR TITLE
Adopt more smart pointers in UIProcess (part 1)

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -277,6 +277,8 @@ private:
     bool m_mockVideoPresentationModeEnabled { false };
     WebCore::FloatSize m_mockPictureInPictureWindowSize { DefaultMockPictureInPictureWindowWidth, DefaultMockPictureInPictureWindowHeight };
 
+    Ref<PlaybackSessionManagerProxy> protectedPlaybackSessionManagerProxy() const;
+
     WeakPtr<WebPageProxy> m_page;
     Ref<PlaybackSessionManagerProxy> m_playbackSessionManagerProxy;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -110,7 +110,7 @@ void WebExtensionContext::actionSetTitle(std::optional<WebExtensionWindowIdentif
         return;
     }
 
-    action.value()->setLabel(title);
+    Ref { action.value() }->setLabel(title);
 
     completionHandler({ });
 }
@@ -126,16 +126,18 @@ void WebExtensionContext::actionSetIcon(std::optional<WebExtensionWindowIdentifi
     }
 
     id parsedIcons = parseJSON(iconsJSON, JSONOptions::FragmentsAllowed);
+    Ref webExtensionAction = action.value();
+
     if (auto *dictionary = dynamic_objc_cast<NSDictionary>(parsedIcons))
-        action.value()->setIcons(dictionary);
+        webExtensionAction->setIcons(dictionary);
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     else if (auto *array = dynamic_objc_cast<NSArray>(parsedIcons))
-        action.value()->setIconVariants(array);
+        webExtensionAction->setIconVariants(array);
 #endif
     else {
-        action.value()->setIcons(nil);
+        webExtensionAction->setIcons(nil);
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-        action.value()->setIconVariants(nil);
+        webExtensionAction->setIconVariants(nil);
 #endif
     }
 
@@ -165,7 +167,7 @@ void WebExtensionContext::actionSetPopup(std::optional<WebExtensionWindowIdentif
         return;
     }
 
-    action.value()->setPopupPath(popupPath);
+    Ref { action.value() }->setPopupPath(popupPath);
 
     completionHandler({ });
 }
@@ -252,7 +254,7 @@ void WebExtensionContext::actionSetBadgeText(std::optional<WebExtensionWindowIde
         return;
     }
 
-    action.value()->setBadgeText(text);
+    Ref { action.value() }->setBadgeText(text);
 
     completionHandler({ });
 }
@@ -278,7 +280,7 @@ void WebExtensionContext::actionSetEnabled(std::optional<WebExtensionTabIdentifi
         return;
     }
 
-    action.value()->setEnabled(enabled);
+    Ref { action.value() }->setEnabled(enabled);
 
     completionHandler({ });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -212,7 +212,7 @@ void WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText(boo
     saveShouldDisplayBlockedResourceCountAsBadgeText(displayActionCountAsBadgeText);
     if (!displayActionCountAsBadgeText) {
         for (auto entry : m_actionTabMap)
-            entry.value->clearBlockedResourceCount();
+            Ref { entry.value }->clearBlockedResourceCount();
     }
 
     completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -386,7 +386,7 @@ void WebExtensionController::removePage(WebPageProxy& page)
     ASSERT(m_pages.contains(page));
     m_pages.remove(page);
 
-    Ref pool = page.configuration().processPool();
+    Ref pool = page.protectedConfiguration()->processPool();
     removeProcessPool(pool);
 
     Ref dataStore = page.websiteDataStore();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -92,7 +92,7 @@ WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses(
 {
     WebProcessProxySet processes;
     for (Ref page : m_pages)
-        processes.add(page->legacyMainFrameProcess());
+        processes.add(page->protectedLegacyMainFrameProcess());
     return processes;
 }
 

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -38,14 +38,17 @@ public:
         : m_page(page)
         , m_process(process)
     {
-        m_process->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
+        protectedProcess()->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
     }
     ~RemotePageVisitedLinkStoreRegistration()
     {
         if (RefPtr page = m_page.get())
-            m_process->removeVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());
+            protectedProcess()->removeVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());
     }
+
 private:
+    Ref<WebProcessProxy> protectedProcess() const { return m_process; }
+
     WeakPtr<WebPageProxy> m_page;
     Ref<WebProcessProxy> m_process;
 };

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -102,7 +102,7 @@ void VisitedLinkStore::removeAll()
 
 void VisitedLinkStore::addVisitedLinkHashFromPage(WebPageProxyIdentifier pageProxyID, SharedStringHash linkHash)
 {
-    if (auto page = WebProcessProxy::webPage(pageProxyID)) {
+    if (RefPtr page = WebProcessProxy::webPage(pageProxyID)) {
         if (!page || !page->addsVisitedLinks())
             return;
     }
@@ -130,13 +130,13 @@ void VisitedLinkStore::didUpdateSharedStringHashes(const Vector<WebCore::SharedS
 {
     ASSERT(!addedHashes.isEmpty() || !removedHashes.isEmpty());
 
-    for (auto& process : m_processes) {
-        ASSERT(process.processPool().processes().containsIf([&](auto& item) { return item.ptr() == &process; }));
+    for (Ref process : m_processes) {
+        ASSERT(process->processPool().processes().containsIf([&](auto& item) { return item.ptr() == process.ptr(); }));
 
         if (addedHashes.size() > 20 || !removedHashes.isEmpty())
-            process.send(Messages::VisitedLinkTableController::AllVisitedLinkStateChanged(), identifier());
+            process->send(Messages::VisitedLinkTableController::AllVisitedLinkStateChanged(), identifier());
         else
-            process.send(Messages::VisitedLinkTableController::VisitedLinkStateChanged(addedHashes), identifier());
+            process->send(Messages::VisitedLinkTableController::VisitedLinkStateChanged(addedHashes), identifier());
     }
 }
 

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -145,7 +145,7 @@ void WebGeolocationManagerProxy::startUpdatingWithProxy(WebProcessProxy& proxy, 
     RefPtr page = WebProcessProxy::webPage(pageProxyID);
     MESSAGE_CHECK(proxy.connection(), !!page);
 
-    auto isValidAuthorizationToken = page->geolocationPermissionRequestManager().isValidAuthorizationToken(authorizationToken);
+    auto isValidAuthorizationToken = page->protectedGeolocationPermissionRequestManager()->isValidAuthorizationToken(authorizationToken);
     MESSAGE_CHECK(proxy.connection(), isValidAuthorizationToken);
 
     auto& perDomainData = *m_perDomainData.ensure(registrableDomain, [] {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14795,6 +14795,11 @@ GeolocationPermissionRequestManagerProxy& WebPageProxy::geolocationPermissionReq
     return internals().geolocationPermissionRequestManager;
 }
 
+Ref<GeolocationPermissionRequestManagerProxy> WebPageProxy::protectedGeolocationPermissionRequestManager()
+{
+    return geolocationPermissionRequestManager();
+}
+
 ScrollPinningBehavior WebPageProxy::scrollPinningBehavior() const
 {
     return internals().scrollPinningBehavior;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -669,6 +669,7 @@ public:
     RefPtr<WebInspectorUIProxy> protectedInspector() const;
 
     GeolocationPermissionRequestManagerProxy& geolocationPermissionRequestManager();
+    Ref<GeolocationPermissionRequestManagerProxy> protectedGeolocationPermissionRequestManager();
 
     void resourceLoadDidSendRequest(ResourceLoadInfo&&, WebCore::ResourceRequest&&);
     void resourceLoadDidPerformHTTPRedirection(ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&);


### PR DESCRIPTION
#### de9684148c23921b360994695679f21f92175579
<pre>
Adopt more smart pointers in UIProcess (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280770">https://bugs.webkit.org/show_bug.cgi?id=280770</a>
<a href="https://rdar.apple.com/137137674">rdar://137137674</a>

Reviewed by Timothy Hatcher.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
(WebKit::VideoPresentationManagerProxy::removeClientForContext):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::setVideoDimensions):
(WebKit::VideoPresentationManagerProxy::protectedPlaybackSessionManagerProxy const):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::actionSetTitle):
(WebKit::WebExtensionContext::actionSetIcon):
(WebKit::WebExtensionContext::actionSetPopup):
(WebKit::WebExtensionContext::actionSetBadgeText):
(WebKit::WebExtensionContext::actionSetEnabled):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::injectedContents const):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::corsDisablingPatterns):
(WebKit::WebExtensionContext::addInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::removePage):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::allProcesses const):
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h:
(WebKit::RemotePageVisitedLinkStoreRegistration::RemotePageVisitedLinkStoreRegistration):
(WebKit::RemotePageVisitedLinkStoreRegistration::~RemotePageVisitedLinkStoreRegistration):
(WebKit::RemotePageVisitedLinkStoreRegistration::protectedProcess const):
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::addVisitedLinkHashFromPage):
(WebKit::VisitedLinkStore::didUpdateSharedStringHashes):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::startUpdatingWithProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::protectedGeolocationPermissionRequestManager):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/284590@main">https://commits.webkit.org/284590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca0b7ae9156c1bd97ee885a1149423b30a63f8fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21048 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55484 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13955 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41575 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63172 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63104 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15518 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4728 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45094 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->