### PR TITLE
Rename KeyboardScrollingAnimator::rubberbandableDirections() to KeyboardScrollingAnimator::scrollingDirections()

### DIFF
--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -169,7 +169,7 @@ float KeyboardScrollingAnimator::scrollDistance(ScrollDirection direction, Scrol
     return step;
 }
 
-RectEdges<bool> KeyboardScrollingAnimator::rubberbandableDirections() const
+RectEdges<bool> KeyboardScrollingAnimator::scrollingDirections() const
 {
     RectEdges<bool> edges;
 
@@ -214,7 +214,7 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
     if (m_scrollTriggeringKeyIsPressed)
         return true;
 
-    if (!rubberbandableDirections().at(boxSideForDirection(direction)))
+    if (!scrollingDirections().at(boxSideForDirection(direction)))
         return false;
 
     if (granularity == ScrollGranularity::Document || (!isKeyRepeat && granularity == ScrollGranularity::Page)) {

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -66,7 +66,7 @@ public:
 private:
     std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection, ScrollGranularity) const;
     float scrollDistance(ScrollDirection, ScrollGranularity) const;
-    RectEdges<bool> rubberbandableDirections() const;
+    RectEdges<bool> scrollingDirections() const;
 
     ScrollableArea& m_scrollableArea;
     bool m_scrollTriggeringKeyIsPressed { false };


### PR DESCRIPTION
#### d762e9feb74c8540b187a2cf823a0f68becc6c9a
<pre>
Rename KeyboardScrollingAnimator::rubberbandableDirections() to KeyboardScrollingAnimator::scrollingDirections()
<a href="https://bugs.webkit.org/show_bug.cgi?id=280777">https://bugs.webkit.org/show_bug.cgi?id=280777</a>
<a href="https://rdar.apple.com/137147372">rdar://137147372</a>

Reviewed by Richard Robinson.

rubberBandableDirections in KeyboardScrollingAnimator does not control rubber banding.
It actually controls regular scrollable directions.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::scrollingDirections const):
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
(WebCore::KeyboardScrollingAnimator::rubberbandableDirections const): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.h:

Canonical link: <a href="https://commits.webkit.org/284634@main">https://commits.webkit.org/284634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8efba899c8f2954e1553dd35a2ec5d8e1f1f92f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55490 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75704 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17307 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63179 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/scale-and-rotate-both-specified-on-animation-keyframes.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-clip-path.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4737 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45108 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->