### PR TITLE
WebGPU support for HDR

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8259,7 +8259,7 @@ WebGPUEnabled:
 
 WebGPUHDREnabled:
   type: bool
-  status: internal
+  status: unstable
   category: dom
   humanReadableName: "WebGPU support for HDR"
   humanReadableDescription: "WebGPU High Dynamic Range through canvas configuration tone mapping mode"

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
@@ -37,6 +37,6 @@ dictionary GPUCanvasConfiguration {
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     sequence<GPUTextureFormat> viewFormats = [];
     GPUPredefinedColorSpace colorSpace = "srgb";
-    [EnabledBySetting=WebGPUHDREnabled] GPUCanvasToneMapping toneMapping = {};
+    GPUCanvasToneMapping toneMapping = {};
     GPUCanvasAlphaMode alphaMode = "opaque";
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucanvastonemapping
 
 [
-    EnabledBySetting=WebGPUEnabled&WebGPUHDREnabled
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUCanvasToneMapping {
   GPUCanvasToneMappingMode mode = "standard";

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMappingMode.idl
@@ -27,7 +27,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucanvastonemappingmode
 
 [
-    EnabledBySetting=WebGPUEnabled&WebGPUHDREnabled
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUCanvasToneMappingMode {
     "standard",

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -279,7 +279,6 @@ JSGPUBindGroup.cpp
 JSGPUBindGroupLayout.cpp
 JSGPUBuffer.cpp
 JSGPUBufferUsage.cpp
-JSGPUCanvasConfiguration.cpp
 JSGPUCanvasContext.cpp
 JSGPUColorWrite.cpp
 JSGPUCommandBuffer.cpp

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -238,7 +238,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     }
 
     textureDescriptor.usage |= MTLTextureUsageRenderTarget;
-    bool needsLuminanceClampFunction = textureDescriptor.pixelFormat == MTLPixelFormatRGBA16Float;
+    bool needsLuminanceClampFunction = textureDescriptor.pixelFormat == MTLPixelFormatRGBA16Float && m_toneMappingMode == WGPUToneMappingMode_Standard;
     auto existingUsage = textureDescriptor.usage;
     for (IOSurface *iosurface in m_ioSurfaces) {
         RefPtr<Texture> parentLuminanceClampTexture;


### PR DESCRIPTION
#### 8dd8eadc14fe77ae80e62ebd663c7fad0348730f
<pre>
WebGPU support for HDR
<a href="https://bugs.webkit.org/show_bug.cgi?id=280864">https://bugs.webkit.org/show_bug.cgi?id=280864</a>
<a href="https://rdar.apple.com/problem/137245923">rdar://problem/137245923</a>

Reviewed by Mike Wyrzykowski.

When a WebGPU canvas is configured with extended tone-mapping,
use ContentsFormat::RGBA16F to display it in HDR.

Tweaked feature flags, so that tone mapping configuration is
always available, but non-&quot;standard&quot; tone mapping mode is only
accepted if the platform supports it and the feature is turned on.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::recreateRenderBuffers):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::computeTextureFormat):
(WebCore::GPUCanvasContextCocoa::configure):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):

Canonical link: <a href="https://commits.webkit.org/284723@main">https://commits.webkit.org/284723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a402a1c6110cb875f51b73d329111ef790edaf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55708 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14188 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18036 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19825 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63407 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76094 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69533 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63431 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63368 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5028 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/261 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19902 "Found 1 new JSC binary failure: testapi, Found 141 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Function/prototype.js.default, ChakraCore.yaml/ChakraCore/test/Operators/instanceof.js.default, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/exception-instanceof.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/instance-of-immediates.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/instanceof-operator.js.layout ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->