### PR TITLE
Deploy downcast<> in DeviceMotionController.cpp

### DIFF
--- a/Source/WebCore/dom/DeviceMotionClient.h
+++ b/Source/WebCore/dom/DeviceMotionClient.h
@@ -44,6 +44,13 @@ public:
     virtual void setController(DeviceMotionController*) = 0;
     virtual DeviceMotionData* lastMotion() const = 0;
     virtual void deviceMotionControllerDestroyed() = 0;
+
+    bool isDeviceMotionClient() const override { return true; }
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DeviceMotionClient)
+static bool isType(const WebCore::DeviceClient& DeviceClient) { return DeviceClient.isDeviceMotionClient(); }
+SPECIALIZE_TYPE_TRAITS_END()
+

--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -69,7 +69,7 @@ void DeviceMotionController::didChangeDeviceMotion(DeviceMotionData* deviceMotio
 
 DeviceMotionClient& DeviceMotionController::deviceMotionClient()
 {
-    return static_cast<DeviceMotionClient&>(m_client.get());
+    return downcast<DeviceMotionClient>(m_client.get());
 }
 
 bool DeviceMotionController::hasLastData()

--- a/Source/WebCore/page/DeviceClient.h
+++ b/Source/WebCore/page/DeviceClient.h
@@ -47,6 +47,8 @@ public:
 
     virtual void startUpdating() = 0;
     virtual void stopUpdating() = 0;
+
+    virtual bool isDeviceMotionClient() const { return false; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d7ae4a018a007c07edde4b0df81cf7d33a44b9e0
<pre>
Deploy downcast&lt;&gt; in DeviceMotionController.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=280866">https://bugs.webkit.org/show_bug.cgi?id=280866</a>

Reviewed by Chris Dumez.

Deploy downcast&lt;&gt; in DeviceMotionController.cpp

* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::deviceMotionClient):
* Source/WebCore/dom/DeviceMotionClient.h:
(isType):
* Source/WebCore/page/DeviceClient.h:
(WebCore::DeviceClient::isDeviceMotionClient const):

Canonical link: <a href="https://commits.webkit.org/284799@main">https://commits.webkit.org/284799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2f3ac1f100072adc82bc677c91402c0ed4195f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55774 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14245 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19925 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76194 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63430 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5103 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10808 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->