### PR TITLE
Render suppression approach -- [UnifiedPDF] There's a tile flicker after resizing has finished

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -685,7 +685,7 @@ public:
     void setShouldPaintUsingCompositeCopy(bool copy) { m_shouldPaintUsingCompositeCopy = copy; }
 
     bool renderingIsSuppressedIncludingDescendants() const { return m_renderingIsSuppressedIncludingDescendants; }
-    void setRenderingIsSuppressedIncludingDescendants(bool suppressed) { m_renderingIsSuppressedIncludingDescendants = suppressed; }
+    virtual void setRenderingIsSuppressedIncludingDescendants(bool suppressed) { m_renderingIsSuppressedIncludingDescendants = suppressed; }
 
     const std::optional<FloatRect>& animationExtent() const { return m_animationExtent; }
     void setAnimationExtent(std::optional<FloatRect> animationExtent) { m_animationExtent = animationExtent; }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -627,6 +627,16 @@ void GraphicsLayerCA::setSize(const FloatSize& size)
     noteLayerPropertyChanged(GeometryChanged);
 }
 
+void GraphicsLayerCA::setRenderingIsSuppressedIncludingDescendants(bool suppressed)
+{
+    if (m_renderingIsSuppressedIncludingDescendants == suppressed)
+        return;
+
+    noteLayerPropertyChanged(std::exchange(m_uncommittedChanges, NoChange));
+
+    GraphicsLayer::setRenderingIsSuppressedIncludingDescendants(suppressed);
+}
+
 void GraphicsLayerCA::setBoundsOrigin(const FloatPoint& origin)
 {
     if (origin == m_boundsOrigin)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -169,7 +169,9 @@ public:
     WEBCORE_EXPORT void setContentsMagnificationFilter(ScalingFilter) override;
 
     bool usesContentsLayer() const override { return m_contentsLayerPurpose != ContentsLayerPurpose::None; }
-    
+
+    WEBCORE_EXPORT void setRenderingIsSuppressedIncludingDescendants(bool) override;
+
     WEBCORE_EXPORT void setShowDebugBorder(bool) override;
     WEBCORE_EXPORT void setShowRepaintCounter(bool) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -116,6 +116,8 @@ public:
     // Updates existing tiles. Can result in temporarily stale content.
     void pdfContentChangedInRect(const WebCore::GraphicsLayer*, float pageScaleFactor, const WebCore::FloatRect& paintingRect, std::optional<PDFLayoutRow>);
 
+    void pdfContentScaleChanged(WebCore::GraphicsLayer*, float newScaleFactor);
+
     void generatePreviewImageForPage(PDFDocumentLayout::PageIndex, float scale);
     RefPtr<WebCore::ImageBuffer> previewImageForPage(PDFDocumentLayout::PageIndex) const;
     void removePreviewForPage(PDFDocumentLayout::PageIndex);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -741,6 +741,22 @@ void AsyncPDFRenderer::invalidateTilesForPaintingRect(float pageScaleFactor, con
     });
 }
 
+// FIXME: This could probably be called whenever a transform is set on the presentation controllers' contents layer, instead of special casing for content scale.
+void AsyncPDFRenderer::pdfContentScaleChanged(GraphicsLayer* layer, float scale)
+{
+    layer->setRenderingIsSuppressedIncludingDescendants(true);
+
+//    RefPtr presentationController = m_presentationController.get();
+
+    // FIXME: Litmus test for the proof of concept. Actually store this callback and call it once all the work is done.
+    Timer::schedule(5_s, [layer/*, presentationController = RefPtr { m_presentationController.get() }*/] {
+        layer->setRenderingIsSuppressedIncludingDescendants(false);
+//        if (presentationController)
+//            presentationController->pluginScheduleRenderingUpdate();
+//        layer->setNeedsDisplay();
+    });
+}
+
 void AsyncPDFRenderer::pdfContentChangedInRect(const GraphicsLayer* layer, float pageScaleFactor, const FloatRect& paintingRect, std::optional<PDFLayoutRow> layoutRow)
 {
     // FIXME: If our platform does not support partial updates (supportsPartialRepaint() is false) then this should behave

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -71,7 +71,7 @@ private:
     void deviceOrPageScaleFactorChanged() override;
 
     void setupLayers(WebCore::GraphicsLayer& scrolledContentsLayer) override;
-    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) override;
+    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation) override;
 
     void updateIsInWindow(bool isInWindow) override;
     void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -79,7 +79,14 @@ public:
     virtual void deviceOrPageScaleFactorChanged() = 0;
 
     virtual void setupLayers(WebCore::GraphicsLayer&) = 0;
-    virtual void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) = 0;
+
+    struct LayoutChangeInformation {
+        bool scaleFactorChanged { false };
+        bool isInitialLayout { false };
+
+        bool scaleFactorChangedAfterInitialLayout() const { return scaleFactorChanged && !isInitialLayout; }
+    };
+    virtual void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation) = 0;
 
     virtual void updateIsInWindow(bool isInWindow) = 0;
     virtual void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) = 0;
@@ -117,6 +124,7 @@ public:
     void releaseMemory();
     RetainPtr<PDFDocument> pluginPDFDocument() const;
     bool pluginShouldCachePagePreviews() const;
