### PR TITLE
[web-animations] remove automatic conversion to and from double for CSSNumberishTime

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -119,10 +119,9 @@ ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<CSSNumberi
     computedTiming.duration = secondsToWebAnimationsAPITime(m_timing.iterationDuration);
     computedTiming.direction = m_timing.direction;
     computedTiming.easing = m_timing.timingFunction->cssText();
-    computedTiming.endTime = secondsToWebAnimationsAPITime(m_timing.endTime);
-    computedTiming.activeDuration = secondsToWebAnimationsAPITime(m_timing.activeDuration);
-    if (localTime)
-        computedTiming.localTime = secondsToWebAnimationsAPITime(*localTime);
+    computedTiming.endTime = m_timing.endTime;
+    computedTiming.activeDuration = m_timing.activeDuration;
+    computedTiming.localTime = localTime;
     computedTiming.simpleIterationProgress = resolvedTiming.simpleIterationProgress;
     computedTiming.progress = resolvedTiming.transformedProgress;
     computedTiming.currentIteration = resolvedTiming.currentIteration;

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -44,9 +44,9 @@ AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimat
     : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, animation, scheduledTime)
 {
     if (timelineTime)
-        m_timelineTime = timelineTime->milliseconds();
+        m_timelineTime = *timelineTime;
     if (currentTime)
-        m_currentTime = currentTime->milliseconds();
+        m_currentTime = *currentTime;
 }
 
 AnimationPlaybackEvent::~AnimationPlaybackEvent() = default;

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -32,12 +32,6 @@
 
 namespace WebCore {
 
-CSSNumberishTime::CSSNumberishTime(double value)
-    : m_type(Type::Time)
-    , m_value(value / 1000)
-{
-}
-
 CSSNumberishTime::CSSNumberishTime(const Seconds& value)
     : m_type(Type::Time)
     , m_value(value.seconds())
@@ -203,13 +197,6 @@ CSSNumberishTime CSSNumberishTime::operator*(double scalar) const
 CSSNumberishTime CSSNumberishTime::operator/(double scalar) const
 {
     return { m_type, m_value / scalar };
-}
-
-CSSNumberishTime::operator double() const
-{
-    if (m_type == Type::Time)
-        return secondsToWebAnimationsAPITime(*this);
-    return m_value;
 }
 
 CSSNumberishTime::operator Seconds() const

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -34,7 +34,6 @@ class CSSNumberishTime {
 public:
     CSSNumberishTime() = default;
 
-    CSSNumberishTime(double);
     CSSNumberishTime(const Seconds&);
     CSSNumberishTime(const CSSNumberish&);
 
@@ -64,7 +63,6 @@ public:
     CSSNumberishTime operator*(double) const;
     CSSNumberishTime operator/(double) const;
 
-    operator double() const;
     operator Seconds() const;
     operator CSSNumberish() const;
 


### PR DESCRIPTION
#### b35c4c0a18e23280d55a6cd6d5c860a1a1b28c08
<pre>
[web-animations] remove automatic conversion to and from double for CSSNumberishTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=280815">https://bugs.webkit.org/show_bug.cgi?id=280815</a>
<a href="https://rdar.apple.com/137188216">rdar://137188216</a>

Reviewed by Anne van Kesteren.

`CSSNumberishTime` has automatic conversion to and from `double` but it&apos;s not actually
needed in practice and also will cause trouble when we start serializing percentage
values through the API because the double conversion will take precedence over the
`CSSNumberish` conversion. So we remove it altogether and change the few call sites
that relied on it.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getComputedTiming const):
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::operator double const): Deleted.
* Source/WebCore/animation/CSSNumberishTime.h:

Canonical link: <a href="https://commits.webkit.org/284608@main">https://commits.webkit.org/284608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23cb90899be67bef5f733339e3361e81643eef69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70001 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49402 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55537 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36018 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41659 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75801 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63234 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14262 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63173 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4807 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91029 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10686 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45205 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/91029 "Build is in progress. Recent messages:") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46279 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->