### PR TITLE
Web Inspector: UAF needs to be prevented for RemoteConnectionToTarget::m_target member variable

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
@@ -28,6 +28,7 @@
 #if ENABLE(REMOTE_INSPECTOR)
 
 #include "JSExportMacros.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
 
@@ -41,13 +42,13 @@ class FrontendChannel;
 
 using TargetID = unsigned;
 
-class RemoteControllableTarget {
+class JS_EXPORT_PRIVATE RemoteControllableTarget : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteControllableTarget> {
 public:
-    JS_EXPORT_PRIVATE RemoteControllableTarget();
-    JS_EXPORT_PRIVATE virtual ~RemoteControllableTarget();
+    RemoteControllableTarget();
+    virtual ~RemoteControllableTarget();
 
-    JS_EXPORT_PRIVATE void init();
-    JS_EXPORT_PRIVATE void update();
+    void init();
+    void update();
 
     virtual void connect(FrontendChannel&, bool isAutomaticConnection = false, bool immediatelyPause = false) = 0;
     virtual void disconnect(FrontendChannel&) = 0;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -727,6 +727,7 @@ JSGlobalObject::~JSGlobalObject()
     clearWeakTickets();
 #if ENABLE(REMOTE_INSPECTOR)
     m_inspectorController->globalObjectDestroyed();
+    m_inspectorDebuggable->globalObjectDestroyed();
 #endif
 
     if (m_debugger)
@@ -836,7 +837,7 @@ void JSGlobalObject::init(VM& vm)
 
 #if ENABLE(REMOTE_INSPECTOR)
     m_inspectorController = makeUnique<Inspector::JSGlobalObjectInspectorController>(*this);
-    m_inspectorDebuggable = makeUnique<JSGlobalObjectDebuggable>(*this);
+    m_inspectorDebuggable = JSGlobalObjectDebuggable::create(*this);
     m_inspectorDebuggable->init();
     m_consoleClient = m_inspectorController->consoleClient();
 #endif

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -442,7 +442,7 @@ public:
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.
     std::unique_ptr<Inspector::JSGlobalObjectInspectorController> m_inspectorController;
-    std::unique_ptr<JSGlobalObjectDebuggable> m_inspectorDebuggable;
+    RefPtr<JSGlobalObjectDebuggable> m_inspectorDebuggable;
 #endif
 
     Ref<WatchpointSet> m_masqueradesAsUndefinedWatchpointSet;
@@ -951,7 +951,7 @@ public:
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.
     Inspector::JSGlobalObjectInspectorController& inspectorController() const { return *m_inspectorController.get(); }
-    JSGlobalObjectDebuggable& inspectorDebuggable() { return *m_inspectorDebuggable.get(); }
+    JSGlobalObjectDebuggable& inspectorDebuggable() { return *m_inspectorDebuggable; }
 #endif
 
     void bumpGlobalLexicalBindingEpoch(VM&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
@@ -29,6 +29,7 @@
 
 #include "RemoteInspectionTarget.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
@@ -44,7 +45,7 @@ class JSGlobalObjectDebuggable final : public Inspector::RemoteInspectionTarget 
     WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectDebuggable);
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectDebuggable);
 public:
-    JSGlobalObjectDebuggable(JSGlobalObject&);
+    static Ref<JSGlobalObjectDebuggable> create(JSGlobalObject&);
     ~JSGlobalObjectDebuggable() final { }
 
     Inspector::RemoteControllableTarget::Type type() const final { return m_type; }
@@ -60,8 +61,15 @@ public:
     bool automaticInspectionAllowed() const final { return true; }
     void pauseWaitingForAutomaticInspection() final;
 
+    void globalObjectDestroyed();
+
 private:
-    JSGlobalObject& m_globalObject;
+    JSGlobalObjectDebuggable(JSGlobalObject&);
+
+    void callOnGlobalObjectRunLoopAndWait(Function<void()>&&) const;
+
+    JSGlobalObject* m_globalObject;
+    Ref<RunLoop> m_globalObjectRunLoop;
     Inspector::RemoteControllableTarget::Type m_type { Inspector::RemoteControllableTarget::Type::JavaScript };
 };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -372,7 +372,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_alternativeTextClient(WTFMove(pageConfiguration.alternativeTextClient))
     , m_consoleClient(makeUniqueRef<PageConsoleClient>(*this))
 #if ENABLE(REMOTE_INSPECTOR)
