### PR TITLE
Flip hi/lo to lo/hi in LowerInt64 and related code

### DIFF
--- a/Source/JavaScriptCore/b3/B3ExtractValue.h
+++ b/Source/JavaScriptCore/b3/B3ExtractValue.h
@@ -35,8 +35,8 @@ class JS_EXPORT_PRIVATE ExtractValue final : public Value {
 public:
 #if CPU(ARM_THUMB2)
     // See LowerInt64 for details
-    static constexpr int s_int64HighBits = 0;
-    static constexpr int s_int64LowBits = 1;
+    static constexpr int s_int64HighBits = 1;
+    static constexpr int s_int64LowBits = 0;
 #endif
 
     static bool accepts(Kind kind) { return kind == Extract; }

--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -70,23 +70,23 @@ public:
             m_block = block;
             for (m_index = 0; m_index < m_block->size(); ++m_index) {
                 m_value = m_block->at(m_index);
-                Value* hi;
                 Value* lo;
+                Value* hi;
                 dataLogLnIf(B3LowerInt64Internal::verbose, "B3LowerInt64: prep for ", deepDump(m_value));
                 if ((m_value->type() == Int64) && (m_value->opcode() == Phi)) {
                     // Upsilon expects the target of a ->setPhi() to be a Phi,
                     // not an identity, so do the (trivial) lowering here.
-                    hi = insert<Value>(m_index + 1, Phi, Int32, m_value->origin());
                     lo = insert<Value>(m_index + 1, Phi, Int32, m_value->origin());
+                    hi = insert<Value>(m_index + 1, Phi, Int32, m_value->origin());
                 } else if (m_value->type() == Int64 || (m_value->opcode() == Upsilon && m_value->child(0)->type() == Int64)) {
-                    hi = insert<Value>(m_index + 1, Identity, m_value->origin(), m_zero);
                     lo = insert<Value>(m_index + 1, Identity, m_value->origin(), m_zero);
+                    hi = insert<Value>(m_index + 1, Identity, m_value->origin(), m_zero);
                 } else
                     continue;
-                m_syntheticValues.add(hi);
                 m_syntheticValues.add(lo);
-                dataLogLnIf(B3LowerInt64Internal::verbose, "Map ", *m_value, " -> (", deepDump(hi), ", ", deepDump(lo), ")");
-                m_mapping.add(m_value, std::pair<Value*, Value*> { hi, lo });
+                m_syntheticValues.add(hi);
+                dataLogLnIf(B3LowerInt64Internal::verbose, "Map ", *m_value, " -> (", deepDump(lo), ", ", deepDump(hi), ")");
+                m_mapping.add(m_value, std::pair<Value*, Value*> { lo, hi });
             }
             m_changed |= !m_insertionSet.isEmpty();
             m_insertionSet.execute(m_block);
@@ -118,15 +118,15 @@ public:
         return m_changed;
     }
 private:
-    void setMapping(Value* value, Value* hi, Value* lo)
+    void setMapping(Value* value, Value* lo, Value* hi)
     {
         std::pair<Value*, Value*> m = getMapping(value);
         ASSERT(m.first->opcode() == Identity);
         ASSERT(m.second->opcode() == Identity);
         ASSERT(m.first->child(0) == m_zero);
         ASSERT(m.second->child(0) == m_zero);
-        m.first->child(0) = hi;
-        m.second->child(0) = lo;
+        m.first->child(0) = lo;
+        m.second->child(0) = hi;
     }
 
     std::pair<Value*, Value*> getMapping(Value* value)
@@ -162,12 +162,12 @@ private:
         return insert<ExtractValue>(index, m_origin, Int32, value, ExtractValue::s_int64HighBits);
     }
 
-    Value* valueHiLo(Value* hi, Value* lo, std::optional<size_t> providedIndex = { })
+    Value* valueLoHi(Value* lo, Value* hi, std::optional<size_t> providedIndex = { })
     {
         size_t index = m_index;
         if (providedIndex)
             index = *providedIndex;
-        return insert<Value>(index, Stitch, m_origin, hi, lo);
+        return insert<Value>(index, Stitch, m_origin, lo, hi);
     }
 
     void valueReplaced()
@@ -197,8 +197,8 @@ private:
         Value* outputHi;
         Value* outputLo;
         Value* shiftComplement = appendToBlock<Value>(block, Sub, m_origin, appendToBlock<Const32Value>(block, m_origin, 32), maskedShift);
-        Value* inputHi = input.first;
-        Value* inputLo = input.second;
+        Value* inputHi = input.second;
+        Value* inputLo = input.first;
 
         if (opcode == SShr) {
             Value* shiftedLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, maskedShift);
