### PR TITLE
AX: Implement TextUnit::LeftWord/RightWord off the main thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-word-nav-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-word-nav-expected.txt
@@ -1,0 +1,109 @@
+This tests that word navigation is working correctly.
+Current character is: w
+Left word is: word1
+Right word is: word1
+
+Current character is: t
+Left word is: test
+Right word is:
+
+Current character is: T
+Left word is: Thisislongword
+Right word is: Thisislongword
+
+Current character is:
+Left word is:
+Right word is: I'll
+
+Current character is:
+Left word is:
+Right word is: try
+
+Current character is: e
+Left word is: editable
+Right word is: editable
+
+Current character is:
+Left word is:
+Right word is: [ATTACHMENT]
+
+Current character is: [ATTACHMENT]
+Left word is: [ATTACHMENT]
+Right word is: d
+
+Current character is: c
+Left word is: can't
+Right word is: can't
+
+Current character is:
+Left word is: 巧克力
+Right word is: 巧克力
+
+Current character is: 克
+Left word is: 巧克力
+Right word is: 巧克力
+
+Current character is: 力
+Left word is: 巧克力
+Right word is: 是
+
+Current character is: 是
+Left word is: 是
+Right word is: 食物
+
+Current character is: ف
+Left word is: كيف
+Right word is:
+
+Current character is:
+Left word is:
+Right word is: حالك
+
+Current character is: h
+Left word is: both
+Right word is:
+
+Current character is: s
+Left word is: spaces
+Right word is:
+
+Current character is: e
+Left word is: some
+Right word is:
+
+Current character is: 'line break'
+Left word is:
+Right word is:
+
+Current character is:
+Left word is:
+Right word is: [ATTACHMENT]
+
+Current character is: [ATTACHMENT]
+Left word is: [ATTACHMENT]
+Right word is: file
+
+Current character is: f
+Left word is: file
+Right word is: file
+
+Current character is: t
+Left word is: Edit
+Right word is:
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+word1 test
+Thisislongword I'll try. Test Contenteditable is working.
+c d
+can't select
+巧克力是食物吗？
+كيف حالك؟
+both   spaces
+line breaks
+some
+text
+test audio file
+Edit text End

