### PR TITLE
[scroll-animations] implement `Animation.progress`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL progress of a newly created animation without an effect is unresolved assert_equals: progress is unresolved expected (object) null but got (undefined) undefined
-FAIL progress of an animation whose currentTime is unresolved is unresolved. assert_equals: progress is unresolved expected (object) null but got (undefined) undefined
-FAIL progress of an animation whose effect's endTime is zero is zero if its currentTime is negative. assert_approx_equals: progress is zero expected a number but got a "undefined"
-FAIL progress of an animation whose effect's endTime is zero is one if its currentTime is non-negative. assert_approx_equals: progress is one expected a number but got a "undefined"
-FAIL progress of an animation whose effect's endTime is infinity is zero. assert_approx_equals: progress is zero expected a number but got a "undefined"
-FAIL progress of an animation is calculated by currentTime / effect endTime. assert_approx_equals: progress is zero expected a number but got a "undefined"
+PASS progress of a newly created animation without an effect is unresolved
+PASS progress of an animation whose currentTime is unresolved is unresolved.
+PASS progress of an animation whose effect's endTime is zero is zero if its currentTime is negative.
+PASS progress of an animation whose effect's endTime is zero is one if its currentTime is non-negative.
+PASS progress of an animation whose effect's endTime is infinity is zero.
+PASS progress of an animation is calculated by currentTime / effect endTime.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL animation.progress reflects the progress of a scroll animation as a number between 0 and 1 assert_equals: The progress is null since the currentTime is unresolved. expected (object) null but got (undefined) undefined
+FAIL animation.progress reflects the progress of a scroll animation as a number between 0 and 1 assert_equals: The current time remains null while in the pending state. expected (object) null but got (number) 0
 FAIL animation.progress reflects the overall progress of a scroll animation with multiple iterations. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
 FAIL animation.progress reflects the overall progress of a scroll animation that uses a view-timeline. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"
 FAIL progresss of a view-timeline is bounded between 0 and 1. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL All property keys are recognized assert_in_array: Test property 'progress' should be one of the properties on  Animation value "progress" not in array ["id", "effect", "timeline", "startTime", "currentTime", "rangeStart", "rangeEnd", "playbackRate", "frameRate", "playState", "replaceState", "pending", "onfinish", "oncancel", "onremove", "ready", "finished", "cancel", "finish", "play", "pause", "updatePlaybackRate", "reverse", "persist", "commitStyles", "Animation constructor"]
+PASS All property keys are recognized
 PASS Animation.id produces expected style change events
 PASS Animation.effect produces expected style change events
 PASS Animation.timeline produces expected style change events
@@ -8,6 +8,7 @@ PASS Animation.currentTime produces expected style change events
 PASS Animation.rangeStart produces expected style change events
 PASS Animation.rangeEnd produces expected style change events
 PASS Animation.playbackRate produces expected style change events
+PASS Animation.progress produces expected style change events
 FAIL Animation.frameRate produces expected style change events assert_own_property: Should have a test for 'frameRate' property expected property "frameRate" missing
 PASS Animation.playState produces expected style change events
 PASS Animation.replaceState produces expected style change events

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -123,6 +123,7 @@ public:
     void setStartTime(std::optional<CSSNumberishTime>);
     virtual std::optional<CSSNumberishTime> bindingsCurrentTime() const { return currentTime(); };
     virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<CSSNumberishTime>&);
+    std::optional<double> progress() const;
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }
     virtual bool bindingsPending() const { return pending(); }

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -57,6 +57,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
     [EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
     [EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
     attribute double playbackRate;
+    [EnabledBySetting=ScrollDrivenAnimationsEnabled] readonly attribute double? progress;
     [ImplementedAs=bindingsFrameRate, EnabledBySetting=WebAnimationsCustomFrameRateEnabled] attribute (FramesPerSecond or AnimationFrameRatePreset) frameRate;
     [ImplementedAs=bindingsPlayState] readonly attribute AnimationPlayState playState;
     [ImplementedAs=bindingsReplaceState] readonly attribute AnimationReplaceState replaceState;


### PR DESCRIPTION
#### 80929161e65fbb2247ba1d356125cefacdbaa631
<pre>
[scroll-animations] implement `Animation.progress`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280887">https://bugs.webkit.org/show_bug.cgi?id=280887</a>
<a href="https://rdar.apple.com/137278217">rdar://137278217</a>

Reviewed by Anne van Kesteren and Tim Nguyen.

Add support for the new `Animation.progress` property.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::progress const):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/284695@main">https://commits.webkit.org/284695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff42775e2e64e7904dd5a35f0968d9bf69c1246e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55669 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19733 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63380 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63314 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4962 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10735 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/168 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->