### PR TITLE
[css-scoping] Implement `:has-slotted` pseudo-class

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7776,11 +7776,7 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOn
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-stroke-width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing.html [ ImageOnlyFailure ]
 
-# has-slotted is not implemeneted - https://bugs.webkit.org/show_bug.cgi?id=280608
-imported/w3c/web-platform-tests/css/css-scoping/has-slotted-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/has-slotted-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/has-slotted-flattened-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/has-slotted-flattened-003.html [ ImageOnlyFailure ]
+# Functional form of :has-slotted() is not implemented.
 imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-001.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-004.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-006.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-changing-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-changing-001-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL empty node is blue assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
-FAIL setting innerHTML to whitespace invalidates and becomes green, then empty string becomes blue assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
-FAIL calling replaceChildren invalidates and becomes green, emptying with replaceChildren becomes blue assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
+PASS empty node is blue
+PASS setting innerHTML to whitespace invalidates and becomes green, then empty string becomes blue
+PASS calling replaceChildren invalidates and becomes green, emptying with replaceChildren becomes blue
 PASS calling append invalidates and becomes green
-FAIL calling replaceChildren(textnode) invalidates and becomes green assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
+PASS calling replaceChildren(textnode) invalidates and becomes green
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-changing-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-changing-002-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL empty node is blue assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
-FAIL manually assigning a text node is green, emptying assignment is blue assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
-FAIL manually assigning a Element is green, emptying assignment is blue assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 255, 0)"
+PASS empty node is blue
+PASS manually assigning a text node is green, emptying assignment is blue
+PASS manually assigning a Element is green, emptying assignment is blue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-changing-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-changing-001.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing content targetting :has-slotted(...) and :has-slotted through a single shadow root assert_equals: expected "rgb(0, 0,  255)" but got "rgb(0, 255, 0)"
+FAIL Changing content targetting :has-slotted(...) and :has-slotted through a single shadow root assert_equals: expected "rgb(0, 255, 0)" but got "rgb(0, 0, 255)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-changing-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-changing-003.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing content targetting :has-slotted(...) and :has-slotted through multiple shadow roots assert_equals: expected "rgb(0, 0,  255)" but got "rgb(0, 255, 0)"
+FAIL Changing content targetting :has-slotted(...) and :has-slotted through multiple shadow roots assert_equals: expected "rgb(0, 255, 0)" but got "rgb(0, 0, 255)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-manual-assignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-manual-assignment-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL :has-slotted does not match or querySelector with no manual assigned nodes ':has-slotted' is not a valid selector.
-FAIL :has-slotted does not match or querySelector with no manual assigned nodes - 2 ':has-slotted' is not a valid selector.
-FAIL :has-slotted does match when a child is manually assigned ':has-slotted' is not a valid selector.
-FAIL :has-slotted no longer matches when no children become manually assigned ':has-slotted' is not a valid selector.
+PASS :has-slotted does not match or querySelector with no manual assigned nodes
+PASS :has-slotted does not match or querySelector with no manual assigned nodes - 2
+PASS :has-slotted does match when a child is manually assigned
+PASS :has-slotted no longer matches when no children become manually assigned
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-query-selector-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-query-selector-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL :has-slotted does not match or querySelector when there are no assigned nodes ':has-slotted' is not a valid selector.
-FAIL :has-slotted must match/querySelector when an element is assigned ':has-slotted' is not a valid selector.
-FAIL :has-slotted does not when child nodes are replaced ':has-slotted' is not a valid selector.
-FAIL :has-slotted must match/querySelector when a text node is assigned ':has-slotted' is not a valid selector.
-FAIL :has-slotted does not match or querySelector when there are no assigned nodes (flattened) ':has-slotted' is not a valid selector.
-FAIL :has-slotted must match/querySelector when an element is assigned (flattened) ':has-slotted' is not a valid selector.
-FAIL :has-slotted does not when child nodes are replaced (flattened) ':has-slotted' is not a valid selector.
-FAIL :has-slotted must match/querySelector when a text node is assigned (flattened) ':has-slotted' is not a valid selector.
+PASS :has-slotted does not match or querySelector when there are no assigned nodes
+PASS :has-slotted must match/querySelector when an element is assigned
+PASS :has-slotted does not when child nodes are replaced
+PASS :has-slotted must match/querySelector when a text node is assigned
+PASS :has-slotted does not match or querySelector when there are no assigned nodes (flattened)
+PASS :has-slotted must match/querySelector when an element is assigned (flattened)
+PASS :has-slotted does not when child nodes are replaced (flattened)
+PASS :has-slotted must match/querySelector when a text node is assigned (flattened)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-slotted.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-slotted.tentative-expected.txt
@@ -17,7 +17,7 @@ FAIL ":has-slotted(foo) + :has-slotted(bar)" should be a valid selector ':has-sl
 FAIL ":not(:has-slotted(foo))" should be a valid selector ':not(:has-slotted(foo))' is not a valid selector.
 FAIL ":has-slotted(div + div)" should be a valid selector ':has-slotted(div + div)' is not a valid selector.
 FAIL ":has-slotted(div:has(> span))" should be a valid selector ':has-slotted(div:has(> span))' is not a valid selector.