@@ -217,7 +217,7 @@ private:
             Value* shiftedIntoHiFromLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, shiftComplement);
             outputHi = appendToBlock<Value>(block, BitOr, m_origin, shiftedHi, shiftedIntoHiFromLo);
         }
-        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputHi), appendToBlock<UpsilonValue>(block, m_origin, outputLo) };
+        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputLo), appendToBlock<UpsilonValue>(block, m_origin, outputHi) };
         appendToBlock<Value>(block, Jump, m_origin);
         return ret;
     }
@@ -228,17 +228,17 @@ private:
         Value* outputLo;
         Value* shift = appendToBlock<Value>(block, Sub, m_origin, maskedShift, appendToBlock<Const32Value>(block, m_origin, 32));
         if (opcode == SShr) {
-            outputLo = appendToBlock<Value>(block, SShr, m_origin, input.first, shift);
-            outputHi = appendToBlock<Value>(block, SShr, m_origin, input.first, appendToBlock<Const32Value>(block, m_origin, 31));
+            outputLo = appendToBlock<Value>(block, SShr, m_origin, input.second, shift);
+            outputHi = appendToBlock<Value>(block, SShr, m_origin, input.second, appendToBlock<Const32Value>(block, m_origin, 31));
         } else if (opcode == ZShr) {
-            outputLo = appendToBlock<Value>(block, ZShr, m_origin, input.first, shift);
+            outputLo = appendToBlock<Value>(block, ZShr, m_origin, input.second, shift);
             outputHi = appendToBlock<Const32Value>(block, m_origin, 0);
         } else {
             RELEASE_ASSERT(opcode == Shl);
-            outputHi = appendToBlock<Value>(block, Shl, m_origin, input.second, shift);
+            outputHi = appendToBlock<Value>(block, Shl, m_origin, input.first, shift);
             outputLo = appendToBlock<Const32Value>(block, m_origin, 0);
         }
-        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputHi), appendToBlock<UpsilonValue>(block, m_origin, outputLo) };
+        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputLo), appendToBlock<UpsilonValue>(block, m_origin, outputHi) };
         appendToBlock<Value>(block, Jump, m_origin);
         return ret;
     }
@@ -248,8 +248,8 @@ private:
         Value* outputHi;
         Value* outputLo;
         Value* rotationComplement = appendToBlock<Value>(block, Sub, m_origin, appendToBlock<Const32Value>(block, m_origin, 32), maskedRotation);
-        Value* inputHi = input.first;
-        Value* inputLo = input.second;
+        Value* inputHi = input.second;
+        Value* inputLo = input.first;
 
         if (opcode == RotR) {
             Value* rotatedLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, maskedRotation);
@@ -267,7 +267,7 @@ private:
             Value* rotatedIntoHiFromLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, rotationComplement);
             outputHi = appendToBlock<Value>(block, BitOr, m_origin, rotatedHi, rotatedIntoHiFromLo);
         }
-        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputHi), appendToBlock<UpsilonValue>(block, m_origin, outputLo) };
+        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputLo), appendToBlock<UpsilonValue>(block, m_origin, outputHi) };
         appendToBlock<Value>(block, Jump, m_origin);
         return ret;
     }
@@ -276,8 +276,8 @@ private:
     {
         Value* outputHi;
         Value* outputLo;
-        Value* inputHi = input.first;
-        Value* inputLo = input.second;
+        Value* inputHi = input.second;
+        Value* inputLo = input.first;
         Value* rotation = appendToBlock<Value>(block, Sub, m_origin, maskedRotation, appendToBlock<Const32Value>(block, m_origin, 32));
         Value* rotationComplement = appendToBlock<Value>(block, Sub, m_origin, appendToBlock<Const32Value>(block, m_origin, 32), rotation);
         if (opcode == RotR) {
@@ -296,7 +296,7 @@ private:
             Value* rotatedIntoHiFromHi = appendToBlock<Value>(block, ZShr, m_origin, inputHi, rotationComplement);
             outputHi = appendToBlock<Value>(block, BitOr, m_origin, rotatedIntoHiFromLo, rotatedIntoHiFromHi);
         }
-        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputHi), appendToBlock<UpsilonValue>(block, m_origin, outputLo) };
+        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputLo), appendToBlock<UpsilonValue>(block, m_origin, outputHi) };
         appendToBlock<Value>(block, Jump, m_origin);
         return ret;
     }
@@ -308,7 +308,7 @@ private:
         return m_insertionSet.insert<CCallValue>(m_index, type, m_origin, Effects::none(), functionAddress, arg);
     }
 
