### PR TITLE
[WPT] video-rvfc/* tests are flakey due to unmuted autoplay policies in Safari

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-xr-session.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-xr-session.https.html
@@ -12,6 +12,7 @@
 
 // Start the video.rVFC callbacks before starting the XR Session.
 let video = document.createElement('video');
+video.muted = true;
 video.src = getVideoURI('/media/movie_5');
 
 var numberVFCs = 0;

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html
@@ -18,6 +18,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
 
     video.requestVideoFrameCallback(done);
     video.src = testVideo.url;
@@ -32,6 +33,7 @@ function rvfcStyleTest(applyStyle, description) {
       const promise = new Promise(resolve => done = resolve);
 
       let video = document.createElement('video');
+      video.muted = true;
       document.body.appendChild(video);
       applyStyle(video);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html
@@ -18,6 +18,7 @@ let testFunction = async function(session, fakeDeviceController, t) {
 
     // Start the video.rVFC callbacks while we are in the the XR Session.
     let video = document.createElement('video');
+    video.muted = true;
     video.src = getVideoURI('/media/movie_5');
 
     var numberVFCs = 0;

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-parallel.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-parallel.html
@@ -12,6 +12,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     let firstTime;
@@ -39,6 +40,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     let secondCallbackId;

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-repeating.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-repeating.html
@@ -12,6 +12,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     let firstTime;
@@ -45,6 +46,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     let maxNumberOfCalls = 10;

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html
@@ -23,6 +23,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     let id = video.requestVideoFrameCallback(
@@ -47,6 +48,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     video.requestVideoFrameCallback(
@@ -72,6 +74,7 @@ promise_test(async function(t) {
     const promise = new Promise(resolve => done = resolve);
 
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     let id = video.requestVideoFrameCallback(
@@ -99,6 +102,7 @@ promise_test(async function(t) {
 
 test(function(t) {
     let video = document.createElement('video');
+    video.muted = true;
     document.body.appendChild(video);
 
     // requestVideoFrameCallback() expects 1 function as a parameter.
@@ -120,6 +124,7 @@ test(function(t) {
 
 promise_test(async function(t) {
     let video = document.createElement('video');
+    video.muted = true;
     video.autoplay = true;
     document.body.appendChild(video);
 


### PR DESCRIPTION
#### 8c48e5a8c292fc95f3eca6952d310405a5c8f76e
<pre>
[WPT] video-rvfc/* tests are flakey due to unmuted autoplay policies in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=280829">https://bugs.webkit.org/show_bug.cgi?id=280829</a>
<a href="https://rdar.apple.com/137135213">rdar://137135213</a>

Reviewed by Eric Carlson.

Mute video elements used when testing requestVideoFrameCallback(). This allows those elements
to begin playback, even absent a user gesture, with default autoplay policies in Safari.

* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-xr-session.https.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-parallel.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-repeating.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html:

Canonical link: <a href="https://commits.webkit.org/284619@main">https://commits.webkit.org/284619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8599b308f7d93534c86eb8f8856898e69d241d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55578 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17837 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75836 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17418 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14294 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60475 "Exiting early after 10 failures. 193 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63201 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4840 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10688 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45241 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->