-FAIL ":has-slotted" should be a valid selector ':has-slotted' is not a valid selector.
+PASS ":has-slotted" should be a valid selector
 PASS "::has-slotted(foo)" should be an invalid selector
 PASS ":has-slotted()" should be an invalid selector
 PASS ":has-slotted(0)" should be an invalid selector

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1205,6 +1205,20 @@ CSSFontVariantEmojiEnabled:
     WebCore:
       default: false
 
+CSSHasSlottedEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS :has-slotted pseudo class"
+  humanReadableDescription: "Enable the :has-slotted pseudo class on Slot elements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSInputSecurityEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -131,6 +131,9 @@
         "future": {
             "conditional": "ENABLE(VIDEO)"
         },
+        "has-slotted": {
+          "settings-flag": "cssHasSlottedEnabled"
+        },
         "has": {
             "argument": "required"
         },

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1136,7 +1136,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         case CSSSelector::PseudoClass::VolumeLocked:
             return matchesVolumeLockedPseudoClass(element);
 #endif
-
+        case CSSSelector::PseudoClass::HasSlotted:
+            return matchesHasSlottedPseudoClass(element);
         case CSSSelector::PseudoClass::Scope: {
             const Node* contextualReferenceNode = !checkingContext.scope ? element.document().documentElement() : checkingContext.scope.get();
             return &element == contextualReferenceNode;

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -263,6 +263,12 @@ ALWAYS_INLINE bool matchesDirPseudoClass(const Element& element, const AtomStrin
     return false;
 }
 
+ALWAYS_INLINE bool matchesHasSlottedPseudoClass(const Element& element)
+{
+    auto* slotElement = dynamicDowncast<HTMLSlotElement>(element);
+    return slotElement && slotElement->hasFlattenedSlottedContent();
+}
+
 ALWAYS_INLINE bool matchesReadOnlyPseudoClass(const Element& element)
 {
     return !element.matchesReadWritePseudoClass();

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -112,6 +112,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssAxisRelativePositionKeywordsEnabled { document.settings().cssAxisRelativePositionKeywordsEnabled() }
     , cssDynamicRangeLimitMixEnabled { document.settings().cssDynamicRangeLimitMixEnabled() }
     , cssConstrainedDynamicRangeLimitEnabled { document.settings().cssConstrainedDynamicRangeLimitEnabled() }
+    , cssHasSlottedEnabled { document.settings().cssHasSlottedEnabled() }
     , webkitMediaTextTrackDisplayQuirkEnabled { document.quirks().needsWebKitMediaTextTrackDisplayQuirk() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
@@ -151,7 +152,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssURLModifiersEnabled                    << 25
         | context.cssAxisRelativePositionKeywordsEnabled    << 26
         | context.cssDynamicRangeLimitMixEnabled            << 27
-        | context.cssConstrainedDynamicRangeLimitEnabled    << 28;
+        | context.cssConstrainedDynamicRangeLimitEnabled    << 28
+        | context.cssHasSlottedEnabled                      << 29;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -85,6 +85,7 @@ struct CSSParserContext {
     bool cssAxisRelativePositionKeywordsEnabled : 1 { false };
     bool cssDynamicRangeLimitMixEnabled : 1 { false };
     bool cssConstrainedDynamicRangeLimitEnabled : 1 { false };
+    bool cssHasSlottedEnabled : 1 { false };
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
 
     // Settings, those affecting properties.

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -35,6 +35,7 @@ namespace WebCore {
 
 CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
     : mode(context.mode)
+    , cssHasSlottedEnabled(context.cssHasSlottedEnabled)
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled(context.imageControlsEnabled)
 #endif
@@ -50,6 +51,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
 
 CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
+    , cssHasSlottedEnabled(document.settings().cssHasSlottedEnabled())
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled(document.settings().imageControlsEnabled())
 #endif
@@ -67,6 +69,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
 {
     add(hasher,
         context.mode,
+        context.cssHasSlottedEnabled,
 #if ENABLE(SERVICE_CONTROLS)
         context.imageControlsEnabled,
 #endif

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -36,6 +36,7 @@ class Document;
 
 struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
+    bool cssHasSlottedEnabled : 1 { false };
 #if ENABLE(SERVICE_CONTROLS)
     bool imageControlsEnabled : 1 { false };
 #endif

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -129,6 +129,7 @@ using PseudoClassesSet = UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<C
     v(operationMatchesModalPseudoClass) \
     v(operationMatchesHtmlDocumentPseudoClass) \
     v(operationMatchesActiveViewTransitionPseudoClass) \
+    v(operationMatchesHasSlottedPseudoClass) \
     v(operationIsUserInvalid) \
     v(operationIsUserValid) \
     v(operationAddStyleRelationFunction) \
@@ -239,6 +240,7 @@ static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsDefine
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFocusPseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFocusVisiblePseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFocusWithinPseudoClass, bool, (const Element&));
+static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesHasSlottedPseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsMediaDocument, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsInRange, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesIndeterminatePseudoClass, bool, (const Element&));
@@ -803,6 +805,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesEnabledPseudoClass, bool, (con
     return matchesEnabledPseudoClass(element);
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesHasSlottedPseudoClass, bool, (const Element& element))
+{
+    COUNT_SELECTOR_OPERATION(operationMatchesHasSlottedPseudoClass);
+    return matchesHasSlottedPseudoClass(element);
+}
+
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIsDefinedElement, bool, (const Element& element))
 {
     COUNT_SELECTOR_OPERATION(operationIsDefinedElement);
@@ -1080,6 +1088,9 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClass::FocusWithin:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusWithinPseudoClass));
+        return FunctionType::SimpleSelectorChecker;
+    case CSSSelector::PseudoClass::HasSlotted:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesHasSlottedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClass::InRange:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsInRange));

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -70,6 +70,7 @@
 #include "PointerEvent.h"
 #include "ProcessingInstruction.h"
 #include "ProgressEvent.h"
+#include "PseudoClassChangeInvalidation.h"
 #include "Quirks.h"
 #include "RenderBlock.h"
 #include "RenderBox.h"
@@ -1375,7 +1376,16 @@ void Node::setManuallyAssignedSlot(HTMLSlotElement* slotElement)
     else if (RefPtr text = dynamicDowncast<Text>(*this))
         RenderTreeUpdater::tearDownRenderer(*text);
 
+    auto* oldSlotElement = manuallyAssignedSlot();
+    std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
+    std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
+
     ensureRareData().setManuallyAssignedSlot(slotElement);
+
+    if (oldSlotElement)
+        oldInvalidation.emplace(*oldSlotElement, CSSSelector::PseudoClass::HasSlotted, oldSlotElement->hasFlattenedSlottedContent());
+    if (slotElement)
+        newInvalidation.emplace(*slotElement, CSSSelector::PseudoClass::HasSlotted, slotElement->hasFlattenedSlottedContent());
 
     InspectorInstrumentation::didChangeAssignedSlot(*this);
 }

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -29,6 +29,7 @@
 #include "ElementInlines.h"
 #include "HTMLSlotElement.h"
 #include "InspectorInstrumentation.h"
