### PR TITLE
Adopt more smart pointers in GPUProcess/graphics (part 6)

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -76,7 +76,7 @@ void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, We
         return;
     }
 
-    m_backing->requestDevice(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = protectedGPU()] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
+    Ref { m_backing }->requestDevice(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = protectedGPU()] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
         if (!devicePtr.get() || !gpuConnectionToWebProcess) {
             callback({ }, { });
             return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -107,7 +107,7 @@ RemoteDevice::RemoteDevice(GPUConnectionToWebProcess& gpuConnectionToWebProcess,
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteDevice::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteDevice::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteDevice::~RemoteDevice() = default;
@@ -122,7 +122,7 @@ RefPtr<IPC::Connection> RemoteDevice::connection() const
 
 void RemoteDevice::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteDevice::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteDevice::messageReceiverName(), m_identifier.toUInt64());
 }
 
 Ref<RemoteQueue> RemoteDevice::queue()
@@ -132,7 +132,7 @@ Ref<RemoteQueue> RemoteDevice::queue()
 
 void RemoteDevice::destroy()
 {
-    m_backing->destroy();
+    protectedBacking()->destroy();
 }
 
 void RemoteDevice::destruct()
@@ -143,7 +143,7 @@ void RemoteDevice::destruct()
 void RemoteDevice::createXRBinding(WebGPUIdentifier identifier)
 {
     Ref objectHeap = m_objectHeap.get();
-    auto binding = m_backing->createXRBinding();
+    auto binding = protectedBacking()->createXRBinding();
     auto remoteBinding = RemoteXRBinding::create(*m_gpuConnectionToWebProcess.get(), *binding, objectHeap, protectedGPU(), m_streamConnection.copyRef(), identifier);
     objectHeap->addObject(identifier, remoteBinding);
 }
@@ -154,7 +154,7 @@ void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebG
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto buffer = m_backing->createBuffer(*convertedDescriptor);
+    auto buffer = protectedBacking()->createBuffer(*convertedDescriptor);
     MESSAGE_CHECK(buffer);
     auto remoteBuffer = RemoteBuffer::create(*buffer, objectHeap, m_streamConnection.copyRef(), protectedGPU(), descriptor.mappedAtCreation, identifier);
     objectHeap->addObject(identifier, remoteBuffer);
