### PR TITLE
Make FrameLoader ref-counted

### DIFF
--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -318,7 +318,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
         windowProxy.window()->setConsoleClient(page->console());
     }
 
-    protectedFrame()->checkedLoader()->dispatchDidClearWindowObjectInWorld(world);
+    protectedFrame()->protectedLoader()->dispatchDidClearWindowObjectInWorld(world);
 }
 
 Ref<LocalFrame> ScriptController::protectedFrame() const

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -108,7 +108,7 @@ void DocumentFontLoader::fontLoadingTimerFired()
     // New font loads may be triggered by layout after the document load is complete but before we have dispatched
     // didFinishLoading for the frame. Make sure the delegate is always dispatched by checking explicitly.
     if (RefPtr frame = m_document->frame())
-        frame->checkedLoader()->checkLoadComplete();
+        frame->protectedLoader()->checkLoadComplete();
 }
 
 void DocumentFontLoader::stopLoadingAndClearFonts()

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -127,7 +127,7 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     if (!localFrame)
         return false;
 
-    if (!localFrame->checkedLoader()->shouldSuppressTextInputFromEditing())
+    if (!localFrame->protectedLoader()->shouldSuppressTextInputFromEditing())
         return false;
 
     if (auto* textEvent = dynamicDowncast<TextEvent>(event))

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -84,7 +84,7 @@ static inline void logBackForwardCacheFailureDiagnosticMessage(Page* page, const
 static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
 {
     PCLOG("+---"_s);
-    CheckedRef frameLoader = frame.loader();
+    Ref frameLoader = frame.loader();
 
     // Prevent page caching if a subframe is still in provisional load stage.
     // We only do this check for subframes because the main frame is reused when navigating to a new page.
@@ -462,7 +462,7 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
     if (!localMainFrame)
         return nullptr;
 
-    localMainFrame->checkedLoader()->stopForBackForwardCache();
+    localMainFrame->protectedLoader()->stopForBackForwardCache();
 
     if (forceSuspension == ForceSuspension::No && !canCache(page))
         return nullptr;
@@ -483,7 +483,7 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
 
     // Stop all loads again before checking if we can still cache the page after firing the pagehide
     // event, since the page may have started ping loads in its pagehide event handler.
-    localMainFrame->checkedLoader()->stopForBackForwardCache();
+    localMainFrame->protectedLoader()->stopForBackForwardCache();
 
     // Check that the page is still page-cacheable after firing the pagehide event. The JS event handlers
     // could have altered the page in a way that could prevent caching.

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -200,7 +200,7 @@ CachedFrame::CachedFrame(Frame& frame)
 
     // The main frame is reused for the navigation and the opener link to its should thus persist.
     if (localFrame) {
-        CheckedRef frameLoader = localFrame->loader();
+        Ref frameLoader = localFrame->loader();
         if (!frame.isMainFrame())
             localFrame->detachFromAllOpenedFrames();
 
@@ -248,7 +248,7 @@ void CachedFrame::open()
     ASSERT(m_document || is<RemoteFrameView>(m_view.get()));
 
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_view.get()))
-        localFrameView->protectedFrame()->checkedLoader()->open(*this);
+        localFrameView->protectedFrame()->protectedLoader()->open(*this);
 }
 
 void CachedFrame::clear()
@@ -291,7 +291,7 @@ void CachedFrame::destroy()
     Ref frame = m_view->frame();
     if (!m_isMainFrame && m_view->frame().page()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get()))
-            localFrame->checkedLoader()->detachViewsAndDocumentLoader();
+            localFrame->protectedLoader()->detachViewsAndDocumentLoader();
         frame->detachFromPage();
     }
     

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -195,7 +195,7 @@ void CachedPage::restore(Page& page)
 
     for (auto& domain : m_loadedSubresourceDomains) {
         if (localMainFrame)
-            localMainFrame->checkedLoader()->client().didLoadFromRegistrableDomain(WTFMove(domain));
+            localMainFrame->protectedLoader()->client().didLoadFromRegistrableDomain(WTFMove(domain));
     }
 
     clear();

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -629,7 +629,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     // Thus, URLs should be empty for now.
     ASSERT(!privateClickMeasurement || (privateClickMeasurement->attributionReportClickSourceURL().isNull() && privateClickMeasurement->attributionReportClickDestinationURL().isNull()));
     
-    frame->checkedLoader()->changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document->shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, WTFMove(privateClickMeasurement));
+    frame->protectedLoader()->changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document->shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, WTFMove(privateClickMeasurement));
 
     sendPings(completedURL);
 

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -330,7 +330,7 @@ bool HTMLPlugInImageElement::requestObject(const String& relativeURL, const Stri
         RefPtr frame = this->document().frame();
         if (!frame)
             return;
-        frame->checkedLoader()->subframeLoader().requestObject(*this, relativeURL, nameAttribute, mimeType, paramNames, paramValues);
+        frame->protectedLoader()->subframeLoader().requestObject(*this, relativeURL, nameAttribute, mimeType, paramNames, paramValues);
     });
     return true;
 }

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -126,7 +126,7 @@ void MediaDocumentParser::createDocumentStructure()
         return;
 
     frame->loader().protectedActiveDocumentLoader()->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
-    frame->checkedLoader()->setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
+    frame->protectedLoader()->setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
 }
 
 void MediaDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -155,7 +155,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
     ResourceResponse response;
     RefPtr<SharedBuffer> data;
 
