### PR TITLE
[scroll-animations] update `AnimationEffectTiming` and `BasicEffectTiming` to use `CSSNumberishTime`

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -89,7 +89,7 @@ public:
     double iterations() const { return m_timing.iterations; }
     ExceptionOr<void> setIterations(double);
 
-    Seconds iterationDuration() const { return m_timing.iterationDuration; }
+    CSSNumberishTime iterationDuration() const { return m_timing.iterationDuration; }
     void setIterationDuration(const Seconds&);
 
     PlaybackDirection direction() const { return m_timing.direction; }
@@ -98,8 +98,8 @@ public:
     TimingFunction* timingFunction() const { return m_timing.timingFunction.get(); }
     void setTimingFunction(const RefPtr<TimingFunction>&);
 
-    Seconds activeDuration() const { return m_timing.activeDuration; }
-    Seconds endTime() const { return m_timing.endTime; }
+    CSSNumberishTime activeDuration() const { return m_timing.activeDuration; }
+    CSSNumberishTime endTime() const { return m_timing.endTime; }
 
     void updateStaticTimingProperties();
 

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -52,13 +52,13 @@ struct AnimationEffectTiming {
     double iterations { 1 };
     Seconds delay { 0_s };
     Seconds endDelay { 0_s };
-    Seconds iterationDuration { 0_s };
-    Seconds activeDuration { 0_s };
-    Seconds endTime { 0_s };
+    CSSNumberishTime iterationDuration { 0_s };
+    CSSNumberishTime activeDuration { 0_s };
+    CSSNumberishTime endTime { 0_s };
 
     void updateComputedProperties();
-    BasicEffectTiming getBasicTiming(std::optional<Seconds> localTime, double playbackRate) const;
-    ResolvedEffectTiming resolve(std::optional<Seconds> localTime, double playbackRate) const;
+    BasicEffectTiming getBasicTiming(std::optional<CSSNumberishTime> localTime, double playbackRate) const;
+    ResolvedEffectTiming resolve(std::optional<CSSNumberishTime> localTime, double playbackRate) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/BasicEffectTiming.h
+++ b/Source/WebCore/animation/BasicEffectTiming.h
@@ -26,16 +26,17 @@
 #pragma once
 
 #include "AnimationEffectPhase.h"
+#include "CSSNumberishTime.h"
 #include <wtf/Markable.h>
 #include <wtf/Seconds.h>
 
 namespace WebCore {
 
 struct BasicEffectTiming {
-    Markable<Seconds, Seconds::MarkableTraits> localTime;
-    Markable<Seconds, Seconds::MarkableTraits> activeTime;
-    Seconds endTime;
-    Seconds activeDuration;
+    std::optional<CSSNumberishTime> localTime;
+    std::optional<CSSNumberishTime> activeTime;
+    CSSNumberishTime endTime;
+    CSSNumberishTime activeDuration;
     AnimationEffectPhase phase;
 };
 

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -32,6 +32,19 @@
 
 namespace WebCore {
 
+CSSNumberishTime::CSSNumberishTime(std::optional<Seconds> time, std::optional<double> percentage)
+{
+    ASSERT(time || percentage);
+    ASSERT(!!time != !!percentage);
+    if (time) {
+        m_type = Type::Time;
+        m_value = time->seconds();
+    } else {
+        m_type = Type::Percentage;
+        m_value = *percentage;
+    }
+}
+
 CSSNumberishTime::CSSNumberishTime(const Seconds& value)
     : m_type(Type::Time)
     , m_value(value.seconds())
@@ -93,6 +106,24 @@ bool CSSNumberishTime::isValid() const
     return m_type == Type::Time;
 }
 
+bool CSSNumberishTime::isInfinity() const
+{
+    return std::isinf(m_value);
+}
+
+bool CSSNumberishTime::isZero() const
+{
+    return !m_value;
+}
+
+bool CSSNumberishTime::approximatelyEqualTo(const CSSNumberishTime& other) const
+{
+    ASSERT(m_type == other.m_type);
+    if (m_type == Type::Time)
+        return std::abs(time()->microseconds() - other.time()->microseconds()) < timeEpsilon.microseconds();
+    return m_value == other.m_value;
+}
+
 CSSNumberishTime CSSNumberishTime::operator+(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
@@ -103,6 +134,12 @@ CSSNumberishTime CSSNumberishTime::operator-(const CSSNumberishTime& other) cons
 {
     ASSERT(m_type == other.m_type);
     return { m_type, m_value - other.m_value };
+}
+
+double CSSNumberishTime::operator/(const CSSNumberishTime& other) const
+{
+    ASSERT(m_type == other.m_type);
+    return m_value / other.m_value;
 }
 
 CSSNumberishTime& CSSNumberishTime::operator+=(const CSSNumberishTime& other)

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -33,17 +33,22 @@ namespace WebCore {
 class CSSNumberishTime {
 public:
     CSSNumberishTime() = default;
+    WEBCORE_EXPORT CSSNumberishTime(std::optional<Seconds>, std::optional<double>);
 
     CSSNumberishTime(const Seconds&);
     CSSNumberishTime(const CSSNumberish&);
 
-    std::optional<Seconds> time() const;
-    std::optional<double> percentage() const;
+    WEBCORE_EXPORT std::optional<Seconds> time() const;
+    WEBCORE_EXPORT std::optional<double> percentage() const;
 
     bool isValid() const;
+    bool isInfinity() const;
+    bool isZero() const;
+    bool approximatelyEqualTo(const CSSNumberishTime&) const;
 
     CSSNumberishTime operator+(const CSSNumberishTime&) const;
     CSSNumberishTime operator-(const CSSNumberishTime&) const;
+    double operator/(const CSSNumberishTime&) const;
     CSSNumberishTime& operator+=(const CSSNumberishTime&);
     CSSNumberishTime& operator-=(const CSSNumberishTime&);
     bool operator<(const CSSNumberishTime&) const;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2117,7 +2117,7 @@ Ref<const Animation> KeyframeEffect::backingAnimationForCompositedRenderer() con
     // FIXME: The iterationStart and endDelay AnimationEffectTiming properties do not have
     // corresponding Animation properties.
     auto animation = Animation::create();
-    animation->setDuration(iterationDuration().seconds());
+    animation->setDuration(iterationDuration().time()->seconds());
     animation->setDelay(delay().seconds());
     animation->setIterationCount(iterations());
     animation->setTimingFunction(timingFunction()->clone());

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -69,7 +69,7 @@ public:
     using AccumulationCallback = Function<void(const Keyframe&)>;
     using InterpolationCallback = Function<void(double intervalProgress, double currentIteration, IterationCompositeOperation)>;
     using RequiresBlendingForAccumulativeIterationCallback = Function<bool()>;
-    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, Seconds iterationDuration, TimingFunction::Before, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
+    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, const CSSNumberishTime& iterationDuration, TimingFunction::Before, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
 
     virtual ~KeyframeInterpolation() = default;
 };

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -329,7 +329,7 @@ void StyleOriginatedAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEv
             auto iterationBoundary = iteration;
             if (m_previousIteration > iteration)
                 iterationBoundary++;
-            auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : 0_s;
+            auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : zeroTime();
             enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime, effectTimeAtIteration(iteration));
         } else if (wasActive && isAfter)
             enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -661,11 +661,17 @@ auto WebAnimation::playState() const -> PlayState
     return PlayState::Running;
 }
 
-Seconds WebAnimation::effectEndTime() const
+CSSNumberishTime WebAnimation::zeroTime() const
+{
+    // FIXME: once we had support for progress-based timelines, return 0% here.
+    return { 0_s };
+}
+
+CSSNumberishTime WebAnimation::effectEndTime() const
 {
     // The target effect end of an animation is equal to the end time of the animation's target effect.
     // If the animation has no target effect, the target effect end is zero.
-    return m_effect ? m_effect->endTime() : 0_s;
+    return m_effect ? m_effect->endTime() : zeroTime();
 }
 
 void WebAnimation::cancel(Silently silently)
@@ -819,7 +825,7 @@ ExceptionOr<void> WebAnimation::finish()
     // 3. Set limit as follows:
     // If animation playback rate > 0, let limit be target effect end.
     // Otherwise, let limit be zero.
-    auto limit = m_playbackRate > 0 ? effectEndTime() : 0_s;
+    auto limit = m_playbackRate > 0 ? effectEndTime() : zeroTime();
 
     // 4. Silently set the current time to limit.
     silentlySetCurrentTime(limit);
@@ -884,7 +890,7 @@ void WebAnimation::updateFinishedState(DidSeek didSeek, SynchronouslyNotify sync
     // 1. Let the unconstrained current time be the result of calculating the current time substituting an unresolved time value
     // for the hold time if did seek is false. If did seek is true, the unconstrained current time is equal to the current time.
     auto unconstrainedCurrentTime = currentTime(didSeek == DidSeek::Yes ? RespectHoldTime::Yes : RespectHoldTime::No);
-    CSSNumberishTime endTime { effectEndTime() };
+    auto endTime = effectEndTime();
 
     // 2. If all three of the following conditions are true,
     //    - the unconstrained current time is resolved, and
@@ -1199,8 +1205,8 @@ ExceptionOr<void> WebAnimation::pause()
     if (!localTime) {
         if (m_playbackRate >= 0) {
             // If animation's playback rate is ≥ 0, let animation's hold time be zero.
-            m_holdTime = 0_s;
-        } else if (effectEndTime() == Seconds::infinity()) {
+            m_holdTime = zeroTime();
+        } else if (effectEndTime().isInfinity()) {
             // Otherwise, if target effect end for animation is positive infinity, throw an InvalidStateError and abort these steps.
             return Exception { ExceptionCode::InvalidStateError };
         } else {

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -178,6 +178,7 @@ protected:
     void initialize();
     void enqueueAnimationEvent(Ref<AnimationEventBase>&&);
     virtual void animationDidFinish();
+    CSSNumberishTime zeroTime() const;
 
 private:
     enum class DidSeek : bool { No, Yes };
@@ -188,7 +189,7 @@ private:
 
     void timingDidChange(DidSeek, SynchronouslyNotify, Silently = Silently::No);
     void updateFinishedState(DidSeek, SynchronouslyNotify);
-    Seconds effectEndTime() const;
+    CSSNumberishTime effectEndTime() const;
     WebAnimation& readyPromiseResolve();
     WebAnimation& finishedPromiseResolve();
     std::optional<CSSNumberishTime> currentTime(RespectHoldTime, std::optional<CSSNumberishTime> = std::nullopt) const;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -212,8 +212,11 @@ static Ref<Inspector::Protocol::Animation::Effect> buildObjectForEffect(Animatio
     effectPayload->setIterationCount(effect.iterations() == std::numeric_limits<double>::infinity() ? -1 : effect.iterations());
     effectPayload->setIterationStart(effect.iterationStart());
 
-    if (auto iterationDuration = protocolValueForSeconds(effect.iterationDuration()))
-        effectPayload->setIterationDuration(iterationDuration.value());
+    // FIXME: convert this to CSSNumberishTime.
+    if (auto durationTime = effect.iterationDuration().time()) {
+        if (auto iterationDuration = protocolValueForSeconds(*durationTime))
+            effectPayload->setIterationDuration(iterationDuration.value());
+    }
 
     if (auto* timingFunction = effect.timingFunction())
         effectPayload->setTimingFunction(timingFunction->cssText());

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6303,6 +6303,11 @@ struct WebCore::AcceleratedEffectValues {
     WebCore::FilterOperations backdropFilter;
 }
 
+class WebCore::CSSNumberishTime {
+    std::optional<Seconds> time();
+    std::optional<double> percentage();
+};
+
 struct WebCore::AnimationEffectTiming {
     RefPtr<WebCore::TimingFunction> timingFunction;
     WebCore::FillMode fill;
@@ -6311,9 +6316,9 @@ struct WebCore::AnimationEffectTiming {
     double iterations;
     Seconds delay;
     Seconds endDelay;
-    Seconds iterationDuration;
-    Seconds activeDuration;
-    Seconds endTime;
+    WebCore::CSSNumberishTime iterationDuration;
+    WebCore::CSSNumberishTime activeDuration;
+    WebCore::CSSNumberishTime endTime;
 };
 
 header: <WebCore/AcceleratedEffect.h>


### PR DESCRIPTION
#### 82e54eaf31dbcf921a25b93e0751869a876bd04f
<pre>
[scroll-animations] update `AnimationEffectTiming` and `BasicEffectTiming` to use `CSSNumberishTime`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280823">https://bugs.webkit.org/show_bug.cgi?id=280823</a>
<a href="https://rdar.apple.com/137200964">rdar://137200964</a>

Reviewed by Cameron McCormack.

We refactor yet more code backing timing computations to `CSSNumberishTime` instead of `Seconds`,
paving the way to supporting percentage values for Scroll-driven Animations.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::durationAPIValue):
(WebCore::AnimationEffect::getBindingsTiming const):
(WebCore::AnimationEffect::getComputedTiming const):
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::iterationDuration const):
(WebCore::AnimationEffect::activeDuration const):
(WebCore::AnimationEffect::endTime const):
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::updateComputedProperties):
(WebCore::AnimationEffectTiming::getBasicTiming const):
(WebCore::AnimationEffectTiming::resolve const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/animation/BasicEffectTiming.h:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::CSSNumberishTime):
(WebCore::CSSNumberishTime::isInfinity const):
(WebCore::CSSNumberishTime::isZero const):
(WebCore::CSSNumberishTime::approximatelyEqualTo const):
(WebCore::CSSNumberishTime::operator/ const):
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::backingAnimationForCompositedRenderer const):
* Source/WebCore/animation/KeyframeInterpolation.cpp:
(WebCore::transformProgressDuration):
(WebCore::KeyframeInterpolation::interpolateKeyframes const):
* Source/WebCore/animation/KeyframeInterpolation.h:
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::invalidateDOMEvents):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::zeroTime const):
(WebCore::WebAnimation::effectEndTime const):
(WebCore::WebAnimation::finish):
(WebCore::WebAnimation::updateFinishedState):
(WebCore::WebAnimation::pause):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/284666@main">https://commits.webkit.org/284666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41ee5f9e0ba5a21b232911eaf8cf7a3158b5723a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22929 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21184 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/41797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19701 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/18284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/75970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14431 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/60575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/75970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/11320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10718 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45374 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->