### PR TITLE
Clean up logic to commit history state from multiple web processes to a shared list in the UI process

### DIFF
--- a/Source/WebCore/history/BackForwardClient.h
+++ b/Source/WebCore/history/BackForwardClient.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "BackForwardItemIdentifier.h"
 #include "FrameIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
@@ -42,10 +43,11 @@ public:
     }
 
     virtual void addItem(FrameIdentifier, Ref<HistoryItem>&&) = 0;
+    virtual void setChildItem(BackForwardItemIdentifier, Ref<HistoryItem>&&) = 0;
 
     virtual void goToItem(HistoryItem&) = 0;
         
-    virtual RefPtr<HistoryItem> itemAtIndex(int) = 0;
+    virtual RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) = 0;
     virtual unsigned backListCount() const = 0;
     virtual unsigned forwardListCount() const = 0;
     virtual bool containsItem(const HistoryItem&) const = 0;

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -44,19 +44,19 @@ BackForwardController::BackForwardController(Page& page, Ref<BackForwardClient>&
 
 BackForwardController::~BackForwardController() = default;
 
-RefPtr<HistoryItem> BackForwardController::backItem()
+RefPtr<HistoryItem> BackForwardController::backItem(std::optional<FrameIdentifier> frameID)
 {
-    return itemAtIndex(-1);
+    return itemAtIndex(-1, frameID);
 }
 
-RefPtr<HistoryItem> BackForwardController::currentItem()
+RefPtr<HistoryItem> BackForwardController::currentItem(std::optional<FrameIdentifier> frameID)
 {
-    return itemAtIndex(0);
+    return itemAtIndex(0, frameID);
 }
 
-RefPtr<HistoryItem> BackForwardController::forwardItem()
+RefPtr<HistoryItem> BackForwardController::forwardItem(std::optional<FrameIdentifier> frameID)
 {
-    return itemAtIndex(1);
+    return itemAtIndex(1, frameID);
 }
 
 Ref<Page> BackForwardController::protectedPage() const
@@ -142,6 +142,11 @@ void BackForwardController::addItem(FrameIdentifier targetFrameID, Ref<HistoryIt
     protectedClient()->addItem(targetFrameID, WTFMove(item));
 }
 
+void BackForwardController::setChildItem(BackForwardItemIdentifier identifier, Ref<HistoryItem>&& item)
+{
+    protectedClient()->setChildItem(identifier, WTFMove(item));
+}
+
 void BackForwardController::setCurrentItem(HistoryItem& item)
 {
     protectedClient()->goToItem(item);
@@ -168,9 +173,9 @@ unsigned BackForwardController::forwardCount() const
     return protectedClient()->forwardListCount();
 }
 
-RefPtr<HistoryItem> BackForwardController::itemAtIndex(int i)
+RefPtr<HistoryItem> BackForwardController::itemAtIndex(int i, std::optional<FrameIdentifier> frameID)
 {
-    return protectedClient()->itemAtIndex(i);
+    return protectedClient()->itemAtIndex(i, frameID.value_or(m_page->mainFrame().frameID()));
 }
 
 Vector<Ref<HistoryItem>> BackForwardController::allItems()

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BackForwardItemIdentifier.h"
 #include "FrameIdentifier.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
@@ -57,20 +58,21 @@ public:
     WEBCORE_EXPORT bool goForward();
 
     void addItem(FrameIdentifier, Ref<HistoryItem>&&);
+    void setChildItem(BackForwardItemIdentifier, Ref<HistoryItem>&&);
     void setCurrentItem(HistoryItem&);
         
     unsigned count() const;
     WEBCORE_EXPORT unsigned backCount() const;
     WEBCORE_EXPORT unsigned forwardCount() const;
 
-    WEBCORE_EXPORT RefPtr<HistoryItem> itemAtIndex(int);
+    WEBCORE_EXPORT RefPtr<HistoryItem> itemAtIndex(int, std::optional<FrameIdentifier> = std::nullopt);
     bool containsItem(const HistoryItem&) const;
 
     void close();
 
-    WEBCORE_EXPORT RefPtr<HistoryItem> backItem();
-    WEBCORE_EXPORT RefPtr<HistoryItem> currentItem();
-    WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem();
+    WEBCORE_EXPORT RefPtr<HistoryItem> backItem(std::optional<FrameIdentifier> = std::nullopt);
+    WEBCORE_EXPORT RefPtr<HistoryItem> currentItem(std::optional<FrameIdentifier> = std::nullopt);
+    WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem(std::optional<FrameIdentifier> = std::nullopt);
 
     Vector<Ref<HistoryItem>> allItems();
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -110,8 +110,9 @@ class UserMessageHandlerDescriptor;
 
 class EmptyBackForwardClient final : public BackForwardClient {
     void addItem(FrameIdentifier, Ref<HistoryItem>&&) final { }
+    void setChildItem(BackForwardItemIdentifier, Ref<HistoryItem>&&) final { }
     void goToItem(HistoryItem&) final { }
-    RefPtr<HistoryItem> itemAtIndex(int) final { return nullptr; }
+    RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) final { return nullptr; }
     unsigned backListCount() const final { return 0; }
     unsigned forwardListCount() const final { return 0; }
     bool containsItem(const HistoryItem&) const final { return false; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -796,18 +796,18 @@ void Page::setOpenedByDOM()
     m_openedByDOM = true;
 }
 
-void Page::goToItem(Frame& mainFrame, HistoryItem& item, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
+void Page::goToItem(Frame& frame, HistoryItem& item, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
     // stopAllLoaders may end up running onload handlers, which could cause further history traversals that may lead to the passed in HistoryItem
     // being deref()-ed. Make sure we can still use it with HistoryController::goToItem later.
     Ref protectedItem { item };
 
-    ASSERT(mainFrame.isMainFrame());
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame)) {
-        if (localMainFrame->checkedHistory()->shouldStopLoadingForHistoryItem(item))
-            localMainFrame->protectedLoader()->stopAllLoadersAndCheckCompleteness();
+    ASSERT(frame.isRootFrame());
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame)) {
+        if (localFrame->checkedHistory()->shouldStopLoadingForHistoryItem(item))
+            localFrame->protectedLoader()->stopAllLoadersAndCheckCompleteness();
     }