-    void splitRange(const HeapRange& original, HeapRange&hi, HeapRange&lo)
+    void splitRange(const HeapRange& original, HeapRange&lo, HeapRange&hi)
     {
         if (original.distance() == 1) {
             // XXX: testb3 uses single-byte range for Int64 access.
@@ -321,7 +321,7 @@ private:
             RELEASE_ASSERT(original.distance() == bytesForWidth(Width64));
             hi = HeapRange(original.begin() + bytesForWidth(Width32), original.end());
             lo = HeapRange(original.begin(), original.begin() + bytesForWidth(Width32));
-            RELEASE_ASSERT(!lo.overlaps(hi));
+            RELEASE_ASSERT(!hi.overlaps(lo));
         }
     }
 
@@ -353,16 +353,16 @@ private:
                 return;
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
-            Value* hi = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
-            Value* lo = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
-            setMapping(m_value, hi, lo);
+            Value* hi = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* lo = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
+            setMapping(m_value, lo, hi);
             valueReplaced();
             return;
         }
         case Const64: {
             Value* hi = insert<Const32Value>(m_index, m_origin, (m_value->asInt() >> 32) & 0xffffffff);
             Value* lo = insert<Const32Value>(m_index, m_origin, m_value->asInt() & 0xffffffff);
-            setMapping(m_value, hi, lo);
+            setMapping(m_value, lo, hi);
             valueReplaced();
             return;
         }
@@ -374,11 +374,11 @@ private:
                 return;
             auto phi = getMapping(m_value->as<UpsilonValue>()->phi());
             auto input = getMapping(m_value->child(0));
-            UpsilonValue* hi = insert<UpsilonValue>(m_index, m_origin, input.first);
-            hi->setPhi(phi.first);
-            UpsilonValue* lo = insert<UpsilonValue>(m_index, m_origin, input.second);
-            lo->setPhi(phi.second);
-            setMapping(m_value, hi, lo);
+            UpsilonValue* lo = insert<UpsilonValue>(m_index, m_origin, input.first);
+            lo->setPhi(phi.first);
+            UpsilonValue* hi = insert<UpsilonValue>(m_index, m_origin, input.second);
+            hi->setPhi(phi.second);
+            setMapping(m_value, lo, hi);
             valueReplaced();
             return;
         }
@@ -401,8 +401,8 @@ private:
                     else {
                         auto childParts = getMapping(child);
 
-                        args.append(childParts.second);
                         args.append(childParts.first);
+                        args.append(childParts.second);
                     }
                     gprCount += Air::cCallArgumentRegisterCount(child->type());
                 } else {
@@ -418,7 +418,6 @@ private:
             cCall->appendArgs(args);
             if (m_value->type() == Int64) {
                 ASSERT(isARM_THUMB2());
-                // Result registers are allocated lo->hi on ARMv7, so undo that here.
                 setMapping(m_value, valueLo(cCall, m_index + 1), valueHi(cCall, m_index + 1));
                 valueReplaced();
             } else
@@ -430,7 +429,7 @@ private:
                 return;
 
             CheckValue* originalCheck = m_value->as<CheckValue>();
-            // Putting together Int64 values with valueHiLo needs to preceed the
+            // Putting together Int64 values with valueLoHi needs to preceed the
             // insertion of the PatchpointValue.
             Vector<Value*> args;
             for (size_t index = 0; index < m_value->numChildren(); ++index) {
@@ -440,7 +439,7 @@ private:
                     // The rep should have been correctly assigned when the
                     // Patchpoint was created, here we simply piece together the
                     // 64-bit value that it expects.
-                    args.append(valueHiLo(childParts.first, childParts.second));
+                    args.append(valueLoHi(childParts.first, childParts.second));
                 } else
                     args.append(child);
             }
@@ -461,7 +460,7 @@ private:
                 check->append(args[index], reps[index]);
             m_value->replaceWithIdentity(check);
             if (m_value->type() == Int64)
-                setMapping(m_value, valueHi(m_value), valueLo(m_value));
+                setMapping(m_value, valueLo(m_value), valueHi(m_value));
             return;
         }
         case Patchpoint: {
@@ -485,8 +484,8 @@ private:
                         || rep.kind() == ValueRep::SomeRegister
                         || rep.kind() == ValueRep::SomeLateRegister
                         || rep.isAny());
-                    args.append(childParts.second);
-                    highArgs.append(childParts.first);
+                    args.append(childParts.first);
+                    highArgs.append(childParts.second);
 
                     if (rep.isStack())
                         rep = B3::ValueRep::stack(checkedSum<intptr_t>(rep.offsetFromFP(), static_cast<intptr_t>(bytesForWidth(Width32))));
@@ -560,7 +559,7 @@ private:
                 else if (rep.isStackArgument())
                     rep = B3::ValueRep::stackArgument(checkedSum<intptr_t>(rep.offsetFromSP(), static_cast<intptr_t>(bytesForWidth(Width32))));
                 patchpoint->resultConstraints.append(rep);