-    auto identifier = loader.document().protectedFrame()->checkedLoader()->loadResourceSynchronously(preflightRequest, ClientCredentialPolicy::CannotAskClientForCredentials, FetchOptions { }, { }, error, response, data);
+    auto identifier = loader.document().protectedFrame()->protectedLoader()->loadResourceSynchronously(preflightRequest, ClientCredentialPolicy::CannotAskClientForCredentials, FetchOptions { }, { }, error, response, data);
 
     if (!error.isNull()) {
         // If the preflight was cancelled by underlying code, it probably means the request was blocked due to some access control policy.

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -218,7 +218,7 @@ public:
     WEBCORE_EXPORT virtual void detachFromFrame(LoadWillContinueInAnotherProcess);
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
-    CheckedPtr<FrameLoader> checkedFrameLoader() const;
+    RefPtr<FrameLoader> protectedFrameLoader() const;
     WEBCORE_EXPORT SubresourceLoader* mainResourceLoader() const;
     WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> mainResourceData() const;
     

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -628,7 +628,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     RefPtr<SharedBuffer> data;
     ResourceError error;
     ResourceResponse response;
-    CheckedRef frameLoader = frame->loader();
+    Ref frameLoader = frame->loader();
     auto identifier = frameLoader->loadResourceSynchronously(request, m_options.clientCredentialPolicy, m_options, *m_originalHeaders, error, response, data);
 
     loadTiming.markEndTime();

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -73,7 +73,7 @@ static inline bool canReferToParentFrameEncoding(const LocalFrame* frame, const 
 void DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL(const String& source, Document* ownerDocument)
 {
     Ref frame = *m_frame;
-    frame->checkedLoader()->stopAllLoaders();
+    frame->protectedLoader()->stopAllLoaders();
 
     // If we are in the midst of changing the frame's document, don't execute script
     // that modifies the document further:
@@ -118,7 +118,7 @@ bool DocumentWriter::begin()
 Ref<Document> DocumentWriter::createDocument(const URL& url, ScriptExecutionContextIdentifier documentIdentifier)
 {
     Ref frame = *m_frame;
-    CheckedRef frameLoader = frame->loader();
+    Ref frameLoader = frame->loader();
 
     auto useSinkDocument = [&]() {
 #if ENABLE(PDF_PLUGIN)
@@ -156,7 +156,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     Ref document = createDocument(url, documentIdentifier);
     
     Ref frame = *m_frame;
-    CheckedRef frameLoader = frame->loader();
+    Ref frameLoader = frame->loader();
 
     // If the new document is for a Plugin but we're supposed to be sandboxed from Plugins,
     // then replace the document with one whose parser will ignore the incoming data (bug 39323)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -102,14 +102,16 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 
 using ContentPolicyDecisionFunction = CompletionHandler<void(PolicyAction)>;
 
-class FrameLoader final : public CanMakeCheckedPtr<FrameLoader> {
+class FrameLoader final {
     WTF_MAKE_NONCOPYABLE(FrameLoader);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameLoader);
     friend class PolicyChecker;
 public:
     FrameLoader(LocalFrame&, UniqueRef<LocalFrameLoaderClient>&&);
     ~FrameLoader();
+
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
 
     WEBCORE_EXPORT void init();
     void initForSynthesizedDocument(const URL&);

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -277,7 +277,7 @@ void LinkLoader::preconnectIfNeeded(const LinkLoadParameters& params, Document& 
     if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !document.protectedSecurityOrigin()->isSameOriginDomain(SecurityOrigin::create(href)))
         storageCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
     ASSERT(document.frame()->loader().networkingContext());
-    platformStrategies()->loaderStrategy()->preconnectTo(document.protectedFrame()->checkedLoader(), href, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href](ResourceError error) {
+    platformStrategies()->loaderStrategy()->preconnectTo(document.protectedFrame()->protectedLoader(), href, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href](ResourceError error) {
         RefPtr document = weakDocument.get();
         if (!document)
             return;
@@ -412,7 +412,7 @@ void LinkLoader::loadLink(const LinkLoadParameters& params, Document& document)
         // FIXME: The href attribute of the link element can be in "//hostname" form, and we shouldn't attempt
         // to complete that as URL <https://bugs.webkit.org/show_bug.cgi?id=48857>.
         if (document.settings().dnsPrefetchingEnabled() && params.href.isValid() && !params.href.isEmpty() && document.frame())
-            document.protectedFrame()->checkedLoader()->client().prefetchDNS(params.href.host().toString());
+            document.protectedFrame()->protectedLoader()->client().prefetchDNS(params.href.host().toString());
     }
 
     preconnectIfNeeded(params, document);

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -87,7 +87,7 @@ void MediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expe
     if (!m_document || !m_document->frame())
         return completionHandler(makeUnexpected(internalError(url)));
 
-    m_document->protectedFrame()->checkedLoader()->client().sendH2Ping(url, WTFMove(completionHandler));
+    m_document->protectedFrame()->protectedLoader()->client().sendH2Ping(url, WTFMove(completionHandler));
 }
 
 RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceRequest&& request, LoadOptions options)

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -133,7 +133,7 @@ static bool frameAndAncestorsCanDisplayInsecureContent(LocalFrame& frame, MixedC
 
     if (allowed) {
         document->setFoundMixedContent(SecurityContext::MixedContentType::Inactive);
-        frame.checkedLoader()->client().didDisplayInsecureContent();
+        frame.protectedLoader()->client().didDisplayInsecureContent();
     }
 
     return allowed;
@@ -157,7 +157,7 @@ bool MixedContentChecker::frameAndAncestorsCanRunInsecureContent(LocalFrame& fra
 
     if (allowed) {
         document->setFoundMixedContent(SecurityContext::MixedContentType::Active);
-        frame.checkedLoader()->client().didRunInsecureContent(securityOrigin);
+        frame.protectedLoader()->client().didRunInsecureContent(securityOrigin);
     }
 
     return allowed;
@@ -241,7 +241,7 @@ void MixedContentChecker::checkFormForMixedContent(LocalFrame& frame, const URL&
     auto message = makeString("The page at "_s, frame.document()->url().stringCenterEllipsizedToLength(), " contains a form which targets an insecure URL "_s, url.stringCenterEllipsizedToLength(), ".\n"_s);
     frame.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, message);
 
-    frame.checkedLoader()->client().didDisplayInsecureContent();
+    frame.protectedLoader()->client().didDisplayInsecureContent();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -144,7 +144,7 @@ protected:
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             return;
-        localFrame->checkedLoader()->clientRedirected(URL(m_url), delay(), WallTime::now() + timer.nextFireInterval(), lockBackForwardList());
+        localFrame->protectedLoader()->clientRedirected(URL(m_url), delay(), WallTime::now() + timer.nextFireInterval(), lockBackForwardList());
     }
 
     void didStopTimer(Frame& frame, NewLoadInProgress newLoadInProgress) override
@@ -159,7 +159,7 @@ protected:
         // gesture state will sometimes be set and sometimes not within
         // dispatchDidCancelClientRedirect().
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
-            localFrame->checkedLoader()->clientRedirectCancelledOrFinished(newLoadInProgress);
+            localFrame->protectedLoader()->clientRedirectCancelledOrFinished(newLoadInProgress);
     }
 
     Document& initiatingDocument() { return m_initiatingDocument.get(); }
@@ -189,7 +189,7 @@ public:
     bool shouldStartTimer(Frame& frame) override
     {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
-        return localFrame && localFrame->checkedLoader()->allAncestorsAreComplete();
+        return localFrame && localFrame->protectedLoader()->allAncestorsAreComplete();
     }
 
     void fire(Frame& frame) override
@@ -217,7 +217,7 @@ public:
         frameLoadRequest.disableNavigationToInvalidURL();
         frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLs());
 
-        localFrame->checkedLoader()->changeLocation(WTFMove(frameLoadRequest));
+        localFrame->protectedLoader()->changeLocation(WTFMove(frameLoadRequest));
     }
 
 private:
@@ -303,7 +303,7 @@ public:
             // Special case for go(0) from a frame -> reload only the frame
             // To follow Firefox and IE's behavior, history reload can only navigate the self frame.
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
-                localFrame->checkedLoader()->changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
+                localFrame->protectedLoader()->changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;
         }
         
@@ -354,7 +354,7 @@ public:
 
         if (page->backForward().currentItem() == historyItem.ptr()) {
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
-                localFrame->checkedLoader()->changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
+                localFrame->protectedLoader()->changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;
         }
 
@@ -409,7 +409,7 @@ public:
         if (localFrame->document() != requestingDocument.ptr())
             navigationHistoryBehavior = NavigationHistoryBehavior::Push;
         frameLoadRequest.setNavigationHistoryBehavior(navigationHistoryBehavior);
-        localFrame->checkedLoader()->loadFrameRequest(WTFMove(frameLoadRequest), submission->protectedEvent().get(), submission->takeState());
+        localFrame->protectedLoader()->loadFrameRequest(WTFMove(frameLoadRequest), submission->protectedEvent().get(), submission->takeState());
     }
 
     void didStartTimer(Frame& frame, Timer& timer) final
@@ -422,7 +422,7 @@ public:
         m_haveToldClient = true;
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
-        localFrame->checkedLoader()->clientRedirected(m_submission->requestURL(), delay(), WallTime::now() + timer.nextFireInterval(), lockBackForwardList());
+        localFrame->protectedLoader()->clientRedirected(m_submission->requestURL(), delay(), WallTime::now() + timer.nextFireInterval(), lockBackForwardList());
     }
 
     void didStopTimer(Frame& frame, NewLoadInProgress newLoadInProgress) final
@@ -439,7 +439,7 @@ public:
         // fact unavailable. We need to be consistent with them, otherwise the
         // gesture state will sometimes be set and sometimes not within
         // dispatchDidCancelClientRedirect().
