### PR TITLE
Implement i18n.getSystemUILanguage and i18n.getPreferredSystemLanguages.

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h
@@ -28,6 +28,7 @@
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <Foundation/NSExtension.h>
+#import <Foundation/NSLocale_Private.h>
 #import <Foundation/NSPrivateDecls.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -57,6 +58,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, NS_NONATOMIC_IOSONLY) void (^requestCompletionBlock)(id <NSCopying>, NSArray *);
 @property (copy, NS_NONATOMIC_IOSONLY) void (^requestCancellationBlock)(id <NSCopying>, NSError *);
 @property (copy, NS_NONATOMIC_IOSONLY) void (^requestInterruptionBlock)(id <NSCopying>);
+@end
+
+@interface NSLocale ()
++ (NSString *)_deviceLanguage;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -368,8 +368,8 @@ JSObjectRef toJSRejectedPromise(JSContextRef context, NSString *callingAPIName, 
 
 NSString *toWebAPI(NSLocale *locale)
 {
-    if (!locale.languageCode)
-        return nil;
+    if (!locale.languageCode.length)
+        return @"und";
 
     if (locale.countryCode.length)
         return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -31,6 +31,7 @@
 #import "WebExtensionAPILocalization.h"
 
 #import "CocoaHelpers.h"
+#import "FoundationSPI.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "WebExtensionContextMessages.h"
@@ -86,6 +87,16 @@ void WebExtensionAPILocalization::getAcceptLanguages(Ref<WebExtensionCallbackHan
     }
 
     callback->call(acceptLanguages.array);
+}
+
+void WebExtensionAPILocalization::getPreferredSystemLanguages(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    callback->call(NSLocale.preferredLanguages);
+}
+
+void WebExtensionAPILocalization::getSystemUILanguage(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    callback->call(NSLocale._deviceLanguage);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
@@ -39,6 +39,8 @@ public:
     NSString *getMessage(NSString* messageName, id substitutions);
     NSString *getUILanguage();
     void getAcceptLanguages(Ref<WebExtensionCallbackHandler>&&);
+    void getPreferredSystemLanguages(Ref<WebExtensionCallbackHandler>&&);
+    void getSystemUILanguage(Ref<WebExtensionCallbackHandler>&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
@@ -36,4 +36,7 @@
 
     void getAcceptLanguages([Optional, CallbackHandler] function callback);
 
+    void getPreferredSystemLanguages([Optional, CallbackHandler] function callback);
+
+    void getSystemUILanguage([Optional, CallbackHandler] function callback);
 };


### PR DESCRIPTION
#### 073492046136ecc131fa22efdb15bac5a3acde81
<pre>
Implement i18n.getSystemUILanguage and i18n.getPreferredSystemLanguages.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280586">https://bugs.webkit.org/show_bug.cgi?id=280586</a>

Reviewed by Brian Weinstein.

WECG issue: <a href="https://github.com/w3c/webextensions/issues/252">https://github.com/w3c/webextensions/issues/252</a>
WECG proposal: <a href="https://github.com/w3c/webextensions/pull/569">https://github.com/w3c/webextensions/pull/569</a>

Also changed the i18n APIs to return `&quot;und&quot;` instead of `undefined` when there is no language code.

* Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::toWebAPI): Return &quot;und&quot; where then is no language code.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getPreferredSystemLanguages):
(WebKit::WebExtensionAPILocalization::getSystemUILanguage):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::localeStringInWebExtensionFormat): Return &quot;und&quot;.
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18n)):
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithFallback)):
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithoutMessages)):
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, i18nWithoutDefaultLocale)):

Canonical link: <a href="https://commits.webkit.org/284637@main">https://commits.webkit.org/284637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f494ddcc421f8746300099a22742aa954e4df77b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60427 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41720 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75867 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14288 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63231 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11249 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10697 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45271 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->