-                setMapping(m_value, valueHi(patchpoint, m_index + 1), valueLo(patchpoint, m_index + 1));
+                setMapping(m_value, valueLo(patchpoint, m_index + 1), valueHi(patchpoint, m_index + 1));
                 valueReplaced();
                 return;
             }
@@ -575,10 +574,10 @@ private:
                 return;
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
-            Value* stitchedLeft = valueHiLo(left.first, left.second, m_index + 1);
-            Value* stitchedRight = valueHiLo(right.first, right.second, m_index + 1);
+            Value* stitchedLeft = valueLoHi(left.first, left.second, m_index + 1);
+            Value* stitchedRight = valueLoHi(right.first, right.second, m_index + 1);
             Value* stitched = insert<Value>(m_index + 1, m_value->opcode(), m_origin, stitchedLeft, stitchedRight);
-            setMapping(m_value, valueHi(stitched, m_index + 1), valueLo(stitched, m_index + 1));
+            setMapping(m_value, valueLo(stitched, m_index + 1), valueHi(stitched, m_index + 1));
             valueReplaced();
             return;
         }
@@ -605,8 +604,8 @@ private:
                 return;
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
-            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
-            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
             Opcode combineOpcode = m_value->opcode() == Equal ? BitAnd : BitOr;
             Value* result = insert<Value>(m_index, combineOpcode, m_origin, highComparison, lowComparison);
             m_value->replaceWithIdentity(result);
@@ -648,9 +647,9 @@ private:
                 return;
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
-            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
-            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
-            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.second, right.second);
+            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
             Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
             m_value->replaceWithIdentity(result);
             return;
@@ -683,9 +682,9 @@ private:
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
             Opcode highComparisonOpcode = m_value->opcode() == BelowEqual ? Below : Above;
-            Value* highComparison = insert<Value>(m_index, highComparisonOpcode, m_origin, left.first, right.first);
-            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
-            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* highComparison = insert<Value>(m_index, highComparisonOpcode, m_origin, left.second, right.second);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.second, right.second);
+            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
             Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
             m_value->replaceWithIdentity(result);
             return;
@@ -718,10 +717,10 @@ private:
                 return;
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
-            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
-            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
+            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.second, right.second);
             Opcode lowComparisonOpcode = m_value->opcode() == LessThan ? Below : Above;
-            Value* lowComparison = insert<Value>(m_index, lowComparisonOpcode, m_origin, left.second, right.second);
+            Value* lowComparison = insert<Value>(m_index, lowComparisonOpcode, m_origin, left.first, right.first);
             Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
             m_value->replaceWithIdentity(result);
             return;
@@ -755,10 +754,10 @@ private:
             auto left = getMapping(m_value->child(0));
             auto right = getMapping(m_value->child(1));
             Opcode highComparisonOpcode = m_value->opcode() == LessEqual ? LessThan : GreaterThan;
-            Value* highComparison = insert<Value>(m_index, highComparisonOpcode, m_origin, left.first, right.first);
-            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
+            Value* highComparison = insert<Value>(m_index, highComparisonOpcode, m_origin, left.second, right.second);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.second, right.second);
             Opcode lowComparisonOpcode = m_value->opcode() == LessEqual ? BelowEqual : AboveEqual;
-            Value* lowComparison = insert<Value>(m_index, lowComparisonOpcode, m_origin, left.second, right.second);
+            Value* lowComparison = insert<Value>(m_index, lowComparisonOpcode, m_origin, left.first, right.first);
             Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
             m_value->replaceWithIdentity(result);
             return;
@@ -771,8 +770,8 @@ private:
             PatchpointValue* patchpoint = insert<PatchpointValue>(m_index + 1, Void, m_origin);
             patchpoint->effects = Effects::none();
             patchpoint->effects.terminal = true;
-            patchpoint->append(retValue.first, ValueRep::reg(GPRInfo::returnValueGPR2));
-            patchpoint->append(retValue.second, ValueRep::reg(GPRInfo::returnValueGPR));
+            patchpoint->append(retValue.second, ValueRep::reg(GPRInfo::returnValueGPR2));
+            patchpoint->append(retValue.first, ValueRep::reg(GPRInfo::returnValueGPR));
             patchpoint->setGenerator([] (CCallHelpers& jit, const StackmapGenerationParams& params) {
                 params.context().code->emitEpilogue(jit);
             });
@@ -860,7 +859,7 @@ private:
             appendToBlock<Value>(check32, Branch, m_origin, isRotationBy32);
             check32->setSuccessors(swap, check);
 