-        localFrame->checkedLoader()->clientRedirectCancelledOrFinished(newLoadInProgress);
+        localFrame->protectedLoader()->clientRedirectCancelledOrFinished(newLoadInProgress);
     }
 
     bool targetIsCurrentFrame() const final
@@ -483,7 +483,7 @@ public:
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());
         frameLoadRequest.setSubstituteData(replacementData);
         frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLs());
-        localFrame->checkedLoader()->load(WTFMove(frameLoadRequest));
+        localFrame->protectedLoader()->load(WTFMove(frameLoadRequest));
     }
 
 private:
@@ -586,7 +586,7 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
         lockBackForwardList = mustLockBackForwardList(m_frame);
 
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame.get());
-    CheckedPtr loader = localFrame ? &localFrame->loader() : nullptr;
+    RefPtr loader = localFrame ? &localFrame->loader() : nullptr;
 
     // If the URL we're going to navigate to is the same as the current one, except for the
     // fragment part, we don't need to schedule the location change.
@@ -735,7 +735,7 @@ void NavigationScheduler::schedule(std::unique_ptr<ScheduledNavigation> redirect
         if (localFrame) {
             if (RefPtr provisionalDocumentLoader = localFrame->loader().provisionalDocumentLoader())
                 provisionalDocumentLoader->stopLoading();
-            localFrame->checkedLoader()->stopLoading(UnloadEventPolicy::UnloadAndPageHide);
+            localFrame->protectedLoader()->stopLoading(UnloadEventPolicy::UnloadAndPageHide);
         }
     }
 
@@ -743,7 +743,7 @@ void NavigationScheduler::schedule(std::unique_ptr<ScheduledNavigation> redirect
     m_redirect = WTFMove(redirect);
 
     if (localFrame && !localFrame->loader().isComplete() && m_redirect->isLocationChange())
-        localFrame->checkedLoader()->completed();
+        localFrame->protectedLoader()->completed();
 
     if (!m_frame->page())
         return;

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -140,7 +140,7 @@ void NetscapePlugInStreamLoader::didReceiveResponse(const ResourceResponse& resp
 
         // Status code can be null when serving from a Web archive.
         if (response.httpStatusCode() && (response.httpStatusCode() < 100 || response.httpStatusCode() >= 400))
-            cancel(checkedFrameLoader()->client().fileDoesNotExistError(response));
+            cancel(protectedFrameLoader()->client().fileDoesNotExistError(response));
     });
 }
 

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -112,7 +112,7 @@ void PingLoader::loadImage(LocalFrame& frame, const URL& url)
     String referrer = SecurityPolicy::generateReferrerHeader(document->referrerPolicy(), request.url(), frame.loader().outgoingReferrerURL(), OriginAccessPatternsForWebProcess::singleton());
     if (!referrer.isEmpty())
         request.setHTTPReferrer(referrer);
-    frame.checkedLoader()->updateRequestAndAddExtraFields(request, IsMainResource::No);
+    frame.protectedLoader()->updateRequestAndAddExtraFields(request, IsMainResource::No);
 
     startPingLoad(frame, request, WTFMove(originalRequestHeader), ShouldFollowRedirects::Yes, ContentSecurityPolicyImposition::DoPolicyCheck, ReferrerPolicy::EmptyString);
 }
