### PR TITLE
[web-animations] make all CSSNumberishTime parameters const references

### DIFF
--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -38,7 +38,7 @@ CSSNumberishTime::CSSNumberishTime(double value)
 {
 }
 
-CSSNumberishTime::CSSNumberishTime(Seconds value)
+CSSNumberishTime::CSSNumberishTime(const Seconds& value)
     : m_type(Type::Time)
     , m_value(value.seconds())
 {
@@ -50,7 +50,7 @@ CSSNumberishTime::CSSNumberishTime(Type type, double value)
 {
 }
 
-CSSNumberishTime::CSSNumberishTime(CSSNumberish value)
+CSSNumberishTime::CSSNumberishTime(const CSSNumberish& value)
 {
     if (auto* doubleValue = std::get_if<double>(&value)) {
         m_type = Type::Time;
@@ -99,13 +99,13 @@ bool CSSNumberishTime::isValid() const
     return m_type == Type::Time;
 }
 
-CSSNumberishTime CSSNumberishTime::operator+(CSSNumberishTime other) const
+CSSNumberishTime CSSNumberishTime::operator+(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return { m_type, m_value + other.m_value };
 }
 
-CSSNumberishTime CSSNumberishTime::operator-(CSSNumberishTime other) const
+CSSNumberishTime CSSNumberishTime::operator-(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return { m_type, m_value - other.m_value };
@@ -125,72 +125,72 @@ CSSNumberishTime& CSSNumberishTime::operator-=(const CSSNumberishTime& other)
     return *this;
 }
 
-bool CSSNumberishTime::operator<(CSSNumberishTime other) const
+bool CSSNumberishTime::operator<(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value < other.m_value;
 }
 
-bool CSSNumberishTime::operator<=(CSSNumberishTime other) const
+bool CSSNumberishTime::operator<=(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value <= other.m_value;
 }
 
-bool CSSNumberishTime::operator>(CSSNumberishTime other) const
+bool CSSNumberishTime::operator>(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value > other.m_value;
 }
 
-bool CSSNumberishTime::operator>=(CSSNumberishTime other) const
+bool CSSNumberishTime::operator>=(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     return m_value >= other.m_value;
 }
 
-bool CSSNumberishTime::operator==(CSSNumberishTime other) const
+bool CSSNumberishTime::operator==(const CSSNumberishTime& other) const
 {
     return m_type == other.m_type && m_value == other.m_value;
 }
 
-CSSNumberishTime CSSNumberishTime::operator+(Seconds other) const
+CSSNumberishTime CSSNumberishTime::operator+(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return { m_type, m_value + other.seconds() };
 }
 
-CSSNumberishTime CSSNumberishTime::operator-(Seconds other) const
+CSSNumberishTime CSSNumberishTime::operator-(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return { m_type, m_value - other.seconds() };
 }
 
-bool CSSNumberishTime::operator<(Seconds other) const
+bool CSSNumberishTime::operator<(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value < other.seconds();
 }
 
-bool CSSNumberishTime::operator<=(Seconds other) const
+bool CSSNumberishTime::operator<=(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value <= other.seconds();
 }
 
-bool CSSNumberishTime::operator>(Seconds other) const
+bool CSSNumberishTime::operator>(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value > other.seconds();
 }
 
-bool CSSNumberishTime::operator>=(Seconds other) const
+bool CSSNumberishTime::operator>=(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return m_value >= other.seconds();
 }
 
-bool CSSNumberishTime::operator==(Seconds other) const
+bool CSSNumberishTime::operator==(const Seconds& other) const
 {
     return m_type == Type::Time && m_value == other.seconds();
 }
@@ -237,7 +237,7 @@ void CSSNumberishTime::dump(TextStream& ts) const
     return;
 }
 
-TextStream& operator<<(TextStream& ts, CSSNumberishTime value)
+TextStream& operator<<(TextStream& ts, const CSSNumberishTime& value)
 {
     value.dump(ts);
     return ts;

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -35,31 +35,31 @@ public:
     CSSNumberishTime() = default;
 
     CSSNumberishTime(double);
-    CSSNumberishTime(Seconds);
-    CSSNumberishTime(CSSNumberish);
+    CSSNumberishTime(const Seconds&);
+    CSSNumberishTime(const CSSNumberish&);
 
     std::optional<Seconds> time() const;
     std::optional<double> percentage() const;
 
     bool isValid() const;
 
-    CSSNumberishTime operator+(CSSNumberishTime) const;
-    CSSNumberishTime operator-(CSSNumberishTime) const;
+    CSSNumberishTime operator+(const CSSNumberishTime&) const;
+    CSSNumberishTime operator-(const CSSNumberishTime&) const;
     CSSNumberishTime& operator+=(const CSSNumberishTime&);
     CSSNumberishTime& operator-=(const CSSNumberishTime&);
-    bool operator<(CSSNumberishTime) const;
-    bool operator<=(CSSNumberishTime) const;
-    bool operator>(CSSNumberishTime) const;
-    bool operator>=(CSSNumberishTime) const;
-    bool operator==(CSSNumberishTime) const;
+    bool operator<(const CSSNumberishTime&) const;
+    bool operator<=(const CSSNumberishTime&) const;
+    bool operator>(const CSSNumberishTime&) const;
+    bool operator>=(const CSSNumberishTime&) const;
+    bool operator==(const CSSNumberishTime&) const;
 
-    CSSNumberishTime operator+(Seconds) const;
-    CSSNumberishTime operator-(Seconds) const;
-    bool operator<(Seconds) const;
-    bool operator<=(Seconds) const;
-    bool operator>(Seconds) const;
-    bool operator>=(Seconds) const;
-    bool operator==(Seconds) const;
+    CSSNumberishTime operator+(const Seconds&) const;
+    CSSNumberishTime operator-(const Seconds&) const;
+    bool operator<(const Seconds&) const;
+    bool operator<=(const Seconds&) const;
+    bool operator>(const Seconds&) const;
+    bool operator>=(const Seconds&) const;
+    bool operator==(const Seconds&) const;
 
     CSSNumberishTime operator*(double) const;
     CSSNumberishTime operator/(double) const;
@@ -79,6 +79,6 @@ private:
     double m_value { 0 };
 };
 
-TextStream& operator<<(TextStream&, CSSNumberishTime);
+TextStream& operator<<(TextStream&, const CSSNumberishTime&);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 10bed2a6ce97a18bbe4ca6f21516c77300c97d81
<pre>
[web-animations] make all CSSNumberishTime parameters const references
<a href="https://bugs.webkit.org/show_bug.cgi?id=280776">https://bugs.webkit.org/show_bug.cgi?id=280776</a>
<a href="https://rdar.apple.com/137146436">rdar://137146436</a>

Reviewed by Dean Jackson.

Sometimes we use non-const values and sometimes we use `const` references
throughout the `CSSNumberishTime` functions. Let&apos;s settle on the latter.

* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::CSSNumberishTime):
(WebCore::CSSNumberishTime::operator+ const):
(WebCore::CSSNumberishTime::operator- const):
(WebCore::CSSNumberishTime::operator&lt; const):
(WebCore::CSSNumberishTime::operator&lt;= const):
(WebCore::CSSNumberishTime::operator&gt; const):
(WebCore::CSSNumberishTime::operator&gt;= const):
(WebCore::CSSNumberishTime::operator== const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/animation/CSSNumberishTime.h:

Canonical link: <a href="https://commits.webkit.org/284599@main">https://commits.webkit.org/284599@main</a>
</pre>