-            appendToBlock<Value>(swap, Stitch, m_origin, input.second, input.first);
+            appendToBlock<Value>(swap, Stitch, m_origin, input.first, input.second);
             std::pair<UpsilonValue*, UpsilonValue*> resultRotationBy32 = std::pair {
                 appendToBlock<UpsilonValue>(swap, m_origin, input.second),
                 appendToBlock<UpsilonValue>(swap, m_origin, input.first)
@@ -904,12 +903,12 @@ private:
                 return;
             auto input = getMapping(m_value->child(0));
             Value* thirtyTwo = insert<Const32Value>(m_index, m_origin, 32);
-            Value* clzHi = insert<Value>(m_index, Clz, m_origin, input.first);
+            Value* clzHi = insert<Value>(m_index, Clz, m_origin, input.second);
             Value* useHi = insert<Value>(m_index, Below, m_origin, clzHi, thirtyTwo);
-            Value* clzLo = insert<Value>(m_index, Clz, m_origin, input.second);
+            Value* clzLo = insert<Value>(m_index, Clz, m_origin, input.first);
             Value* clzIfLo = insert<Value>(m_index, Add, m_origin, clzLo, thirtyTwo);
             Value* result = insert<Value>(m_index, Select, m_origin, useHi, clzHi, clzIfLo);
-            setMapping(m_value, insert<Const32Value>(m_index, m_origin, 0), result);
+            setMapping(m_value, result, insert<Const32Value>(m_index, m_origin, 0));
             valueReplaced();
             return;
         }
@@ -918,7 +917,7 @@ private:
             auto index = m_value->as<ExtractValue>()->index();
             if (originalTuple->type() == Int64) {
                 auto input = getMapping(originalTuple);
-                m_value->replaceWithIdentity(index ? input.second : input.first);
+                m_value->replaceWithIdentity(index ? input.first : input.second);
                 return;
             }
             auto originalTupleType = m_proc.tupleForType(originalTuple->type());
@@ -939,7 +938,7 @@ private:
             Value* hi = insert<ExtractValue>(m_index, m_origin, Int32, tuple, m_proc.tupleForType(originalTuple->type()).size() + highBitsIndex);
             Value* lo = insert<ExtractValue>(m_index, m_origin, Int32, tuple, index);
             valueReplaced();
-            setMapping(m_value, hi, lo);
+            setMapping(m_value, lo, hi);
             return;
         }
         case Abs:
@@ -978,10 +977,10 @@ private:
             return;
         case BitwiseCast: {
             if (m_value->type() == Int64) {
-                setMapping(m_value, valueHi(m_value, m_index + 1), valueLo(m_value, m_index + 1));
+                setMapping(m_value, valueLo(m_value, m_index + 1), valueHi(m_value, m_index + 1));
             } else if (m_value->child(0)->type() == Int64) {
                 auto input = getMapping(m_value->child(0));
-                Value* cast = insert<Value>(m_index, BitwiseCast, m_origin, valueHiLo(input.first, input.second));
+                Value* cast = insert<Value>(m_index, BitwiseCast, m_origin, valueLoHi(input.first, input.second));
                 m_value->replaceWithIdentity(cast);
             }
 
@@ -996,14 +995,14 @@ private:
             if (m_value->child(0)->type() != Int64)
                 return;
             auto input = getMapping(m_value->child(0));
-            m_value->replaceWithIdentity(input.second);
+            m_value->replaceWithIdentity(input.first);
             return;
         }
         case TruncHigh: {
             if (m_value->child(0)->type() != Int64)
                 return;
             auto input = getMapping(m_value->child(0));
-            m_value->replaceWithIdentity(input.first);
+            m_value->replaceWithIdentity(input.second);
             return;
         }
         case Stitch: {
@@ -1033,22 +1032,22 @@ private:
             }
             auto left = getMapping(m_value->child(1));
             auto right = getMapping(m_value->child(2));
-            Value* selectHi = insert<Value>(m_index, Select, m_origin, selector, left.first, right.first);
-            Value* selectLo = insert<Value>(m_index, Select, m_origin, selector, left.second, right.second);
-            setMapping(m_value, selectHi, selectLo);
+            Value* selectHi = insert<Value>(m_index, Select, m_origin, selector, left.second, right.second);
+            Value* selectLo = insert<Value>(m_index, Select, m_origin, selector, left.first, right.first);
+            setMapping(m_value, selectLo, selectHi);
             valueReplaced();
             return;
         }
         case ZExt32: {
             Value* hi = insert<Const32Value>(m_index, m_origin, 0);
-            setMapping(m_value, hi, m_value->child(0));
+            setMapping(m_value, m_value->child(0), hi);
             valueReplaced();
             return;
         }
         case SExt32: {
             Value* signBit = insert<Value>(m_index, BitAnd, m_origin, m_value->child(0), insert<Const32Value>(m_index, m_origin, 0x80000000));
             Value* hi = insert<Value>(m_index, SShr, m_origin, signBit, insert<Const32Value>(m_index, m_origin, 31));
-            setMapping(m_value, hi, m_value->child(0));
+            setMapping(m_value, m_value->child(0), hi);
             valueReplaced();
             return;
         }
