### PR TITLE
[JSC] Remove unnecessary ICU version checks

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -393,7 +393,7 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
 
         // 3.k. If style is "2-digit", then
         //     i. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumIntegerDigits", 2F).
-        skeletonBuilder.append(" integer-width/"_s, WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
+        skeletonBuilder.append(" integer-width/*"_s);
         if (style == IntlDurationFormat::UnitStyle::TwoDigit)
             skeletonBuilder.append("00"_s);
         else

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -504,14 +504,10 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
             skeletonBuilder.append(" sign-except-zero"_s);
         break;
     case SignDisplay::Negative:
-        // Only ICU69~ supports negative sign display. Ignore this option if linked ICU does not support it.
-        // https://github.com/unicode-org/icu/commit/1aa0dad8e06ecc99bff442dd37f6daa2d39d9a5a
-        if (WTF::ICU::majorVersion() >= 69) {
-            if (useAccounting)
-                skeletonBuilder.append(" sign-accounting-negative"_s);
-            else
-                skeletonBuilder.append(" sign-negative"_s);
-        }
+        if (useAccounting)
+            skeletonBuilder.append(" sign-accounting-negative"_s);
+        else
+            skeletonBuilder.append(" sign-negative"_s);
         break;
     }
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -197,24 +197,12 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
     case RoundingMode::Trunc:
         skeletonBuilder.append(" rounding-mode-down"_s);
         break;
-    case RoundingMode::HalfCeil: {
-        // Only ICU69~ supports half-ceiling. Ignore this option if linked ICU does not support it.
-        // https://github.com/unicode-org/icu/commit/e8dfea9bb6bb27596731173b352759e44ad06b21
-        if (WTF::ICU::majorVersion() >= 69)
-            skeletonBuilder.append(" rounding-mode-half-ceiling"_s);
-        else
-            skeletonBuilder.append(" rounding-mode-half-up"_s); // Default option.
+    case RoundingMode::HalfCeil:
+        skeletonBuilder.append(" rounding-mode-half-ceiling"_s);
         break;
-    }
-    case RoundingMode::HalfFloor: {
-        // Only ICU69~ supports half-flooring. Ignore this option if linked ICU does not support it.
-        // https://github.com/unicode-org/icu/commit/e8dfea9bb6bb27596731173b352759e44ad06b21
-        if (WTF::ICU::majorVersion() >= 69)
-            skeletonBuilder.append(" rounding-mode-half-floor"_s);
-        else
-            skeletonBuilder.append(" rounding-mode-half-up"_s); // Default option.
+    case RoundingMode::HalfFloor:
+        skeletonBuilder.append(" rounding-mode-half-floor"_s);
         break;
-    }
     case RoundingMode::HalfExpand:
         skeletonBuilder.append(" rounding-mode-half-up"_s);
         break;
@@ -227,7 +215,7 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
     }
 
     // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#integer-width
-    skeletonBuilder.append(" integer-width/"_s, WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
+    skeletonBuilder.append(" integer-width/*"_s);
     for (unsigned i = 0; i < intlInstance->m_minimumIntegerDigits; ++i)
         skeletonBuilder.append('0');
 
@@ -265,23 +253,19 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
         }
         case IntlRoundingType::MorePrecision:
         case IntlRoundingType::LessPrecision:
-            // Before Intl.NumberFormat v3, it was CompactRounding mode, where we do not configure anything.
-            // So, if linked ICU is ~68, we do nothing.
-            if (WTF::ICU::majorVersion() >= 69) {
-                // https://github.com/unicode-org/icu/commit/d7db6c1f8655bb53153695b09a50029fd04a8364
-                // https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#precision
-                skeletonBuilder.append(" ."_s);
-                for (unsigned i = 0; i < intlInstance->m_minimumFractionDigits; ++i)
-                    skeletonBuilder.append('0');
-                for (unsigned i = 0; i < intlInstance->m_maximumFractionDigits - intlInstance->m_minimumFractionDigits; ++i)
-                    skeletonBuilder.append('#');
-                skeletonBuilder.append('/');
-                for (unsigned i = 0; i < intlInstance->m_minimumSignificantDigits; ++i)
-                    skeletonBuilder.append('@');
-                for (unsigned i = 0; i < intlInstance->m_maximumSignificantDigits - intlInstance->m_minimumSignificantDigits; ++i)
-                    skeletonBuilder.append('#');
-                skeletonBuilder.append(intlInstance->m_roundingType == IntlRoundingType::MorePrecision ? 'r' : 's');
-            }
+            // https://github.com/unicode-org/icu/commit/d7db6c1f8655bb53153695b09a50029fd04a8364
+            // https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#precision
+            skeletonBuilder.append(" ."_s);
+            for (unsigned i = 0; i < intlInstance->m_minimumFractionDigits; ++i)
+                skeletonBuilder.append('0');
+            for (unsigned i = 0; i < intlInstance->m_maximumFractionDigits - intlInstance->m_minimumFractionDigits; ++i)
+                skeletonBuilder.append('#');
+            skeletonBuilder.append('/');
+            for (unsigned i = 0; i < intlInstance->m_minimumSignificantDigits; ++i)
+                skeletonBuilder.append('@');
+            for (unsigned i = 0; i < intlInstance->m_maximumSignificantDigits - intlInstance->m_minimumSignificantDigits; ++i)
+                skeletonBuilder.append('#');
+            skeletonBuilder.append(intlInstance->m_roundingType == IntlRoundingType::MorePrecision ? 'r' : 's');
             break;
         }
     }
@@ -292,10 +276,7 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
     case IntlTrailingZeroDisplay::Auto:
         break;
     case IntlTrailingZeroDisplay::StripIfInteger:
-        // Only ICU69~ supports trailing zero display. Ignore this option if linked ICU does not support it.
-        // https://github.com/unicode-org/icu/commit/b79c299f90d4023ac237db3d0335d568bf21cd36
-        if (WTF::ICU::majorVersion() >= 69)
-            skeletonBuilder.append("/w"_s);
+        skeletonBuilder.append("/w"_s);
         break;
     }
 }


### PR DESCRIPTION
#### af62f09a1fad0b72293a7f0d082704d92116cb9a
<pre>
[JSC] Remove unnecessary ICU version checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=280865">https://bugs.webkit.org/show_bug.cgi?id=280865</a>
<a href="https://rdar.apple.com/137246002">rdar://137246002</a>

Reviewed by Ross Kirsling.

Now, ICU baseline is 70, and removing unnecessary runtime ICU version checks.

* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::appendNumberFormatDigitOptionsToSkeleton):

Canonical link: <a href="https://commits.webkit.org/284654@main">https://commits.webkit.org/284654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e6925c8819d81c0afc89e6369b49f2ba97213c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22882 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60471 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17902 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/19654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63238 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75923 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69365 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17487 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63262 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4904 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91147 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10711 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45327 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/19865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->