--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-word-nav.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-word-nav.html
@@ -1,0 +1,201 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a modern-style rewrite of mac/text-marker-word-nav.html, and should replace it after AccessibilityThreadTextApisEnabled is enabled by default. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<title>Line Range for Text Marker</title>
+<meta charset="utf-8"> 
+</head>
+<body>
+
+<div id="text" tabindex="0">word1 test</div>
+<span id="span">Thisis</span>longword I<span>'ll try.</span>
+Test Content<span id="target" contenteditable="true">editable is working.</span>
+
+<div id="text2">
+c <img src="#" aria-label="blah" style="background-color: #aaaaaa; width: 100px; height: 100px;">d
+</div>
+
+<div class="userselect" id="text3">can't select</div>
+
+<div id="text4">
+巧克力是食物吗？
+</div>
+<div id="text4a">
+كيف حالك؟
+</div>
+
+<pre id="text5">
+both   spaces
+line breaks
+</pre>
+
+<div id="text6">
+some<br>text
+</div>
+
+<div id="text7">
+test audio <audio controls><source src="test.mp3" type="audio/mpeg"></audio>file
+</div>
+
+<p id="text8">
+<strong>Edit</strong>
+text End
+</p>
+
+
+<script>
+var output = "This tests that word navigation is working correctly.\n";
+
+if (window.accessibilityController) {
+    var text = accessibilityController.accessibleElementById("text");
+    // Get the actual text node.
+    text = text.childAtIndex(0);
+
+    // Check that we can get the word range. Land at "w" in "word1 test".
+    var textMarkerRange = text.textMarkerRangeForElement(text);
+    var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    var currentMarker = advanceAndVerify(startMarker, 1, text);
+    
+    // Check that we are at the end of paragraph, so right word should be empty
+    currentMarker = advanceAndVerify(currentMarker, 9, text);
+    
+    // Check the case with span
+    // At "T" in "Thisis", should return the word as "Thisislongword".
+    currentMarker = advanceAndVerify(currentMarker, 1, text);
+    // // At " " before "I", the word should be "I'll".
+    currentMarker = advanceAndVerify(currentMarker, 14, text);
+    // // At " " before "try", the word should excludes "."
+    currentMarker = advanceAndVerify(currentMarker, 5, text);
+
+    // Check the case with contenteditable
+    // At "e" in "editable", the word should NOT include "Content" before it.
+    currentMarker = advanceAndVerify(currentMarker, 18, text);
+
+    // // Check the case with replaced node, the replaced node should be considered a word.
+    var text2 = accessibilityController.accessibleElementById("text2");
+    textMarkerRange = text2.textMarkerRangeForElement(text2);
+    currentMarker = text2.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(currentMarker, 2, text2);
+    currentMarker = advanceAndVerify(currentMarker, 1, text2);
+
+    // Check user-select:none is also working.
+    var text3 = accessibilityController.accessibleElementById("text3");
+    textMarkerRange = text3.textMarkerRangeForElement(text3);
+    currentMarker = text3.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(currentMarker, 1, text3);
+
+    // Check multi-language, Chinese here.
+    var text4 = accessibilityController.accessibleElementById("text4");
+    textMarkerRange = text4.textMarkerRangeForElement(text4);
+    currentMarker = text4.startTextMarkerForTextMarkerRange(textMarkerRange);
+    // Make sure when we are at the beginning of line, it won't go to previous node.
+    // FIXME: Left word in the live tree returns a word, which is inconsistent with other left words when at the beginning of a word.
+    currentMarker = advanceAndVerify(currentMarker, 0, text4);
+    // FIXME: Currently returns an incorrect leftword: 克力 instead of 巧克力. Appears the word break iterator is not grabbing the first character.
+    currentMarker = advanceAndVerify(currentMarker, 2, text4);
+    currentMarker = advanceAndVerify(currentMarker, 1, text4);
+    currentMarker = advanceAndVerify(currentMarker, 1, text4);
+
+    // And Arabic
+    var text4a = accessibilityController.accessibleElementById("text4a");
+    textMarkerRange = text4a.textMarkerRangeForElement(text4a);
+    currentMarker = text4a.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(currentMarker, 3, text4a);
+    currentMarker = advanceAndVerify(currentMarker, 1, text4a);
+
+    // Check text in pre tag with line breaks.
+    var text5 = accessibilityController.accessibleElementById("text5");
+    textMarkerRange = text5.textMarkerRangeForElement(text5);
+    currentMarker = text5.startTextMarkerForTextMarkerRange(textMarkerRange);
+    // At "h" in "both", right word should be "   ".
+    currentMarker = advanceAndVerify(currentMarker, 4, text5);
+    // At the end of first line, right word should be new line.
+    currentMarker = advanceAndVerify(currentMarker, 9, text5);
+
+    // Check text with br tag in it.
+    var text6 = accessibilityController.accessibleElementById("text6");
+    textMarkerRange = text6.textMarkerRangeForElement(text6);
+    currentMarker = text6.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(currentMarker, 4, text6); /* Right word here is *linebreak* */
+    // FIXME: Previous expectation had left and right word both be empty. This new expectation expects that the right and left words are the words on either side of the line break.
+    currentMarker = advanceAndVerify(currentMarker, 1, text6);
+
+    // Check <audio> element.
+    var text7 = accessibilityController.accessibleElementById("text7");
+    textMarkerRange = text7.textMarkerRangeForElement(text7);
+    currentMarker = text7.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(currentMarker, 11, text7);
+    currentMarker = advanceAndVerify(currentMarker, 1, text7);
+    currentMarker = advanceAndVerify(currentMarker, 1, text7);
+
+    // For node with text node children, we should treat the visual space as word boundary.
+    var text8 = accessibilityController.accessibleElementById("text8");
+    textMarkerRange = text8.textMarkerRangeForElement(text8);
+    currentMarker = text8.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(currentMarker, 4, text8);
+
+    debug(output);
+}
+
+function advanceAndVerify(currentMarker, offset, obj) {
+    var previousMarker = currentMarker;
+    for (var i = 0; i < offset; i++) {
+        previousMarker = currentMarker;
+        currentMarker = obj.nextTextMarker(previousMarker);
+    }
+    verifyWordRangeForTextMarker(previousMarker, currentMarker, obj);
+    return currentMarker;
+}
+
+function replaceAttachmentInString(str) {
+    var newline = '\n';
+    str =  str.replace(String.fromCharCode(65532), "[ATTACHMENT]");
+    str = str.replace(newline, "'line break'");
+    return str;
+}
+
+function verifyWordRangeForTextMarker(preMarker, textMarker, obj) {
+    var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
+    var currentCharacter = replaceAttachmentInString(obj.stringForTextMarkerRange(markerRange));
+    output += `Current character is: ${currentCharacter}\n`;
+    
+    var previousWordRange = obj.leftWordTextMarkerRangeForTextMarker(textMarker);
+    var nextWordRange = obj.rightWordTextMarkerRangeForTextMarker(textMarker);
+    var preWord = replaceAttachmentInString(obj.stringForTextMarkerRange(previousWordRange));
+    var nextWord = replaceAttachmentInString(obj.stringForTextMarkerRange(nextWordRange));
+    output += `Left word is: ${preWord}\n`;
+    output += `Right word is: ${nextWord}\n`;
+    output += "\n";
+}
+
+function verifyDocument(obj) {
+    var start = obj.startTextMarker;
+    
+    // Going forward.
+    output += "Test going forward.\n";
+    var current = start;
+    var endWord = "End";
+    var currWord = "";
+    while(currWord != endWord) {
+        var nextWordRange = obj.rightWordTextMarkerRangeForTextMarker(current);
+        currWord = obj.stringForTextMarkerRange(nextWordRange);
+        current = obj.nextWordEndTextMarkerForTextMarker(current);
+    }
+    output += `End word: ${replaceAttachmentInString(currWord)}`;
+    
+    // Going backwards
+    output += "\nTest going backwards.";
+    var startWord = "word1";
+    currWord = ""; 
+    while(currWord != startWord) {
+        var previousWordRange = obj.leftWordTextMarkerRangeForTextMarker(current);
+        currWord = obj.stringForTextMarkerRange(previousWordRange);
+        current = obj.previousWordStartTextMarkerForTextMarker(current);
+    }
+    output += `\nStart word: ${replaceAttachmentInString(currWord)}`;
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -49,6 +49,15 @@ enum class LineRangeType : uint8_t {
     Right,
 };
 
+enum class WordRangeType : uint8_t {
+    Left,
+    Right,
+};
+
+// Options for findMarker
+enum class CoalesceObjectBreaks : bool { No, Yes };
+enum class IgnoreBRs : bool { No, Yes };
+
 struct TextMarkerData {
     unsigned treeID;
     unsigned objectID;
@@ -163,14 +172,20 @@ public:
     bool isInTextRun() const;
 
     // Find the next or previous marker, optionally stopping at the given ID and returning an invalid marker.
-    AXTextMarker findMarker(AXDirection, std::optional<AXID> = std::nullopt) const;
+    AXTextMarker findMarker(AXDirection, CoalesceObjectBreaks = CoalesceObjectBreaks::Yes, IgnoreBRs = IgnoreBRs::No, std::optional<AXID> = std::nullopt) const;
     // Starting from this text marker, creates a new position for the given direction and text unit type.
     AXTextMarker findMarker(AXDirection, AXTextUnit, AXTextUnitBoundary, std::optional<AXID> stopAtID = std::nullopt) const;
     AXTextMarker previousLineStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Line, AXTextUnitBoundary::Start, stopAtID); }
     AXTextMarker nextLineEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Line, AXTextUnitBoundary::End, stopAtID); }