@@ -146,7 +146,7 @@ void PingLoader::sendPing(LocalFrame& frame, const URL& pingURL, const URL& dest
     Ref sourceOrigin = document->securityOrigin();
     FrameLoader::addHTTPOriginIfNeeded(request, SecurityPolicy::generateOriginHeader(document->referrerPolicy(), request.url(), sourceOrigin, OriginAccessPatternsForWebProcess::singleton()));
 
-    frame.checkedLoader()->updateRequestAndAddExtraFields(request, IsMainResource::No);
+    frame.protectedLoader()->updateRequestAndAddExtraFields(request, IsMainResource::No);
 
     // https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing
     if (document->securityOrigin().isSameOriginAs(SecurityOrigin::create(pingURL).get())
@@ -200,7 +200,7 @@ void PingLoader::sendViolationReport(LocalFrame& frame, const URL& reportURL, Re
     HTTPHeaderMap originalRequestHeader = request.httpHeaderFields();
 
     if (reportType == ViolationReportType::ContentSecurityPolicy)
-        frame.checkedLoader()->updateRequestAndAddExtraFields(request, IsMainResource::No);
+        frame.protectedLoader()->updateRequestAndAddExtraFields(request, IsMainResource::No);
 
     String referrer = SecurityPolicy::generateReferrerHeader(document->referrerPolicy(), reportURL, frame.loader().outgoingReferrerURL(), OriginAccessPatternsForWebProcess::singleton());
     if (!referrer.isEmpty())
@@ -217,7 +217,7 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
     // Document in the Frame, but the activeDocumentLoader will be associated
     // with the provisional DocumentLoader if there is a provisional
     // DocumentLoader.
-    bool shouldUseCredentialStorage = frame.checkedLoader()->client().shouldUseCredentialStorage(frame.loader().activeDocumentLoader(), identifier);
+    bool shouldUseCredentialStorage = frame.protectedLoader()->client().shouldUseCredentialStorage(frame.loader().activeDocumentLoader(), identifier);
     ResourceLoaderOptions options;
     options.credentials = shouldUseCredentialStorage ? FetchOptions::Credentials::Include : FetchOptions::Credentials::Omit;
     options.redirect = shouldFollowRedirects == ShouldFollowRedirects::Yes ? FetchOptions::Redirect::Follow : FetchOptions::Redirect::Error;

--- a/Source/WebCore/loader/ProgressTracker.cpp
+++ b/Source/WebCore/loader/ProgressTracker.cpp
@@ -122,7 +122,7 @@ void ProgressTracker::progressStarted(LocalFrame& frame)
 
         m_progressHeartbeatTimer.startRepeating(progressHeartbeatInterval);
         RefPtr originatingProgressFrame = m_originatingProgressFrame;
-        originatingProgressFrame->checkedLoader()->loadProgressingStatusChanged();
+        originatingProgressFrame->protectedLoader()->loadProgressingStatusChanged();
 
         bool isMainFrame = !originatingProgressFrame->tree().parent();
         auto elapsedTimeSinceMainLoadComplete = MonotonicTime::now() - m_mainLoadCompletionTime;
@@ -183,10 +183,10 @@ void ProgressTracker::finalProgressComplete()
     if (m_isMainLoad)
         m_mainLoadCompletionTime = MonotonicTime::now();
 
-    frame->checkedLoader()->client().setMainFrameDocumentReady(true);
+    frame->protectedLoader()->client().setMainFrameDocumentReady(true);
     m_client->progressFinished(*frame);
     protectedPage()->progressFinished(*frame);
-    frame->checkedLoader()->loadProgressingStatusChanged();
+    frame->protectedLoader()->loadProgressingStatusChanged();
 
     InspectorInstrumentation::frameStoppedLoading(*frame);
 }
@@ -312,7 +312,7 @@ void ProgressTracker::progressHeartbeatTimerFired()
     m_totalBytesReceivedBeforePreviousHeartbeat = m_totalBytesReceived;
 
     if (RefPtr originatingProgressFrame = m_originatingProgressFrame)
-        originatingProgressFrame->checkedLoader()->loadProgressingStatusChanged();
+        originatingProgressFrame->protectedLoader()->loadProgressingStatusChanged();
 
     if (m_progressValue >= finalProgressValue)
         m_progressHeartbeatTimer.stop();

--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -64,12 +64,12 @@ void ResourceLoadNotifier::didReceiveAuthenticationChallenge(ResourceLoader* loa
 
 void ResourceLoadNotifier::didReceiveAuthenticationChallenge(ResourceLoaderIdentifier identifier, DocumentLoader* loader, const AuthenticationChallenge& currentWebChallenge)
 {
-    protectedFrame()->checkedLoader()->client().dispatchDidReceiveAuthenticationChallenge(loader, identifier, currentWebChallenge);
+    protectedFrame()->protectedLoader()->client().dispatchDidReceiveAuthenticationChallenge(loader, identifier, currentWebChallenge);
 }
 
 void ResourceLoadNotifier::willSendRequest(ResourceLoader* loader, ResourceRequest& clientRequest, const ResourceResponse& redirectResponse)
 {
-    protectedFrame()->checkedLoader()->applyUserAgentIfNeeded(clientRequest);
+    protectedFrame()->protectedLoader()->applyUserAgentIfNeeded(clientRequest);
 
     dispatchWillSendRequest(loader->protectedDocumentLoader().get(), *loader->identifier(), clientRequest, redirectResponse, loader->protectedCachedResource().get(), loader);
 }
@@ -108,7 +108,7 @@ void ResourceLoadNotifier::didFailToLoad(ResourceLoader* loader, const ResourceE
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
     Ref frame = m_frame.get();
     if (!error.isNull())
-        frame->checkedLoader()->client().dispatchDidFailLoading(loader->protectedDocumentLoader().get(), loader->options().mode == FetchOptions::Mode::Navigate ? IsMainResourceLoad::Yes : IsMainResourceLoad::No, *loader->identifier(), error);
+        frame->protectedLoader()->client().dispatchDidFailLoading(loader->protectedDocumentLoader().get(), loader->options().mode == FetchOptions::Mode::Navigate ? IsMainResourceLoad::Yes : IsMainResourceLoad::No, *loader->identifier(), error);
 
     InspectorInstrumentation::didFailLoading(frame.ptr(), loader->protectedDocumentLoader().get(), *loader->identifier(), error);
 }
@@ -116,13 +116,13 @@ void ResourceLoadNotifier::didFailToLoad(ResourceLoader* loader, const ResourceE
 void ResourceLoadNotifier::assignIdentifierToInitialRequest(ResourceLoaderIdentifier identifier, IsMainResourceLoad isMainResourceLoad, DocumentLoader* loader, const ResourceRequest& request)
 {
     bool pageIsProvisionallyLoading = false;
-    if (CheckedPtr frameLoader = loader ? loader->frameLoader() : nullptr)
+    if (RefPtr frameLoader = loader ? loader->frameLoader() : nullptr)
         pageIsProvisionallyLoading = frameLoader->provisionalDocumentLoader() == loader;
 
     if (pageIsProvisionallyLoading)
         m_initialRequestIdentifier = identifier;
 
-    protectedFrame()->checkedLoader()->client().assignIdentifierToInitialRequest(identifier, isMainResourceLoad, loader, request);
+    protectedFrame()->protectedLoader()->client().assignIdentifierToInitialRequest(identifier, isMainResourceLoad, loader, request);
 }
 
 void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, ResourceLoaderIdentifier identifier, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
@@ -140,7 +140,7 @@ void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, Resou
     if (RefPtr documentLoader = m_frame->loader().documentLoader())
         documentLoader->didTellClientAboutLoad(request.url().string());
 
-    frame->checkedLoader()->client().dispatchWillSendRequest(loader, identifier, request, redirectResponse);
+    frame->protectedLoader()->client().dispatchWillSendRequest(loader, identifier, request, redirectResponse);
 
     // If the URL changed, then we want to put that new URL in the "did tell client" set too.
     if (!request.isNull() && oldRequestURL != request.url().string()) {
@@ -155,7 +155,7 @@ void ResourceLoadNotifier::dispatchDidReceiveResponse(DocumentLoader* loader, Re
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
     Ref frame = m_frame.get();
-    frame->checkedLoader()->client().dispatchDidReceiveResponse(loader, identifier, r);
+    frame->protectedLoader()->client().dispatchDidReceiveResponse(loader, identifier, r);
 
     InspectorInstrumentation::didReceiveResourceResponse(frame, identifier, loader, r, resourceLoader);
 }
@@ -164,7 +164,7 @@ void ResourceLoadNotifier::dispatchDidReceiveData(DocumentLoader* loader, Resour
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
     Ref frame = m_frame.get();
-    frame->checkedLoader()->client().dispatchDidReceiveContentLength(loader, identifier, expectedDataLength);
+    frame->protectedLoader()->client().dispatchDidReceiveContentLength(loader, identifier, expectedDataLength);
 
     InspectorInstrumentation::didReceiveData(frame.ptr(), identifier, buffer, encodedDataLength);
 }
@@ -173,7 +173,7 @@ void ResourceLoadNotifier::dispatchDidFinishLoading(DocumentLoader* loader, IsMa
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
     Ref frame = m_frame.get();
-    frame->checkedLoader()->client().dispatchDidFinishLoading(loader, isMainResourceLoad, identifier);
+    frame->protectedLoader()->client().dispatchDidFinishLoading(loader, isMainResourceLoad, identifier);
 
     InspectorInstrumentation::didFinishLoading(frame.ptr(), loader, identifier, networkLoadMetrics, resourceLoader);
 }
@@ -182,7 +182,7 @@ void ResourceLoadNotifier::dispatchDidFailLoading(DocumentLoader* loader, IsMain
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
     Ref frame = m_frame.get();
-    frame->checkedLoader()->client().dispatchDidFailLoading(loader, isMainResourceLoad, identifier, error);
+    frame->protectedLoader()->client().dispatchDidFailLoading(loader, isMainResourceLoad, identifier, error);
 
     InspectorInstrumentation::didFailLoading(frame.ptr(), loader, identifier, error);
 }

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -81,7 +81,7 @@ public:
 #endif
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
-    WEBCORE_EXPORT CheckedPtr<FrameLoader> checkedFrameLoader() const;
+    WEBCORE_EXPORT RefPtr<FrameLoader> protectedFrameLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
     WEBCORE_EXPORT RefPtr<DocumentLoader> protectedDocumentLoader() const;
     const ResourceRequest& originalRequest() const { return m_originalRequest; }

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -94,7 +94,7 @@ void FrameLoader::SubframeLoader::createFrameIfNecessary(HTMLFrameOwnerElement& 
 {
     if (ownerElement.contentFrame())
         return;
-    protectedFrame()->checkedLoader()->client().createFrame(frameName, ownerElement);
+    protectedFrame()->protectedLoader()->client().createFrame(frameName, ownerElement);
     if (!ownerElement.contentFrame())
         return;
 
@@ -307,7 +307,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
 
     RefPtr subFrame = frame->loader().client().createFrame(name, ownerElement);
     if (!subFrame)  {
-        frame->checkedLoader()->checkCallImplicitClose();
+        frame->protectedLoader()->checkCallImplicitClose();
         document->decrementLoadEventDelayCount();
         return nullptr;
     }
@@ -326,13 +326,13 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     // which case, Referrer Policy is applied).
     auto referrerToUse = url.isAboutBlank() ? referrer.string() : SecurityPolicy::generateReferrerHeader(policy, url, referrer, OriginAccessPatternsForWebProcess::singleton());
 
-    frame->checkedLoader()->loadURLIntoChildFrame(url, referrerToUse, subFrame.get());
+    frame->protectedLoader()->loadURLIntoChildFrame(url, referrerToUse, subFrame.get());
 
     document->decrementLoadEventDelayCount();
 
     // The frame's onload handler may have removed it from the document.
     if (!subFrame || !subFrame->tree().parent()) {
-        frame->checkedLoader()->checkCallImplicitClose();
+        frame->protectedLoader()->checkCallImplicitClose();
         return nullptr;
     }
 
@@ -342,7 +342,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     // actually completed below. (Note that we set m_isComplete to false even for synchronous
     // loads, so that checkCompleted() below won't bail early.)
     // FIXME: Can we remove this entirely? m_isComplete normally gets set to false when a load is committed.
-    subFrame->checkedLoader()->started();
+    subFrame->protectedLoader()->started();
    
     {
         CheckedPtr renderWidget = dynamicDowncast<RenderWidget>(ownerElement.renderer());
@@ -351,7 +351,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
             renderWidget->setWidget(WTFMove(view));
     }
 
-    frame->checkedLoader()->checkCallImplicitClose();
+    frame->protectedLoader()->checkCallImplicitClose();
 
     // Some loads are performed synchronously (e.g., about:blank and loads
     // cancelled by returning a null ResourceRequest from requestFromDelegate).
@@ -363,7 +363,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     // it's being added to the child list. It would be a good idea to
     // create the child first, then invoke the loader separately.
     if (subFrame->loader().state() == FrameState::Complete && !subFrame->loader().policyDocumentLoader())
-        subFrame->checkedLoader()->checkCompleted();
+        subFrame->protectedLoader()->checkCompleted();
 
     if (!subFrame->tree().parent())
         return nullptr;
@@ -375,7 +375,7 @@ bool FrameLoader::SubframeLoader::shouldUsePlugin(const URL& url, const String& 
 {
     Ref frame = m_frame.get();
 
-    ObjectContentType objectType = frame->checkedLoader()->client().objectContentType(url, mimeType);
+    ObjectContentType objectType = frame->protectedLoader()->client().objectContentType(url, mimeType);
     // If an object's content can't be handled and it has no fallback, let
     // it be handled as a plugin to show the broken plugin icon.
     useFallback = objectType == ObjectContentType::None && hasFallback;

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -678,17 +678,17 @@ void ApplicationCacheGroup::didFailLoadingManifest(ApplicationCacheResourceLoade
         cacheUpdateFailed();
         break;
     case ApplicationCacheResourceLoader::Error::NotFound:
-        InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().protectedDocumentLoader().get(), *m_currentResourceIdentifier, m_frame->checkedLoader()->cancelledError(m_manifestLoader->resource()->resourceRequest()));
+        InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().protectedDocumentLoader().get(), *m_currentResourceIdentifier, m_frame->protectedLoader()->cancelledError(m_manifestLoader->resource()->resourceRequest()));
         m_frame->protectedDocument()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache manifest could not be fetched, because the manifest had a "_s, m_manifestLoader->resource()->response().httpStatusCode(), " response."_s));
         manifestNotFound();
         break;
     case ApplicationCacheResourceLoader::Error::NotOK:
-        InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().protectedDocumentLoader().get(), *m_currentResourceIdentifier, m_frame->checkedLoader()->cancelledError(m_manifestLoader->resource()->resourceRequest()));
+        InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().protectedDocumentLoader().get(), *m_currentResourceIdentifier, m_frame->protectedLoader()->cancelledError(m_manifestLoader->resource()->resourceRequest()));
         m_frame->protectedDocument()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache manifest could not be fetched, because the manifest had a "_s, m_manifestLoader->resource()->response().httpStatusCode(), " response."_s));
         cacheUpdateFailed();
         break;
     case ApplicationCacheResourceLoader::Error::RedirectForbidden:
-        InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().protectedDocumentLoader().get(), *m_currentResourceIdentifier, m_frame->checkedLoader()->cancelledError(m_manifestLoader->resource()->resourceRequest()));
+        InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().protectedDocumentLoader().get(), *m_currentResourceIdentifier, m_frame->protectedLoader()->cancelledError(m_manifestLoader->resource()->resourceRequest()));
         m_frame->protectedDocument()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, "Application Cache manifest could not be fetched, because a redirection was attempted."_s);
         cacheUpdateFailed();
         break;

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -189,7 +189,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         }
     }
 
-    CheckedRef frameLoader = frame->loader();
+    Ref frameLoader = frame->loader();
     if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !m_options.keepAlive && !shouldUsePingLoad(type())) {
         while (true) {
             if (frameLoader->state() == FrameState::Provisional)

--- a/Source/WebCore/loader/mac/ResourceLoaderMac.mm
+++ b/Source/WebCore/loader/mac/ResourceLoaderMac.mm
@@ -40,7 +40,7 @@ void ResourceLoader::willCacheResponseAsync(ResourceHandle*, NSCachedURLResponse
 {
     if (m_options.sendLoadCallbacks == SendCallbackPolicy::DoNotSendCallbacks)
         return completionHandler(nullptr);
-    checkedFrameLoader()->client().willCacheResponse(protectedDocumentLoader().get(), *identifier(), response, WTFMove(completionHandler));
+    protectedFrameLoader()->client().willCacheResponse(protectedDocumentLoader().get(), *identifier(), response, WTFMove(completionHandler));
 }
 
 }

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -247,7 +247,7 @@ void MathMLElement::defaultEventHandler(Event& event)
             const auto& href = attributeWithoutSynchronization(hrefAttr);
             event.setDefaultHandled();
             if (RefPtr frame = document().frame())
-                frame->checkedLoader()->changeLocation(document().completeURL(href), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
+                frame->protectedLoader()->changeLocation(document().completeURL(href), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
             return;
         }
     }

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -352,7 +352,7 @@ void Chrome::mouseDidMoveOverElement(const HitTestResult& result, OptionSet<Plat
 {
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
         if (result.innerNode() && result.innerNode()->document().isDNSPrefetchEnabled())
-            localMainFrame->checkedLoader()->client().prefetchDNS(result.absoluteLinkURL().host().toString());
+            localMainFrame->protectedLoader()->client().prefetchDNS(result.absoluteLinkURL().host().toString());
     }
 
     String toolTip;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -276,7 +276,7 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
         return;
     newPage->chrome().show();
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(newPage->mainFrame()))
-        localMainFrame->checkedLoader()->loadFrameRequest(WTFMove(frameLoadRequest), event, { });
+        localMainFrame->protectedLoader()->loadFrameRequest(WTFMove(frameLoadRequest), event, { });
 }
 
 #if PLATFORM(GTK)
@@ -425,10 +425,10 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
             page->checkedBackForward()->goBackOrForward(1);
         break;
     case ContextMenuItemTagStop:
-        frame->checkedLoader()->stop();
+        frame->protectedLoader()->stop();
         break;
     case ContextMenuItemTagReload:
-        frame->checkedLoader()->reload();
+        frame->protectedLoader()->reload();
         break;
     case ContextMenuItemTagCut:
         frame->editor().command("Cut"_s).execute();
@@ -1077,7 +1077,7 @@ void ContextMenuController::populate()
     m_context.setSelectedText(selectedText);
 
     if (!m_context.hitTestResult().isContentEditable()) {
-        CheckedRef loader = frame->loader();
+        Ref loader = frame->loader();
         URL linkURL = m_context.hitTestResult().absoluteLinkURL();
         if (!linkURL.isEmpty()) {
             if (loader->client().canHandleRequest(ResourceRequest(linkURL))) {
@@ -1315,7 +1315,7 @@ void ContextMenuController::populate()
             }
         }
 
-        CheckedRef loader = frame->loader();
+        Ref loader = frame->loader();
         URL linkURL = m_context.hitTestResult().absoluteLinkURL();
         if (!linkURL.isEmpty()) {
             if (loader->client().canHandleRequest(ResourceRequest(linkURL))) {

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -118,7 +118,7 @@ void DOMWindow::close()
     }
 
     RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
-    if (localFrame && !localFrame->checkedLoader()->shouldClose())
+    if (localFrame && !localFrame->protectedLoader()->shouldClose())
         return;
 
     ResourceLoadObserver::shared().updateCentralStatisticsStore([] { });

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -69,7 +69,7 @@ void DOMWindowExtension::suspendForBackForwardCache()
     Ref protectedThis { *this };
 
     Ref frame = *this->frame();
-    frame->checkedLoader()->client().dispatchWillDisconnectDOMWindowExtensionFromGlobalObject(this);
+    frame->protectedLoader()->client().dispatchWillDisconnectDOMWindowExtensionFromGlobalObject(this);
 
     m_disconnectedFrame = WTFMove(frame);
 }
@@ -82,7 +82,7 @@ void DOMWindowExtension::resumeFromBackForwardCache()
 
     m_disconnectedFrame = nullptr;
 
-    protectedFrame()->checkedLoader()->client().dispatchDidReconnectDOMWindowExtensionToGlobalObject(this);
+    protectedFrame()->protectedLoader()->client().dispatchDidReconnectDOMWindowExtensionToGlobalObject(this);
 }
 
 void DOMWindowExtension::willDestroyGlobalObjectInCachedFrame()
@@ -94,7 +94,7 @@ void DOMWindowExtension::willDestroyGlobalObjectInCachedFrame()
     Ref protectedThis { *this };
 
     if (RefPtr disconnectedFrame = m_disconnectedFrame)
-        disconnectedFrame->checkedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
+        disconnectedFrame->protectedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
     m_disconnectedFrame = nullptr;
 
     // DOMWindowExtension lifetime isn't tied directly to the LocalDOMWindow itself so it is important that it unregister
@@ -116,7 +116,7 @@ void DOMWindowExtension::willDestroyGlobalObjectInFrame()
     if (!m_wasDetached) {
         RefPtr frame = this->frame();
         ASSERT(frame);
-        frame->checkedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
+        frame->protectedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
     }
 
     // DOMWindowExtension lifetime isn't tied directly to the LocalDOMWindow itself so it is important that it unregister
@@ -138,7 +138,7 @@ void DOMWindowExtension::willDetachGlobalObjectFromFrame()
 
     RefPtr frame = this->frame();
     ASSERT(frame);
-    frame->checkedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
+    frame->protectedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
 
     m_wasDetached = true;
 }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -295,7 +295,7 @@ bool DragController::performDragOperation(DragData&& dragData)
     FrameLoadRequest frameLoadRequest { *localMainFrame, resourceRequest };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setIsRequestFromClientOrUserInput();