@@ -1067,7 +1066,7 @@ private:
             Value* maskedInput = insert<Value>(m_index, BitAnd, m_origin, m_value->child(0), insert<Const32Value>(m_index, m_origin, inputMask));
             Value* lo = insert<Value>(m_index, BitOr, m_origin, maskedInput, shiftedExtension);
             Value* hi = extension;
-            setMapping(m_value, hi, lo);
+            setMapping(m_value, lo, hi);
             valueReplaced();
             return;
         }
@@ -1089,10 +1088,10 @@ private:
             if (!(m_value->type() == Int64 || (!hasUnalignedFPMemoryAccess() && m_value->type() == Double)))
                 return;
             HeapRange rangeHi, rangeLo;
-            splitRange(memory->range(), rangeHi, rangeLo);
+            splitRange(memory->range(), rangeLo, rangeHi);
 
             HeapRange fenceRangeHi, fenceRangeLo;
-            splitRange(memory->fenceRange(), fenceRangeHi, fenceRangeLo);
+            splitRange(memory->fenceRange(), fenceRangeLo, fenceRangeHi);
 
             // Assumes little-endian arch.
             CheckedInt32 offsetHi = CheckedInt32(memory->offset()) + CheckedInt32(bytesForWidth(Width32));
@@ -1108,10 +1107,10 @@ private:
             lo->setRange(rangeLo);
             lo->setFenceRange(fenceRangeLo);
             if (m_value->type() == Double) {
-                Value* result = insert<Value>(m_index, BitwiseCast, m_origin, valueHiLo(hi, lo));
+                Value* result = insert<Value>(m_index, BitwiseCast, m_origin, valueLoHi(lo, hi));
                 m_value->replaceWithIdentity(result);
             } else {
-                setMapping(m_value, hi, lo);
+                setMapping(m_value, lo, hi);
                 valueReplaced();
             }
             return;
@@ -1125,7 +1124,7 @@ private:
             std::pair<Value*, Value*> value;
             if (!hasUnalignedFPMemoryAccess() && m_value->child(0)->type() == Double) {
                 Value* asInt64 = insert<Value>(m_index, BitwiseCast, m_origin, m_value->child(0));
-                value = { valueHi(asInt64), valueLo(asInt64) };
+                value = { valueLo(asInt64), valueHi(asInt64) };
             } else if (!hasUnalignedFPMemoryAccess() && m_value->child(0)->type() == Float) {
                 Value* asInt32 = insert<Value>(m_index, BitwiseCast, m_origin, m_value->child(0));
                 MemoryValue* store = insert<MemoryValue>(m_index, Store, m_origin, asInt32, memory->child(1));
@@ -1140,20 +1139,20 @@ private:
                 return;
 
             HeapRange rangeHi, rangeLo;
-            splitRange(memory->range(), rangeHi, rangeLo);
+            splitRange(memory->range(), rangeLo, rangeHi);
 
             HeapRange fenceRangeHi, fenceRangeLo;
-            splitRange(memory->fenceRange(), fenceRangeHi, fenceRangeLo);
+            splitRange(memory->fenceRange(), fenceRangeLo, fenceRangeHi);
 
 
-            MemoryValue* hi = insert<MemoryValue>(m_index, Store, m_origin, value.first, memory->child(1));
+            MemoryValue* hi = insert<MemoryValue>(m_index, Store, m_origin, value.second, memory->child(1));
             CheckedInt32 offsetHi = CheckedInt32(memory->offset()) + CheckedInt32(bytesForWidth(Width32));
             RELEASE_ASSERT(!offsetHi.hasOverflowed());
             hi->setOffset(offsetHi);
             hi->setRange(rangeHi);
             hi->setFenceRange(fenceRangeHi);
 
-            MemoryValue* lo = insert<MemoryValue>(m_index, Store, m_origin, value.second, memory->child(1));
+            MemoryValue* lo = insert<MemoryValue>(m_index, Store, m_origin, value.first, memory->child(1));
             lo->setOffset(memory->offset());
             lo->setRange(rangeLo);
             lo->setFenceRange(fenceRangeLo);
@@ -1164,7 +1163,7 @@ private:
             if (m_value->child(0)->type() != Int64)
                 return;
             auto input = getMapping(m_value->child(0));
-            Value* arg = valueHiLo(input.first, input.second);
+            Value* arg = valueLoHi(input.first, input.second);
             m_value->replaceWithIdentity(unaryCCall(Math::f64_convert_s_i64, m_value->type(), arg));
             return;
         }
@@ -1172,7 +1171,7 @@ private:
             if (m_value->child(0)->type() != Int64)
                 return;
             auto input = getMapping(m_value->child(0));
