### PR TITLE
Annotate RemoteAudioSessionProxy message endpoints with feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4691,6 +4691,8 @@ MediaDevicesEnabled:
 MediaEnabled:
   type: bool
   status: embedder
+  humanReadableName: "HTML Media Elements"
+  humanReadableDescription: "Enable HTML media elements <audio>, <video> and <track>"
   condition: ENABLE(VIDEO)
   defaultValue:
     WebKitLegacy:
@@ -4699,6 +4701,20 @@ MediaEnabled:
       default: true
     WebCore:
       default: true
+
+MediaPlaybackEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "Media Playback Functionalities"
+  humanReadableDescription: "Enable media playback functionalities"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+  sharedPreferenceForWebProcess: true
 
 MediaPreferredFullscreenWidth:
   type: double

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -109,6 +109,7 @@ public:
     static UniqueRef<AudioSession> create();
     static void setSharedSession(UniqueRef<AudioSession>&&);
     static AudioSession& sharedSession();
+    static bool enableMediaPlayback();
 
     using ChangedObserver = WTF::Observer<void(AudioSession&)>;
     static void addAudioSessionChangedObserver(const ChangedObserver&);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -309,16 +309,12 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     , m_presentingApplicationAuditToken(parameters.presentingApplicationAuditToken ? std::optional(parameters.presentingApplicationAuditToken->auditToken()) : std::nullopt)
 #endif
     , m_isLockdownModeEnabled(parameters.isLockdownModeEnabled)
-#if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
-    , m_routingArbitrator(LocalAudioSessionRoutingArbitrator::create(*this))
-#endif
     , m_sharedPreferencesForWebProcess(WTFMove(parameters.sharedPreferencesForWebProcess))
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
-#if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
-    gpuProcess.protectedAudioSessionManager()->session().setRoutingArbitrationClient(m_routingArbitrator.get());
-#endif
+    // This must be called before any media playback function is invoked.
+    enableMediaPlaybackIfNecessary();
 
     // Use this flag to force synchronous messages to be treated as asynchronous messages in the WebProcess.
     // Otherwise, the WebProcess would process incoming synchronous IPC while waiting for a synchronous IPC
@@ -400,7 +396,8 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
     assertIsMainThread();
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
-    m_routingArbitrator->processDidTerminate();
+    if (m_routingArbitrator)
+        m_routingArbitrator->processDidTerminate();
 #endif
 
 #if USE(AUDIO_SESSION)
@@ -1256,6 +1253,21 @@ void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPrefe
     m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess);
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
     protectedLibWebRTCCodecsProxy()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+#endif
+    enableMediaPlaybackIfNecessary();
+}
+
+void GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary()
+{
+#if USE(AUDIO_SESSION)
+    if (!WebCore::AudioSession::enableMediaPlayback())
+        return;
+#endif
+
+#if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
+    ASSERT(!m_routingArbitrator);
+    m_routingArbitrator = LocalAudioSessionRoutingArbitrator::create(*this);
+    protectedGPUProcess()->protectedAudioSessionManager()->session().setRoutingArbitrationClient(m_routingArbitrator.get());
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -349,6 +349,7 @@ private:
 #if PLATFORM(MAC) && ENABLE(WEBGL)
     void dispatchDisplayWasReconfigured();
 #endif
+    void enableMediaPlaybackIfNecessary();
 
     static uint64_t gObjectCountForTesting;
 
@@ -444,7 +445,7 @@ private:
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
-    UniqueRef<LocalAudioSessionRoutingArbitrator> m_routingArbitrator;
+    std::unique_ptr<LocalAudioSessionRoutingArbitrator> m_routingArbitrator;
 #endif
 #if ENABLE(IPC_TESTING_API)
     IPCTester m_ipcTester;

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -34,7 +34,7 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     void ClearNowPlayingInfo()
     void SetNowPlayingInfo(struct WebCore::NowPlayingInfo nowPlayingInfo)
 #if USE(AUDIO_SESSION)
-    EnsureAudioSession() -> (struct WebKit::RemoteAudioSessionConfiguration configuration) Synchronous
+    [EnabledBy=MediaPlaybackEnabled] EnsureAudioSession() -> (struct WebKit::RemoteAudioSessionConfiguration configuration) Synchronous
 #endif
 #if PLATFORM(IOS_FAMILY)
     EnsureMediaSessionHelper()

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
@@ -41,9 +41,9 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalAudioSessionRoutingArbitrator);
 
