### PR TITLE
Copy files provided by WKWebView clients on iOS that implement runOpenPanel instead of moving them

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -877,8 +877,9 @@ bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFr
         RetainPtr<NSFileCoordinator> uploadFileCoordinator = adoptNS([[NSFileCoordinator alloc] init]);
         RetainPtr<NSFileManager> uploadFileManager = adoptNS([[NSFileManager alloc] init]);
         for (NSURL *url in URLs) {
-            auto [maybeMovedURL, temporaryURL] = [WKFileUploadPanel _copyToNewTemporaryDirectory:url fileCoordinator:uploadFileCoordinator.get() fileManager:uploadFileManager.get()];
-            filenames.append(maybeMovedURL.get().path);
+            auto [success, maybeMovedURL, temporaryURL] = [WKFileUploadPanel _moveToNewTemporaryDirectory:url fileCoordinator:uploadFileCoordinator.get() fileManager:uploadFileManager.get() asCopy:YES];
+            if (success)
+                filenames.append(maybeMovedURL.get().path);
         }
 #else
         for (NSURL *url in URLs)

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
@@ -53,7 +53,13 @@ enum class PickerDismissalReason : uint8_t;
 - (NSArray<NSString *> *)currentAvailableActionTitles;
 - (NSArray<NSString *> *)acceptedTypeIdentifiers;
 
-+ (std::pair<RetainPtr<NSURL>, RetainPtr<NSURL>>)_copyToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager;
+struct TemporaryFileMoveResults {
+    bool succeeded;
+    RetainPtr<NSURL> maybeMovedURL;
+    RetainPtr<NSURL> temporaryDirectoryURL;
+};
+
++ (TemporaryFileMoveResults)_moveToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager asCopy:(BOOL)asCopy;
 @end
 
 @protocol WKFileUploadPanelDelegate <NSObject>


### PR DESCRIPTION
#### c7848af1a37aecc610881b05c2a42bff60a8bf82
<pre>
Copy files provided by WKWebView clients on iOS that implement runOpenPanel instead of moving them
<a href="https://bugs.webkit.org/show_bug.cgi?id=280847">https://bugs.webkit.org/show_bug.cgi?id=280847</a>
<a href="https://rdar.apple.com/137172156">rdar://137172156</a>

Reviewed by Abrar Rahman Protyasha.

UIDelegate::UIClient::runOpenPanel now copies the URLs provided by implementations of runOpenPanel in WKUIDelegates rather than moving them. This ensures that the workaround for <a href="https://bugs.webkit.org/show_bug.cgi?id=228683">https://bugs.webkit.org/show_bug.cgi?id=228683</a> will not result in files being lost if the URL points to an original file rather than an imported copy.

* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::runOpenPanel):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:

Canonical link: <a href="https://commits.webkit.org/284651@main">https://commits.webkit.org/284651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfbc6917fe075269cd6400649f73e9675e6c8f14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22868 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21123 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60459 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41752 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75909 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14330 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63256 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11275 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45313 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/72 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->