### PR TITLE
Implement :local-link pseudo selector

### DIFF
--- a/LayoutTests/fast/selectors/local-link-1-expected.txt
+++ b/LayoutTests/fast/selectors/local-link-1-expected.txt
@@ -1,0 +1,10 @@
+Test the basic matching of the :local-link selector.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(document.getElementById("target-tag-1")).backgroundColor is "rgb(255, 0, 0)"
+PASS getComputedStyle(document.getElementById("target-tag-2")).backgroundColor is "rgb(255, 0, 0)"
+PASS getComputedStyle(document.getElementById("target-tag-3")).backgroundColor is "rgb(255, 255, 255)"
+PASS getComputedStyle(document.getElementById("target-tag-4")).backgroundColor is "rgb(255, 255, 255)"
+

--- a/LayoutTests/fast/selectors/local-link-1.html
+++ b/LayoutTests/fast/selectors/local-link-1.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+* {
+    background-color:white;
+}
+:local-link {
+    background-color: red;
+}
+</style>
+
+</head>
+<body>
+    <div style="display:none">
+        <div data-description="Anchors basics.">
+            <a id="target-tag-1" href="#target-tag-3">Link1</a>
+            <a id="target-tag-2" href="#target-tag-4">Link2</a>
+            <a id="target-tag-3" href="http://www.webkit.org">Link3</a>
+            <a id="target-tag-4" href="http://www.webkit.org">Link4</a>
+        </div>
+    </div>
+</body>
+<script>
+
+description('Test the basic matching of the :local-link selector.');
+
+
+
+// Styling.
+var expectedStyles = [['target-tag-1', 'rgb(255, 0, 0)'],
+                      ['target-tag-2', 'rgb(255, 0, 0)'],
+                      ['target-tag-3',  'rgb(255, 255, 255)'],
+                      ['target-tag-4',  'rgb(255, 255, 255)'],];
+
+for (var i = 0; i < expectedStyles.length; ++i)
+    shouldBeEqualToString('getComputedStyle(document.getElementById("' + expectedStyles[i][0] + '")).backgroundColor', "" + expectedStyles[i][1]);
+
+</script>

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -161,6 +161,7 @@
         "last-child": {},
         "last-of-type": {},
         "link": {},
+        "local-link": {},
         "modal": {},
         "muted": {
             "conditional": "ENABLE(VIDEO)"

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -290,7 +290,6 @@ static SelectorChecker::LocalContext localContextForParent(const SelectorChecker
 SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& checkingContext, LocalContext& context, PseudoIdSet& dynamicPseudoIdSet) const
 {
     MatchType matchType = MatchType::Element;
-
     // The first selector has to match.
     if (!checkOne(checkingContext, context, matchType))
         return MatchResult::fails(Match::SelectorFailsLocally);
@@ -1016,6 +1015,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         case CSSSelector::PseudoClass::Link:
             // :visited and :link matches are separated later when applying the style. Here both classes match all links...
             return element.isLink();
+        case CSSSelector::PseudoClass::LocalLink:
+            return element.getAttribute(WebCore::HTMLNames::hrefAttr).startsWith('#');
         case CSSSelector::PseudoClass::Visited:
             // ...except if :visited matching is disabled for ancestor/sibling matching.
             // Inside functional pseudo class except for :not, :visited never matches.

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -241,6 +241,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             case CSSSelector::PseudoClass::Link:
             case CSSSelector::PseudoClass::Visited:
             case CSSSelector::PseudoClass::AnyLink:
+            case CSSSelector::PseudoClass::LocalLink:
                 linkSelector = selector;
                 break;
             case CSSSelector::PseudoClass::Focus:


### PR DESCRIPTION
#### a896757bbdebd46b3271d1142918adb6463bb6c9
<pre>
Implement :local-link pseudo selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=280609">https://bugs.webkit.org/show_bug.cgi?id=280609</a>

Implement :local-link pseudo selector

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/fast/selectors/local-link-1-expected.txt: Added.
* LayoutTests/fast/selectors/local-link-1.html: Added.
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementMatching):
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsLocalLink):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a896757bbdebd46b3271d1142918adb6463bb6c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55514 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13995 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63209 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63147 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11165 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45162 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->