-            Value* arg = valueHiLo(input.first, input.second);
+            Value* arg = valueLoHi(input.first, input.second);
             m_value->replaceWithIdentity(unaryCCall(Math::f32_convert_s_i64, m_value->type(), arg));
             return;
         }
@@ -1181,9 +1180,9 @@ private:
                 return;
             auto input = getMapping(m_value->child(0));
             Value* zero32 = insert<Const32Value>(m_index, m_origin, 0);
-            Value* zero = valueHiLo(zero32, zero32);
-            m_value->replaceWithIdentity(insert<Value>(m_index, Sub, m_origin, zero, valueHiLo(input.first, input.second)));
-            setMapping(m_value, valueHi(m_value, m_index + 1), valueLo(m_value, m_index + 1));
+            Value* zero = valueLoHi(zero32, zero32);
+            m_value->replaceWithIdentity(insert<Value>(m_index, Sub, m_origin, zero, valueLoHi(input.first, input.second)));
+            setMapping(m_value, valueLo(m_value, m_index + 1), valueHi(m_value, m_index + 1));
             return;
         }
         default: {

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -134,7 +134,7 @@ public:
                 m_int64ValueToTmps.ensure(value, [&] {
                     auto hi = tmpForType(Int32);
                     auto lo = tmpForType(Int32);
-                    std::tuple<Tmp, Tmp> pair = { hi, lo };
+                    std::tuple<Tmp, Tmp> pair = { lo, hi };
                     return pair;
                 });
             }
@@ -2939,7 +2939,7 @@ private:
         using namespace Air;
         switch (m_value->opcode()) {
         case Const64: {
-            auto [hi, lo] = tmpsForInt64(m_value);
+            auto [lo, hi] = tmpsForInt64(m_value);
             append(Move, Arg::bigImmHi32(m_value->asInt()), hi);
             append(Move, Arg::bigImmLo32(m_value->asInt()), lo);
             return;
@@ -2947,16 +2947,16 @@ private:
         case B3::Add:
         case B3::Sub: {
             ASSERT(isValidForm(Add64, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp));
-            auto [ leftHi, leftLo ] = tmpsForInt64(m_value->child(0));
-            auto [ rightHi, rightLo ] = tmpsForInt64(m_value->child(1));
-            auto [ resultHi, resultLo ] = tmpsForInt64(m_value);
+            auto [ leftLo, leftHi ] = tmpsForInt64(m_value->child(0));
+            auto [ rightLo, rightHi ] = tmpsForInt64(m_value->child(1));
+            auto [ resultLo, resultHi ] = tmpsForInt64(m_value);
             append(m_value->opcode() == B3::Add ? Add64 : Sub64, leftHi, leftLo, rightHi, rightLo, resultHi, resultLo);
             return;
         }
         case B3::Mul: {
-            auto [ leftHi, leftLo ] = tmpsForInt64(m_value->child(0));
-            auto [ rightHi, rightLo ] = tmpsForInt64(m_value->child(1));
-            auto [ resultHi, resultLo ] = tmpsForInt64(m_value);
+            auto [ leftLo, leftHi ] = tmpsForInt64(m_value->child(0));
+            auto [ rightLo, rightHi ] = tmpsForInt64(m_value->child(1));
+            auto [ resultLo, resultHi ] = tmpsForInt64(m_value);
 
             Tmp tmpHiLo = tmpForType(Int32);
             Tmp tmpLoHi = tmpForType(Int32);
@@ -2970,11 +2970,11 @@ private:
         }
         case B3::BitwiseCast: {
             if (m_value->type() == Int64) {
-                auto [ resultHi, resultLo ] = tmpsForInt64(m_value);
+                auto [ resultLo, resultHi ] = tmpsForInt64(m_value);
                 append(Air::MoveDoubleTo64, tmp(m_value->child(0)), resultHi, resultLo);
             } else {
                 ASSERT(m_value->child(0)->type() == Int64);
-                auto [ argHi, argLo ] = tmpsForInt64(m_value->child(0));
+                auto [ argLo, argHi ] = tmpsForInt64(m_value->child(0));
                 append(Move64ToDouble, argHi, argLo, tmp(m_value));
                 return;
             }
@@ -2990,9 +2990,9 @@ private:
             return;
         }
         case Stitch: {
-            auto [resHi, resLo] = tmpsForInt64(m_value);
-            auto hi = tmp(m_value->child(0));
-            auto lo = tmp(m_value->child(1));
+            auto [resLo, resHi] = tmpsForInt64(m_value);
+            auto lo = tmp(m_value->child(0));
+            auto hi = tmp(m_value->child(1));
             append(relaxedMoveForType(Int32), hi, resHi);
             append(relaxedMoveForType(Int32), lo, resLo);
             return;

--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
@@ -219,9 +219,9 @@ Inst buildCCall(Code& code, Value* origin, const Vector<Arg>& arguments)
 }
 
 #if CPU(ARM_THUMB2)
-Value* ArgumentValueList::makeStitch(B3::BasicBlock*, Value* hi, Value* low) const
+Value* ArgumentValueList::makeStitch(B3::BasicBlock*, Value* low, Value* hi) const
 {
-    return block->appendNew<Value>(procedure, Stitch, Origin(), hi, low);
+    return block->appendNew<Value>(procedure, Stitch, Origin(), low, hi);
 }
 #endif
 
@@ -275,8 +275,7 @@ Value* ArgumentValueList::makeCCallValue(B3::BasicBlock* block, size_t idx) cons
     case Int64:
         RELEASE_ASSERT(argCount == sizeof(uint64_t) / sizeof(uintptr_t));
 #if CPU(ARM_THUMB2)
-            return makeStitch(block, makeCCallValue(block, Int32, underlyingArgs[firstUnderlyingArg + 1]),
-                makeCCallValue(block, Int32, underlyingArgs[firstUnderlyingArg]));
+            return makeStitch(block, makeCCallValue(block, Int32, underlyingArgs[firstUnderlyingArg]), makeCCallValue(block, Int32, underlyingArgs[firstUnderlyingArg + 1]));
 #else
         return makeCCallValue(block, types[idx], underlyingArgs[firstUnderlyingArg]);
 #endif

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -1484,7 +1484,7 @@ auto OMGIRGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
                 ASSERT(rep.location.jsr().tagGPR() != InvalidGPRReg);
                 Value* argLo = m_currentBlock->appendNew<B3::ArgumentRegValue>(m_proc, Origin(), rep.location.jsr().payloadGPR());
                 Value* argHi = m_currentBlock->appendNew<B3::ArgumentRegValue>(m_proc, Origin(), rep.location.jsr().tagGPR());
-                argument = m_currentBlock->appendNew<Value>(m_proc, Stitch, Origin(), argHi, argLo);
+                argument = m_currentBlock->appendNew<Value>(m_proc, Stitch, Origin(), argLo, argHi);
             }
         } else if (rep.location.isFPR()) {
             if (type.isVector()) {
@@ -1728,7 +1728,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
                     }
                     auto lo = m_currentBlock->appendNew<ExtractValue>(m_proc, origin(), Int32, callResult, i);
                     auto hi = m_currentBlock->appendNew<ExtractValue>(m_proc, origin(), Int32, callResult, logicalReturnCount + highBitsIndex);
-                    auto stitched = m_currentBlock->appendNew<Value>(m_proc, Stitch, origin(), hi, lo);
+                    auto stitched = m_currentBlock->appendNew<Value>(m_proc, Stitch, origin(), lo, hi);
                     results.append(push(stitched));
                     continue;
                 }