-    localMainFrame->checkedLoader()->load(WTFMove(frameLoadRequest));
+    localMainFrame->protectedLoader()->load(WTFMove(frameLoadRequest));
     return true;
 }
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1830,7 +1830,7 @@ HandleUserInputEventResult EventHandler::handleMousePressEvent(const PlatformMou
     UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent));
 
     // FIXME (bug 68185): this call should be made at another abstraction layer
-    frame->checkedLoader()->resetMultipleFormSubmissionProtection();
+    frame->protectedLoader()->resetMultipleFormSubmissionProtection();
 
 #if !ENABLE(IOS_TOUCH_EVENTS)
     cancelFakeMouseMoveEvent();
@@ -3853,7 +3853,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     UserTypingGestureIndicator typingGestureIndicator(frame);
 
     // FIXME (bug 68185): this call should be made at another abstraction layer
-    frame->checkedLoader()->resetMultipleFormSubmissionProtection();
+    frame->protectedLoader()->resetMultipleFormSubmissionProtection();
 
     // In IE, access keys are special, they are handled after default keydown processing, but cannot be canceled - this is hard to match.
     // On Mac OS X, we process them before dispatching keydown, as the default keydown handler implements Emacs key bindings, which may conflict

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -277,7 +277,7 @@ bool LocalDOMWindow::dispatchAllPendingBeforeUnloadEvents()
         if (!frame)
             continue;
 
