### PR TITLE
rememberthemilk.com: REGRESSION (280692@main): Clicking on the dropdown list doesn't expand to display its content

### DIFF
--- a/LayoutTests/fast/css/attribute-selector-for-style-inline-invalidation-expected.html
+++ b/LayoutTests/fast/css/attribute-selector-for-style-inline-invalidation-expected.html
@@ -1,0 +1,1 @@
+<div style="color: green">This is green</div>

--- a/LayoutTests/fast/css/attribute-selector-for-style-inline-invalidation.html
+++ b/LayoutTests/fast/css/attribute-selector-for-style-inline-invalidation.html
@@ -1,0 +1,10 @@
+<style>
+[style*="display: none;"] { display:block !important; color: green; }
+</style>
+<div id=t>This is green</div>
+<script>
+document.body.offsetTop;
+t.style.display = "block";
+document.body.offsetTop;
+t.style.display = "none";
+</script>

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -302,7 +302,7 @@ void ScopeRuleSets::collectFeatures() const
 
     m_customPropertyNamesInStyleContainerQueries = std::nullopt;
 
-    m_cachedHasComplexSelectorsForStyleAttribute = std::nullopt;
+    m_cachedSelectorsForStyleAttribute = std::nullopt;
 
     m_features.shrinkToFit();
 }
@@ -393,28 +393,23 @@ const HashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQue
     return *m_customPropertyNamesInStyleContainerQueries;
 }
 
-bool ScopeRuleSets::hasSelectorsForStyleAttribute() const
-{
-    return !!attributeInvalidationRuleSets(HTMLNames::styleAttr->localName());
-}
-
-bool ScopeRuleSets::hasComplexSelectorsForStyleAttribute() const
+SelectorsForStyleAttribute ScopeRuleSets::selectorsForStyleAttribute() const
 {
     auto compute = [&] {
         auto* ruleSets = attributeInvalidationRuleSets(HTMLNames::styleAttr->localName());
         if (!ruleSets)
-            return false;
+            return SelectorsForStyleAttribute::None;
         for (auto& ruleSet : *ruleSets) {
             if (ruleSet.matchElement != MatchElement::Subject)
-                return true;
+                return SelectorsForStyleAttribute::NonSubjectPosition;
         }
-        return false;
+        return SelectorsForStyleAttribute::SubjectPositionOnly;
     };
 
-    if (!m_cachedHasComplexSelectorsForStyleAttribute)
-        m_cachedHasComplexSelectorsForStyleAttribute = compute();
+    if (!m_cachedSelectorsForStyleAttribute)
+        m_cachedSelectorsForStyleAttribute = compute();
 
-    return *m_cachedHasComplexSelectorsForStyleAttribute;
+    return *m_cachedSelectorsForStyleAttribute;
 }
 
 bool ScopeRuleSets::hasMatchingUserOrAuthorStyle(const Function<bool(RuleSet&)>& predicate)

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -53,6 +53,8 @@ struct InvalidationRuleSet {
     IsNegation isNegation;
 };
 
+enum class SelectorsForStyleAttribute : uint8_t { None, SubjectPositionOnly, NonSubjectPosition };
+
 class ScopeRuleSets {
 public:
     ScopeRuleSets(Resolver&);
@@ -78,8 +80,7 @@ public:
 
     const HashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
 
-    bool hasSelectorsForStyleAttribute() const;
-    bool hasComplexSelectorsForStyleAttribute() const;
+    SelectorsForStyleAttribute selectorsForStyleAttribute() const;
 
     void setUsesSharedUserStyle(bool b) { m_usesSharedUserStyle = b; }
     void initializeUserStyle();
@@ -131,7 +132,7 @@ private:
 
     mutable std::optional<HashSet<AtomString>> m_customPropertyNamesInStyleContainerQueries;
 
-    mutable std::optional<bool> m_cachedHasComplexSelectorsForStyleAttribute;
+    mutable std::optional<SelectorsForStyleAttribute> m_cachedSelectorsForStyleAttribute;
 
     mutable unsigned m_defaultStyleVersionOnFeatureCollection { 0 };
     mutable unsigned m_userAgentMediaQueryRuleCountOnUpdate { 0 };


### PR DESCRIPTION
#### e4b32fa1e5ad36f902f1f65343186cb47db735c4
<pre>
rememberthemilk.com: REGRESSION (280692@main): Clicking on the dropdown list doesn&apos;t expand to display its content
<a href="https://bugs.webkit.org/show_bug.cgi?id=280787">https://bugs.webkit.org/show_bug.cgi?id=280787</a>
<a href="https://rdar.apple.com/136259655">rdar://136259655</a>

Reviewed by Alan Baradlay.

The page uses attribute selectors that query the value of the style attribute

[style*=&quot;display: none;&quot;].b-FS-n { display: block; … }

With the optimization implemented in 280692@main we fail to invalidate correctly when the
inline style is programmatically mutated, affecting the value of the style attribute.

* LayoutTests/fast/css/attribute-selector-for-style-inline-invalidation-expected.html: Added.
* LayoutTests/fast/css/attribute-selector-for-style-inline-invalidation.html: Added.
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::dirtyStyleAttribute):
(WebCore::StyledElement::invalidateStyleAttribute):

Uses normal element invalidation instead of optimized inline style one if we have any selectors targeting style attribute.

* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::collectFeatures const):
(WebCore::Style::ScopeRuleSets::selectorsForStyleAttribute const):

Unify the collection of style attribute selector data.

(WebCore::Style::ScopeRuleSets::hasSelectorsForStyleAttribute const): Deleted.
(WebCore::Style::ScopeRuleSets::hasComplexSelectorsForStyleAttribute const): Deleted.
* Source/WebCore/style/StyleScopeRuleSets.h:

Canonical link: <a href="https://commits.webkit.org/284588@main">https://commits.webkit.org/284588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7aebf5587b8c42aff23bfc2d59010a9765205127

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22682 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20938 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13972 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72995 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60317 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41615 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19464 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75729 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14154 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63126 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11145 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45133 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->