### PR TITLE
Avoid hit-testing to clipped regions of the selection highlight when SelectionHonorsOverflowScrolling is enabled

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller.html
+++ b/LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller-expected.txt
@@ -1,0 +1,19 @@
+Verifies that the selection highlight is clipped to overflow scrolling container. Select all the text in the scrollable container below, scroll the container to the top, and then tap the button. Verify that a click event is dispatched on the button
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+1. Select all of the below text
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.
+
+You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.
+
+Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.
+
+
+2. Then tap here
+PASS Selected text
+PASS handledClick became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller.html
+++ b/LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+#target {
+    border: 1px solid tomato;
+    padding: 3px;
+    font-size: 24px;
+}
+
+.scrollable {
+    width: 300px;
+    height: 150px;
+    border: solid 1px lightgray;
+    border-radius: 4px;
+    box-sizing: border-box;
+    overflow-y: scroll;
+    line-height: 1.5em;
+    outline: none;
+    padding: 1em;
+}
+
+button {
+    font-size: 18px;
+    padding: 0.5em;
+    border: 0.5px solid lightgray;
+    border-radius: 6px;
+    background-color: white;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+handledClick = false;
+
+addEventListener("load", async () => {
+    let button = document.querySelector("button");
+    let scroller = document.querySelector(".scrollable");
+
+    description("Verifies that the selection highlight is clipped to overflow scrolling container. Select all the text in the scrollable container below, scroll the container to the top, and then tap the button. Verify that a click event is dispatched on the button");
+    button.addEventListener("click", () => {
+        handledClick = true;
+    });
+
+    await UIHelper.longPressElement(document.querySelector(".scrollable"));
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Selected text");
+
+    getSelection().selectAllChildren(scroller);
+    await UIHelper.ensureStablePresentationUpdate();
+
+    await UIHelper.activateElement(button);
+    await shouldBecomeEqual("handledClick", "true");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="description"></div>
+    <div class="scrollable">
+        <strong>1. Select all of the below text</strong>
+        <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+        <p>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.</p>
+        <p>Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+    </div>
+    <br>
+    <div><button>2. Then tap here</button></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -53,6 +53,7 @@
 @end
 
 @interface UIView (WebKitInternal)
+- (BOOL)_wk_isAncestorOf:(UIView *)child;
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
 @end
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -219,6 +219,15 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 @implementation UIView (WebKitInternal)
 
+- (BOOL)_wk_isAncestorOf:(UIView *)child
+{
+    for (RetainPtr parent = [child superview]; parent; parent = [parent superview]) {
+        if (parent == self)
+            return YES;
+    }
+    return NO;
+}
+
 - (UIViewController *)_wk_viewControllerForFullScreenPresentation
 {
     auto controller = self.window.rootViewController;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5613,6 +5613,11 @@ void WebPage::computeSelectionClipRectAndEnclosingScroller(EditorState& state, c
     if (!state.isContentEditable && selection.isCaret())
         return;
 
+    if (!m_selectionHonorsOverflowScrolling) {
+        state.visualData->selectionClipRect = editableRootBounds;
+        return;
+    }
+
     ScrollingNodeID enclosingScrollingNodeID;
     IntRect enclosingScrollingClipRect;
     IntRect innerScrollingClipRect;
@@ -5631,17 +5636,6 @@ void WebPage::computeSelectionClipRectAndEnclosingScroller(EditorState& state, c
 
     if (enclosingScrollingNodeID)
         state.visualData->enclosingScrollingNodeID = { WTFMove(enclosingScrollingNodeID) };
-
-    if (!m_selectionHonorsOverflowScrolling) {
-        state.visualData->selectionClipRect = editableRootBounds;
-        if (!enclosingScrollingClipRect.isEmpty()) {
-            if (state.visualData->selectionClipRect.isEmpty())
-                state.visualData->selectionClipRect = enclosingScrollingClipRect;
-            else
-                state.visualData->selectionClipRect.intersect(enclosingScrollingClipRect);
-        }
-        return;
-    }
 
     if (!innerScrollingClipRect.isEmpty()) {
         // We need to clip the selection to the inner scroller, even if that scroller does not have a

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -204,7 +204,7 @@ private:
 
     int64_t pasteboardChangeCount() const final;
 
-    void clipSelectionViewRectToContentView(CGRect&) const;
+    CGRect selectionViewBoundsClippedToContentView(UIView *, std::optional<CGRect>&& = std::nullopt) const;
 
     JSRetainPtr<JSStringRef> scrollbarStateForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID, bool) const override;
 


### PR DESCRIPTION
#### f53873bd7d834857bf3994606867d863fcd6b575
<pre>
Avoid hit-testing to clipped regions of the selection highlight when SelectionHonorsOverflowScrolling is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280778">https://bugs.webkit.org/show_bug.cgi?id=280778</a>
<a href="https://rdar.apple.com/137126898">rdar://137126898</a>

Reviewed by Abrar Rahman Protyasha.

Currently, when `SelectionHonorsOverflowScrolling` is enabled, a tap inside of the selection bounds
in root view coordinates ignores overflow clipping. This means that if the selection is clipped and
inside of a subscrollable region, it&apos;s possible to tap outside of the subscrollable region and
toggle the edit menu visibility instead of handling the tap as a synthetic click.

To fix this, we adjust `-_pointIsInsideSelectionRect:outBoundingRect:` to take text selection
highlights inside subscrollable regions into account, and return `NO` in this case. See below for
more details.

* LayoutTests/editing/selection/ios/selection-clip-rect-in-overflow-scroller.html:

Adjust this existing test to enable `SelectionHonorsOverflowScrolling`, now that we no longer set a
selection clip rect when `m_selectionHonorsOverflowScrolling` is `false`.

* LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller.html: Added.

Add a new layout test to exercise this fix by setting a clipped selection inside of an overflow
scroller, and verifying that it&apos;s possible to tap (i.e. fire the `click` event over) a button that
would otherwise be covered by the selection view if it were parented underneath the root view.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_isAncestorOf:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _pointIsInsideSelectionRect:outBoundingRect:]):

Implement the main fix here — in the case where `pointIsInSelectionRect` is `YES` (i.e. the
selection rects in root view coordinates contains the point), additionally use `-hitTest:withEvent:`
to check whether the tap actually hit-tests to content that is in the same scroll view as the
selection. In the case described above, for example, this would hit-test to the content view&apos;s
`_interactionViewsContainerView` instead of a child scroll view containing the selection.

(-[WKContentView _selectionContainerScrollView]):
(-[WKContentView _selectionContainerViewInternal]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeSelectionClipRectAndEnclosingScroller const):

When `SelectionHonorsOverflowScrolling` is disabled, don&apos;t attempt to set a selection clip rect.
While this results in a visually clipped selection rect, hit-testing is still broken because it
doesn&apos;t take selection clipping into account.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(-[UIScrollView _wtr_visibleBoundsInCoordinateSpace:]):
(WTR::UIScriptControllerIOS::selectionViewBoundsClippedToContentView const):
(WTR::UIScriptControllerIOS::selectionStartGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionCaretViewRect const):
(WTR::UIScriptControllerIOS::selectionRangeViewRects const):
(WTR::UIScriptControllerIOS::clipSelectionViewRectToContentView const): Deleted.

Teach `UIScriptController`&apos;s selection geometry getters to handle the case where the selection is in
a subscrollable region, and `SelectionHonorsOverflowScrolling` is enabled. Since we (may) no longer
use `selectionClipRect` in this case, we need to instead return the part of the selection rect that
is visible to the user, accounting for child scrollers.

Canonical link: <a href="https://commits.webkit.org/284587@main">https://commits.webkit.org/284587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26d0165592a9024d2ee094bbf8a978f97a1ab382

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20910 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13962 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75701 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17304 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63109 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15516 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4736 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45105 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->