+    AXTextMarker nextWordStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Word, AXTextUnitBoundary::Start, stopAtID); }
+    AXTextMarker nextWordEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Word, AXTextUnitBoundary::End, stopAtID); }
+    AXTextMarker previousWordStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Word, AXTextUnitBoundary::Start, stopAtID); }
+    AXTextMarker previousWordEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Word, AXTextUnitBoundary::End, stopAtID); }
 
     // Creates a range for the line this marker points to.
     AXTextMarkerRange lineRange(LineRangeType) const;
+    // Creates a range for the word specified by the line range type.
+    AXTextMarkerRange wordRange(WordRangeType) const;
     // Given a character offset relative to this marker, find the next marker the offset points to.
     AXTextMarker nextMarkerFromOffset(unsigned) const;
     // Returns the number of intermediate text markers between this and the root.
@@ -203,6 +218,8 @@ private:
     bool atLineBoundaryForDirection(AXDirection) const;
     bool atLineStart() const { return atLineBoundaryForDirection(AXDirection::Previous); }
     bool atLineEnd() const { return atLineBoundaryForDirection(AXDirection::Next); }
+    // True when two nodes are visually the same (i.e. on the boundary of an object)
+    bool equivalentTextPosition(const AXTextMarker&) const;
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
     TextMarkerData m_data;

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -122,6 +122,7 @@ struct AXTextRuns {
         return { containingBlock, runs[index].lineIndex };
     }
     String substring(unsigned start, unsigned length = StringImpl::MaxLength) const;
+    String toString() const { return substring(0); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1134,7 +1134,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         // text APIs off the main-thread because this allows them to be part of the AX tree, which is
         // traversed to compute text markers.
         auto* node = this->node();
-        return !node || !node->hasEditableStyle();
+        return !node;
 #else
         return true;
 #endif
@@ -1448,6 +1448,12 @@ AXTextRuns AccessibilityRenderObject::textRuns()
             return containingBlock ? AXTextRuns(containingBlock, { AXTextRun(0, inputElement->value().isolatedCopy()) }) : AXTextRuns();
         }
         return { };
