### PR TITLE
Refactor IPInt entry and return paths

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -124,6 +124,7 @@ LLINT_DECLARE_ROUTINE_VALIDATE(js_to_wasm_wrapper_entry);
 LLINT_DECLARE_ROUTINE_VALIDATE(wasm_to_wasm_wrapper_entry);
 LLINT_DECLARE_ROUTINE_VALIDATE(wasm_to_js_wrapper_entry);
 LLINT_DECLARE_ROUTINE_VALIDATE(ipint_trampoline);
+LLINT_DECLARE_ROUTINE_VALIDATE(ipint_entry);
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 #define LLINT_OP_EXTRAS(validateLabel) bitwise_cast<void*>(validateLabel)
@@ -183,6 +184,7 @@ static LLIntOperations llintOperations()
             LLINT_ROUTINE(wasm_to_wasm_wrapper_entry)
             LLINT_ROUTINE(wasm_to_js_wrapper_entry)
             LLINT_ROUTINE(ipint_trampoline)
+            LLINT_ROUTINE(ipint_entry)
 
             LLINT_OP(op_catch)
             LLINT_OP(wasm_catch)

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1495,6 +1495,7 @@ op :js_to_wasm_wrapper_entry
 op :wasm_to_wasm_wrapper_entry
 op :wasm_to_js_wrapper_entry
 op :ipint_trampoline
+op :ipint_entry
 
 op :js_trampoline_op_call
 op :js_trampoline_op_call_ignore_result
@@ -1516,6 +1517,7 @@ op :wasm_trampoline_wasm_call_ref
 op :wasm_trampoline_wasm_tail_call
 op :wasm_trampoline_wasm_tail_call_indirect
 op :wasm_trampoline_wasm_tail_call_ref
+op :wasm_trampoline_wasm_ipint_call
 
 end_section :NativeHelpers
 
@@ -1574,6 +1576,7 @@ op :throw_from_fault_handler_trampoline_reg_instance
 op :call_return_location
 op :call_indirect_return_location
 op :call_ref_return_location
+op :ipint_call_return_location
 
 # FIXME: Wasm and JS LLInt should share common opcodes
 # https://bugs.webkit.org/show_bug.cgi?id=203656

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -538,9 +538,7 @@ end
 # 4. Interpreter entrypoints #
 ##############################
 
-global _ipint_entry
-_ipint_entry:
-.ipint_entry:
+op(ipint_entry, macro()
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     preserveCallerPCAndCFR()
     saveIPIntRegisters()
@@ -548,7 +546,12 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     getIPIntCallee()
 
     ipintEntry()
+else
+    break
+end
+end)
 
+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 .ipint_entry_end_local:
     argumINTEnd()
 
@@ -575,9 +578,14 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 .ipint_exit:
     restoreIPIntRegisters()
     restoreCallerPCAndCFR()
-    ret
+    if ARM64E
+        leap _g_config, ws0
+        jmp JSCConfigGateMapOffset + (constexpr Gate::returnFromLLInt) * PtrSize[ws0], NativeToJITGatePtrTag
+    else
+        ret
+    end
 else
-    ret
+    break
 end
 
 macro ipintCatchCommon()
@@ -658,7 +666,7 @@ end
 
 op(ipint_trampoline, macro ()
     tagReturnAddress sp
-    jmp .ipint_entry
+    jmp _ipint_entry
 end)
 
 #################################

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -1191,3 +1191,14 @@ argumINTAlign(_stack)
 
 argumINTAlign(_end)
     jmp .ipint_entry_end_local
+
+
+_wasm_trampoline_wasm_ipint_call:
+_wasm_trampoline_wasm_ipint_call_wide16:
+_wasm_trampoline_wasm_ipint_call_wide32:
+    break
+
+_wasm_ipint_call_return_location:
+_wasm_ipint_call_return_location_wide16:
+_wasm_ipint_call_return_location_wide32:
+    break

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -5242,9 +5242,22 @@ mintAlign(_call)
     ipintReloadMemory()
     pop t3, t2
 
-    # Make the call
-    call targetEntrypoint, WasmEntryPtrTag
+    move sc2, ws0
 
+    # Make the call
+if ARM64E
+    leap _g_config, ws1
+    jmp JSCConfigGateMapOffset + (constexpr Gate::wasm_ipint_call) * PtrSize[ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
+end
+
+_wasm_trampoline_wasm_ipint_call:
+_wasm_trampoline_wasm_ipint_call_wide16:
+_wasm_trampoline_wasm_ipint_call_wide32:
+    call ws0, WasmEntryPtrTag
+
+_wasm_ipint_call_return_location:
+_wasm_ipint_call_return_location_wide16:
+_wasm_ipint_call_return_location_wide32:
     # Restore the stack pointer
     addp FirstArgumentOffset - CallerFrameAndPCSize, sp
     loadh [MC], sc0  # number of stack args

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2803,6 +2803,10 @@ op(ipint_trampoline, macro ()
     crash()
 end)
 
+op(ipint_entry, macro ()
+    crash()
+end)
+
 _wasm_trampoline_wasm_call:
 _wasm_trampoline_wasm_call_indirect:
 _wasm_trampoline_wasm_call_ref:
@@ -2821,6 +2825,13 @@ _wasm_trampoline_wasm_tail_call_ref_wide16:
 _wasm_trampoline_wasm_tail_call_wide32:
 _wasm_trampoline_wasm_tail_call_indirect_wide32:
 _wasm_trampoline_wasm_tail_call_ref_wide32:
+_wasm_trampoline_wasm_ipint_call:
+_wasm_trampoline_wasm_ipint_call_wide16:
+_wasm_trampoline_wasm_ipint_call_wide32:
+
+_wasm_ipint_call_return_location:
+_wasm_ipint_call_return_location_wide16:
+_wasm_ipint_call_return_location_wide32:
     crash()
 
 end # WEBASSEMBLY

--- a/Source/JavaScriptCore/runtime/Gate.h
+++ b/Source/JavaScriptCore/runtime/Gate.h
@@ -64,6 +64,7 @@ namespace JSC {
     v(wasm_call, WasmEntryPtrTag) \
     v(wasm_call_indirect, WasmEntryPtrTag) \
     v(wasm_call_ref, WasmEntryPtrTag) \
+    v(wasm_ipint_call, WasmEntryPtrTag) \
 
 #else
 #define JSC_WASM_GATE_OPCODES(v)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -518,6 +518,8 @@ static inline UGPRPair doWasmCall(JSWebAssemblyInstance* instance, Wasm::Functio
         *callee = boxedCallee;
     }
 
+    RELEASE_ASSERT(WTF::isTaggedWith<WasmEntryPtrTag>(codePtr));
+
     WASM_CALL_RETURN(instance, codePtr);
 }
 


### PR DESCRIPTION
#### 28cd493e3325ad45bb6c47b7c33c619d11715863
<pre>
Refactor IPInt entry and return paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=280844">https://bugs.webkit.org/show_bug.cgi?id=280844</a>
<a href="https://rdar.apple.com/137227009">rdar://137227009</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

This patch aligns the IPInt entry and exit paths with LLInt&apos;s entry and exit. This fixes issues with
pointer tagging during execution.

* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::inPlaceInterpreterEntryThunk):

Canonical link: <a href="https://commits.webkit.org/285137@main">https://commits.webkit.org/285137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cafda494e4524652331503a5648882b18c2ddba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21858 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55979 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14455 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20218 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63798 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76487 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69925 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63723 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63659 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5345 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91706 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10985 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45887 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19997 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/tail-call-bbq.js.wasm-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->