+    void pluginScheduleRenderingUpdate();
 
 protected:
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String&, WebCore::GraphicsLayer::Type);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -170,6 +170,11 @@ bool PDFPresentationController::pluginShouldCachePagePreviews() const
     return m_plugin->shouldCachePagePreviews();
 }
 
+void PDFPresentationController::pluginScheduleRenderingUpdate()
+{
+    m_plugin->scheduleRenderingUpdate();
+}
+
 PDFDocumentLayout::PageIndex PDFPresentationController::nearestPageIndexForDocumentPoint(const FloatPoint& point) const
 {
     if (m_plugin->isLocked())

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -60,7 +60,7 @@ private:
     void deviceOrPageScaleFactorChanged() override { }
 
     void setupLayers(WebCore::GraphicsLayer& scrolledContentsLayer) override;
-    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) override;
+    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor, LayoutChangeInformation) override;
 
     void updateIsInWindow(bool isInWindow) override;
     void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;
@@ -105,6 +105,7 @@ private:
 
     RefPtr<WebCore::GraphicsLayer> m_pageBackgroundsContainerLayer;
     RefPtr<WebCore::GraphicsLayer> m_contentsLayer;
+    RefPtr<WebCore::GraphicsLayer> m_scalingLayer;
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
     RefPtr<WebCore::GraphicsLayer> m_selectionLayer;
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -268,7 +268,9 @@ private:
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;
     void setPageScaleFactor(double scale, std::optional<WebCore::IntPoint> origin) final;
-    void setScaleFactor(double scale, std::optional<WebCore::IntPoint> origin = std::nullopt);
+
+    enum class IsInitialLayout : bool { No, Yes };
+    void setScaleFactor(double scale, std::optional<WebCore::IntPoint> origin = std::nullopt, IsInitialLayout = IsInitialLayout::No);
 
     enum class CheckForMagnificationGesture : bool { No, Yes };
     void deviceOrPageScaleFactorChanged(CheckForMagnificationGesture = CheckForMagnificationGesture::No);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -584,7 +584,7 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
     m_scrollContainerLayer->setPosition(scrollContainerRect.location());
     m_scrollContainerLayer->setSize(scrollContainerRect.size());
 
-    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
+    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor, { });
     updateSnapOffsets();
 
     didChangeSettings();
@@ -1053,7 +1053,7 @@ void UnifiedPDFPlugin::didEndMagnificationGesture()
     deviceOrPageScaleFactorChanged();
 }
 
-void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPoint> originInRootViewCoordinates)
+void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPoint> originInRootViewCoordinates, IsInitialLayout isInitialLayout)
 {
     RefPtr page = this->page();
     if (!page)
@@ -1093,7 +1093,7 @@ void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPo
 
     deviceOrPageScaleFactorChanged(CheckForMagnificationGesture::Yes);
 
-    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
+    m_presentationController->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor, { .scaleFactorChanged = true, .isInitialLayout = isInitialLayout == IsInitialLayout::Yes });
     updateSnapOffsets();
 
 #if PLATFORM(MAC)
@@ -1226,7 +1226,7 @@ void UnifiedPDFPlugin::updateLayout(AdjustScaleAfterLayout shouldAdjustScale, st
     if (shouldAdjustScale == AdjustScaleAfterLayout::Yes && m_view) {
         auto initialScaleFactor = initialScale();
         LOG_WITH_STREAM(PDF, stream << "UnifiedPDFPlugin::updateLayout - on first layout, chose scale for actual size " << initialScaleFactor);
-        setScaleFactor(initialScaleFactor);
+        setScaleFactor(initialScaleFactor, std::nullopt, IsInitialLayout::Yes);
 
         m_shouldUpdateAutoSizeScale = ShouldUpdateAutoSizeScale::No;
     }


### PR DESCRIPTION
#### 1c1a3fce883cdf74f61afcce79ed7b098d2f65a3
<pre>
Render suppression approach -- [UnifiedPDF] There&apos;s a tile flicker after resizing has finished
<a href="https://bugs.webkit.org/show_bug.cgi?id=270041">https://bugs.webkit.org/show_bug.cgi?id=270041</a>
<a href="https://rdar.apple.com/123566595">rdar://123566595</a>

Reviewed by NOBODY (OOPS!).

WIP.

This approach tries suppressing rendering on the contents layer before
layer-&gt;setTransform() is called.

This first version just sets up a long timer to check whether this idea
works, but really we should store a callback that unsuppresses rendering
on the respective layer once the AsyncPDFRenderer is done with its work.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setRenderingIsSuppressedIncludingDescendants):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setRenderingIsSuppressedIncludingDescendants):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::pdfContentScaleChanged):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::updateLayersOnLayoutChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
(WebKit::PDFPresentationController::LayoutChangeInformation::scaleFactorChangedAfterInitialLayout const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::pluginScheduleRenderingUpdate):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::teardown):
(WebKit::PDFScrollingPresentationController::setupLayers):
(WebKit::PDFScrollingPresentationController::updateLayersOnLayoutChange):
(WebKit::PDFScrollingPresentationController::updateIsInWindow):
(WebKit::PDFScrollingPresentationController::updateDebugBorders):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::updateLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c1a3fce883cdf74f61afcce79ed7b098d2f65a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21238 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63239 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4870 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->