### PR TITLE
[CoordinatedGraphics] Rename TiledBackingStore as CoordinatedBackingStoreProxy

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -133,10 +133,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
-#if USE(COORDINATED_GRAPHICS)
-#include "TiledBackingStore.h"
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 #include "DocumentLoader.h"
 #include "LegacyTileCache.h"

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -46,6 +46,8 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp
 
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -53,17 +55,15 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
-        platform/graphics/texmap/coordinated/Tile.cpp
-        platform/graphics/texmap/coordinated/TiledBackingStore.cpp
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
+        platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
-        platform/graphics/texmap/coordinated/Tile.h
-        platform/graphics/texmap/coordinated/TiledBackingStore.h
-        platform/graphics/texmap/coordinated/TiledBackingStoreClient.h
     )
 
     if (USE_GSTREAMER)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
@@ -29,14 +29,14 @@
 #pragma once
 
 #include "CoordinatedBackingStore.h"
-#include "TiledBackingStore.h"
-#include "TiledBackingStoreClient.h"
+#include "CoordinatedBackingStoreProxy.h"
+#include "CoordinatedBackingStoreProxyClient.h"
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace Nicosia {
 
-class BackingStore final : public ThreadSafeRefCounted<BackingStore>, public WebCore::TiledBackingStoreClient {
+class BackingStore final : public ThreadSafeRefCounted<BackingStore>, public WebCore::CoordinatedBackingStoreProxyClient {
 public:
     static Ref<BackingStore> create()
     {
@@ -80,7 +80,7 @@ public:
         LayerState(LayerState&&) = delete;
         LayerState& operator=(LayerState&&) = delete;
 
-        std::unique_ptr<WebCore::TiledBackingStore> mainBackingStore;
+        std::unique_ptr<WebCore::CoordinatedBackingStoreProxy> mainBackingStore;
 
         TileUpdate update;
         bool isFlushing { false };
@@ -106,7 +106,7 @@ public:
 
     TileUpdate takeUpdate();
 
-    // TiledBackingStoreClient
+    // CoordinatedBackingStoreProxyClient
     // FIXME: Move these to private once updateTile() is not called from CoordinatedGrahpicsLayer.
     void tiledBackingStoreHasPendingTileCreation() override;
     void createTile(uint32_t, float) override;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -168,7 +168,7 @@ void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper,
     }
 
     // targetRect is on the contents coordinate system, so we must compare two rects on the contents coordinate system.
-    // See TiledBackingStore.
+    // See CoodinatedBackingStoreProxy.
     TransformationMatrix adjustedTransform = transform * adjustedTransformForRect(targetRect);
 
     paintTilesToTextureMapper(previousTilesToPaint, textureMapper, adjustedTransform, opacity, rect());

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -17,15 +17,14 @@
  Boston, MA 02110-1301, USA.
  */
 
-#ifndef TiledBackingStore_h
-#define TiledBackingStore_h
+#pragma once
 
 #if USE(COORDINATED_GRAPHICS)
 
+#include "CoordinatedBackingStoreProxyTile.h"
 #include "FloatPoint.h"
 #include "IntPoint.h"
 #include "IntRect.h"
-#include "Tile.h"
 #include <wtf/Assertions.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
@@ -33,32 +32,32 @@
 namespace WebCore {
 
 class GraphicsContext;
-class TiledBackingStoreClient;
+class CoordinatedBackingStoreProxyClient;
 
-class TiledBackingStore {
-    WTF_MAKE_TZONE_ALLOCATED(TiledBackingStore);
-    WTF_MAKE_NONCOPYABLE(TiledBackingStore);
+class CoordinatedBackingStoreProxy {
+    WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
+    WTF_MAKE_NONCOPYABLE(CoordinatedBackingStoreProxy);
 public:
-    TiledBackingStore(TiledBackingStoreClient&, float contentsScale = 1.f);
-    ~TiledBackingStore();
+    CoordinatedBackingStoreProxy(CoordinatedBackingStoreProxyClient&, float contentsScale = 1.f);
+    ~CoordinatedBackingStoreProxy();
 
-    TiledBackingStoreClient& client() { return m_client; }
+    CoordinatedBackingStoreProxyClient& client() { return m_client; }
 
     void setTrajectoryVector(const FloatPoint&);
     void createTilesIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& contentsRect);
 
     float contentsScale() const { return m_contentsScale; }
 
-    Vector<std::reference_wrapper<Tile>> dirtyTiles();
+    Vector<std::reference_wrapper<CoordinatedBackingStoreProxyTile>> dirtyTiles();
 
     void invalidate(const IntRect& dirtyRect);
 
     WEBCORE_EXPORT IntRect mapToContents(const IntRect&) const;
     IntRect mapFromContents(const IntRect&) const;
 
-    IntRect tileRectForCoordinate(const Tile::Coordinate&) const;
-    Tile::Coordinate tileCoordinateForPoint(const IntPoint&) const;
-    double tileDistance(const IntRect& viewport, const Tile::Coordinate&) const;
+    IntRect tileRectForCoordinate(const CoordinatedBackingStoreProxyTile::Coordinate&) const;
+    CoordinatedBackingStoreProxyTile::Coordinate tileCoordinateForPoint(const IntPoint&) const;
+    double tileDistance(const IntRect& viewport, const CoordinatedBackingStoreProxyTile::Coordinate&) const;
 
     IntRect coverRect() const { return m_coverRect; }
     bool visibleAreaIsCovered() const;
@@ -75,12 +74,12 @@ private:
     float coverageRatio(const IntRect&) const;
     void adjustForContentsRect(IntRect&) const;
 
-    void paintCheckerPattern(GraphicsContext*, const IntRect&, const Tile::Coordinate&);
+    void paintCheckerPattern(GraphicsContext*, const IntRect&, const CoordinatedBackingStoreProxyTile::Coordinate&);
 
 private:
-    TiledBackingStoreClient& m_client;
+    CoordinatedBackingStoreProxyClient& m_client;
 
-    typedef HashMap<Tile::Coordinate, std::unique_ptr<Tile>> TileMap;
+    typedef HashMap<CoordinatedBackingStoreProxyTile::Coordinate, std::unique_ptr<CoordinatedBackingStoreProxyTile>> TileMap;
     TileMap m_tiles;
 
     IntSize m_tileSize;
@@ -99,10 +98,9 @@ private:
 
     bool m_pendingTileCreation;
 
-    friend class Tile;
+    friend class CoordinatedBackingStoreProxyTile;
 };
 
 }
 
-#endif
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
@@ -30,9 +30,9 @@ namespace WebCore {
 class GraphicsContext;
 class SurfaceUpdateInfo;
 
-class TiledBackingStoreClient {
+class CoordinatedBackingStoreProxyClient {
 public:
-    virtual ~TiledBackingStoreClient() = default;
+    virtual ~CoordinatedBackingStoreProxyClient() = default;
     virtual void tiledBackingStoreHasPendingTileCreation() = 0;
 
     virtual void createTile(uint32_t tileID, float) = 0;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp
@@ -24,12 +24,12 @@
  */
 
 #include "config.h"
-#include "Tile.h"
+#include "CoordinatedBackingStoreProxyTile.h"
 
 #if USE(COORDINATED_GRAPHICS)
 
-#include "TiledBackingStore.h"
-#include "TiledBackingStoreClient.h"
+#include "CoordinatedBackingStoreProxy.h"
+#include "CoordinatedBackingStoreProxyClient.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Tile);
 
 static const uint32_t InvalidTileID = 0;
 
-Tile::Tile(TiledBackingStore& tiledBackingStore, const Coordinate& tileCoordinate)
+CoordinatedBackingStoreProxyTile::CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy& tiledBackingStore, const Coordinate& tileCoordinate)
     : m_tiledBackingStore(tiledBackingStore)
     , m_ID(InvalidTileID)
     , m_coordinate(tileCoordinate)
@@ -47,13 +47,13 @@ Tile::Tile(TiledBackingStore& tiledBackingStore, const Coordinate& tileCoordinat
 {
 }
 
-Tile::~Tile()
+CoordinatedBackingStoreProxyTile::~CoordinatedBackingStoreProxyTile()
 {
     if (m_ID != InvalidTileID)
         m_tiledBackingStore.client().removeTile(m_ID);
 }
 
-void Tile::ensureTileID()
+void CoordinatedBackingStoreProxyTile::ensureTileID()
 {
     static uint32_t id = 1;
     if (m_ID == InvalidTileID) {
@@ -65,29 +65,29 @@ void Tile::ensureTileID()
     }
 }
 
-bool Tile::isDirty() const
+bool CoordinatedBackingStoreProxyTile::isDirty() const
 {
     return !m_dirtyRect.isEmpty();
 }
 
-bool Tile::isReadyToPaint() const
+bool CoordinatedBackingStoreProxyTile::isReadyToPaint() const
 {
     return m_ID != InvalidTileID;
 }
 
-void Tile::invalidate(const IntRect& dirtyRect)
+void CoordinatedBackingStoreProxyTile::invalidate(const IntRect& dirtyRect)
 {
     IntRect tileDirtyRect = intersection(dirtyRect, m_rect);
     if (!tileDirtyRect.isEmpty())
         m_dirtyRect.unite(tileDirtyRect);
 }
 
-void Tile::markClean()
+void CoordinatedBackingStoreProxyTile::markClean()
 {
     m_dirtyRect = { };
 }
 
-void Tile::resize(const IntSize& newSize)
+void CoordinatedBackingStoreProxyTile::resize(const IntSize& newSize)
 {
     m_rect = IntRect(m_rect.location(), newSize);
     m_dirtyRect = m_rect;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef Tile_h
-#define Tile_h
+#pragma once
 
 #if USE(COORDINATED_GRAPHICS)
 
@@ -35,15 +34,15 @@
 
 namespace WebCore {
 
-class TiledBackingStore;
+class CoordinatedBackingStoreProxy;
 
-class Tile {
-    WTF_MAKE_TZONE_ALLOCATED(Tile);
+class CoordinatedBackingStoreProxyTile {
+    WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxyTile);
 public:
     typedef IntPoint Coordinate;
 
-    Tile(TiledBackingStore&, const Coordinate&);
-    ~Tile();
+    CoordinatedBackingStoreProxyTile(CoordinatedBackingStoreProxy&, const Coordinate&);
+    ~CoordinatedBackingStoreProxyTile();
 
     uint32_t tileID() const { return m_ID; }
     void ensureTileID();
@@ -59,7 +58,7 @@ public:
     void resize(const IntSize&);
 
 private:
-    TiledBackingStore& m_tiledBackingStore;
+    CoordinatedBackingStoreProxy& m_tiledBackingStore;
     uint32_t m_ID;
     Coordinate m_coordinate;
     IntRect m_rect;
@@ -70,4 +69,3 @@ private:
 
 #endif // USE(COORDINATED_GRAPHICS)
 
-#endif // Tile_h

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -26,6 +26,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
+#include "CoordinatedBackingStoreProxy.h"
 #include "CoordinatedImageBackingStore.h"
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
@@ -36,7 +37,6 @@
 #include "NicosiaBackingStore.h"
 #include "ScrollableArea.h"
 #include "TextureMapperPlatformLayerProxyProvider.h"
-#include "TiledBackingStore.h"
 #include "TransformOperation.h"
 #include <algorithm>
 #ifndef NDEBUG
@@ -1152,15 +1152,15 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
     // Address the content scale adjustment.
     if (m_pendingContentsScaleAdjustment) {
         if (layerState.mainBackingStore && layerState.mainBackingStore->contentsScale() != effectiveContentsScale()) {
-            // Discard the TiledBackingStore object to reconstruct it with new content scale.
+            // Discard the CoodinatedBackingStoreProxy object to reconstruct it with new content scale.
             layerState.mainBackingStore = nullptr;
         }
         m_pendingContentsScaleAdjustment = false;
     }
 
-    // Ensure the TiledBackingStore object, and enforce a complete repaint if it's not been present yet.
+    // Ensure the CoordinatedBackingStoreProxy object, and enforce a complete repaint if it's not been present yet.
     if (!layerState.mainBackingStore) {
-        layerState.mainBackingStore = makeUnique<TiledBackingStore>(*m_nicosia.backingStore, effectiveContentsScale());
+        layerState.mainBackingStore = makeUnique<CoordinatedBackingStoreProxy>(*m_nicosia.backingStore, effectiveContentsScale());
         m_pendingVisibleRectAdjustment = true;
     }
 


### PR DESCRIPTION
#### 1e65b5f338b7e2c1c4e2c5156d20943d1ebed64f
<pre>
[CoordinatedGraphics] Rename TiledBackingStore as CoordinatedBackingStoreProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=280880">https://bugs.webkit.org/show_bug.cgi?id=280880</a>

Reviewed by Miguel Gomez.

CoordinatedBackingStore is the tiled backing store implementation in the
compositor side, so use the same name with the Proxy suffix to clarify
the relationship between them.

* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp: Renamed from Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.cpp.
(WebCore::innerBottomRight):
(WebCore::CoordinatedBackingStoreProxy::CoordinatedBackingStoreProxy):
(WebCore::CoordinatedBackingStoreProxy::setTrajectoryVector):
(WebCore::CoordinatedBackingStoreProxy::createTilesIfNeeded):
(WebCore::CoordinatedBackingStoreProxy::invalidate):
(WebCore::CoordinatedBackingStoreProxy::dirtyTiles):
(WebCore::CoordinatedBackingStoreProxy::tileDistance const):
(WebCore::CoordinatedBackingStoreProxy::coverageRatio const):
(WebCore::CoordinatedBackingStoreProxy::visibleAreaIsCovered const):
(WebCore::CoordinatedBackingStoreProxy::createTiles):
(WebCore::CoordinatedBackingStoreProxy::adjustForContentsRect const):
(WebCore::CoordinatedBackingStoreProxy::computeCoverAndKeepRect const):
(WebCore::CoordinatedBackingStoreProxy::resizeEdgeTiles):
(WebCore::CoordinatedBackingStoreProxy::setKeepRect):
(WebCore::CoordinatedBackingStoreProxy::removeAllNonVisibleTiles):
(WebCore::CoordinatedBackingStoreProxy::mapToContents const):
(WebCore::CoordinatedBackingStoreProxy::mapFromContents const):
(WebCore::CoordinatedBackingStoreProxy::tileRectForCoordinate const):
(WebCore::CoordinatedBackingStoreProxy::tileCoordinateForPoint const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h: Renamed from Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.h.
(WebCore::CoordinatedBackingStoreProxy::client):
(WebCore::CoordinatedBackingStoreProxy::contentsScale const):
(WebCore::CoordinatedBackingStoreProxy::coverRect const):
(WebCore::CoordinatedBackingStoreProxy::setCoverRect):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h: Renamed from Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStoreClient.h.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.cpp: Renamed from Source/WebCore/platform/graphics/texmap/coordinated/Tile.cpp.
(WebCore::CoordinatedBackingStoreProxyTile::CoordinatedBackingStoreProxyTile):
(WebCore::CoordinatedBackingStoreProxyTile::~CoordinatedBackingStoreProxyTile):
(WebCore::CoordinatedBackingStoreProxyTile::ensureTileID):
(WebCore::CoordinatedBackingStoreProxyTile::isDirty const):
(WebCore::CoordinatedBackingStoreProxyTile::isReadyToPaint const):
(WebCore::CoordinatedBackingStoreProxyTile::invalidate):
(WebCore::CoordinatedBackingStoreProxyTile::markClean):
(WebCore::CoordinatedBackingStoreProxyTile::resize):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyTile.h: Renamed from Source/WebCore/platform/graphics/texmap/coordinated/Tile.h.
(WebCore::CoordinatedBackingStoreProxyTile::tileID const):
(WebCore::CoordinatedBackingStoreProxyTile::coordinate const):
(WebCore::CoordinatedBackingStoreProxyTile::rect const):
(WebCore::CoordinatedBackingStoreProxyTile::dirtyRect const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::updateContentBuffers):

Canonical link: <a href="https://commits.webkit.org/284675@main">https://commits.webkit.org/284675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e2ff640fc9cf8f582db6de11fda879b8ef96095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21195 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73243 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41809 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19712 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/63735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/18295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75981 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14402 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63361 "Failed to checkout and rebase branch from PR 34692") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14442 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/60587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63301 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11332 "Failed to checkout and rebase branch from PR 34692") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10726 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45385 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46459 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->