### PR TITLE
Provide a swift implementation for CommandEncoder::clearBuffer

### DIFF
--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -556,12 +556,15 @@ inline bool startsWithLettersIgnoringASCIICase(const String& string, ASCIILitera
 
 inline namespace StringLiterals {
 
+#ifndef __swift__
+// Swift will import this as global and then all literals will be WTF.String
+// instead of Swift.String
 inline String operator"" _str(const char* characters, size_t)
 {
     return ASCIILiteral::fromLiteralUnsafe(characters);
 }
 
-#ifndef __swift__ // FIXME: rdar://136156228
+// FIXME: rdar://136156228
 inline String operator"" _str(const UChar* characters, size_t length)
 {
     return String({ characters, length });

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -137,6 +137,9 @@
 		941C1EE62CA33255004D4220 /* Queue.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACA9C273A426D0095F8D5 /* Queue.h */; };
 		941C1EE72CA46829004D4220 /* Instance.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACAA0273A426D0095F8D5 /* Instance.h */; };
 		941C64B72CAB4A0700A63214 /* Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACA9B273A426D0095F8D5 /* Device.h */; };
+		94200C4F2CADBCAD00484401 /* CommandEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACA9E273A426D0095F8D5 /* CommandEncoder.h */; };
+		94200C512CADBD7200484401 /* CommandEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94200C502CADBD6B00484401 /* CommandEncoder.swift */; };
+		94200C522CADBE5200484401 /* CommandsMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C582FF827E04131009B40F0 /* CommandsMixin.h */; };
 		9478714A2C98CECB003DB695 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947871492C98CEC6003DB695 /* Buffer.swift */; };
 		9478714C2C98D31A003DB695 /* WebGPUSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 9478714B2C98D314003DB695 /* WebGPUSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94CC0FE62CA203B300CB3264 /* WebGPUSwiftInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 94CC0FE52CA203AB00CB3264 /* WebGPUSwiftInternal.h */; };
@@ -250,7 +253,7 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		1CA5B4EF2A6F28C400E5F297 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = /usr/share/man/man1/;
 			dstSubfolderSpec = 0;
 			files = (
@@ -259,7 +262,7 @@
 		};
 		97FA1A7D29C085740052D650 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = /usr/share/man/man1/;
 			dstSubfolderSpec = 0;
 			files = (
@@ -452,6 +455,7 @@
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
 		941C1EE42CA328EE004D4220 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		94200C502CADBD6B00484401 /* CommandEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandEncoder.swift; sourceTree = "<group>"; };
 		947871492C98CEC6003DB695 /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
 		9478714B2C98D314003DB695 /* WebGPUSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUSwift.h; sourceTree = "<group>"; };
 		94CC0FE52CA203AB00CB3264 /* WebGPUSwiftInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUSwiftInternal.h; sourceTree = "<group>"; };
@@ -611,6 +615,7 @@
 				1C5ACAE2273A55CD0095F8D5 /* CommandBuffer.mm */,
 				1C5ACA9E273A426D0095F8D5 /* CommandEncoder.h */,
 				1C5ACAAB273A426D0095F8D5 /* CommandEncoder.mm */,
+				94200C502CADBD6B00484401 /* CommandEncoder.swift */,
 				1C582FF827E04131009B40F0 /* CommandsMixin.h */,
 				1C582FF727E04131009B40F0 /* CommandsMixin.mm */,
 				1C5ACAAA273A426D0095F8D5 /* ComputePassEncoder.h */,
@@ -891,6 +896,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CEBD7E72716AFBA00A5254D /* WebGPU.h in Headers */,
+				94200C4F2CADBCAD00484401 /* CommandEncoder.h in Headers */,
+				94200C522CADBE5200484401 /* CommandsMixin.h in Headers */,
 				941C64B72CAB4A0700A63214 /* Device.h in Headers */,
 				0D30F93929F1FAC50055D9F1 /* ExternalTexture.h in Headers */,
 				941C1EE72CA46829004D4220 /* Instance.h in Headers */,
@@ -1193,6 +1200,7 @@
 				9478714A2C98CECB003DB695 /* Buffer.swift in Sources */,
 				1C5ACAE3273A55CD0095F8D5 /* CommandBuffer.mm in Sources */,
 				1C5ACAC9273A426E0095F8D5 /* CommandEncoder.mm in Sources */,
+				94200C512CADBD7200484401 /* CommandEncoder.swift in Sources */,
 				1C582FF927E04131009B40F0 /* CommandsMixin.mm in Sources */,
 				1C5ACAC6273A426D0095F8D5 /* ComputePassEncoder.mm in Sources */,
 				1C5ACAC0273A426D0095F8D5 /* ComputePipeline.mm in Sources */,

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -29,6 +29,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
@@ -84,7 +85,7 @@ public:
     void writeTimestamp(QuerySet&, uint32_t queryIndex);
     void setLabel(String&&);
 
-    Device& device() const { return m_device; }
+    Device& device() const SWIFT_RETURNS_INDEPENDENT_VALUE { return m_device; }
 
     bool isValid() const { return m_commandBuffer; }
     void lock(bool);
@@ -110,13 +111,14 @@ public:
     void addTexture(const Texture&);
     id<MTLCommandBuffer> commandBuffer() const;
     void setExistingEncoder(id<MTLCommandEncoder>);
+    void generateInvalidEncoderStateError();
+    bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&);
     CommandEncoder(Device&);
 
     NSString* errorValidatingCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);