-        if (!frame->checkedLoader()->shouldClose())
+        if (!frame->protectedLoader()->shouldClose())
             return false;
 
         window->enableSuddenTermination();
@@ -1141,7 +1141,7 @@ void LocalDOMWindow::stop()
     SetForScope isStopping { m_isStopping, true };
     // We must check whether the load is complete asynchronously, because we might still be parsing
     // the document until the callstack unwinds.
-    frame->checkedLoader()->stopForUserCancel(true);
+    frame->protectedLoader()->stopForUserCancel(true);
 }
 
 void LocalDOMWindow::alert(const String& message)
@@ -1461,7 +1461,7 @@ void LocalDOMWindow::setName(const AtomString& string)
         return;
 
     frame->tree().setSpecifiedName(string);
-    frame->checkedLoader()->client().frameNameChanged(string.string());
+    frame->protectedLoader()->client().frameNameChanged(string.string());
 }
 
 void LocalDOMWindow::setStatus(const String& string)
@@ -2336,7 +2336,7 @@ void LocalDOMWindow::dispatchLoadEvent()
     // Send a separate load event to the element that owns this frame.
     if (RefPtr ownerFrame = frame()) {
         if (is<RemoteFrame>(ownerFrame->tree().parent()))
-            ownerFrame->checkedLoader()->client().dispatchLoadEventToOwnerElementInAnotherProcess();
+            ownerFrame->protectedLoader()->client().dispatchLoadEventToOwnerElementInAnotherProcess();
         else if (RefPtr owner = ownerFrame->ownerElement())
             owner->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
     }
@@ -2665,7 +2665,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     if (!firstWindow.allowPopUp()) {
         // Because FrameTree::findFrameForNavigation() returns true for empty strings, we must check for empty frame names.
         // Otherwise, illegitimate window.open() calls with no name will pass right through the popup blocker.
-        if (frameName.isEmpty() || !frame->checkedLoader()->findFrameForNavigation(frameName, activeDocument.get()))
+        if (frameName.isEmpty() || !frame->protectedLoader()->findFrameForNavigation(frameName, activeDocument.get()))
             return RefPtr<WindowProxy> { nullptr };
     }
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -189,7 +189,7 @@ LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifie
 
 void LocalFrame::init()
 {
-    checkedLoader()->init();
+    protectedLoader()->init();
 }
 
 Ref<LocalFrame> LocalFrame::createMainFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, SandboxFlags effectiveSandboxFlags, Frame* opener)
@@ -211,7 +211,7 @@ LocalFrame::~LocalFrame()
 {
     setView(nullptr);
 
-    CheckedRef loader = this->loader();
+    Ref loader = this->loader();
     if (!loader->isComplete())
         loader->closeURL();
 
@@ -272,7 +272,7 @@ void LocalFrame::setView(RefPtr<LocalFrameView>&& view)
     // Only one form submission is allowed per view of a part.
     // Since this part may be getting reused as a result of being
     // pulled from the back/forward cache, reset this flag.
-    checkedLoader()->resetMultipleFormSubmissionProtection();
+    protectedLoader()->resetMultipleFormSubmissionProtection();
 }
 
 CheckedRef<Editor> LocalFrame::checkedEditor()