-UniqueRef<LocalAudioSessionRoutingArbitrator> LocalAudioSessionRoutingArbitrator::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess)
+std::unique_ptr<LocalAudioSessionRoutingArbitrator> LocalAudioSessionRoutingArbitrator::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess)
 {
-    return makeUniqueRef<LocalAudioSessionRoutingArbitrator>(gpuConnectionToWebProcess);
+    return makeUnique<LocalAudioSessionRoutingArbitrator>(gpuConnectionToWebProcess);
 }
 
 LocalAudioSessionRoutingArbitrator::LocalAudioSessionRoutingArbitrator(GPUConnectionToWebProcess& gpuConnectionToWebProcess)

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -48,13 +48,13 @@ class LocalAudioSessionRoutingArbitrator final
 public:
     USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionRoutingArbitrationClient);
 
-    static UniqueRef<LocalAudioSessionRoutingArbitrator> create(GPUConnectionToWebProcess&);
+    static std::unique_ptr<LocalAudioSessionRoutingArbitrator> create(GPUConnectionToWebProcess&);
+    LocalAudioSessionRoutingArbitrator(GPUConnectionToWebProcess&);
     virtual ~LocalAudioSessionRoutingArbitrator();
 
     void processDidTerminate();
 
 private:
-    LocalAudioSessionRoutingArbitrator(GPUConnectionToWebProcess&);
 
     // AudioSessionRoutingArbitrationClient
     void beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType, ArbitrationCallback&&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -196,6 +196,14 @@ void RemoteAudioSessionProxy::triggerEndInterruptionForTesting()
     AudioSession::sharedSession().endInterruptionForTesting();
 }
 