+#include "PseudoClassChangeInvalidation.h"
 #include "RenderTreeUpdater.h"
 #include "ShadowRoot.h"
 #include "TypedElementDescendantIteratorInlines.h"
@@ -311,8 +312,13 @@ void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowR
     RenderTreeUpdater::tearDownRenderersAfterSlotChange(shadowRootHost);
     shadowRootHost->invalidateStyleForSubtree();
 
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+
     auto assignedNodes = std::exchange(slot->assignedNodes, { });
     m_slotAssignmentsIsValid = false;
+
+    if (auto* slotElement = slot->element.get())
+        styleInvalidation.emplace(*slotElement, CSSSelector::PseudoClass::HasSlotted, slotElement->hasFlattenedSlottedContent());
 
     if (RefPtr slotElement = findFirstSlotElement(*slot)) {
         if (shadowRoot.shouldFireSlotchangeEvent())
@@ -390,9 +396,14 @@ void NamedSlotAssignment::willRemoveAssignedNode(Node& node, ShadowRoot&)
     if (!slot || slot->assignedNodes.isEmpty())
         return;
 
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+
     slot->assignedNodes.removeFirstMatching([&node](const auto& item) {
         return item.get() == &node;
     });
+
+    if (auto* slotElement = slot->element.get())
+        styleInvalidation.emplace(*slotElement, CSSSelector::PseudoClass::HasSlotted, slotElement->hasFlattenedSlottedContent());
 
     InspectorInstrumentation::didChangeAssignedSlot(node);
 }