+    }
+
+    if (is<HTMLImageElement>(node()) || is<HTMLMediaElement>(node())) {
+        auto* renderer = this->renderer();
+        auto* containingBlock = renderer ? renderer->containingBlock() : nullptr;
+        return containingBlock ? AXTextRuns(containingBlock, { AXTextRun(0, String(span(objectReplacementCharacter))) }) : AXTextRuns();
     }
 
     WeakPtr renderText = dynamicDowncast<RenderText>(renderer());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -86,6 +86,8 @@ public:
     bool shouldEmitNewlinesBeforeAndAfterNode() const final { return boolAttributeValue(AXPropertyName::ShouldEmitNewlinesBeforeAndAfterNode); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
+    AXTextMarkerRange textMarkerRange() const final;
+
 private:
     constexpr ProcessID processID() const final { return tree()->processID(); }
     void detachRemoteParts(AccessibilityDetachmentType) final;
@@ -394,7 +396,6 @@ private:
 
     std::optional<SimpleRange> simpleRange() const final;
     VisiblePositionRange visiblePositionRange() const final;
-    AXTextMarkerRange textMarkerRange() const final;
 
     String selectedText() const final;
     VisiblePositionRange visiblePositionRangeForLine(unsigned) const final;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3054,6 +3054,20 @@ enum class TextUnit {
 
 - (AXTextMarkerRangeRef)textMarkerRangeAtTextMarker:(AXTextMarkerRef)textMarker forUnit:(TextUnit)textUnit
 {
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis()) {
+        AXTextMarker inputMarker { textMarker };
+        switch (textUnit) {
+        case TextUnit::LeftWord:
+            return inputMarker.wordRange(WordRangeType::Left).platformData().autorelease();
+        case TextUnit::RightWord:
+            return inputMarker.wordRange(WordRangeType::Right).platformData().autorelease();
+        default:
+            // TODO: Not implemented!
+            break;
+        }
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
     return Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRangeRef>([textMarker = retainPtr(textMarker), &textUnit, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRangeRef> {
         auto* backingObject = protectedSelf.get().axBackingObject;
         if (!backingObject)


### PR DESCRIPTION
#### bcf367428ee3db2103c809b74980932a50f902f2
<pre>
AX: Implement TextUnit::LeftWord/RightWord off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=280825">https://bugs.webkit.org/show_bug.cgi?id=280825</a>
<a href="https://rdar.apple.com/134579687">rdar://134579687</a>

Reviewed by Tyler Wilcock.

This patch implements the `AXLeftWordTextMarkerRangeForTextMarker` and `AXRightWordTextMarkerRangeForTextMarker` attributes using the secondary thread text markers. To mimic the live tree’s current behavior, several edges cases had to be considered:
* If at the end of a paragraph (containing block), return without a word.
* If we are finding the left word, and we are at a start word boundary, that should return the whitespace prior to the word (if any).
* If we are finding the right word, and are at the end boundary of a word, return the whitespace to the right of the word.

To verify this new behavior, the test `text-marker-word-nav` was ported over from the live tree, with some modifications. APIs that still used the live tree were removed, due to some issues with interop between live and isolated tree text markers. Three test cases were are currently failing with FIXMEs: two due to the word break iterator with Chinese characters, and one due to line break behavior.

In order to accurately accommodate handling word navigation, I had to make a change to the `findMarker` method to allow for coalescing object boundaries. This is the cases where the end position of one object is equivalent visually/in position to the start position of the next object. Coalescing mimics behavior from the live tree.

* LayoutTests/accessibility/ax-thread-text-apis/text-marker-word-nav-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/text-marker-word-nav.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineNumberForIndex const):
(WebCore::AXTextMarker::atLineBoundaryForDirection const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::findLastBefore const):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::wordRange const):
(WebCore::AXTextMarker::equivalentTextPosition const):
(WebCore::AXTextMarker::partialOrderByTraversal const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::nextWordStart const):
(WebCore::AXTextMarker::nextWordEnd const):
(WebCore::AXTextMarker::previousWordStart const):
(WebCore::AXTextMarker::previousWordEnd const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::toString const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper textMarkerRangeAtTextMarker:forUnit:]):

Canonical link: <a href="https://commits.webkit.org/284938@main">https://commits.webkit.org/284938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed27371c033acf7c03262d284804184f7922bcdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21963 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14595 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36563 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15172 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11905 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5552 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/928 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->