### PR TITLE
[JSC] AI should do more sparse conditional constant propagation

### DIFF
--- a/JSTests/stress/sparse-conditional-basic.js
+++ b/JSTests/stress/sparse-conditional-basic.js
@@ -1,0 +1,11 @@
+function test(v) {
+    if (typeof v === 'number')
+        return v | 0 === v;
+    return v + 20;
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    test(32);
+    test("Hello");
+}

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -394,13 +394,14 @@ private:
     Vector<AbstractValue> m_tupleAbstractValues;
     FastBitVector m_activeVariables;
     BasicBlock* m_block;
+    HashMap<Node*, VirtualRegister> m_nodeForVariableAtTail; // This is a simple cache to help speed up sparse conditional propagation.
 
     bool m_isValid;
     AbstractInterpreterClobberState m_clobberState;
     StructureClobberState m_structureClobberState;
     AbstractValueClobberEpoch m_epochAtHead;
     AbstractValueClobberEpoch m_effectEpoch;
-    
+
     BranchDirection m_branchDirection; // This is only set for blocks that end in Branch and that execute to completion (i.e. m_isValid == true).
 };
 


### PR DESCRIPTION
#### df4f6f1ed833d20d9dcbd483c0915b0c9d476a7c
<pre>
[JSC] AI should do more sparse conditional constant propagation
<a href="https://bugs.webkit.org/show_bug.cgi?id=182581">https://bugs.webkit.org/show_bug.cgi?id=182581</a>
<a href="https://rdar.apple.com/137172522">rdar://137172522</a>

Reviewed by NOBODY (OOPS!).

This is paving subsequent changes for further optimizations.
Right now, we are not leveraging the information like the following.

    if (typeof x === &apos;number&apos;) {
        ... // x is always number
    } else if (typeof x === &apos;string&apos;) {
        ... // x is always string
    }

Right now, x&apos;s type information is just propagated into each branch. So
x can be String | Number or something wider. But by using the above
pattern, we can narrow down x&apos;s abstract value, like, for the first if&apos;s
then branch, we can pass x filtered with SpecFullNumber.

This patch does this proven type information (and constants). When
generating a new abstract values for each branch in DFGInPlaceAbstractState,
we produce different abstract values for then and else branches based on
the condition used in that branch (like, `typeof x === &apos;number&apos;`) so
that each branch can take narrower types and can do further
optimizations.

* JSTests/stress/sparse-conditional-basic.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
(JSC::DFG::InPlaceAbstractState::merge):
(JSC::DFG::InPlaceAbstractState::mergeToSuccessors):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df4f6f1ed833d20d9dcbd483c0915b0c9d476a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56990 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15497 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19754 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21880 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65450 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78167 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71575 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65444 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64711 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6589 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47540 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20543 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->