### PR TITLE
disassembler/zydis/Zydis/ZydisSharedData.c: error: comparison of integers of different signs: 'ZydisInternalElementType' (aka 'enum ZydisInternalElementType_') and 'unsigned long long'

### DIFF
--- a/Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisSharedData.c
+++ b/Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisSharedData.c
@@ -177,7 +177,7 @@ void ZydisGetElementInfo(ZydisInternalElementType element, ZydisElementType* typ
         { ZYDIS_ELEMENT_TYPE_CC       ,   5 }
     };
 
-    ZYAN_ASSERT(element < ZYAN_ARRAY_LENGTH(lookup));
+    ZYAN_ASSERT((ZyanUSize)element < ZYAN_ARRAY_LENGTH(lookup));
 
     *type = lookup[element].type;
     *size = lookup[element].size;


### PR DESCRIPTION
#### 9987de5f04ac3ff6aa8278b1f72bfe86c79af895
<pre>
disassembler/zydis/Zydis/ZydisSharedData.c: error: comparison of integers of different signs: &apos;ZydisInternalElementType&apos; (aka &apos;enum ZydisInternalElementType_&apos;) and &apos;unsigned long long&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=280875">https://bugs.webkit.org/show_bug.cgi?id=280875</a>

Reviewed by Yusuke Suzuki.

Windows port Debug build couldn&apos;t compile Zydis.

&gt; Source\JavaScriptCore\disassembler/zydis/Zydis/ZydisSharedData.c(180,25): error: comparison of integers of different signs: &apos;ZydisInternalElementType&apos; (aka &apos;enum ZydisInternalElementType_&apos;) and &apos;unsigned long long&apos; [-Werror,-Wsign-compare]
&gt;   180 |     ZYAN_ASSERT(element &lt; ZYAN_ARRAY_LENGTH(lookup));
&gt;       |     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~

Cherry-picked the upstream fix.
&lt;<a href="https://github.com/zyantific/zydis/commit/90d54ee8f4f62231bd7dbc0e5f010681b89c5128">https://github.com/zyantific/zydis/commit/90d54ee8f4f62231bd7dbc0e5f010681b89c5128</a>&gt;

* Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisSharedData.c:
(ZydisGetElementInfo):

Canonical link: <a href="https://commits.webkit.org/284663@main">https://commits.webkit.org/284663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864c78baf5b64ada7930f1e530707842cbb46138

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70161 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21179 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73227 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19696 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63280 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75965 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69407 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14386 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63288 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4932 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91189 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10715 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45369 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/19874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->