@@ -297,7 +297,7 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
     if (isMainFrame()) {
         if (RefPtr page = this->page())
             page->didChangeMainDocument(newDocument.get());
-        checkedLoader()->client().dispatchDidChangeMainDocument();
+        protectedLoader()->client().dispatchDidChangeMainDocument();
     }
 
     if (RefPtr previousDocument = m_doc) {
@@ -341,22 +341,22 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
 
 void LocalFrame::frameDetached()
 {
-    checkedLoader()->frameDetached();
+    protectedLoader()->frameDetached();
 }
 
 bool LocalFrame::preventsParentFromBeingComplete() const
 {
-    return !checkedLoader()->isComplete() && (!ownerElement() || !ownerElement()->isLazyLoadObserverActive());
+    return !protectedLoader()->isComplete() && (!ownerElement() || !ownerElement()->isLazyLoadObserverActive());
 }
 
 void LocalFrame::changeLocation(FrameLoadRequest&& request)
 {
-    checkedLoader()->changeLocation(WTFMove(request));
+    protectedLoader()->changeLocation(WTFMove(request));
 }
 
 void LocalFrame::didFinishLoadInAnotherProcess()
 {
-    checkedLoader()->provisionalLoadFailedInAnotherProcess();
+    protectedLoader()->provisionalLoadFailedInAnotherProcess();
 }
 
 void LocalFrame::invalidateContentEventRegionsIfNeeded(InvalidateContentEventRegionsReason reason)
@@ -722,7 +722,7 @@ void LocalFrame::injectUserScripts(UserScriptInjectionTime injectionTime)
 
 void LocalFrame::injectUserScriptImmediately(DOMWrapperWorld& world, const UserScript& script)
 {
-    CheckedRef loader = this->loader();
+    Ref loader = this->loader();
 #if ENABLE(APP_BOUND_DOMAINS)
     if (loader->client().shouldEnableInAppBrowserPrivacyProtections()) {
         if (RefPtr document = this->document())
@@ -788,12 +788,12 @@ void LocalFrame::clearTimers()
     clearTimers(protectedView().get(), protectedDocument().get());
 }
 
-CheckedRef<const FrameLoader> LocalFrame::checkedLoader() const
+Ref<const FrameLoader> LocalFrame::protectedLoader() const
 {
     return m_loader.get();
 }
 
-CheckedRef<FrameLoader> LocalFrame::checkedLoader()
+Ref<FrameLoader> LocalFrame::protectedLoader()
 {
     return m_loader.get();
 }
@@ -811,7 +811,7 @@ CheckedRef<const ScriptController> LocalFrame::checkedScript() const
 void LocalFrame::willDetachPage()
 {
     if (RefPtr parent = dynamicDowncast<LocalFrame>(tree().parent()))
-        parent->checkedLoader()->checkLoadComplete();
+        parent->protectedLoader()->checkLoadComplete();
 
     for (auto& observer : m_destructionObservers)
         observer.willDetachPage();
@@ -1248,7 +1248,7 @@ void LocalFrame::documentURLDidChange(const URL& url)
 {
     if (RefPtr page = this->page(); page && isMainFrame()) {
         page->setMainFrameURL(url);
-        checkedLoader()->client().broadcastMainFrameURLChangeToOtherProcesses(url);
+        protectedLoader()->client().broadcastMainFrameURLChangeToOtherProcesses(url);
     }
 }
 
@@ -1323,7 +1323,7 @@ void LocalFrame::didAccessWindowProxyPropertyViaOpener(WindowProxyProperty prope
         return;
 
     m_accessedWindowProxyPropertiesViaOpener.add(property);
-    checkedLoader()->client().didAccessWindowProxyPropertyViaOpener(WTFMove(openerMainFrameOrigin), property);
+    protectedLoader()->client().didAccessWindowProxyPropertyViaOpener(WTFMove(openerMainFrameOrigin), property);
 }
 
 #endif

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -163,8 +163,8 @@ public:
 
     const FrameLoader& loader() const { return m_loader.get(); }
     FrameLoader& loader() { return m_loader.get(); }
-    CheckedRef<const FrameLoader> checkedLoader() const;
-    CheckedRef<FrameLoader> checkedLoader();
+    Ref<const FrameLoader> protectedLoader() const;
+    Ref<FrameLoader> protectedLoader();
 
     FrameSelection& selection() { return document()->selection(); }
     const FrameSelection& selection() const { return document()->selection(); }

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -364,13 +364,13 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
 
     RefPtr lexicalFrame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
-    ResourceRequest resourceRequest { frame()->protectedDocument()->url(), frame()->checkedLoader()->outgoingReferrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
+    ResourceRequest resourceRequest { frame()->protectedDocument()->url(), frame()->protectedLoader()->outgoingReferrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
     FrameLoadRequest frameLoadRequest { *frame()->document(), frame()->protectedDocument()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
     frameLoadRequest.setLockHistory(LockHistory::Yes);
     frameLoadRequest.setLockBackForwardList(LockBackForwardList::Yes);
     frameLoadRequest.setShouldOpenExternalURLsPolicy(frame()->protectedDocument()->shouldOpenExternalURLsPolicyToPropagate());
 
-    frame()->checkedLoader()->changeLocation(WTFMove(frameLoadRequest));
+    frame()->protectedLoader()->changeLocation(WTFMove(frameLoadRequest));
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);
 }

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -473,7 +473,7 @@ void EventHandler::mouseDown(WebEvent *event)
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     // FIXME: Why is this here? EventHandler::handleMousePressEvent() calls it.
-    protectedFrame()->checkedLoader()->resetMultipleFormSubmissionProtection();
+    protectedFrame()->protectedLoader()->resetMultipleFormSubmissionProtection();
 
     m_mouseDownView = nil;
 

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -143,7 +143,7 @@ void SVGAElement::defaultEventHandler(Event& event)
             event.setDefaultHandled();
 
             if (RefPtr frame = document().frame())
-                frame->checkedLoader()->changeLocation(protectedDocument()->completeURL(url), target, &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
+                frame->protectedLoader()->changeLocation(protectedDocument()->completeURL(url), target, &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
             return;
         }
     }

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -486,7 +486,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
 
         localMainFrame->setView(LocalFrameView::create(*localMainFrame));
         localMainFrame->init();
-        CheckedRef loader = localMainFrame->loader();
+        Ref loader = localMainFrame->loader();
         ASSERT(localMainFrame->effectiveSandboxFlags() == SandboxFlags::all());
 
         RefPtr frameView = localMainFrame->view();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -226,7 +226,7 @@ void WebLocalFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderI
         return;
 
     bool pageIsProvisionallyLoading = false;
-    CheckedPtr frameLoader = loader ? loader->frameLoader() : nullptr;
+    RefPtr frameLoader = loader ? loader->frameLoader() : nullptr;
     if (frameLoader)
         pageIsProvisionallyLoading = frameLoader->provisionalDocumentLoader() == loader;
 


### PR DESCRIPTION
#### 16a1e589946b35b125b6f0d06fe7ba88ad48608f
<pre>
Make FrameLoader ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280855">https://bugs.webkit.org/show_bug.cgi?id=280855</a>

Reviewed by Ryosuke Niwa.

Make FrameLoader ref-counted, by forwarding the ref-counting to its owning frame.

* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::initScriptForWindowProxy):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removeVisualUpdatePreventedReasons):
(WebCore::Document::open):
(WebCore::Document::implicitClose):
(WebCore::Document::userAgent const):
(WebCore::Document::processMetaHttpEquiv):
(WebCore::Document::finishedParsing):
(WebCore::Document::loadEventDelayTimerFired):
(WebCore::Document::checkCompleted):
(WebCore::Document::decrementActiveParserCount):
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::fontLoadingTimerFired):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::shouldSuppressEventDispatchInDOM):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheFrame):
(WebCore::BackForwardCache::trySuspendPage):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrame::CachedFrame):
(WebCore::CachedFrame::open):
(WebCore::CachedFrame::destroy):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::requestObject):
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::MediaDocumentParser::createDocumentStructure):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::protectedFrameLoader const):
(WebCore::DocumentLoader::setRequest):
(WebCore::DocumentLoader::setMainDocumentError):
(WebCore::DocumentLoader::mainReceivedError):
(WebCore::DocumentLoader::stopLoading):
(WebCore::DocumentLoader::commitIfReady):
(WebCore::DocumentLoader::notifyFinished):
(WebCore::DocumentLoader::finishedLoading):
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::doCrossOriginOpenerHandlingOfResponse):
(WebCore::DocumentLoader::tryLoadingSubstituteData):
(WebCore::DocumentLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::continueAfterContentPolicy):
(WebCore::DocumentLoader::commitLoad):
(WebCore::DocumentLoader::interruptedForPolicyChangeError const):
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::dataReceived):
(WebCore::DocumentLoader::setupForReplace):
(WebCore::DocumentLoader::clearMainResourceLoader):
(WebCore::DocumentLoader::isLoadingInAPISense const):
(WebCore::DocumentLoader::setTitle):
(WebCore::DocumentLoader::removeSubresourceLoader):
(WebCore::DocumentLoader::maybeLoadEmpty):
(WebCore::DocumentLoader::startLoadingMainResource):
(WebCore::DocumentLoader::loadMainResource):
(WebCore::DocumentLoader::cancelPolicyCheckIfNeeded):
(WebCore::DocumentLoader::cancelMainResourceLoad):
(WebCore::DocumentLoader::maybeFinishLoadingMultipartContent):
(WebCore::DocumentLoader::handleProvisionalLoadFailureFromContentFilter):
(WebCore::DocumentLoader::handleContentFilterDidBlock):
(WebCore::DocumentLoader::checkedFrameLoader const): Deleted.
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL):
(WebCore::DocumentWriter::createDocument):
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::ref const):
(WebCore::FrameLoader::deref const):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::completed):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::stopAllLoaders):
(WebCore::FrameLoader::stopForBackForwardCache):
(WebCore::FrameLoader::provisionalLoadFailedInAnotherProcess):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::closeOldDataSources):
(WebCore::FrameLoader::subframeIsLoading const):
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::checkLoadComplete):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::saveScrollPositionAndViewStateToItem):
(WebCore::HistoryController::restoreScrollPositionAndViewState):
(WebCore::HistoryController::saveDocumentState):
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateForCommit):
(WebCore::HistoryController::updateForSameDocumentNavigation):
(WebCore::HistoryController::recursiveGoToItem):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
(WebCore::LinkLoader::loadLink):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::sendH2Ping):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::frameAndAncestorsCanDisplayInsecureContent):
(WebCore::MixedContentChecker::frameAndAncestorsCanRunInsecureContent):
(WebCore::MixedContentChecker::checkFormForMixedContent):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleLocationChange):
(WebCore::NavigationScheduler::schedule):
* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::didReceiveResponse):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::loadImage):
(WebCore::PingLoader::sendPing):
(WebCore::PingLoader::sendViolationReport):
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
(WebCore::PolicyChecker::checkNewWindowPolicy):
(WebCore::PolicyChecker::stopCheck):
(WebCore::PolicyChecker::cannotShowMIMEType):
(WebCore::PolicyChecker::handleUnimplementablePolicy):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::progressStarted):
(WebCore::ProgressTracker::finalProgressComplete):
(WebCore::ProgressTracker::progressHeartbeatTimerFired):
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::didReceiveAuthenticationChallenge):
(WebCore::ResourceLoadNotifier::willSendRequest):
(WebCore::ResourceLoadNotifier::didFailToLoad):
(WebCore::ResourceLoadNotifier::assignIdentifierToInitialRequest):
(WebCore::ResourceLoadNotifier::dispatchWillSendRequest):
(WebCore::ResourceLoadNotifier::dispatchDidReceiveResponse):
(WebCore::ResourceLoadNotifier::dispatchDidReceiveData):
(WebCore::ResourceLoadNotifier::dispatchDidFinishLoading):
(WebCore::ResourceLoadNotifier::dispatchDidFailLoading):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::protectedFrameLoader const):
(WebCore::ResourceLoader::willSendRequestInternal):
(WebCore::ResourceLoader::didReceiveResponse):
(WebCore::ResourceLoader::didReceiveBuffer):
(WebCore::ResourceLoader::didFinishLoadingOnePart):
(WebCore::ResourceLoader::cleanupForError):
(WebCore::ResourceLoader::cancelledError):
(WebCore::ResourceLoader::blockedError):
(WebCore::ResourceLoader::blockedByContentBlockerError):
(WebCore::ResourceLoader::cannotShowURLError):
(WebCore::ResourceLoader::httpsUpgradeRedirectLoopError):
(WebCore::ResourceLoader::shouldUseCredentialStorage):
(WebCore::ResourceLoader::didReceiveAuthenticationChallenge):
(WebCore::ResourceLoader::canAuthenticateAgainstProtectionSpace):
(WebCore::ResourceLoader::connectionProperties):
(WebCore::ResourceLoader::checkedFrameLoader const): Deleted.
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::createFrameIfNecessary):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
(WebCore::FrameLoader::SubframeLoader::shouldUsePlugin):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::didFailLoadingManifest):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::shouldPerformHTTPSUpgrade):
(WebCore::CachedResourceLoader::shouldContinueAfterNotifyingLoadedFromMemoryCache):
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::cachePolicy const):
(WebCore::CachedResourceLoader::loadDone):
* Source/WebCore/loader/mac/ResourceLoaderMac.mm:
(WebCore::ResourceLoader::willCacheResponseAsync):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::defaultEventHandler):
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::mouseDidMoveOverElement):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::openNewWindow):
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close):
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::suspendForBackForwardCache):
(WebCore::DOMWindowExtension::resumeFromBackForwardCache):
(WebCore::DOMWindowExtension::willDestroyGlobalObjectInCachedFrame):
(WebCore::DOMWindowExtension::willDestroyGlobalObjectInFrame):
(WebCore::DOMWindowExtension::willDetachGlobalObjectFromFrame):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::performDragOperation):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchAllPendingBeforeUnloadEvents):
(WebCore::LocalDOMWindow::stop):
(WebCore::LocalDOMWindow::setName):
(WebCore::LocalDOMWindow::dispatchLoadEvent):
(WebCore::LocalDOMWindow::open):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::init):
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::setView):
(WebCore::LocalFrame::setDocument):
(WebCore::LocalFrame::frameDetached):
(WebCore::LocalFrame::preventsParentFromBeingComplete const):
(WebCore::LocalFrame::changeLocation):
(WebCore::LocalFrame::didFinishLoadInAnotherProcess):
(WebCore::LocalFrame::injectUserScriptImmediately):
(WebCore::LocalFrame::protectedLoader const):
(WebCore::LocalFrame::protectedLoader):
(WebCore::LocalFrame::willDetachPage):
(WebCore::LocalFrame::documentURLDidChange):
(WebCore::LocalFrame::didAccessWindowProxyPropertyViaOpener):
(WebCore::LocalFrame::checkedLoader const): Deleted.
(WebCore::LocalFrame::checkedLoader): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::reload):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::goToItem):
(WebCore::Page::setDefersLoading):
(WebCore::Page::updateRendering):
(WebCore::Page::setMemoryCacheClientCallsEnabled):
(WebCore::Page::addRelevantRepaintedObject):
(WebCore::Page::injectUserStyleSheet):
(WebCore::Page::setupForRemoteWorker):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::mouseDown):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::defaultEventHandler):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::dataChanged):

Canonical link: <a href="https://commits.webkit.org/284652@main">https://commits.webkit.org/284652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1aec53d3804b53a8aa986f7892fcada3afa1643

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21108 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14092 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17879 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75894 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17467 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63252 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4883 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10710 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45298 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->