### PR TITLE
[iOS] Clipping fails in position: relative; text fields when SelectionHonorsOverflowScrolling is enabled

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-clip-in-position-relative-text-field-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-clip-in-position-relative-text-field-expected.txt
@@ -1,0 +1,12 @@
+
+Verifies that the selection is clipped inside of a horizontally scrollable text field, that's inside an overflow: scroll; container. To manually test, select all the text inside of the text field below and scroll down in the subscrollable container.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS scroller.getBoundingClientRect().width is >= selectionRectBeforeScrolling.width
+PASS selectionRectAfterScrolling?.width || 0 is 0
+PASS selectionRectAfterScrolling?.height || 0 is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-clip-in-position-relative-text-field.html
+++ b/LayoutTests/editing/selection/ios/selection-clip-in-position-relative-text-field.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+input {
+    position: relative;
+    font-size: 24px;
+    width: 250px;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+    border: solid 1px lightgray;
+    border-radius: 6px;
+    box-sizing: border-box;
+    overflow-y: scroll;
+    line-height: 1.5em;
+    outline: none;
+    padding: 1em;
+    margin-top: 100px;
+}
+
+.tall {
+    height: 400px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection is clipped inside of a horizontally scrollable text field, that's inside an overflow: scroll; container. To manually test, select all the text inside of the text field below and scroll down in the subscrollable container.");
+
+    let input = document.querySelector("input");
+    scroller = document.querySelector(".container");
+
+    await UIHelper.activateElementAndWaitForInputSession(input);
+    document.execCommand("SelectAll");
+    selectionRectBeforeScrolling = (await UIHelper.waitForSelectionToAppear())[0];
+
+    shouldBeGreaterThanOrEqual("scroller.getBoundingClientRect().width", "selectionRectBeforeScrolling.width");
+
+    let {x, y} = UIHelper.midPointOfRect(scroller.getBoundingClientRect());
+    while (scroller.scrollTop < 120) {
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(x, y + 60)
+            .move(x, y - 60, 0.25)
+            .end()
+            .takeResult());
+    }
+
+    selectionRectAfterScrolling = (await UIHelper.getUISelectionViewRects())[0];
+    shouldBe("selectionRectAfterScrolling?.width || 0", "0");
+    shouldBe("selectionRectAfterScrolling?.height || 0", "0");
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="container">
+        <input type="text" value="The quick brown fox jumped over the lazy dog.">
+        <div class="tall"></div>
+    </div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller.html
+++ b/LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller.html
@@ -50,7 +50,7 @@ addEventListener("load", async () => {
         handledClick = true;
     });
 
-    await UIHelper.longPressElement(document.querySelector(".scrollable"));
+    await UIHelper.longPressElement(scroller);
     await UIHelper.waitForSelectionToAppear();
     testPassed("Selected text");
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5594,7 +5594,7 @@ static void forEachEnclosingScroller(const VisibleSelection& selection, Function
         } else if (CheckedPtr layer = scroller->layer()) {
             CheckedPtr scrollableArea = layer->scrollableArea();
             if (!scrollableArea)
-                break;
+                continue;
 
             scrollerClipRectInContent = scroller->absoluteBoundingBoxRect();
             enclosingScrollingNodeID = scrollableArea->scrollingNodeID();


### PR DESCRIPTION
#### 91675a20f98f106e9ae7313d58d459bbdbdb5f3d
<pre>
[iOS] Clipping fails in position: relative; text fields when SelectionHonorsOverflowScrolling is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280863">https://bugs.webkit.org/show_bug.cgi?id=280863</a>
<a href="https://rdar.apple.com/137243937">rdar://137243937</a>

Reviewed by Aditya Keerthi.

It&apos;s possible for a scrollable `RenderBox` (i.e. `canBeScrolledAndHasScrollableArea()` is `true`) to
not have a `ScrollableArea`. In this case, we currently bail from the ancestor walk altogether;
however, this means we could potentially miss a scrolling node that&apos;s further up the render tree.

Fix this by continuing on to the next scroller, rather than breaking from the for loop entirely
during this traversal.

* LayoutTests/editing/selection/ios/selection-clip-in-position-relative-text-field-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-clip-in-position-relative-text-field.html: Added.

Add a layout test to exercise the change.

* LayoutTests/editing/selection/ios/selection-hit-testing-in-overflow-scroller.html:

Drive-by fix: delete a redundant `querySelector` call.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::forEachEnclosingScroller):
(WebKit::WebPage::computeSelectionClipRectAndEnclosingScroller const):

Canonical link: <a href="https://commits.webkit.org/284659@main">https://commits.webkit.org/284659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a162cc20f5dfb157c4286a8fe3bbd6f468f8a1e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22887 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21142 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14103 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60473 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17904 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75928 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17489 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14389 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60542 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4906 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45332 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->