+std::optional<SharedPreferencesForWebProcess> RemoteAudioSessionProxy::sharedPreferencesForWebProcess() const
+{
+    if (RefPtr gpuConnectionToWebProcess = m_gpuConnection.get())
+        return gpuConnectionToWebProcess->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -44,6 +44,7 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 class RemoteAudioSessionProxyManager;
+struct SharedPreferencesForWebProcess;
 
 class RemoteAudioSessionProxy
     : public RefCounted<RemoteAudioSessionProxy>, public IPC::MessageReceiver {
@@ -81,6 +82,7 @@ public:
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
     explicit RemoteAudioSessionProxy(GPUConnectionToWebProcess&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -25,6 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
 
+[EnabledBy=MediaPlaybackEnabled]
 messages -> RemoteAudioSessionProxy NotRefCounted {
     SetCategory(enum:uint8_t WebCore::AudioSessionCategory type, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     SetPreferredBufferSize(uint64_t preferredBufferSize)

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPageUpdatePreferences.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPageUpdatePreferences.cpp.erb
@@ -31,6 +31,7 @@
 #include "WebPreferencesDefinitions.h"
 #include "WebPreferencesKeys.h"
 #include "WebPreferencesStore.h"
+#include "WebProcess.h"
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Page.h>
 #include <WebCore/Settings.h>
@@ -69,6 +70,9 @@ void WebPage::updatePreferencesGenerated(const WebPreferencesStore& store)
 #endif
 <%- end -%>
 <%- end -%>
+
+    if (store.getBoolValueForKey(WebPreferencesKey::mediaPlaybackEnabledKey()))
+        WebProcess::singleton().enableMediaPlayback();
 }
 
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -473,7 +473,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (WKWebViewAudioRoutingArbitrationStatus)_audioRoutingArbitrationStatus
 {
 #if ENABLE(ROUTING_ARBITRATION)
-    switch (_page->legacyMainFrameProcess().audioSessionRoutingArbitrator().arbitrationStatus()) {
+    WeakPtr arbitrator = _page->legacyMainFrameProcess().audioSessionRoutingArbitrator();
+    if (!arbitrator)
+        return WKWebViewAudioRoutingArbitrationStatusNone;
+
+    switch (arbitrator->arbitrationStatus()) {
     case WebKit::AudioSessionRoutingArbitratorProxy::ArbitrationStatus::None: return WKWebViewAudioRoutingArbitrationStatusNone;
     case WebKit::AudioSessionRoutingArbitratorProxy::ArbitrationStatus::Pending: return WKWebViewAudioRoutingArbitrationStatusPending;
     case WebKit::AudioSessionRoutingArbitratorProxy::ArbitrationStatus::Active: return WKWebViewAudioRoutingArbitrationStatusActive;
@@ -487,7 +491,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (double)_audioRoutingArbitrationUpdateTime
 {
 #if ENABLE(ROUTING_ARBITRATION)
-    return _page->legacyMainFrameProcess().audioSessionRoutingArbitrator().arbitrationUpdateTime().secondsSinceEpoch().seconds();
+    WeakPtr arbitrator = _page->legacyMainFrameProcess().audioSessionRoutingArbitrator();
+    if (!arbitrator)
+        return 0;
+
+    return arbitrator->arbitrationUpdateTime().secondsSinceEpoch().seconds();
 #else
     return 0;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -443,7 +443,7 @@ public:
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION)
-    AudioSessionRoutingArbitratorProxy& audioSessionRoutingArbitrator() { return m_routingArbitrator.get(); }
+    AudioSessionRoutingArbitratorProxy* audioSessionRoutingArbitrator() { return m_routingArbitrator.get(); }
 #endif
 
 #if ENABLE(IPC_TESTING_API)
@@ -636,6 +636,7 @@ private:
     bool shouldDropNearSuspendedAssertionAfterDelay() const;
 
     void updateRuntimeStatistics();
+    void enableMediaPlaybackIfNecessary();
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     void setupLogStream(uint32_t pid, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&&);
@@ -776,7 +777,7 @@ private:
     std::unique_ptr<WebLockRegistryProxy> m_webLockRegistry;
     std::unique_ptr<WebPermissionControllerProxy> m_webPermissionController;
 #if ENABLE(ROUTING_ARBITRATION)
-    UniqueRef<AudioSessionRoutingArbitratorProxy> m_routingArbitrator;
+    std::unique_ptr<AudioSessionRoutingArbitratorProxy> m_routingArbitrator;
 #endif
     bool m_isConnectedToHardwareConsole { true };
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -170,7 +170,7 @@ void GPUProcessConnection::didClose(IPC::Connection&)
     webProcess.gpuProcessConnectionClosed();
 
 #if ENABLE(ROUTING_ARBITRATION)
-    if (auto* arbitrator = WebProcess::singleton().supplement<AudioSessionRoutingArbitrator>())
+    if (auto* arbitrator = WebProcess::singleton().audioSessionRoutingArbitrator())
         arbitrator->leaveRoutingAbritration();
 #endif
 
@@ -339,7 +339,7 @@ void GPUProcessConnection::didReceiveRemoteCommand(PlatformMediaSession::RemoteC
 #if ENABLE(ROUTING_ARBITRATION)
 void GPUProcessConnection::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, AudioSessionRoutingArbitrationClient::ArbitrationCallback&& callback)
 {
-    if (auto* arbitrator = WebProcess::singleton().supplement<AudioSessionRoutingArbitrator>()) {
+    if (auto* arbitrator = WebProcess::singleton().audioSessionRoutingArbitrator()) {
         arbitrator->beginRoutingArbitrationWithCategory(category, WTFMove(callback));
         return;
     }
@@ -350,7 +350,7 @@ void GPUProcessConnection::beginRoutingArbitrationWithCategory(AudioSession::Cat
 
 void GPUProcessConnection::endRoutingArbitration()
 {
-    if (auto* arbitrator = WebProcess::singleton().supplement<AudioSessionRoutingArbitrator>()) {
+    if (auto* arbitrator = WebProcess::singleton().audioSessionRoutingArbitrator()) {
         arbitrator->leaveRoutingAbritration();
         return;
     }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -335,10 +335,6 @@ WebProcess::WebProcess()
     addSupplement<RemoteLegacyCDMFactory>();
 #endif
 
-#if ENABLE(ROUTING_ARBITRATION)
-    addSupplement<AudioSessionRoutingArbitrator>();
-#endif
-
 #if ENABLE(GPU_PROCESS)
     addSupplement<RemoteMediaEngineConfigurationFactory>();
 #endif
@@ -2404,6 +2400,18 @@ void WebProcess::updateCachedCookiesEnabled()
 bool WebProcess::requiresScriptTelemetryForURL(const URL& url, const WebCore::SecurityOrigin& topOrigin) const
 {
     return m_scriptTelemetryFilter && m_scriptTelemetryFilter->matches(url, topOrigin);
+}
+
+void WebProcess::enableMediaPlayback()
+{
+#if USE(AUDIO_SESSION)
+    if (!WebCore::AudioSession::enableMediaPlayback())
+        return;
+#endif
+
+#if ENABLE(ROUTING_ARBITRATION)
+    m_routingArbitrator = makeUnique<AudioSessionRoutingArbitrator>(*this);
+#endif
 }
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -120,6 +120,7 @@ struct ServiceWorkerContextData;
 namespace WebKit {
 
 class AudioMediaStreamTrackRendererInternalUnitManager;
+class AudioSessionRoutingArbitrator;
 class GamepadData;
 class GPUProcessConnection;
 class InjectedBundle;
@@ -449,6 +450,10 @@ public:
 
     bool haveStorageAccessQuirksForDomain(const WebCore::RegistrableDomain&);
     void updateCachedCookiesEnabled();
+    void enableMediaPlayback();
+#if ENABLE(ROUTING_ARBITRATION)
+    AudioSessionRoutingArbitrator* audioSessionRoutingArbitrator() const { return m_routingArbitrator.get(); }
+#endif
 
 private:
     WebProcess();
@@ -837,6 +842,9 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     std::unique_ptr<SpeechRecognitionRealtimeMediaSourceManager> m_speechRecognitionRealtimeMediaSourceManager;
+#endif
+#if ENABLE(ROUTING_ARBITRATION)
+    std::unique_ptr<AudioSessionRoutingArbitrator> m_routingArbitrator;
 #endif
     bool m_hadMainFrameMainResourcePrivateRelayed { false };
     bool m_imageAnimationEnabled { true };

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -49,11 +49,6 @@ AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process
 
 AudioSessionRoutingArbitrator::~AudioSessionRoutingArbitrator() = default;
 
-ASCIILiteral AudioSessionRoutingArbitrator::supplementName()
-{
-    return "AudioSessionRoutingArbitrator"_s;
-}
-
 void AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
     WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::AudioSessionRoutingArbitratorProxy::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), AudioSessionRoutingArbitratorProxy::destinationId());

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(ROUTING_ARBITRATION)
 
-#include "WebProcessSupplement.h"
 #include <WebCore/AudioSession.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -36,9 +35,7 @@ namespace WebKit {
 
 class WebProcess;
 
-class AudioSessionRoutingArbitrator final
-    : public WebProcessSupplement
-    , public WebCore::AudioSessionRoutingArbitrationClient {
+class AudioSessionRoutingArbitrator final : public WebCore::AudioSessionRoutingArbitrationClient {
     WTF_MAKE_TZONE_ALLOCATED(AudioSessionRoutingArbitrator);
 public:
     USING_CAN_MAKE_WEAKPTR(WebCore::AudioSessionRoutingArbitrationClient);

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1490,6 +1490,9 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         if (WTF::IOSApplication::isMobileSafari())
             WebCore::DeprecatedGlobalSettings::setShouldManageAudioSessionCategory(true);
 #endif
+#if USE(AUDIO_SESSION)
+        WebCore::AudioSession::enableMediaPlayback();
+#endif
 
 #if ENABLE(VIDEO)
         WebCore::HTMLMediaElement::setMediaCacheDirectory(FileSystem::pathByAppendingComponent(String(NSTemporaryDirectory()), "MediaCache/"_s));


### PR DESCRIPTION
#### c30d02a4249dd3d959e0397fe5d2a1ebf15250c3
<pre>
Annotate RemoteAudioSessionProxy message endpoints with feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=280238">https://bugs.webkit.org/show_bug.cgi?id=280238</a>
<a href="https://rdar.apple.com/136540877">rdar://136540877</a>

Reviewed by Eric Carlson.

Add a feature flag for guarding media playback functionalities and annotate RemoteAudioSessionProxy messages with it.
This means when media playback is disabled, web process should not be sending RemoteAudioSessionProxy messages to GPU
process.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::dummyAudioSession):
(WebCore::AudioSession::enableMediaPlayback):
(WebCore::AudioSession::sharedSession):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp:
(WebKit::LocalAudioSessionRoutingArbitrator::create):
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/Scripts/PreferencesTemplates/WebPageUpdatePreferences.cpp.erb:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _audioRoutingArbitrationStatus]):
(-[WKWebView _audioRoutingArbitrationUpdateTime]):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::m_webPermissionController):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::enableMediaPlaybackIfNecessary):
(WebKit::WebProcessProxy::updateSharedPreferencesForWebProcess):
(WebKit::m_routingArbitrator): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didClose):
(WebKit::GPUProcessConnection::beginRoutingArbitrationWithCategory):
(WebKit::GPUProcessConnection::endRoutingArbitration):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::m_nonVisibleProcessMemoryCleanupTimer):
(WebKit::WebProcess::enableMediaPlayback):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::AudioSessionRoutingArbitrator::supplementName): Deleted.
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):

Canonical link: <a href="https://commits.webkit.org/284930@main">https://commits.webkit.org/284930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/311b8cd0318cdce5673f42491f3d0382b42e6347

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23691 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21941 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61144 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/70427 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18578 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/64042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76737 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70167 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18142 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61203 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11890 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46131 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/906 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20043 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48486 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->