### PR TITLE
Forward `_UUID_.notification` notification from the UIProcess

### DIFF
--- a/Source/WebKit/Resources/cocoa/NotificationAllowList/EmbeddedForwardedNotifications.def
+++ b/Source/WebKit/Resources/cocoa/NotificationAllowList/EmbeddedForwardedNotifications.def
@@ -1,5 +1,6 @@
 WK_NOTIFICATION_COMMENT("These notifyd notifications are forwarded from the UIProcess to the WebProcess on embedded platforms.")
 
+WK_NOTIFICATION("_UUID_.notification")
 WK_NOTIFICATION("CPActiveCountryCodeChanged.Internal")
 WK_NOTIFICATION("MCManagedBooksChanged")
 WK_NOTIFICATION("PINPolicyChangedNotification")


### PR DESCRIPTION
#### 041e7c9d7ecc27d3ac9555a7b2d6ad9a08d5e99c
<pre>
Forward `_UUID_.notification` notification from the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=280831">https://bugs.webkit.org/show_bug.cgi?id=280831</a>
<a href="https://rdar.apple.com/135191830">rdar://135191830</a>

Reviewed by Sihui Liu.

For notifications that are being observed in the WebContent process, we need to forward them from the UI process.
Otherwise, the WebContent process will not respond to these notifications, because we are blocking access to
notifyd in the sandbox.

* Source/WebKit/Resources/cocoa/NotificationAllowList/EmbeddedForwardedNotifications.def:

Canonical link: <a href="https://commits.webkit.org/284640@main">https://commits.webkit.org/284640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52166b13843aa14414c4bc32a77dc7b1d2bb33fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55579 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14053 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41696 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63279 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63202 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4843 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10699 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45242 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->