### PR TITLE
Mark message invalid when its endpoint is disabled at runtime

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
@@ -40,6 +40,8 @@ namespace WebKit {
 
 void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
+    bool runtimeEnablementCheckFailed = false;
+    UNUSED_VARIABLE(runtimeEnablementCheckFailed);
     auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!sharedPreferences || !(sharedPreferences->someFeature && sharedPreferences->otherFeature)) {
@@ -48,6 +50,7 @@ void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connect
             return;
 #endif // ENABLE(IPC_TESTING_API)
         ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledByAndConjunction", IPC::description(decoder.messageName()).characters());
+        connection.markCurrentlyDispatchedMessageAsInvalid();
         return;
     }
     Ref protectedThis { *this };
@@ -60,6 +63,8 @@ void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connect
         return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    if (runtimeEnablementCheckFailed)
+        connection.markCurrentlyDispatchedMessageAsInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
@@ -40,6 +40,8 @@ namespace WebKit {
 
 void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
+    bool runtimeEnablementCheckFailed = false;
+    UNUSED_VARIABLE(runtimeEnablementCheckFailed);
     auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!sharedPreferences || !(sharedPreferences->someFeature || sharedPreferences->otherFeature)) {
@@ -48,6 +50,7 @@ void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connecti
             return;
 #endif // ENABLE(IPC_TESTING_API)
         ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledByOrConjunction", IPC::description(decoder.messageName()).characters());
+        connection.markCurrentlyDispatchedMessageAsInvalid();
         return;
     }
     Ref protectedThis { *this };
@@ -60,6 +63,8 @@ void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connecti
         return;
 #endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    if (runtimeEnablementCheckFailed)
+        connection.markCurrentlyDispatchedMessageAsInvalid();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 329b7147fa4009624dfe844d9b0babb4019be3ab
<pre>
Mark message invalid when its endpoint is disabled at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=280858">https://bugs.webkit.org/show_bug.cgi?id=280858</a>
<a href="https://rdar.apple.com/137241292">rdar://137241292</a>

Reviewed by Ryosuke Niwa.

When runtime enablement check fails, receiver process should request termination on sender process, to align with
MESSAGE_CHECK failure.

* Source/WebKit/Scripts/webkit/messages.py:
(async_message_statement):
(generate_enabled_by_for_receiver):
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByAndConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp:
(WebKit::TestWithEnabledBy::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByOrConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):

Canonical link: <a href="https://commits.webkit.org/284681@main">https://commits.webkit.org/284681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e89c75e4037a2d6d913041655f34ebdc260fd4be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21321 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55635 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14116 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36102 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/69664 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41788 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19690 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63290 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4929 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->