@@ -441,15 +452,21 @@ void NamedSlotAssignment::assignSlots(ShadowRoot& shadowRoot)
 void NamedSlotAssignment::assignToSlot(Node& child, const AtomString& slotName)
 {
     ASSERT(!slotName.isNull());
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (slotName == defaultSlotName()) {
         auto defaultSlotEntry = m_slots.find(defaultSlotName());
-        if (defaultSlotEntry != m_slots.end())
+        if (defaultSlotEntry != m_slots.end()) {
             defaultSlotEntry->value->assignedNodes.append(child);
+            if (auto* slotElement = defaultSlotEntry->value->element.get())
+                styleInvalidation.emplace(*slotElement, CSSSelector::PseudoClass::HasSlotted, slotElement->hasFlattenedSlottedContent());
+        }
     } else {
         auto addResult = m_slots.ensure(slotName, [] {
             return makeUnique<Slot>();
         });
         addResult.iterator->value->assignedNodes.append(child);
+        if (auto* slotElement = addResult.iterator->value->element.get())
+            styleInvalidation.emplace(*slotElement, CSSSelector::PseudoClass::HasSlotted, slotElement->hasFlattenedSlottedContent());
     }
 
     InspectorInstrumentation::didChangeAssignedSlot(child);
@@ -618,5 +635,4 @@ void ManualSlotAssignment::didMutateTextNodesOfShadowHost(ShadowRoot&)
 }
 
 }
-
 

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -147,6 +147,43 @@ static void flattenAssignedNodes(Vector<Ref<Node>>& nodes, const HTMLSlotElement
     }
 }
 
+static bool containsAssignedNodeIgnoringSlots(const HTMLSlotElement& slot)
+{
+    if (!slot.containingShadowRoot())
+        return false;
+
+    auto* assignedNodes = slot.assignedNodes();
+    if (!assignedNodes) {
+        for (RefPtr<Node> child = slot.firstChild(); child; child = child->nextSibling()) {
+            if (auto* slot = dynamicDowncast<HTMLSlotElement>(*child)) {
+                if (containsAssignedNodeIgnoringSlots(*slot))
+                    return true;
+            } else if (is<Text>(*child) || is<Element>(*child))
+                return true;
+        }
+        return false;
+    }
+    for (auto& weakNode : *assignedNodes) {
+        if (!weakNode) [[unlikely]] {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+        if (auto* slot = dynamicDowncast<HTMLSlotElement>(*weakNode)) {
+            if (containsAssignedNodeIgnoringSlots(*slot))
+                return true;
+        } else {
+            ASSERT(is<Text>(*weakNode) || is<Element>(*weakNode));
+            return true;
+        }
+    }
+    return false;
+}
+
+bool HTMLSlotElement::hasFlattenedSlottedContent() const
+{
+    return containsAssignedNodeIgnoringSlots(*this);
+}
+
 Vector<Ref<Node>> HTMLSlotElement::assignedNodes(const AssignedNodesOptions& options) const
 {
     if (options.flatten) {

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -56,6 +56,9 @@ public:
     bool isInInsertedIntoAncestor() const { return m_isInInsertedIntoAncestor; }
 
     void updateAccessibilityOnSlotChange() const;
+
+    bool hasFlattenedSlottedContent() const;
+
 private:
     HTMLSlotElement(const QualifiedName&, Document&);
 


### PR DESCRIPTION
#### 91135a212d4d93f0cb68154a91d2b11303378c95
<pre>
[css-scoping] Implement `:has-slotted` pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=280608">https://bugs.webkit.org/show_bug.cgi?id=280608</a>

Reviewed by NOBODY (OOPS!).

This implements the :has-slotted pseudo selector as specified in CSSWG
<a href="https://drafts.csswg.org/css-scoping/#the-has-slotted-pseudo.">https://drafts.csswg.org/css-scoping/#the-has-slotted-pseudo.</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-changing-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-changing-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-changing-001.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-changing-003.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-manual-assignment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/has-slotted-query-selector-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-slotted.tentative-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesHasSlottedPseudoClass):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::setManuallyAssignedSlot):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::didChangeSlot):
(WebCore::NamedSlotAssignment::willRemoveAssignedNode):
(WebCore::NamedSlotAssignment::assignToSlot):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::containsAssignedNodeIgnoringSlots):
(WebCore::HTMLSlotElement::hasFlattenedSlottedContent const):
* Source/WebCore/html/HTMLSlotElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91135a212d4d93f0cb68154a91d2b11303378c95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83411 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112708 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23983 "Found 1 new test failure: fast/filter-image/clipped-filter.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59575 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/102251 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118573 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/108312 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36799 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27259 "Found 1 new test failure: fast/shadow-dom/host-child-append-performance.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92416 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92238 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/42164 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132588 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36354 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35893 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->