-    bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
     NSString* validateFinishError() const;
     bool validatePopDebugGroup() const;
     NSString* errorValidatingComputePassDescriptor(const WGPUComputePassDescriptor&) const;
@@ -149,6 +151,16 @@ private:
     id<MTLSharedEvent> m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
     const Ref<Device> m_device;
-};
+} SWIFT_SHARED_REFERENCE(retainCommandEncoder, releaseCommandEncoder);
 
 } // namespace WebGPU
+
+inline void retainCommandEncoder(WebGPU::CommandEncoder* obj)
+{
+    WTF::retainRefCounted(obj);
+}
+
+inline void releaseCommandEncoder(WebGPU::CommandEncoder* obj)
+{
+    WTF::releaseRefCounted(obj);
+}

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public func clearBuffer(
+    commandEncoder: WebGPU.CommandEncoder, buffer: WebGPU.Buffer, offset: UInt64, size: inout UInt64
+) {
+    commandEncoder.clearBuffer(buffer: buffer, offset: offset, size: &size)
+}
+
+extension WebGPU.CommandEncoder {
+    public func clearBuffer(buffer: WebGPU.Buffer, offset: UInt64, size: inout UInt64) {
+        guard self.prepareTheEncoderState() else {
+            self.generateInvalidEncoderStateError()
+            return
+        }
+        if size == UInt64.max {
+            let initialSize = buffer.initialSize()
+            let (subtractionResult, didOverflow) = initialSize.subtractingReportingOverflow(offset)
+            if didOverflow {
+                self.device().generateAValidationError(
+                    "CommandEncoder::clearBuffer(): offset > buffer.size")
+                return
+            }
+            size = subtractionResult
+        }
+
+        if !self.validateClearBuffer(buffer, offset, size) {
+            self.makeInvalid("GPUCommandEncoder.clearBuffer validation failed")
+            return
+        }
+        buffer.setCommandEncoder(self, false)
+        buffer.indirectBufferInvalidated()
+        guard let offsetInt = Int(exactly: offset), let sizeInt = Int(exactly: size) else {
+            return
+        }
+        let range = offsetInt..<(offsetInt + sizeInt)
+        if buffer.isDestroyed() || sizeInt == 0 || range.upperBound > buffer.buffer().length {
+            return
+        }
+        guard let blitCommandEncoder = ensureBlitCommandEncoder() else {
+            return
+        }
+        blitCommandEncoder.fill(buffer: buffer.buffer(), range: range, value: 0)
+    }
+}

--- a/Source/WebGPU/WebGPU/CommandsMixin.h
+++ b/Source/WebGPU/WebGPU/CommandsMixin.h
@@ -32,8 +32,9 @@ class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpucommandsmixin
 class CommandsMixin {
-protected:
+public:
     bool prepareTheEncoderState() const;
+protected:
     NSString* encoderStateName() const;
     static bool computedSizeOverflows(const Buffer&, uint64_t offset, uint64_t& size);
 

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -123,7 +123,7 @@ public:
     const HardwareCapabilities::BaseCapabilities& baseCapabilities() const { return m_capabilities.baseCapabilities; }
 
     id<MTLDevice> device() const { return m_device; }
-
+    void generateAValidationError(NSString * message);
     void generateAValidationError(String&& message);
     void generateAnOutOfMemoryError(String&& message);
     void generateAnInternalError(String&& message);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -344,6 +344,11 @@ auto Device::currentErrorScope(WGPUErrorFilter type) -> ErrorScope*
     return nullptr;
 }
 