@@ -166,7 +166,7 @@ void RemoteDevice::createTexture(const WebGPU::TextureDescriptor& descriptor, We
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto texture = m_backing->createTexture(*convertedDescriptor);
+    auto texture = protectedBacking()->createTexture(*convertedDescriptor);
     MESSAGE_CHECK(texture);
     auto remoteTexture = RemoteTexture::create(*m_gpuConnectionToWebProcess.get(), protectedGPU(), texture.releaseNonNull(), objectHeap, m_streamConnection.copyRef(), identifier);
     objectHeap->addObject(identifier, remoteTexture);
@@ -178,7 +178,7 @@ void RemoteDevice::createSampler(const WebGPU::SamplerDescriptor& descriptor, We
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto sampler = m_backing->createSampler(*convertedDescriptor);
+    auto sampler = protectedBacking()->createSampler(*convertedDescriptor);
     MESSAGE_CHECK(sampler);
     auto remoteSampler = RemoteSampler::create(*sampler, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteSampler);
@@ -217,7 +217,7 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor, pixelBuffer);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto externalTexture = m_backing->importExternalTexture(*convertedDescriptor);
+    auto externalTexture = protectedBacking()->importExternalTexture(*convertedDescriptor);
     MESSAGE_CHECK(externalTexture);
     auto remoteExternalTexture = RemoteExternalTexture::create(*externalTexture, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteExternalTexture);
@@ -249,7 +249,7 @@ void RemoteDevice::createBindGroupLayout(const WebGPU::BindGroupLayoutDescriptor
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto bindGroupLayout = m_backing->createBindGroupLayout(*convertedDescriptor);
+    auto bindGroupLayout = protectedBacking()->createBindGroupLayout(*convertedDescriptor);
     MESSAGE_CHECK(bindGroupLayout);
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(*bindGroupLayout, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteBindGroupLayout);
@@ -261,7 +261,7 @@ void RemoteDevice::createPipelineLayout(const WebGPU::PipelineLayoutDescriptor& 
     auto convertedDescriptor =  objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto pipelineLayout = m_backing->createPipelineLayout(*convertedDescriptor);
+    auto pipelineLayout = protectedBacking()->createPipelineLayout(*convertedDescriptor);
     MESSAGE_CHECK(pipelineLayout);
     auto remotePipelineLayout = RemotePipelineLayout::create(*pipelineLayout,  objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remotePipelineLayout);
@@ -273,7 +273,7 @@ void RemoteDevice::createBindGroup(const WebGPU::BindGroupDescriptor& descriptor
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto bindGroup = m_backing->createBindGroup(*convertedDescriptor);
+    auto bindGroup = protectedBacking()->createBindGroup(*convertedDescriptor);
     MESSAGE_CHECK(bindGroup);
     auto remoteBindGroup = RemoteBindGroup::create(*bindGroup, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteBindGroup);
@@ -285,7 +285,7 @@ void RemoteDevice::createShaderModule(const WebGPU::ShaderModuleDescriptor& desc
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto shaderModule = m_backing->createShaderModule(*convertedDescriptor);
+    auto shaderModule = protectedBacking()->createShaderModule(*convertedDescriptor);
     MESSAGE_CHECK(shaderModule);
     auto remoteShaderModule = RemoteShaderModule::create(*shaderModule, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteShaderModule);
@@ -298,7 +298,7 @@ void RemoteDevice::createComputePipeline(const WebGPU::ComputePipelineDescriptor
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto computePipeline = m_backing->createComputePipeline(*convertedDescriptor);
+    auto computePipeline = protectedBacking()->createComputePipeline(*convertedDescriptor);
     MESSAGE_CHECK(computePipeline);
     auto remoteComputePipeline = RemoteComputePipeline::create(*computePipeline, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteComputePipeline);
@@ -310,7 +310,7 @@ void RemoteDevice::createRenderPipeline(const WebGPU::RenderPipelineDescriptor& 
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto renderPipeline = m_backing->createRenderPipeline(*convertedDescriptor);
+    auto renderPipeline = protectedBacking()->createRenderPipeline(*convertedDescriptor);
     MESSAGE_CHECK(renderPipeline);
     auto remoteRenderPipeline = RemoteRenderPipeline::create(*renderPipeline, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteRenderPipeline);
@@ -318,14 +318,15 @@ void RemoteDevice::createRenderPipeline(const WebGPU::RenderPipelineDescriptor& 
 
 void RemoteDevice::createComputePipelineAsync(const WebGPU::ComputePipelineDescriptor& descriptor, WebGPUIdentifier identifier, CompletionHandler<void(bool, String&&)>&& callback)
 {
-    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
+    Ref objectHeap = m_objectHeap.get();
+    auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(false, ""_s);
         return;
     }
 
-    m_backing->createComputePipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), gpu = protectedGPU(), identifier] (RefPtr<WebCore::WebGPU::ComputePipeline>&& computePipeline, String&& error) mutable {
+    protectedBacking()->createComputePipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap, streamConnection = m_streamConnection.copyRef(), gpu = protectedGPU(), identifier] (RefPtr<WebCore::WebGPU::ComputePipeline>&& computePipeline, String&& error) mutable {
         bool result = computePipeline.get();
         if (result) {
             auto remoteComputePipeline = RemoteComputePipeline::create(computePipeline.releaseNonNull(), objectHeap, WTFMove(streamConnection), gpu, identifier);
@@ -337,14 +338,15 @@ void RemoteDevice::createComputePipelineAsync(const WebGPU::ComputePipelineDescr
 
 void RemoteDevice::createRenderPipelineAsync(const WebGPU::RenderPipelineDescriptor& descriptor, WebGPUIdentifier identifier, CompletionHandler<void(bool, String&&)>&& callback)
 {
-    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
+    Ref objectHeap = m_objectHeap.get();
+    auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(false, ""_s);
         return;
     }
 
-    m_backing->createRenderPipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), gpu = protectedGPU(), identifier] (RefPtr<WebCore::WebGPU::RenderPipeline>&& renderPipeline, String&& error) mutable {
+    protectedBacking()->createRenderPipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap, streamConnection = m_streamConnection.copyRef(), gpu = protectedGPU(), identifier] (RefPtr<WebCore::WebGPU::RenderPipeline>&& renderPipeline, String&& error) mutable {
         bool result = renderPipeline.get();
         if (result) {
             auto remoteRenderPipeline = RemoteRenderPipeline::create(renderPipeline.releaseNonNull(), objectHeap, WTFMove(streamConnection), gpu, identifier);
@@ -363,7 +365,7 @@ void RemoteDevice::createCommandEncoder(const std::optional<WebGPU::CommandEncod
         MESSAGE_CHECK(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
     }
-    auto commandEncoder = m_backing->createCommandEncoder(convertedDescriptor);
+    auto commandEncoder = protectedBacking()->createCommandEncoder(convertedDescriptor);
     MESSAGE_CHECK(commandEncoder);
     auto remoteCommandEncoder = RemoteCommandEncoder::create(*m_gpuConnectionToWebProcess.get(), protectedGPU(), *commandEncoder, objectHeap, m_streamConnection.copyRef(), identifier);
     objectHeap->addObject(identifier, remoteCommandEncoder);
@@ -375,7 +377,7 @@ void RemoteDevice::createRenderBundleEncoder(const WebGPU::RenderBundleEncoderDe
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto renderBundleEncoder = m_backing->createRenderBundleEncoder(*convertedDescriptor);
+    auto renderBundleEncoder = protectedBacking()->createRenderBundleEncoder(*convertedDescriptor);
     MESSAGE_CHECK(renderBundleEncoder);
     auto remoteRenderBundleEncoder = RemoteRenderBundleEncoder::create(*m_gpuConnectionToWebProcess.get(), protectedGPU(), *renderBundleEncoder, objectHeap, m_streamConnection.copyRef(), identifier);
     objectHeap->addObject(identifier, remoteRenderBundleEncoder);
@@ -387,7 +389,7 @@ void RemoteDevice::createQuerySet(const WebGPU::QuerySetDescriptor& descriptor, 
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto querySet = m_backing->createQuerySet(*convertedDescriptor);
+    auto querySet = protectedBacking()->createQuerySet(*convertedDescriptor);
     MESSAGE_CHECK(querySet);
     auto remoteQuerySet = RemoteQuerySet::create(*querySet, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
     objectHeap->addObject(identifier, remoteQuerySet);
@@ -395,12 +397,12 @@ void RemoteDevice::createQuerySet(const WebGPU::QuerySetDescriptor& descriptor, 
 
 void RemoteDevice::pushErrorScope(WebCore::WebGPU::ErrorFilter errorFilter)
 {
-    m_backing->pushErrorScope(errorFilter);
+    protectedBacking()->pushErrorScope(errorFilter);
 }
 
 void RemoteDevice::popErrorScope(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&& callback)
 {
-    m_backing->popErrorScope([callback = WTFMove(callback)] (bool success, std::optional<WebCore::WebGPU::Error>&& error) mutable {
+    protectedBacking()->popErrorScope([callback = WTFMove(callback)] (bool success, std::optional<WebCore::WebGPU::Error>&& error) mutable {
         if (!error) {
             callback(success, std::nullopt);
             return;
@@ -418,7 +420,7 @@ void RemoteDevice::popErrorScope(CompletionHandler<void(bool, std::optional<WebG
 
 void RemoteDevice::resolveUncapturedErrorEvent(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&& callback)
 {
-    m_backing->resolveUncapturedErrorEvent([callback = WTFMove(callback)] (bool hasUncapturedError, std::optional<WebCore::WebGPU::Error>&& error) mutable {
+    protectedBacking()->resolveUncapturedErrorEvent([callback = WTFMove(callback)] (bool hasUncapturedError, std::optional<WebCore::WebGPU::Error>&& error) mutable {
         if (!error) {
             callback(hasUncapturedError, std::nullopt);
             return;
@@ -436,14 +438,28 @@ void RemoteDevice::resolveUncapturedErrorEvent(CompletionHandler<void(bool, std:
 
 void RemoteDevice::resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&& callback)
 {
-    m_backing->resolveDeviceLostPromise([callback = WTFMove(callback)] (WebCore::WebGPU::DeviceLostReason reason) mutable {
+    protectedBacking()->resolveDeviceLostPromise([callback = WTFMove(callback)] (WebCore::WebGPU::DeviceLostReason reason) mutable {
         callback(reason);
     });
 }
 
 void RemoteDevice::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::Device> RemoteDevice::protectedBacking()
+{
+    return m_backing;
+}
+Ref<WebGPU::ObjectHeap> RemoteDevice::protectedObjectHeap() const
+{
+    return m_objectHeap.get();
+}
+
+Ref<IPC::StreamServerConnection> RemoteDevice::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -115,7 +115,9 @@ private:
     RemoteDevice& operator=(RemoteDevice&&) = delete;
 
     WebCore::WebGPU::Device& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
+    Ref<WebCore::WebGPU::Device> protectedBacking();
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 
     RefPtr<IPC::Connection> connection() const;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -77,7 +77,9 @@ private:
     RemotePresentationContext& operator=(RemotePresentationContext&&) = delete;
 
     WebCore::WebGPU::PresentationContext& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
+    Ref<WebCore::WebGPU::PresentationContext> protectedBacking();
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -47,7 +47,7 @@ RemoteShaderModule::RemoteShaderModule(WebCore::WebGPU::ShaderModule& shaderModu
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteShaderModule::~RemoteShaderModule() = default;
@@ -59,12 +59,12 @@ void RemoteShaderModule::destruct()
 
 void RemoteShaderModule::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&& callback)
 {
-    m_backing->compilationInfo([callback = WTFMove(callback)] (Ref<WebCore::WebGPU::CompilationInfo>&& compilationMessage) mutable {
+    protectedBacking()->compilationInfo([callback = WTFMove(callback)] (Ref<WebCore::WebGPU::CompilationInfo>&& compilationMessage) mutable {
         auto convertedMessages = compilationMessage->messages().map([] (const Ref<WebCore::WebGPU::CompilationMessage>& message) {
             return WebGPU::CompilationMessage {
                 message->message(),
@@ -81,7 +81,17 @@ void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::C
 
 void RemoteShaderModule::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    protectedBacking()->setLabel(WTFMove(label));
+}
+
+Ref<WebCore::WebGPU::ShaderModule> RemoteShaderModule::protectedBacking()
+{
+    return m_backing;
+}
+
+Ref<IPC::StreamServerConnection> RemoteShaderModule::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -77,6 +77,8 @@ private:
     RemoteShaderModule& operator=(RemoteShaderModule&&) = delete;
 
     WebCore::WebGPU::ShaderModule& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::ShaderModule> protectedBacking();
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -54,7 +54,8 @@ RemoteAdapterProxy::~RemoteAdapterProxy()
 
 void RemoteAdapterProxy::requestDevice(const WebCore::WebGPU::DeviceDescriptor& descriptor, CompletionHandler<void(RefPtr<WebCore::WebGPU::Device>&&)>&& callback)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    Ref convertToBackingContext = m_convertToBackingContext;
+    auto convertedDescriptor = convertToBackingContext->convertToBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor)
         return callback(nullptr);
@@ -106,7 +107,7 @@ void RemoteAdapterProxy::requestDevice(const WebCore::WebGPU::DeviceDescriptor& 
         supportedLimits.maxComputeWorkgroupSizeZ,
         supportedLimits.maxComputeWorkgroupsPerDimension
     );
-    auto result = RemoteDeviceProxy::create(WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), *this, m_convertToBackingContext, identifier, queueIdentifier);
+    auto result = RemoteDeviceProxy::create(WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), *this, convertToBackingContext, identifier, queueIdentifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     callback(WTFMove(result));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -86,12 +86,12 @@ RefPtr<WebCore::WebGPU::XRBinding> RemoteDeviceProxy::createXRBinding()
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    return RemoteXRBindingProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteXRBindingProxy::create(*this, protectedConvertToBackingContext(), identifier);
 }
 
 RefPtr<WebCore::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const WebCore::WebGPU::BufferDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -100,14 +100,14 @@ RefPtr<WebCore::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const WebCore::W
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteBufferProxy::create(*this, m_convertToBackingContext, identifier, convertedDescriptor->mappedAtCreation);
+    auto result = RemoteBufferProxy::create(*this, protectedConvertToBackingContext(), identifier, convertedDescriptor->mappedAtCreation);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore::WebGPU::TextureDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -116,14 +116,14 @@ RefPtr<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore:
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteTextureProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+    auto result = RemoteTextureProxy::create(protectedRoot(), protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const WebCore::WebGPU::SamplerDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -132,7 +132,7 @@ RefPtr<WebCore::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const WebCore:
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteSamplerProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteSamplerProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
@@ -141,7 +141,7 @@ RefPtr<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTextur
 {
     auto identifier = WebGPUIdentifier::generate();
 
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -165,7 +165,7 @@ RefPtr<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTextur
         return nullptr;
 #endif
 
-    auto result = RemoteExternalTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteExternalTextureProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
@@ -173,14 +173,14 @@ RefPtr<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTextur
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
 void RemoteDeviceProxy::updateExternalTexture(const WebCore::WebGPU::ExternalTexture& externalTexture, const WebCore::MediaPlayerIdentifier& mediaPlayerIdentifier)
 {
-    auto sendResult = send(Messages::RemoteDevice::UpdateExternalTexture(m_convertToBackingContext->convertToBacking(externalTexture), mediaPlayerIdentifier));
+    auto sendResult = send(Messages::RemoteDevice::UpdateExternalTexture(protectedConvertToBackingContext()->convertToBacking(externalTexture), mediaPlayerIdentifier));
     UNUSED_PARAM(sendResult);
 }
 #endif
 
 RefPtr<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayout(const WebCore::WebGPU::BindGroupLayoutDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -189,14 +189,14 @@ RefPtr<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayou
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteBindGroupLayoutProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteBindGroupLayoutProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::PipelineLayout> RemoteDeviceProxy::createPipelineLayout(const WebCore::WebGPU::PipelineLayoutDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -205,14 +205,14 @@ RefPtr<WebCore::WebGPU::PipelineLayout> RemoteDeviceProxy::createPipelineLayout(
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemotePipelineLayoutProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemotePipelineLayoutProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::BindGroup> RemoteDeviceProxy::createBindGroup(const WebCore::WebGPU::BindGroupDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -221,14 +221,14 @@ RefPtr<WebCore::WebGPU::BindGroup> RemoteDeviceProxy::createBindGroup(const WebC
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteBindGroupProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteBindGroupProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::ShaderModule> RemoteDeviceProxy::createShaderModule(const WebCore::WebGPU::ShaderModuleDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -237,14 +237,14 @@ RefPtr<WebCore::WebGPU::ShaderModule> RemoteDeviceProxy::createShaderModule(cons
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteShaderModuleProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteShaderModuleProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::ComputePipeline> RemoteDeviceProxy::createComputePipeline(const WebCore::WebGPU::ComputePipelineDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -253,14 +253,14 @@ RefPtr<WebCore::WebGPU::ComputePipeline> RemoteDeviceProxy::createComputePipelin
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteComputePipelineProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteComputePipelineProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::RenderPipeline> RemoteDeviceProxy::createRenderPipeline(const WebCore::WebGPU::RenderPipelineDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -269,14 +269,14 @@ RefPtr<WebCore::WebGPU::RenderPipeline> RemoteDeviceProxy::createRenderPipeline(
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteRenderPipelineProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteRenderPipelineProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::ComputePipelineDescriptor& descriptor, CompletionHandler<void(RefPtr<WebCore::WebGPU::ComputePipeline>&&, String&&)>&& callback)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(nullptr, "GPUDevice.createComputePipelineAsync() descriptor is invalid"_s);
@@ -290,7 +290,7 @@ void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::Comput
             return;
         }
 
-        auto computePipelineResult = RemoteComputePipelineProxy::create(protectedThis, protectedThis->m_convertToBackingContext, identifier);
+        auto computePipelineResult = RemoteComputePipelineProxy::create(protectedThis, protectedThis->protectedConvertToBackingContext(), identifier);
         computePipelineResult->setLabel(WTFMove(label));
         callback(WTFMove(computePipelineResult), ""_s);
     });
@@ -299,7 +299,7 @@ void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::Comput
 
 void RemoteDeviceProxy::createRenderPipelineAsync(const WebCore::WebGPU::RenderPipelineDescriptor& descriptor, CompletionHandler<void(RefPtr<WebCore::WebGPU::RenderPipeline>&&, String&&)>&& callback)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return callback(nullptr, "GPUDevice.createRenderPipelineAsync() descriptor is invalid"_s);
 
@@ -310,7 +310,7 @@ void RemoteDeviceProxy::createRenderPipelineAsync(const WebCore::WebGPU::RenderP
             return;
         }
 
-        auto renderPipelineResult = RemoteRenderPipelineProxy::create(protectedThis, protectedThis->m_convertToBackingContext, identifier);
+        auto renderPipelineResult = RemoteRenderPipelineProxy::create(protectedThis, protectedThis->protectedConvertToBackingContext(), identifier);
         renderPipelineResult->setLabel(WTFMove(label));
         callback(WTFMove(renderPipelineResult), ""_s);
     });
@@ -321,7 +321,7 @@ RefPtr<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(
 {
     std::optional<CommandEncoderDescriptor> convertedDescriptor;
     if (descriptor) {
-        convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
+        convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(*descriptor);
         if (!convertedDescriptor)
             return nullptr;
     }
@@ -331,14 +331,14 @@ RefPtr<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteCommandEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteCommandEncoderProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::RenderBundleEncoder> RemoteDeviceProxy::createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -347,14 +347,14 @@ RefPtr<WebCore::WebGPU::RenderBundleEncoder> RemoteDeviceProxy::createRenderBund
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteRenderBundleEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteRenderBundleEncoderProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
 RefPtr<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCore::WebGPU::QuerySetDescriptor& descriptor)
 {
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    auto convertedDescriptor = protectedConvertToBackingContext()->convertToBacking(descriptor);
     if (!convertedDescriptor)
         return nullptr;
 
@@ -363,7 +363,7 @@ RefPtr<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCor
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteQuerySetProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteQuerySetProxy::create(*this, protectedConvertToBackingContext(), identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
@@ -424,6 +424,11 @@ void RemoteDeviceProxy::resolveDeviceLostPromise(CompletionHandler<void(WebCore:
         callback(reason);
     });
     UNUSED_PARAM(sendResult);
+}
+
+Ref<ConvertToBackingContext> RemoteDeviceProxy::protectedConvertToBackingContext() const
+{
+    return m_convertToBackingContext;
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -114,6 +114,8 @@ private:
     void setLabelInternal(const String&) final;
     void resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&&) final;
 
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const;
+
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteAdapterProxy> m_parent;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -49,7 +49,7 @@ RemotePresentationContextProxy::~RemotePresentationContextProxy() = default;
 
 bool RemotePresentationContextProxy::configure(const WebCore::WebGPU::CanvasConfiguration& canvasConfiguration)
 {
-    auto convertedConfiguration = m_convertToBackingContext->convertToBacking(canvasConfiguration);
+    auto convertedConfiguration = protectedConvertToBackingContext()->convertToBacking(canvasConfiguration);
     if (!convertedConfiguration)
         return false;
 
@@ -72,7 +72,7 @@ RefPtr<WebCore::WebGPU::Texture> RemotePresentationContextProxy::getCurrentTextu
         if (sendResult != IPC::Error::NoError)
             return nullptr;
 
-        m_currentTexture = RemoteTextureProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+        m_currentTexture = RemoteTextureProxy::create(protectedRoot(), protectedConvertToBackingContext(), identifier);
     }
 
     return m_currentTexture;
@@ -90,6 +90,11 @@ void RemotePresentationContextProxy::present(bool presentToGPUProcess)
 RefPtr<WebCore::NativeImage> RemotePresentationContextProxy::getMetalTextureAsNativeImage(uint32_t, bool&)
 {
     RELEASE_ASSERT_NOT_REACHED();
+}
+
+Ref<ConvertToBackingContext> RemotePresentationContextProxy::protectedConvertToBackingContext() const
+{
+    return m_convertToBackingContext;
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -69,6 +69,8 @@ private:
     RemotePresentationContextProxy& operator=(RemotePresentationContextProxy&&) = delete;
 
     WebGPUIdentifier backing() const { return m_backing; }
+    Ref<ConvertToBackingContext> protectedConvertToBackingContext() const;
+
     RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t, bool& isIOSurfaceSupportedFormat) final;
 
     template<typename T>


### PR DESCRIPTION
#### 41a1c99f58fcef1a446468ff959bc9ea41a3dd36
<pre>
Adopt more smart pointers in GPUProcess/graphics (part 6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=280846">https://bugs.webkit.org/show_bug.cgi?id=280846</a>
<a href="https://rdar.apple.com/137229955">rdar://137229955</a>

Reviewed by Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::requestDevice):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::RemoteDevice):
(WebKit::RemoteDevice::stopListeningForIPC):
(WebKit::RemoteDevice::destroy):
(WebKit::RemoteDevice::createXRBinding):
(WebKit::RemoteDevice::createBuffer):
(WebKit::RemoteDevice::createTexture):
(WebKit::RemoteDevice::createSampler):
(WebKit::RemoteDevice::importExternalTextureFromVideoFrame):
(WebKit::RemoteDevice::createBindGroupLayout):
(WebKit::RemoteDevice::createPipelineLayout):
(WebKit::RemoteDevice::createBindGroup):
(WebKit::RemoteDevice::createShaderModule):
(WebKit::RemoteDevice::createComputePipeline):
(WebKit::RemoteDevice::createRenderPipeline):
(WebKit::RemoteDevice::createComputePipelineAsync):
(WebKit::RemoteDevice::createRenderPipelineAsync):
(WebKit::RemoteDevice::createCommandEncoder):
(WebKit::RemoteDevice::createRenderBundleEncoder):
(WebKit::RemoteDevice::createQuerySet):
(WebKit::RemoteDevice::pushErrorScope):
(WebKit::RemoteDevice::popErrorScope):
(WebKit::RemoteDevice::resolveUncapturedErrorEvent):
(WebKit::RemoteDevice::resolveDeviceLostPromise):
(WebKit::RemoteDevice::setLabel):
(WebKit::RemoteDevice::protectedBacking):
(WebKit::RemoteDevice::protectedObjectHeap const):
(WebKit::RemoteDevice::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::RemotePresentationContext):
(WebKit::RemotePresentationContext::stopListeningForIPC):
(WebKit::RemotePresentationContext::configure):
(WebKit::RemotePresentationContext::unconfigure):
(WebKit::RemotePresentationContext::present):
(WebKit::RemotePresentationContext::getCurrentTexture):
(WebKit::RemotePresentationContext::protectedBacking):
(WebKit::RemotePresentationContext::protectedObjectHeap const):
(WebKit::RemotePresentationContext::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp:
(WebKit::RemoteShaderModule::RemoteShaderModule):
(WebKit::RemoteShaderModule::stopListeningForIPC):
(WebKit::RemoteShaderModule::compilationInfo):
(WebKit::RemoteShaderModule::setLabel):
(WebKit::RemoteShaderModule::protectedBacking):
(WebKit::RemoteShaderModule::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::requestDevice):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createXRBinding):
(WebKit::WebGPU::RemoteDeviceProxy::createBuffer):
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createSampler):
(WebKit::WebGPU::RemoteDeviceProxy::importExternalTexture):
(WebKit::WebGPU::RemoteDeviceProxy::updateExternalTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createBindGroupLayout):
(WebKit::WebGPU::RemoteDeviceProxy::createPipelineLayout):
(WebKit::WebGPU::RemoteDeviceProxy::createBindGroup):
(WebKit::WebGPU::RemoteDeviceProxy::createShaderModule):
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipeline):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipeline):
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createCommandEncoder):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderBundleEncoder):
(WebKit::WebGPU::RemoteDeviceProxy::createQuerySet):
(WebKit::WebGPU::RemoteDeviceProxy::protectedConvertToBackingContext const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
(WebKit::WebGPU::RemotePresentationContextProxy::configure):
(WebKit::WebGPU::RemotePresentationContextProxy::getCurrentTexture):
(WebKit::WebGPU::RemotePresentationContextProxy::protectedConvertToBackingContext const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/284694@main">https://commits.webkit.org/284694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba4217bfeee70aa742453601beb34e78da7c1ad7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14083 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41727 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14295 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17447 "Found 1 new test failure: pageoverlay/overlay-small-frame-mouse-events.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63236 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11254 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4869 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10734 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->