### PR TITLE
[scroll-animations] update `EffectTiming.duration` to use `CSSNumberish`

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -597,6 +597,7 @@ animation/CSSTransitionEvent.cpp
 animation/CompositeOperation.cpp
 animation/CustomEffect.cpp
 animation/DocumentTimeline.cpp
+animation/EffectTiming.cpp
 animation/ElementAnimationRareData.cpp
 animation/FrameRateAligner.cpp
 animation/KeyframeEffect.cpp

--- a/Source/WebCore/animation/CustomEffect.cpp
+++ b/Source/WebCore/animation/CustomEffect.cpp
@@ -49,8 +49,12 @@ ExceptionOr<Ref<CustomEffect>> CustomEffect::create(Document& document, Ref<Cust
         } else {
             auto effectTimingOptions = std::get<EffectTiming>(optionsValue);
 
+            auto convertedDuration = effectTimingOptions.durationAsDoubleOrString();
+            if (!convertedDuration)
+                return Exception { ExceptionCode::TypeError };
+
             timing = {
-                effectTimingOptions.duration,
+                *convertedDuration,
                 effectTimingOptions.iterations,
                 effectTimingOptions.delay,
                 effectTimingOptions.endDelay,

--- a/Source/WebCore/animation/EffectTiming.cpp
+++ b/Source/WebCore/animation/EffectTiming.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EffectTiming.h"
+
+namespace WebCore {
+
+OptionalDoubleOrString EffectTiming::durationAsDoubleOrString() const
+{
+    return WTF::switchOn(duration,
+        [](double doubleDuration) -> OptionalDoubleOrString { return doubleDuration; },
+        [](const String& stringDuration) -> OptionalDoubleOrString { return stringDuration; },
+        [](const RefPtr<CSSNumericValue>&) -> OptionalDoubleOrString { return std::nullopt; }
+    );
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/EffectTiming.h
+++ b/Source/WebCore/animation/EffectTiming.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSNumericValue.h"
 #include "CommonAtomStrings.h"
 #include "FillMode.h"
 #include "PlaybackDirection.h"
@@ -33,8 +34,10 @@
 
 namespace WebCore {
 
+using OptionalDoubleOrString = std::optional<std::variant<double, String>>;
+
 struct EffectTiming {
-    std::variant<double, String> duration { autoAtom() };
+    std::variant<double, RefPtr<CSSNumericValue>, String> duration { autoAtom() };
     double delay { 0 };
     double endDelay { 0 };
     double iterationStart { 0 };
@@ -42,6 +45,7 @@ struct EffectTiming {
     String easing { "linear"_s };
     FillMode fill { FillMode::Auto };
     PlaybackDirection direction { PlaybackDirection::Normal };
+    OptionalDoubleOrString durationAsDoubleOrString() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/EffectTiming.idl
+++ b/Source/WebCore/animation/EffectTiming.idl
@@ -32,7 +32,7 @@
     FillMode fill = "auto";
     double iterationStart = 0.0;
     unrestricted double iterations = 1.0;
-    (unrestricted double or DOMString) duration = "auto";
+    (unrestricted double or CSSNumericValue or DOMString) duration = "auto";
     PlaybackDirection direction = "normal";
     DOMString easing = "linear";
 };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -596,8 +596,12 @@ ExceptionOr<Ref<KeyframeEffect>> KeyframeEffect::create(JSGlobalObject& lexicalG
             if (setPseudoElementResult.hasException())
                 return setPseudoElementResult.releaseException();
 
+            auto convertedDuration = keyframeEffectOptions.durationAsDoubleOrString();
+            if (!convertedDuration)
+                return Exception { ExceptionCode::TypeError };
+
             timing = {
-                keyframeEffectOptions.duration,
+                *convertedDuration,
                 keyframeEffectOptions.iterations,
                 keyframeEffectOptions.delay,
                 keyframeEffectOptions.endDelay,


### PR DESCRIPTION
#### 1e783c0e6d6a20328d171fcbfcc91384ddb0c263
<pre>
[scroll-animations] update `EffectTiming.duration` to use `CSSNumberish`
<a href="https://bugs.webkit.org/show_bug.cgi?id=279728">https://bugs.webkit.org/show_bug.cgi?id=279728</a>
<a href="https://rdar.apple.com/136031070">rdar://136031070</a>

Reviewed by Tim Nguyen.

Add CSSNumericValue as one of the options for `EffectTiming.duration`. Since percentage
values are not allowed as input, we add the `EffectTiming::durationAsDoubleOrString()`
to convert this value for the `double` and `DOMString` case.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CustomEffect.cpp:
(WebCore::CustomEffect::create):
* Source/WebCore/animation/EffectTiming.cpp: Added.
(WebCore::EffectTiming::durationAsDoubleOrString const):
* Source/WebCore/animation/EffectTiming.h:
* Source/WebCore/animation/EffectTiming.idl:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::create):

Canonical link: <a href="https://commits.webkit.org/284623@main">https://commits.webkit.org/284623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92b902c0f824d9a3b3bec56601ca588f1a843776

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60409 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17840 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75840 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17423 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63212 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4844 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->