+void Device::generateAValidationError(NSString * message)
+{
+    generateAValidationError(String { message });
+}
+
 void Device::generateAValidationError(String&& message)
 {
     // https://gpuweb.github.io/gpuweb/#abstract-opdef-generate-a-validation-error

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -28,11 +28,11 @@ private let largeBufferSize = 32 * 1024 * 1024
 public func writeBuffer(
     queue: WebGPU.Queue, buffer: WebGPU.Buffer, bufferOffset: UInt64, data: SpanUInt8
 ) {
-    queue.writeBuffer(mtlBuffer: buffer.buffer(), bufferOffset: bufferOffset, data: data)
+    queue.writeBuffer(buffer, bufferOffset: bufferOffset, data: data)
 }
 
 extension WebGPU.Queue {
-    public func writeBuffer(mtlBuffer: any MTLBuffer, bufferOffset: UInt64, data: SpanUInt8) {
+    public func writeBuffer(_ buffer: WebGPU.Buffer, bufferOffset: UInt64, data: SpanUInt8) {
         let device = self.device()
         guard let blitCommandEncoder = ensureBlitCommandEncoder() else {
             return
@@ -52,7 +52,8 @@ extension WebGPU.Queue {
             return
         }
         blitCommandEncoder.copy(
-            from: tempBuffer, sourceOffset: 0, to: mtlBuffer, destinationOffset: Int(bufferOffset),
+            from: tempBuffer, sourceOffset: 0, to: buffer.buffer(),
+            destinationOffset: Int(bufferOffset),
             size: data.size())
         if noCopy {
             finalizeBlitCommandEncoder()

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -166,6 +166,8 @@ WGPU_EXPORT void wgpuDeviceClearUncapturedErrorCallback(WGPUDevice device) WGPU_
 
 #if ENABLE(WEBGPU_SWIFT) && defined(__WEBGPU__)
 #include "Buffer.h"
+#include "CommandEncoder.h"
+#include "CommandsMixin.h"
 #include "Device.h"
 #include "Queue.h"
 #endif


### PR DESCRIPTION
#### 6a9a052fc36c271ed249b88a35d652594a5107c7
<pre>
Provide a swift implementation for CommandEncoder::clearBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=280767">https://bugs.webkit.org/show_bug.cgi?id=280767</a>
<a href="https://rdar.apple.com/137134098">rdar://137134098</a>

Reviewed by Mike Wyrzykowski.

It&apos;s a 1 to 1 replacement of the Obj-C version.

Testing:
compile with make release BUILD_WEBKIT_OPTIONS=&quot;--webGpuSwift&quot;.
Then run:
1. http/tests/webgpu/webgpu/api/validation/encoding/cmds/clearBuffer.html
2. http/tests/webgpu/webgpu/api/operation/command_buffer/clearBuffer.html

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/CommandEncoder.h:
(retainCommandEncoder):
(releaseCommandEncoder):
(WebGPU::CommandEncoder::device const): Deleted.
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::generateInvalidEncoderStateError):
(WebGPU::CommandEncoder::clearBuffer):
* Source/WebGPU/WebGPU/CommandEncoder.swift: Copied from Source/WebGPU/WebGPU/CommandsMixin.h.
(clearBuffer(_:buffer:offset:size:)):
(WebGPU.clearBuffer(_:offset:size:)):
* Source/WebGPU/WebGPU/CommandsMixin.h:
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::generateAValidationError):
* Source/WebGPU/WebGPU/WebGPUExt.h:

Canonical link: <a href="https://commits.webkit.org/284713@main">https://commits.webkit.org/284713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/439c6fac791cee722de20db311f13b7a5e77b5bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55685 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14170 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17993 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19761 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63343 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76030 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69469 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63334 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15576 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4989 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91250 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/197 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19888 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->