-    , m_inspectorDebuggable(makeUniqueRef<PageDebuggable>(*this))
+    , m_inspectorDebuggable(PageDebuggable::create(*this))
 #endif
     , m_socketProvider(WTFMove(pageConfiguration.socketProvider))
     , m_cookieJar(WTFMove(pageConfiguration.cookieJar))
@@ -502,6 +502,9 @@ Page::~Page()
     }
 
     m_inspectorController->inspectedPageDestroyed();
+#if ENABLE(REMOTE_INSPECTOR)
+    m_inspectorDebuggable->detachFromPage();
+#endif
 
     forEachLocalFrame([] (LocalFrame& frame) {
         frame.willDetachPage();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1436,7 +1436,7 @@ private:
     UniqueRef<PageConsoleClient> m_consoleClient;
 
 #if ENABLE(REMOTE_INSPECTOR)
-    UniqueRef<PageDebuggable> m_inspectorDebuggable;
+    Ref<PageDebuggable> m_inspectorDebuggable;
 #endif
 
     RefPtr<IDBClient::IDBConnectionToServer> m_idbConnectionToServer;

--- a/Source/WebCore/page/PageDebuggable.h
+++ b/Source/WebCore/page/PageDebuggable.h
@@ -39,7 +39,7 @@ class PageDebuggable final : public Inspector::RemoteInspectionTarget {
     WTF_MAKE_TZONE_ALLOCATED(PageDebuggable);
     WTF_MAKE_NONCOPYABLE(PageDebuggable);
 public:
-    PageDebuggable(Page&);
+    static Ref<PageDebuggable> create(Page&);
     ~PageDebuggable() = default;
 
     Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::Page; }
@@ -56,8 +56,12 @@ public:
     const String& nameOverride() const { return m_nameOverride; }
     void setNameOverride(const String&);
 
+    void detachFromPage();
+
 private:
-    Page& m_page;
+    explicit PageDebuggable(Page&);
+
+    Page* m_page;
     String m_nameOverride;
 };
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
@@ -38,6 +38,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerDebuggable);
 
 using namespace Inspector;
 
+Ref<ServiceWorkerDebuggable> ServiceWorkerDebuggable::create(ServiceWorkerThreadProxy& serviceWorkerThreadProxy, const ServiceWorkerContextData& data)
+{
+    return adoptRef(*new ServiceWorkerDebuggable(serviceWorkerThreadProxy, data));
+}
+
 ServiceWorkerDebuggable::ServiceWorkerDebuggable(ServiceWorkerThreadProxy& serviceWorkerThreadProxy, const ServiceWorkerContextData& data)
     : m_serviceWorkerThreadProxy(serviceWorkerThreadProxy)
     , m_scopeURL(data.registration.scopeURL.string())
@@ -46,17 +51,20 @@ ServiceWorkerDebuggable::ServiceWorkerDebuggable(ServiceWorkerThreadProxy& servi
 
 void ServiceWorkerDebuggable::connect(FrontendChannel& channel, bool, bool)
 {
-    m_serviceWorkerThreadProxy.inspectorProxy().connectToWorker(channel);
+    if (RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get())
+        serviceWorkerThreadProxy->inspectorProxy().connectToWorker(channel);
 }
 
 void ServiceWorkerDebuggable::disconnect(FrontendChannel& channel)
 {
-    m_serviceWorkerThreadProxy.inspectorProxy().disconnectFromWorker(channel);
+    if (RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get())
+        serviceWorkerThreadProxy->inspectorProxy().disconnectFromWorker(channel);
 }
 
 void ServiceWorkerDebuggable::dispatchMessageFromRemote(String&& message)
 {
-    m_serviceWorkerThreadProxy.inspectorProxy().sendMessageToWorker(WTFMove(message));
+    if (RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get())
+        serviceWorkerThreadProxy->inspectorProxy().sendMessageToWorker(WTFMove(message));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
@@ -40,7 +40,7 @@ class ServiceWorkerDebuggable final : public Inspector::RemoteInspectionTarget {
     WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerDebuggable);
     WTF_MAKE_NONCOPYABLE(ServiceWorkerDebuggable);
 public:
-    ServiceWorkerDebuggable(ServiceWorkerThreadProxy&, const ServiceWorkerContextData&);
+    static Ref<ServiceWorkerDebuggable> create(ServiceWorkerThreadProxy&, const ServiceWorkerContextData&);
     ~ServiceWorkerDebuggable() = default;
 
     Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::ServiceWorker; }
@@ -54,7 +54,9 @@ public:
     void dispatchMessageFromRemote(String&& message) final;
 
 private:
-    ServiceWorkerThreadProxy& m_serviceWorkerThreadProxy;
+    ServiceWorkerDebuggable(ServiceWorkerThreadProxy&, const ServiceWorkerContextData&);
+
+    ThreadSafeWeakPtr<ServiceWorkerThreadProxy> m_serviceWorkerThreadProxy;
     String m_scopeURL;
 };
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -69,7 +69,7 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWork
     : m_page(WTFMove(page))
     , m_document(*dynamicDowncast<LocalFrame>(m_page->mainFrame())->document())
 #if ENABLE(REMOTE_INSPECTOR)