-    mainFrame.checkedHistory()->goToItem(item, type, shouldTreatAsContinuingLoad);
+    frame.checkedHistory()->goToItem(item, type, shouldTreatAsContinuingLoad);
 }
 
 void Page::setGroupName(const String& name)

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -125,15 +125,4 @@ void FrameState::setDocumentState(const Vector<AtomString>& documentState, Shoul
         validateDocumentState(m_documentState);
 }
 
-const FrameState* FrameState::stateForFrameID(WebCore::FrameIdentifier frameID) const
-{
-    if (this->frameID == frameID)
-        return this;
-    for (auto& child : children) {
-        if (auto* state = child->stateForFrameID(frameID))
-            return state;
-    }
-    return nullptr;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -82,8 +82,6 @@ public:
     void setDocumentState(const Vector<AtomString>&, ShouldValidate = ShouldValidate::No);
     static bool validateDocumentState(const Vector<AtomString>&);
 
-    const FrameState* stateForFrameID(WebCore::FrameIdentifier) const;
-
     String urlString;
     String originalURLString;
     String referrer;

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebBackForwardListFrameItem.h"
+
+#include "SessionState.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::create(WebBackForwardListItem* item, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&& frameState)
+{
+    return adoptRef(*new WebBackForwardListFrameItem(item, parentItem, WTFMove(frameState)));
+}
+
+WebBackForwardListFrameItem::WebBackForwardListFrameItem(WebBackForwardListItem* item, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&& frameState)
+    : m_backForwardListItem(item)
+    , m_frameState(WTFMove(frameState))
+    , m_parent(parentItem)
+{
+    auto result = allItems().add(*m_frameState->identifier, *this);
+    ASSERT_UNUSED(result, result.isNewEntry);
+    for (auto& child : m_frameState->children)
+        m_children.append(WebBackForwardListFrameItem::create(item, this, child.copyRef()));
+}
+
+WebBackForwardListFrameItem::~WebBackForwardListFrameItem()
+{
+    ASSERT(allItems().get(*m_frameState->identifier) == this);
+    allItems().remove(*m_frameState->identifier);
+}
+
+HashMap<BackForwardItemIdentifier, WeakRef<WebBackForwardListFrameItem>>& WebBackForwardListFrameItem::allItems()
+{
+    static MainThreadNeverDestroyed<HashMap<BackForwardItemIdentifier, WeakRef<WebBackForwardListFrameItem>>> items;
+    return items;
+}
+
+WebBackForwardListFrameItem* WebBackForwardListFrameItem::itemForID(BackForwardItemIdentifier identifier)
+{
+    return allItems().get(identifier);
+}
+
+std::optional<FrameIdentifier> WebBackForwardListFrameItem::frameID() const
+{
+    return m_frameState->frameID;
+}
+
+BackForwardItemIdentifier WebBackForwardListFrameItem::identifier() const
+{
+    return *m_frameState->identifier;
+}
+
+WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemForFrameID(FrameIdentifier frameID)
+{
+    if (m_frameState->frameID == frameID)
+        return this;
+    for (auto& child : m_children) {
+        if (auto* childFrameItem = child->childItemForFrameID(frameID))
+            return childFrameItem;
+    }
+    return nullptr;
+}
+
+WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
+{
+    return m_backForwardListItem.get();
+}
+
+RefPtr<WebBackForwardListItem> WebBackForwardListFrameItem::protectedBackForwardListItem() const
+{
+    return m_backForwardListItem.get();
+}
+
+void WebBackForwardListFrameItem::addChild(Ref<FrameState>&& frameState)
+{
+    m_frameState->children.append(frameState.copyRef());
+    m_children.append(WebBackForwardListFrameItem::create(protectedBackForwardListItem().get(), this, WTFMove(frameState)));
+}
+
+WebBackForwardListFrameItem& WebBackForwardListFrameItem::rootFrame()
+{
+    Ref rootFrame = *this;
+    while (rootFrame->m_parent && rootFrame->m_parent->identifier().processIdentifier() == identifier().processIdentifier())
+        rootFrame = *rootFrame->m_parent;
+    return rootFrame.get();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/BackForwardItemIdentifier.h>
+#include <WebCore/FrameIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+
+namespace WebKit {
+
+class FrameState;
+class WebBackForwardListItem;
+
+class WebBackForwardListFrameItem : public RefCountedAndCanMakeWeakPtr<WebBackForwardListFrameItem> {
+public:
+    static Ref<WebBackForwardListFrameItem> create(WebBackForwardListItem*, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&&);
+    ~WebBackForwardListFrameItem();
+
+    static WebBackForwardListFrameItem* itemForID(WebCore::BackForwardItemIdentifier);
+    static HashMap<WebCore::BackForwardItemIdentifier, WeakRef<WebBackForwardListFrameItem>>& allItems();
+
+    FrameState& frameState() const { return m_frameState; }
+    void setFrameState(Ref<FrameState>&& frameState) { m_frameState = WTFMove(frameState); }
+
+    std::optional<WebCore::FrameIdentifier> frameID() const;
+    WebCore::BackForwardItemIdentifier identifier() const;
+
+    WebBackForwardListFrameItem* parent() const { return m_parent.get(); }
+    WebBackForwardListFrameItem& rootFrame();
+    WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
+
+    WebBackForwardListItem* backForwardListItem() const;
+    RefPtr<WebBackForwardListItem> protectedBackForwardListItem() const;
+
+    void addChild(Ref<FrameState>&&);
+
+private:
+    WebBackForwardListFrameItem(WebBackForwardListItem*, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&&);
+
+    WeakPtr<WebBackForwardListItem> m_backForwardListItem;
+    Ref<FrameState> m_frameState;
+    WeakPtr<WebBackForwardListFrameItem> m_parent;
+    Vector<Ref<WebBackForwardListFrameItem>> m_children;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -48,6 +48,7 @@ namespace WebKit {
 class SuspendedPageProxy;
 class WebBackForwardCache;
 class WebBackForwardCacheEntry;
+class WebBackForwardListFrameItem;
 
 class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem> {
 public:
@@ -57,19 +58,19 @@ public:
     static WebBackForwardListItem* itemForID(const WebCore::BackForwardItemIdentifier&);
     static HashMap<WebCore::BackForwardItemIdentifier, WeakRef<WebBackForwardListItem>>& allItems();
 
-    WebCore::BackForwardItemIdentifier itemID() const { return *m_mainFrameState->identifier; }
+    WebCore::BackForwardItemIdentifier itemID() const;
     WebPageProxyIdentifier pageID() const { return m_pageID; }
 
     WebCore::ProcessIdentifier lastProcessIdentifier() const { return m_lastProcessIdentifier; }
     void setLastProcessIdentifier(const WebCore::ProcessIdentifier& identifier) { m_lastProcessIdentifier = identifier; }
 
-    void setMainFrameState(Ref<FrameState>&& mainFrameState) { m_mainFrameState = WTFMove(mainFrameState); }
-    FrameState& mainFrameState() const { return m_mainFrameState; }
+    void setRootFrameState(Ref<FrameState>&&);
+    FrameState& rootFrameState() const;
 
-    const String& originalURL() const { return m_mainFrameState->originalURLString; }
-    const String& url() const { return m_mainFrameState->urlString; }
-    const String& title() const { return m_mainFrameState->title; }
-    bool wasCreatedByJSWithoutUserInteraction() const { return m_mainFrameState->wasCreatedByJSWithoutUserInteraction; }
+    const String& originalURL() const;
+    const String& url() const;
+    const String& title() const;
+    bool wasCreatedByJSWithoutUserInteraction() const;
 
     const URL& resourceDirectoryURL() const { return m_resourceDirectoryURL; }
     void setResourceDirectoryURL(URL&& url) { m_resourceDirectoryURL = WTFMove(url); }
@@ -89,15 +90,16 @@ public:
     WebBackForwardCacheEntry* backForwardCacheEntry() const { return m_backForwardCacheEntry.get(); }
     SuspendedPageProxy* suspendedPage() const;
 
-    void setFrameID(WebCore::FrameIdentifier frameID) { m_frameID = frameID; }
-    std::optional<WebCore::FrameIdentifier> frameID() const { return m_frameID; }
+    void setNavigatedFrameID(WebCore::FrameIdentifier frameID) { m_navigatedFrameID = frameID; }
+    std::optional<WebCore::FrameIdentifier> navigatedFrameID() const { return m_navigatedFrameID; }
 
-    void addRootChildFrameItem(Ref<WebBackForwardListItem>&& item) { m_rootChildFrameItems.append(WTFMove(item)); }
     WebBackForwardListItem* childItemForFrameID(WebCore::FrameIdentifier) const;
     WebBackForwardListItem* childItemForProcessID(WebCore::ProcessIdentifier) const;
 
-    void setMainFrameItem(WebBackForwardListItem* item) { m_mainFrameItem = item; }
-    WebBackForwardListItem* mainFrameItem() { return m_mainFrameItem.get(); }
+    WebBackForwardListFrameItem& rootFrameItem() { return m_rootFrameItem.get(); }
+
+    void setIsRemoteFrameNavigation(bool isRemoteFrameNavigation) { m_isRemoteFrameNavigation = isRemoteFrameNavigation; }
+    bool isRemoteFrameNavigation() const { return m_isRemoteFrameNavigation; }
 
 #if !LOG_DISABLED
     String loggingString();
@@ -114,17 +116,16 @@ private:
 
     RefPtr<WebsiteDataStore> m_dataStoreForWebArchive;
 
-    Ref<FrameState> m_mainFrameState;
+    Ref<WebBackForwardListFrameItem> m_rootFrameItem;
     URL m_resourceDirectoryURL;
     WebPageProxyIdentifier m_pageID;
     WebCore::ProcessIdentifier m_lastProcessIdentifier;
-    Markable<WebCore::FrameIdentifier> m_frameID;
+    Markable<WebCore::FrameIdentifier> m_navigatedFrameID;
     std::unique_ptr<WebBackForwardCacheEntry> m_backForwardCacheEntry;
-    WeakPtr<WebBackForwardListItem> m_mainFrameItem;
-    Vector<Ref<WebBackForwardListItem>> m_rootChildFrameItems;
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     RefPtr<ViewSnapshot> m_snapshot;
 #endif
+    bool m_isRemoteFrameNavigation { false };
 };
 
 typedef Vector<Ref<WebBackForwardListItem>> BackForwardListItemVector;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -239,6 +239,7 @@ Shared/SharedStringHashStore.cpp
 Shared/SharedStringHashTableReadOnly.cpp
 Shared/SharedStringHashTable.cpp
 Shared/UserData.cpp
+Shared/WebBackForwardListFrameItem.cpp
 Shared/WebBackForwardListItem.cpp
 Shared/WebCompiledContentRuleList.cpp
 Shared/WebCompiledContentRuleListData.cpp

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp
@@ -38,15 +38,18 @@ WKTypeID WKBackForwardListItemGetTypeID()
 
 WKURLRef WKBackForwardListItemCopyURL(WKBackForwardListItemRef itemRef)
 {
-    return WebKit::toCopiedURLAPI(toImpl(itemRef)->url());
+    Ref item = *toImpl(itemRef);
+    return WebKit::toCopiedURLAPI(item->url());
 }
 
 WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef itemRef)
 {
-    return WebKit::toCopiedAPI(toImpl(itemRef)->title());
+    Ref item = *toImpl(itemRef);
+    return WebKit::toCopiedAPI(item->title());
 }
 
 WKURLRef WKBackForwardListItemCopyOriginalURL(WKBackForwardListItemRef itemRef)
 {
-    return WebKit::toCopiedURLAPI(toImpl(itemRef)->originalURL());
+    Ref item = *toImpl(itemRef);
+    return WebKit::toCopiedURLAPI(item->originalURL());
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -77,7 +77,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (CGPoint)_scrollPosition
 {
-    return CGPointMake(_item->mainFrameState().scrollPosition.x(), _item->mainFrameState().scrollPosition.y());
+    return CGPointMake(_item->rootFrameState().scrollPosition.x(), _item->rootFrameState().scrollPosition.y());
 }
 
 - (BOOL)_wasCreatedByJSWithoutUserInteraction

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -508,9 +508,9 @@ void ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess
     m_page->logDiagnosticMessageWithValueDictionary(message, description, valueDictionary, shouldSample);
 }
 
-void ProvisionalPageProxy::backForwardAddItem(FrameIdentifier targetFrameID, Ref<FrameState>&& mainFrameState)
+void ProvisionalPageProxy::backForwardAddItem(IPC::Connection& connection, FrameIdentifier targetFrameID, Ref<FrameState>&& mainFrameState)
 {
-    m_page->backForwardAddItemShared(protectedProcess(), targetFrameID, WTFMove(mainFrameState), m_replacedDataStoreForWebArchiveLoad ? LoadedWebArchive::Yes : LoadedWebArchive::No);
+    m_page->backForwardAddItemShared(connection, targetFrameID, WTFMove(mainFrameState), m_replacedDataStoreForWebArchiveLoad ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
 void ProvisionalPageProxy::didDestroyNavigation(WebCore::NavigationIdentifier navigationID)

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -181,7 +181,7 @@ private:
     void startURLSchemeTask(IPC::Connection&, URLSchemeTaskParameters&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void decidePolicyForNavigationActionSync(NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
-    void backForwardAddItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
+    void backForwardAddItem(IPC::Connection&, WebCore::FrameIdentifier, Ref<FrameState>&&);
     void didDestroyNavigation(WebCore::NavigationIdentifier);
 #if USE(QUICK_LOOK)
     void requestPasswordForQuickLookDocumentInMainFrame(const String& fileName, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -87,8 +87,6 @@ public:
     Vector<Ref<FrameState>> itemStates() const;
     Vector<Ref<FrameState>> filteredItemStates(Function<bool(WebBackForwardListItem&)>&&) const;
 
-    void addRootChildFrameItem(Ref<WebBackForwardListItem>&&) const;
-
 #if !LOG_DISABLED
     String loggingString();
 #endif

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -40,6 +40,7 @@
 #include "ProvisionalFrameProxy.h"
 #include "ProvisionalPageProxy.h"
 #include "RemotePageProxy.h"
+#include "WebBackForwardListFrameItem.h"
 #include "WebFramePolicyListenerProxy.h"
 #include "WebNavigationState.h"
 #include "WebPageMessages.h"
@@ -674,6 +675,16 @@ WebFrameProxy& WebFrameProxy::rootFrame()
 bool WebFrameProxy::isMainFrame() const
 {
     return m_frameLoadState.isMainFrame() == IsMainFrame::Yes;
+}
+
+void WebFrameProxy::setPendingChildBackForwardItem(WebBackForwardListFrameItem* pendingChildBackForwardItem)
+{
+    m_pendingChildBackForwardItem = pendingChildBackForwardItem;
+}
+
+WebBackForwardListFrameItem* WebFrameProxy::takePendingChildBackForwardItem()
+{
+    return std::exchange(m_pendingChildBackForwardItem, nullptr).get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -64,6 +64,7 @@ class FrameProcess;
 class ProvisionalFrameProxy;
 class BrowsingWarning;
 class UserData;
+class WebBackForwardListFrameItem;
 class WebFramePolicyListenerProxy;
 class WebPageProxy;
 class WebProcessProxy;
@@ -195,8 +196,9 @@ public:
     TraversalResult traverseNext(CanWrap) const;
     TraversalResult traversePrevious(CanWrap);
 
-    void setHasPendingBackForwardItem(bool hasPendingBackForwardItem) { m_hasPendingBackForwardItem = hasPendingBackForwardItem; }
-    bool hasPendingBackForwardItem() { return m_hasPendingBackForwardItem; }
+    void setPendingChildBackForwardItem(WebBackForwardListFrameItem*);
+    bool hasPendingChildBackForwardItem() const { return !!m_pendingChildBackForwardItem; };
+    WebBackForwardListFrameItem* takePendingChildBackForwardItem();
 
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
     void setRemoteFrameSize(WebCore::IntSize size) { m_remoteFrameSize = size; }
@@ -238,7 +240,7 @@ private:
 #endif
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)> m_navigateCallback;
     const WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
-    bool m_hasPendingBackForwardItem { false };
+    WeakPtr<WebBackForwardListFrameItem> m_pendingChildBackForwardItem;
     std::optional<WebCore::IntSize> m_remoteFrameSize;
     WebCore::SandboxFlags m_effectiveSandboxFlags;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -452,6 +452,7 @@ class VisitedLinkStore;
 class WebAuthenticatorCoordinatorProxy;
 class WebBackForwardCache;
 class WebBackForwardList;
+class WebBackForwardListFrameItem;
 class WebBackForwardListItem;
 class WebColorPickerClient;
 class WebContextMenuItemData;
@@ -2056,7 +2057,7 @@ public:
     void startURLSchemeTaskShared(IPC::Connection&, Ref<WebProcessProxy>&&, WebCore::PageIdentifier, URLSchemeTaskParameters&&);
     void loadDataWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::SessionHistoryVisibility);
     void loadRequestWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume);
-    void backForwardAddItemShared(Ref<WebProcessProxy>&&, WebCore::FrameIdentifier, Ref<FrameState>&&, LoadedWebArchive);
+    void backForwardAddItemShared(IPC::Connection&, WebCore::FrameIdentifier, Ref<FrameState>&&, LoadedWebArchive);
     void backForwardGoToItemShared(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void decidePolicyForNavigationActionSyncShared(Ref<WebProcessProxy>&&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void didDestroyNavigationShared(Ref<WebProcessProxy>&&, WebCore::NavigationIdentifier);
@@ -2552,7 +2553,7 @@ private:
 
     bool canCreateFrame(WebCore::FrameIdentifier) const;
 
-    RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListItem&, WebCore::FrameLoadType);
+    RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListItem&, WebBackForwardListFrameItem&, WebCore::FrameLoadType);
 
     void updateActivityState(OptionSet<WebCore::ActivityState> flagsToUpdate);
     void updateThrottleState();
@@ -2759,10 +2760,11 @@ private:
     std::optional<IPC::AsyncReplyID> willPerformPasteCommand(WebCore::DOMPasteAccessCategory, CompletionHandler<void()>&&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 
     // Back/Forward list management
-    void backForwardAddItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
+    void backForwardAddItem(IPC::Connection&, WebCore::FrameIdentifier, Ref<FrameState>&&);
+    void backForwardSetChildItem(WebCore::BackForwardItemIdentifier, Ref<FrameState>&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardListContainsItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(bool)>&&);
-    void backForwardItemAtIndex(IPC::Connection&, int32_t index, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);
+    void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
     void backForwardClear();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -198,9 +198,10 @@ messages -> WebPageProxy {
 #endif
 
     # BackForward messages
-    BackForwardAddItem(WebCore::FrameIdentifier targetFrameID, Ref<WebKit::FrameState> mainFrameState)
+    BackForwardAddItem(WebCore::FrameIdentifier targetFrameID, Ref<WebKit::FrameState> rootFrameState)
+    BackForwardSetChildItem(WebCore::BackForwardItemIdentifier identifier, Ref<WebKit::FrameState> frameState)
     BackForwardGoToItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
-    BackForwardItemAtIndex(int32_t itemIndex) -> (std::optional<WebCore::BackForwardItemIdentifier> itemID) Synchronous
+    BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (std::optional<WebCore::BackForwardItemIdentifier> itemID) Synchronous
     BackForwardListContainsItem(WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardClear()

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1102,7 +1102,7 @@ void WebProcessProxy::updateBackForwardItem(Ref<FrameState>&& mainFrameState)
             protectedProcessPool()->checkedBackForwardCache()->removeEntry(*item);
     }
 
-    item->setMainFrameState(WTFMove(mainFrameState));
+    item->setRootFrameState(WTFMove(mainFrameState));
 }
 
 void WebProcessProxy::getNetworkProcessConnection(CompletionHandler<void(NetworkProcessConnectionInfo&&)>&& reply)

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -219,7 +219,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
         WebCore::FloatSize swipeLayerSizeInDeviceCoordinates(liveSwipeViewFrame.size);
         swipeLayerSizeInDeviceCoordinates.scale(deviceScaleFactor);
         
-        BOOL shouldRestoreScrollPosition = targetItem->mainFrameState().shouldRestoreScrollPosition;
+        BOOL shouldRestoreScrollPosition = targetItem->rootFrameState().shouldRestoreScrollPosition;
         WebCore::IntPoint currentScrollPosition = WebCore::roundedIntPoint(m_webPageProxy->viewScrollPosition());
 
         if (snapshot->hasImage() && snapshot->size() == swipeLayerSizeInDeviceCoordinates && deviceScaleFactor == snapshot->deviceScaleFactor() && (shouldRestoreScrollPosition || (currentScrollPosition == snapshot->viewScrollPosition())))

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9661818E25AE100CE1F88 /* FindClient.h */; };
 		0201B9522C238F4800227220 /* WebPageProxyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0201B9512C238EFE00227220 /* WebPageProxyTesting.h */; };
 		0201B9552C238FA800227220 /* WebPageTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0201B9532C238F8500227220 /* WebPageTesting.h */; };
+		020E13132CA5F2FE002C616E /* WebBackForwardListFrameItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 020E13112CA5F2F1002C616E /* WebBackForwardListFrameItem.h */; };
 		0237F5EA2C4B40E800AD23EF /* WebExtensionSidebarParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */; };
 		0237F5EC2C4EC77300AD23EF /* WebExtensionContextAPISidebarCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0237F5EB2C4EC76800AD23EF /* WebExtensionContextAPISidebarCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
@@ -3098,6 +3099,8 @@
 		0201B9542C238F8E00227220 /* WebPageTesting.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageTesting.cpp; sourceTree = "<group>"; };
 		020A179F2C99FCF90012CFA5 /* WebExtensionActionClickBehavior.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionActionClickBehavior.h; sourceTree = "<group>"; };
 		020A17A12C99FD9B0012CFA5 /* WebExtensionActionClickBehavior.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionActionClickBehavior.serialization.in; sourceTree = "<group>"; };
+		020E13112CA5F2F1002C616E /* WebBackForwardListFrameItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebBackForwardListFrameItem.h; sourceTree = "<group>"; };
+		020E13122CA5F2F1002C616E /* WebBackForwardListFrameItem.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebBackForwardListFrameItem.cpp; sourceTree = "<group>"; };
 		0214701A2995D2FE0077AFD6 /* DrawingAreaCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DrawingAreaCocoa.mm; sourceTree = "<group>"; };
 		0214701B2995D3860077AFD6 /* DrawingArea.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DrawingArea.cpp; sourceTree = "<group>"; };
 		0237C21428C168D10018A851 /* WebGPUSupportedFeatures.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUSupportedFeatures.serialization.in; sourceTree = "<group>"; };
@@ -9323,6 +9326,8 @@
 				46C52F892B94366000D9890E /* VisitedLinkTableIdentifier.h */,
 				46CE3B1023D8C83D0016A96A /* WebBackForwardListCounts.h */,
 				516BF1D12AE5CD42009A0204 /* WebBackForwardListCounts.serialization.in */,
+				020E13122CA5F2F1002C616E /* WebBackForwardListFrameItem.cpp */,
+				020E13112CA5F2F1002C616E /* WebBackForwardListFrameItem.h */,
 				518D2CAB12D5153B003BB93B /* WebBackForwardListItem.cpp */,
 				518D2CAC12D5153B003BB93B /* WebBackForwardListItem.h */,
 				7C4ABECE1AA8E9F00088AA37 /* WebCompiledContentRuleList.cpp */,
@@ -16986,6 +16991,7 @@
 				46F9B26323526EF3006FE5FA /* WebBackForwardCacheEntry.h in Headers */,
 				BC72BA1E11E64907001EB4EA /* WebBackForwardList.h in Headers */,
 				46CE3B1123D8C8490016A96A /* WebBackForwardListCounts.h in Headers */,
+				020E13132CA5F2FE002C616E /* WebBackForwardListFrameItem.h in Headers */,
 				518D2CAE12D5153B003BB93B /* WebBackForwardListItem.h in Headers */,
 				BC72B9FB11E6476B001EB4EA /* WebBackForwardListProxy.h in Headers */,
 				512B6792294B8CB8000C0760 /* WebBadgeClient.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -96,6 +96,12 @@ void WebBackForwardListProxy::addItem(FrameIdentifier targetFrameID, Ref<History
     m_page->send(Messages::WebPageProxy::BackForwardAddItem(targetFrameID, toFrameState(item.get())));
 }
 
+void WebBackForwardListProxy::setChildItem(BackForwardItemIdentifier identifier, Ref<HistoryItem>&& item)
+{
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::BackForwardSetChildItem(identifier, toFrameState(item)));
+}
+
 void WebBackForwardListProxy::goToItem(HistoryItem& item)
 {
     if (!m_page)
@@ -106,12 +112,12 @@ void WebBackForwardListProxy::goToItem(HistoryItem& item)
     m_cachedBackForwardListCounts = backForwardListCounts;
 }
 
-RefPtr<HistoryItem> WebBackForwardListProxy::itemAtIndex(int itemIndex)
+RefPtr<HistoryItem> WebBackForwardListProxy::itemAtIndex(int itemIndex, FrameIdentifier frameID)
 {
     if (!m_page)
         return nullptr;
 
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::BackForwardItemAtIndex(itemIndex), m_page->identifier());
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::BackForwardItemAtIndex(itemIndex, frameID), m_page->identifier());
     auto [itemID] = sendResult.takeReplyOr(std::nullopt);
     if (!itemID)
         return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -51,10 +51,11 @@ private:
     WebBackForwardListProxy(WebPage&);
 
     void addItem(WebCore::FrameIdentifier, Ref<WebCore::HistoryItem>&&) override;
+    void setChildItem(WebCore::BackForwardItemIdentifier, Ref<WebCore::HistoryItem>&&) final;
 
     void goToItem(WebCore::HistoryItem&) override;
         
-    RefPtr<WebCore::HistoryItem> itemAtIndex(int) override;
+    RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
     unsigned backListCount() const override;
     unsigned forwardListCount() const override;
     bool containsItem(const WebCore::HistoryItem&) const final;

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <WebCore/BackForwardClient.h>
+#include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
@@ -45,6 +46,7 @@ public:
     WebView *webView() { return m_webView; }
 
     void addItem(WebCore::FrameIdentifier, Ref<WebCore::HistoryItem>&&) override;
+    void setChildItem(WebCore::BackForwardItemIdentifier, Ref<WebCore::HistoryItem>&&) final { }
     void goBack();
     void goForward();
     void goToItem(WebCore::HistoryItem&) override;
@@ -52,7 +54,7 @@ public:
     RefPtr<WebCore::HistoryItem> backItem();
     RefPtr<WebCore::HistoryItem> currentItem();
     RefPtr<WebCore::HistoryItem> forwardItem();
-    RefPtr<WebCore::HistoryItem> itemAtIndex(int) override;
+    RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
 
     void backListWithLimit(int, Vector<Ref<WebCore::HistoryItem>>&);
     void forwardListWithLimit(int, Vector<Ref<WebCore::HistoryItem>>&);

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -199,7 +199,7 @@ unsigned BackForwardList::forwardListCount() const
     return m_current == NoCurrentItemIndex ? 0 : m_entries.size() - m_current - 1;
 }
 
-RefPtr<HistoryItem> BackForwardList::itemAtIndex(int index)
+RefPtr<HistoryItem> BackForwardList::itemAtIndex(int index, WebCore::FrameIdentifier)
 {
     // Do range checks without doing math on index to avoid overflow.
     if (index < -static_cast<int>(m_current))

--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -335,7 +335,10 @@ static bool bumperCarBackForwardHackNeeded()
 
 - (WebHistoryItem *)itemAtIndex:(int)index
 {
-    return retainPtr(kit(core(self)->itemAtIndex(index).get())).autorelease();
+    if (auto* mainFrame = core([core(self)->webView() mainFrame]))
+        return retainPtr(kit(core(self)->itemAtIndex(index, mainFrame->frameID()).get())).autorelease();
+    ASSERT_NOT_REACHED();
+    return nullptr;
 }
 
 @end


### PR DESCRIPTION
#### f8b36c9289f3c027fce896b5637ebe6d15505c32
<pre>
Clean up logic to commit history state from multiple web processes to a shared list in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=280876">https://bugs.webkit.org/show_bug.cgi?id=280876</a>
<a href="https://rdar.apple.com/137261520">rdar://137261520</a>

Reviewed by Alex Christensen.

This change is a step towards having a more complete list of back/forward state in the UI process with
site isolation. I added `WebBackForwardListFrameItem` and changed `WebBackForwardListItem` to hold a
reference to it instead of `FrameState`. This will allow the UI process to better manage history state by
frame, as web processes can no longer commit history state for the entire frame tree. More details are
provided below.

* Source/WebCore/history/BackForwardClient.h:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::backItem):
(WebCore::BackForwardController::currentItem):
(WebCore::BackForwardController::forwardItem):
(WebCore::BackForwardController::itemAtIndex):
These functions should not be able to request history items for the entire frame tree. Instead, web
processes should only be given history items for the frames they host.

(WebCore::BackForwardController::setChildItem):
This function notifies the UI process when a frame embeds a local child frame.

* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/loader/EmptyClients.cpp:

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::goToItem):
Create and navigate history item trees starting from the root frame, as the main frame may be
out-of-process.

* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::stateForFrameID const): Deleted.
* Source/WebKit/Shared/SessionState.h:
This function has been replaced with `WebBackForwardListFrameItem::childItemForFrameID`.

* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::WebBackForwardListItem):
(WebKit::WebBackForwardListItem::~WebBackForwardListItem):
(WebKit::WebBackForwardListItem::itemIsInSameDocument const):
(WebKit::WebBackForwardListItem::itemIsClone):
(WebKit::WebBackForwardListItem::itemID const):
(WebKit::WebBackForwardListItem::setRootFrameState):
(WebKit::WebBackForwardListItem::rootFrameState const):
(WebKit::WebBackForwardListItem::originalURL const):
(WebKit::WebBackForwardListItem::url const):
(WebKit::WebBackForwardListItem::title const):
(WebKit::WebBackForwardListItem::wasCreatedByJSWithoutUserInteraction const):

(WebKit::WebBackForwardListItem::childItemForFrameID const): Deleted.
(WebKit::WebBackForwardListItem::childItemForProcessID const): Deleted.
These functions are replaced by `WebBackForwardListFrameItem::childItemForFrameID`.

* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::setNavigatedFrameID):
(WebKit::WebBackForwardListItem::navigatedFrameID const):
(WebKit::WebBackForwardListItem::mainFrameItem):
(WebKit::WebBackForwardListItem::setIsRemoteFrameNavigation):
(WebKit::WebBackForwardListItem::itemID const): Deleted.
(WebKit::WebBackForwardListItem::setMainFrameState): Deleted.
(WebKit::WebBackForwardListItem::mainFrameState const): Deleted.
(WebKit::WebBackForwardListItem::originalURL const): Deleted.
(WebKit::WebBackForwardListItem::url const): Deleted.
(WebKit::WebBackForwardListItem::title const): Deleted.
(WebKit::WebBackForwardListItem::wasCreatedByJSWithoutUserInteraction const): Deleted.
(WebKit::WebBackForwardListItem::setFrameID): Deleted.
(WebKit::WebBackForwardListItem::frameID const): Deleted.
(WebKit::WebBackForwardListItem::addRootChildFrameItem): Deleted.
(WebKit::WebBackForwardListItem::setMainFrameItem): Deleted.
`m_rootChildFrameItems` is replaced by `m_mainFrameState`.

Also add `m_isRemoteFrameNavigation` to indicate when a back/forward item was created by a navigation
from a process unable to construct history state for the main frame. This change is necessary because
some functions on this object, such as `url()`, have callers that expect this to return the URL for the
main frame.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp:
(WKBackForwardListItemCopyURL):
(WKBackForwardListItemCopyTitle):
(WKBackForwardListItemCopyOriginalURL)
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem _scrollPosition]):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::backForwardAddItem):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::itemForID):
(WebKit::WebBackForwardList::goToItem):
(WebKit::WebBackForwardList::backForwardListState const):
(WebKit::WebBackForwardList::filteredItemStates const):
(WebKit::WebBackForwardList::addRootChildFrameItem const): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setPendingChildBackForwardItem):
(WebKit::WebFrameProxy::takePendingChildBackForwardItem):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::hasPendingChildBackForwardItem const):
(WebKit::WebFrameProxy::setHasPendingBackForwardItem): Deleted.
(WebKit::WebFrameProxy::hasPendingBackForwardItem): Deleted.
If a frame expects history state for a child frame to be committed from another process, add the frame
item to `WebFrameProxy`, allowing it to later add the corresponding child item.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goBack):

(WebKit::WebPageProxy::goToBackForwardItem):
Update this function to use state from the navigating frame item. The root frame identifier needs to be
sent to the web process, as it is what will have been added to the history item map in the web process.

(WebKit::WebPageProxy::continueNavigationInNewProcess):

(WebKit::WebPageProxy::backForwardAddItem):
(WebKit::WebPageProxy::backForwardAddItemShared):
Change the `WebProcessProxy` parameter to an `IPC::Connection` so we can use it to know when the frame
that has navigated is remote.

(WebKit::WebPageProxy::backForwardSetChildItem):

(WebKit::WebPageProxy::backForwardItemAtIndex):
Return history state for the specified frame rather than sending the entire frame tree.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::updateBackForwardItem):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::setChildItem):
(WebKit::WebBackForwardListProxy::itemAtIndex):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::goToBackForwardItem):
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/BackForwardList.mm:
(BackForwardList::itemAtIndex):
* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
(-[WebBackForwardList itemAtIndex:]):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigateFrameWithSiblingsBackForward)):
Add a test for `FIXME: This will not always select the correct child item if there are multiple root
frames in the same process.` which this change resolves.

Canonical link: <a href="https://commits.webkit.org/284750@main">https://commits.webkit.org/284750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e605a2ef412addad85b51da999e73ef9ee8866a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21497 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55723 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76127 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63379 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5050 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/294 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->