@@ -5044,7 +5044,7 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndex, const TypeDefinit
                     }
                     auto lo = m_currentBlock->appendNew<ExtractValue>(m_proc, origin(), Int32, callResult, i);
                     auto hi = m_currentBlock->appendNew<ExtractValue>(m_proc, origin(), Int32, callResult, logicalReturnCount + highBitsIndex);
-                    auto stitched = m_currentBlock->appendNew<Value>(m_proc, Stitch, origin(), hi, lo);
+                    auto stitched = m_currentBlock->appendNew<Value>(m_proc, Stitch, origin(), lo, hi);
                     results.append(push(stitched));
                     continue;
                 }


### PR DESCRIPTION
#### 6230d08a66f31deb1424750b12cb5eefb3eef881
<pre>
Flip hi/lo to lo/hi in LowerInt64 and related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=280826">https://bugs.webkit.org/show_bug.cgi?id=280826</a>

Reviewed by Justin Michaud.

AirCCallingConvention allocates registers in order, so passing the low
bits of an Int64 avoids the need to massage things. However, we want to
have a consistent order in all related code to avoid silly mistakes, so
this changes everything other than the assembler to use lo, hi ordering.

* Source/JavaScriptCore/b3/B3ExtractValue.h:
* Source/JavaScriptCore/b3/B3LowerInt64.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp:
(JSC::B3::Air::ArgumentValueList::makeStitch const):
(JSC::B3::Air::ArgumentValueList::makeCCallValue const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addArguments):
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
(JSC::Wasm::OMGIRGenerator::addCall):

Canonical link: <a href="https://commits.webkit.org/284674@main">https://commits.webkit.org/284674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d45c7d238d8a8e2dc643b2ad50eaa9b7260bc99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21184 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72143 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55559 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14043 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17836 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19561 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63142 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75829 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69272 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17413 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63274 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 100 flakes 109 failures; Uploaded test results; 50 flakes 50 failures; Compiled WebKit; Running layout-tests-repeat-failures-without-change") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63196 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4839 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91054 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45230 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/19857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->