### PR TITLE
Fix testSShrCompare* to work on 32-bits

### DIFF
--- a/Source/JavaScriptCore/b3/testb3_8.cpp
+++ b/Source/JavaScriptCore/b3/testb3_8.cpp
@@ -1530,8 +1530,8 @@ void testSShrCompare32(int32_t constantValue)
     auto compile = [&](B3::Opcode opcode, uint32_t shiftAmount, uint32_t constantValue) {
         Procedure proc;
         BasicBlock* root = proc.addBlock();
-        auto* value = root->appendNew<Value>(proc, Trunc, Origin(), root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0));
-        auto* shifted = root->appendNew<Value>(proc, SShr, Origin(), value, root->appendNew<Const32Value>(proc, Origin(), shiftAmount));
+        auto arguments = cCallArgumentValues<int32_t>(proc, root);
+        auto* shifted = root->appendNew<Value>(proc, SShr, Origin(), arguments[0], root->appendNew<Const32Value>(proc, Origin(), shiftAmount));
         auto* constant = root->appendNew<Const32Value>(proc, Origin(), constantValue);
         auto* comparison = root->appendNew<Value>(proc, opcode, Origin(), shifted, constant);
         root->appendNewControlValue(proc, Return, Origin(), comparison);
@@ -1565,8 +1565,8 @@ void testSShrCompare64(int64_t constantValue)
     auto compile = [&](B3::Opcode opcode, uint64_t shiftAmount, uint64_t constantValue) {
         Procedure proc;
         BasicBlock* root = proc.addBlock();
-        auto* value = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
-        auto* shifted = root->appendNew<Value>(proc, SShr, Origin(), value, root->appendNew<Const32Value>(proc, Origin(), shiftAmount));
+        auto arguments = cCallArgumentValues<uint64_t>(proc, root);
+        auto* shifted = root->appendNew<Value>(proc, SShr, Origin(), arguments[0], root->appendNew<Const32Value>(proc, Origin(), shiftAmount));
         auto* constant = root->appendNew<Const64Value>(proc, Origin(), constantValue);
         auto* comparison = root->appendNew<Value>(proc, opcode, Origin(), shifted, constant);
         root->appendNewControlValue(proc, Return, Origin(), comparison);


### PR DESCRIPTION
#### 379ed4e35a3b812c793cdfc56eb84ee758c05097
<pre>
Fix testSShrCompare* to work on 32-bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=280818">https://bugs.webkit.org/show_bug.cgi?id=280818</a>

Reviewed by Justin Michaud.

Use cCallArgumentValues to abstract away 32/64-bit differences in
incoming args.

* Source/JavaScriptCore/b3/testb3_8.cpp:
(testSShrCompare32):
(testSShrCompare64):

Canonical link: <a href="https://commits.webkit.org/284683@main">https://commits.webkit.org/284683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8583fc0faf61dc50ac1cd100c0d715a9c626cf5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55548 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14036 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19547 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75814 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69258 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17386 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63248 "Found 1 new test failure: webanimations/accelerated-translate-animation-additional-animation-added-in-flight.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4816 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45216 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19851 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->