-    , m_remoteDebuggable(makeUnique<ServiceWorkerDebuggable>(*this, contextData))
+    , m_remoteDebuggable(ServiceWorkerDebuggable::create(*this, contextData))
 #endif
     , m_serviceWorkerThread(ServiceWorkerThread::create(WTFMove(contextData), WTFMove(workerData), WTFMove(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, idbConnectionProxy(m_document), m_document->socketProvider(), WTFMove(notificationClient), m_page->sessionID(), m_document->noiseInjectionHashSalt(), m_document->advancedPrivacyProtections()))
     , m_cacheStorageProvider(cacheStorageProvider)

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -127,7 +127,7 @@ private:
     Ref<Page> m_page;
     Ref<Document> m_document;
 #if ENABLE(REMOTE_INSPECTOR)
-    std::unique_ptr<ServiceWorkerDebuggable> m_remoteDebuggable;
+    Ref<ServiceWorkerDebuggable> m_remoteDebuggable;
 #endif
     Ref<ServiceWorkerThread> m_serviceWorkerThread;
     CacheStorageProvider& m_cacheStorageProvider;

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -30,7 +30,7 @@
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
@@ -40,8 +40,8 @@ class WebPageDebuggable final : public Inspector::RemoteInspectionTarget {
     WTF_MAKE_TZONE_ALLOCATED(WebPageDebuggable);
     WTF_MAKE_NONCOPYABLE(WebPageDebuggable);
 public:
-    WebPageDebuggable(WebPageProxy&);
-    ~WebPageDebuggable() = default;
+    static Ref<WebPageDebuggable> create(WebPageProxy&);
+    ~WebPageDebuggable();
 
     Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::WebPage; }
 
@@ -57,10 +57,12 @@ public:
     const String& nameOverride() const final { return m_nameOverride; }
     void setNameOverride(const String&);
 
-private:
-    Ref<WebPageProxy> protectedPage() const;
+    void detachFromPage();
 
-    WeakRef<WebPageProxy> m_page;
+private:
+    explicit WebPageDebuggable(WebPageProxy&);
+
+    WeakPtr<WebPageProxy> m_page;
     String m_nameOverride;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3570,7 +3570,7 @@ private:
 
     const std::unique_ptr<WebPageInspectorController> m_inspectorController;
 #if ENABLE(REMOTE_INSPECTOR)
-    std::unique_ptr<WebPageDebuggable> m_inspectorDebuggable;
+    RefPtr<WebPageDebuggable> m_inspectorDebuggable;
 #endif
 
     std::optional<SpellDocumentTag> m_spellDocumentTag;


### PR DESCRIPTION
#### 2a508351f154cb9a1ff2789d0fceb615f4dd2d7d
<pre>
Web Inspector: UAF needs to be prevented for RemoteConnectionToTarget::m_target member variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=276192">https://bugs.webkit.org/show_bug.cgi?id=276192</a>
<a href="https://rdar.apple.com/129782183">rdar://129782183</a>

Reviewed by Geoffrey Garen.

`RemoteConnectionToTarget::m_target` was a raw pointer and used from multiple thread.
We have evidence from the radar that `m_target` could be used-after-free in
`RemoteConnectionToTarget::close()`.

To address the issue, I am updating `m_target` to use a ThreadSafeWeakPtr instead
of a raw pointer so that it gets nulled out on target destruction, and still safe
to use from multiple thread.

Of course, using ThreadSafeWeakPtr required updating `RemoteControllableTarget` to
subclass `ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr` and be refcounted. This
required a decent amount of refactoring.

I am also adding WTF_GUARDED_BY_LOCK for the m_target so that the compiler tells
us when we&apos;re using it without a lock. It did find a few problems which I fixed.

* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp:
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget): Deleted.
(Inspector::RemoteConnectionToTarget::close): Deleted.
(Inspector::RemoteConnectionToTarget::targetClosed): Deleted.
(Inspector::RemoteConnectionToTarget::targetIdentifier const): Deleted.
(Inspector::RemoteConnectionToTarget::sendMessageToFrontend): Deleted.
* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::RemoteConnectionToTarget::targetIdentifier const):
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::close):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget):
(Inspector::RemoteConnectionToTarget::sendMessageToFrontend):
(Inspector::RemoteConnectionToTarget::setupRunLoop):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::~JSGlobalObject):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::inspectorDebuggable):
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
(JSC::JSGlobalObjectDebuggable::create):
(JSC::JSGlobalObjectDebuggable::JSGlobalObjectDebuggable):
(JSC::JSGlobalObjectDebuggable::name const):
(JSC::JSGlobalObjectDebuggable::connect):
(JSC::JSGlobalObjectDebuggable::disconnect):
(JSC::JSGlobalObjectDebuggable::dispatchMessageFromRemote):
(JSC::JSGlobalObjectDebuggable::pauseWaitingForAutomaticInspection):
(JSC::JSGlobalObjectDebuggable::globalObjectDestroyed):
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
(WebCore::Page::~Page):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageDebuggable.cpp:
(WebCore::PageDebuggable::create):
(WebCore::PageDebuggable::PageDebuggable):
(WebCore::PageDebuggable::name const):
(WebCore::PageDebuggable::url const):
(WebCore::PageDebuggable::hasLocalDebugger const):
(WebCore::PageDebuggable::connect):
(WebCore::PageDebuggable::disconnect):
(WebCore::PageDebuggable::dispatchMessageFromRemote):
(WebCore::PageDebuggable::setIndicating):
(WebCore::PageDebuggable::detachFromPage):
* Source/WebCore/page/PageDebuggable.h:
* Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp:
(WebCore::ServiceWorkerDebuggable::create):
(WebCore::ServiceWorkerDebuggable::connect):
(WebCore::ServiceWorkerDebuggable::disconnect):
(WebCore::ServiceWorkerDebuggable::dispatchMessageFromRemote):
* Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::Debuggable::create):
(WebKit::WebAutomationSession::Debuggable::Debuggable):
(WebKit::WebAutomationSession::Debuggable::sessionDestroyed):
(WebKit::WebAutomationSession::Debuggable::name const):
(WebKit::WebAutomationSession::Debuggable::dispatchMessageFromRemote):
(WebKit::WebAutomationSession::Debuggable::connect):
(WebKit::WebAutomationSession::Debuggable::disconnect):
(WebKit::WebAutomationSession::WebAutomationSession):
(WebKit::WebAutomationSession::~WebAutomationSession):
(WebKit::WebAutomationSession::connect):
(WebKit::WebAutomationSession::init):
(WebKit::WebAutomationSession::isPaired const):
(WebKit::WebAutomationSession::isPendingTermination const):
(WebKit::WebAutomationSession::terminate):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:
(WebKit::WebPageDebuggable::create):
(WebKit::WebPageDebuggable::WebPageDebuggable):
(WebKit::WebPageDebuggable::detachFromPage):
(WebKit::WebPageDebuggable::name const):
(WebKit::WebPageDebuggable::url const):
(WebKit::WebPageDebuggable::hasLocalDebugger const):
(WebKit::WebPageDebuggable::connect):
(WebKit::WebPageDebuggable::disconnect):
(WebKit::WebPageDebuggable::dispatchMessageFromRemote):
(WebKit::WebPageDebuggable::setIndicating):
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::close):
* Source/WebKit/UIProcess/WebPageProxy.h:

Originally-landed-as: 280938.63@safari-7619-branch (996e25f1fd95). <a href="https://rdar.apple.com/136111011">rdar://136111011</a>
Canonical link: <a href="https://commits.webkit.org/285039@main">https://commits.webkit.org/285039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fdf5dba5871c3216f76adc6e5359b64dae56fd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22343 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14832 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20865 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64444 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77149 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70568 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61492 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5843 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92354 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10935 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46532 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1311 "Found 9 new failures in page/PageDebuggable.h, UIProcess/Automation/WebAutomationSession.cpp, workers/service/context/ServiceWorkerInspectorProxy.h, UIProcess/Automation/WebAutomationSession.h and found 1 fixed file: workers/service/context/ServiceWorkerDebuggable.h") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20371 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->