### PR TITLE
text-spacing: text-autospace: Extend implementation to ideograph-numeric

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    .no-autospace {
+        text-autospace: no-autospace;
+    }
+    .auto-space {
+        text-autospace: ideograph-alpha;
+    }
+    .manual-space {
+        margin-left: 0.125em;
+    }
+    p {
+        font-size: 40px;
+        margin: 2px;
+        font-family: Ahem;
+    }
+</style>
+</head>
+<body>
+    <p class="no-autospace">4<span>水水</span></p>
+    <p class="no-autospace">4<span class="manual-space">水水</span></p>
+    <p class="no-autospace">4<span class="manual-space">水水</span></p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    .no-autospace {
+        text-autospace: no-autospace;
+    }
+    .auto-space {
+        text-autospace: ideograph-alpha;
+    }
+    .manual-space {
+        margin-left: 0.125em;
+    }
+    p {
+        font-size: 40px;
+        margin: 2px;
+        font-family: Ahem;
+    }
+</style>
+</head>
+<body>
+    <p class="no-autospace">4<span>水水</span></p>
+    <p class="no-autospace">4<span class="manual-space">水水</span></p>
+    <p class="no-autospace">4<span class="manual-space">水水</span></p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="match" href="text-autospace-ideograph-numeric-001-ref.html">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    .no-autospace {
+        text-autospace: no-autospace;
+    }
+    .auto-space {
+        text-autospace: ideograph-numeric;
+    }
+    .manual-space {
+        margin-left: 0.125em;
+    }
+    p {
+        font-size: 40px;
+        margin: 2px;
+        font-family: Ahem;
+    }
+</style>
+</head>
+<body>
+    <p class="no-autospace">4水水</p>
+    <p class="auto-space">4水水</p>
+    <p class="no-autospace">4<span class="manual-space">水水</span></p>
+</body>
+</html>

--- a/Source/WebCore/platform/text/TextSpacing.cpp
+++ b/Source/WebCore/platform/text/TextSpacing.cpp
@@ -35,8 +35,13 @@ using namespace TextSpacing;
 bool TextAutospace::shouldApplySpacing(CharacterClass firstCharacterClass, CharacterClass secondCharacterClass) const
 {
     constexpr uint8_t ideographAlphaMask = static_cast<uint8_t>(CharacterClass::Ideograph) | static_cast<uint8_t>(CharacterClass::NonIdeographLetter);
-    if (hasIdeographAlpha())
-        return (static_cast<uint8_t>(firstCharacterClass) | static_cast<uint8_t>(secondCharacterClass)) == ideographAlphaMask;
+    constexpr uint8_t ideographNumericMask = static_cast<uint8_t>(CharacterClass::Ideograph) | static_cast<uint8_t>(CharacterClass::NonIdeographNumeral);
+
+    uint8_t characterClassesMask = (static_cast<uint8_t>(firstCharacterClass) | static_cast<uint8_t>(secondCharacterClass));
+    if (hasIdeographAlpha() && characterClassesMask == ideographAlphaMask)
+        return true;
+    if (hasIdeographNumeric() && characterClassesMask == ideographNumericMask)
+        return true;
     return false;
 }
 


### PR DESCRIPTION
#### fa51e9f9065c366d5c712e6059a74fffbda8adc3
<pre>
text-spacing: text-autospace: Extend implementation to ideograph-numeric
<a href="https://bugs.webkit.org/show_bug.cgi?id=280806">https://bugs.webkit.org/show_bug.cgi?id=280806</a>
<a href="https://rdar.apple.com/133310966">rdar://133310966</a>

Reviewed by Brent Fulgham.

With this patch we will also apply auto space between for
according to the ideograph-numeric rule, i.e.: between
a ideograph character and a non-ideograph numeral character.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-ideograph-numeric-001.html: Added.
* Source/WebCore/platform/text/TextSpacing.cpp:
(WebCore::TextAutospace::shouldApplySpacing const):

Canonical link: <a href="https://commits.webkit.org/284632@main">https://commits.webkit.org/284632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/286c8f35eec3e910d718677bdb95d771d6deabb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22732 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72096 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14011 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36004 "Passed tests") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19514 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63568 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18129 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Passed layout tests; 7 flakes") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75779 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63221 "Passed tests") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63160 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11181 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4786 "Build is in progress. Recent messages:OS: Ventura (13.6.9), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 11 flakes") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45183 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->