### PR TITLE
[JSC] Use `@argumentCount` instead of `arguments.length` in builtin JS

### DIFF
--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -27,7 +27,7 @@ function of(/* items... */)
 {
     "use strict";
 
-    var length = arguments.length;
+    var length = @argumentCount();
     var array = this !== @Array && @isConstructor(this) ? new this(length) : @newArrayWithSize(length);
     for (var k = 0; k < length; ++k)
         @putByValDirect(array, k, arguments[k]);

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -350,7 +350,7 @@ function concatSlowPath()
     "use strict";
 
     var currentElement = @toObject(this, "Array.prototype.concat requires that |this| not be null or undefined");
-    var argCount = arguments.length;
+    var argCount = @argumentCount();
 
     var result = @newArrayWithSpecies(0, currentElement);
     var resultIsArray = @isJSArray(result);
@@ -637,12 +637,13 @@ function toSpliced(start, deleteCount /*, ...items */)
     var actualDeleteCount;
 
     // Step 8-10.
-    if (arguments.length === 0)
+    var argCount = @argumentCount();
+    if (argCount === 0)
         actualDeleteCount = 0;
-    else if (arguments.length === 1)
+    else if (argCount === 1)
         actualDeleteCount = length - actualStart;
     else {
-        insertCount = arguments.length - 2;
+        insertCount = argCount - 2;
         var tempDeleteCount = @toIntegerOrInfinity(deleteCount);
         tempDeleteCount = tempDeleteCount > 0 ? tempDeleteCount : 0;
         actualDeleteCount = @min(tempDeleteCount, length - actualStart);

--- a/Source/JavaScriptCore/builtins/FunctionPrototype.js
+++ b/Source/JavaScriptCore/builtins/FunctionPrototype.js
@@ -29,7 +29,7 @@ function call(thisArgument)
 
     var argumentValues = [];
     // Start from 1 to ignore thisArgument
-    for (var i = 1; i < arguments.length; i++)
+    for (var i = 1; i < @argumentCount(); i++)
         @putByValDirect(argumentValues, i-1, arguments[i]);
 
     return this.@apply(thisArgument, argumentValues);

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -359,7 +359,7 @@ function try(callback /*, ...args */)
         @throwTypeError("|this| is not an object");
 
     var args = [];
-    for (var i = 1; i < arguments.length; i++)
+    for (var i = 1; i < @argumentCount(); i++)
         @putByValDirect(args, i - 1, arguments[i]);
 
     var promiseCapability = @newPromiseCapability(this);

--- a/Source/JavaScriptCore/builtins/StringConstructor.js
+++ b/Source/JavaScriptCore/builtins/StringConstructor.js
@@ -31,7 +31,7 @@ function raw(template)
 
     var rawSegments = @toObject(cookedSegments.raw, "String.raw requires template.raw not be null or undefined");
 
-    var numberOfSubstitutions = arguments.length - 1;
+    var numberOfSubstitutions = @argumentCount() - 1;
 
     var segmentCount = @toLength(rawSegments.length);
 

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -327,7 +327,7 @@ function stringConcatSlowPath()
     "use strict";
 
     var result = @toString(this);
-    for (var i = 0, length = arguments.length; i < length; ++i)
+    for (var i = 0, length = @argumentCount(); i < length; ++i)
         result += @toString(arguments[i]);
     return result;
 }

--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -27,7 +27,7 @@
 function of(/* items... */)
 {
     "use strict";
-    var len = arguments.length;
+    var len = @argumentCount();
 
     if (!@isConstructor(this))
         @throwTypeError("TypedArray.of requires |this| to be a constructor");


### PR DESCRIPTION
#### f687e2bb46ac009038255a33108a580c87095d88
<pre>
[JSC] Use `@argumentCount` instead of `arguments.length` in builtin JS
<a href="https://bugs.webkit.org/show_bug.cgi?id=280816">https://bugs.webkit.org/show_bug.cgi?id=280816</a>

Reviewed by Yusuke Suzuki.

This patch changes to use `@argumentCount` instead of `arguments.length` in builtin JS code for
consistency.

* Source/JavaScriptCore/builtins/ArrayConstructor.js:
(of):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(linkTimeConstant.concatSlowPath):
(toSpliced):
* Source/JavaScriptCore/builtins/FunctionPrototype.js:
(call):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(try):
* Source/JavaScriptCore/builtins/StringConstructor.js:
(raw):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(linkTimeConstant.stringConcatSlowPath):
* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
(of):

Canonical link: <a href="https://commits.webkit.org/284616@main">https://commits.webkit.org/284616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b3513e78710525dd747c4ba21b7ffefdd04559d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57205 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21013 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55539 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14026 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19539 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75804 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69250 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63178 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4810 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91032 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45208 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/19849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47553 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46023 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->