### PR TITLE
Add missing `SecureContext` to `ClipboardItem` interface

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.idl
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/clipboard-apis/#clipboard-item-interface
+
 typedef (DOMString or Blob) ClipboardItemDataType;
 typedef Promise<ClipboardItemDataType> ClipboardItemData;
 
@@ -33,11 +35,12 @@ dictionary ClipboardItemOptions {
 };
 
 [
+    SecureContext,
     Exposed=Window,
     EnabledBySetting=AsyncClipboardAPIEnabled,
     GenerateIsReachable=ReachableFromNavigator
 ] interface ClipboardItem {
-    constructor(record<DOMString, ClipboardItemData> items, optional ClipboardItemOptions options);
+    constructor(record<DOMString, ClipboardItemData> items, optional ClipboardItemOptions options = {});
 
     readonly attribute FrozenArray<DOMString> types;
     [NewObject] Promise<Blob> getType(DOMString type);


### PR DESCRIPTION
#### a16fdf97cf49d6f365c9610d258ed25b9652960f
<pre>
Add missing `SecureContext` to `ClipboardItem` interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=280817">https://bugs.webkit.org/show_bug.cgi?id=280817</a>
<a href="https://rdar.apple.com/137197266">rdar://137197266</a>

Reviewed by Wenson Hsieh.

This patch adds missing `SecureContext` from `ClipboardItem` interface as
per web specification [1]:

[1] <a href="https://w3c.github.io/clipboard-apis/#clipboard-item-interface">https://w3c.github.io/clipboard-apis/#clipboard-item-interface</a>

It also do drive-by to add specification link and `{}` to constructor
argument.

* Source/WebCore/Modules/async-clipboard/ClipboardItem.idl:

Canonical link: <a href="https://commits.webkit.org/284611@main">https://commits.webkit.org/284611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da98d59e49aed9c883f44bbd22c7a28eb583bfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21169 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55547 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14033 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17812 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63249 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4820 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45215 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46289 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->