### PR TITLE
Don't use page tiles for site-isolated root frames.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/compositing/iframes/resize-from-zero-size-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/compositing/iframes/resize-from-zero-size-expected.txt
@@ -1,0 +1,54 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 18.00 18.00)
+          (bounds 400.00 300.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 400.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 400.00 300.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 400.00 300.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 18.00 10.00)
+                                  (bounds 210.00 210.00)
+                                  (contentsOpaque 1)
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/http/tests/site-isolation/compositing/iframes/resize-from-zero-size.html
+++ b/LayoutTests/http/tests/site-isolation/compositing/iframes/resize-from-zero-size.html
@@ -1,0 +1,48 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        #wrapper {
+            width: 0px;
+            height: 0px;
+            border: 10px solid gray;
+        }
+        iframe {
+            height: 100%;
+            width: 100%;
+            background-color: red;
+            border: none;
+        }
+
+        #wrapper.resized {
+            height: 300px;
+            width: 400px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                document.getElementById('wrapper').classList.add('resized');
+                if (window.testRunner) {
+                     document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+                     testRunner.notifyDone();
+                }
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+
+<div id="wrapper">
+    <iframe class="composited" src="http://localhost:8000/root/compositing/iframes/resources/composited-subframe.html"></iframe>
+</div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3389,6 +3389,10 @@ bool RenderLayerBacking::paintsIntoWindow() const
             return false;
 #endif
 
+        // Site-isolated root frames don't have a window to paint into.
+        if (m_isRootFrameRenderViewLayer && !m_isMainFrameRenderViewLayer)
+            return false;
+
         return compositor().rootLayerAttachment() != RenderLayerCompositor::RootLayerAttachedViaEnclosingFrame;
     }
     

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4394,7 +4394,7 @@ bool RenderLayerCompositor::shouldCompositeOverflowControls() const
     if (documentUsesTiledBacking())
         return true;
 
-    if (m_overflowControlsHostLayer && isMainFrameCompositor())
+    if (m_overflowControlsHostLayer && isRootFrameCompositor())
         return true;
 
 #if !USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -194,7 +194,7 @@ void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool fl
 
 bool RemoteLayerTreeDrawingArea::shouldUseTiledBackingForFrameView(const LocalFrameView& frameView) const
 {
-    return frameView.frame().isRootFrame()
+    return frameView.frame().isMainFrame()
         || m_webPage->corePage()->settings().asyncFrameScrollingEnabled();
 }
 


### PR DESCRIPTION
#### 47d58db3a2312ee61e0f5341596b2e4b792d283e
<pre>
Don&apos;t use page tiles for site-isolated root frames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280874">https://bugs.webkit.org/show_bug.cgi?id=280874</a>
&lt;<a href="https://rdar.apple.com/137259998">rdar://137259998</a>&gt;

Reviewed by Alex Christensen.

&lt;iframe&gt;s don&apos;t create an implicit set of page tiles, they only get tiling
sub-layers as needed based on size.

Currently with site-isolation, and cross-origin &lt;iframe&gt; (a &apos;root&apos; frame) is
getting page tiles, which will use more memory than is necessary.

The test for this is a duplicate of an existing test (with an identical path,
modulo the http/tests/site-isolation prefix), only changed to access the frame
content via a different origin. The expectation file is also an identical copy.
In the future, we will ideally be able to have both versions of the test
reference the same expectation file, to stop these diverging.

* LayoutTests/http/tests/site-isolation/compositing/iframes/resize-from-zero-size.html: Added.
* LayoutTests/http/tests/site-isolation/compositing/iframes/resize-from-zero-size-expected: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintsIntoWindow const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::shouldUseTiledBackingForFrameView const):

Canonical link: <a href="https://commits.webkit.org/284782@main">https://commits.webkit.org/284782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5484cdc7584dde1e2dfa55cbdadd3ab67e859601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55775 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14247 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41958 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18114 "Found 3 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html imported/w3c/web-platform-tests/css/css-grid/subgrid/alignment-in-subgridded-axes-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63496 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63433 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5105 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/364 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->