### PR TITLE
REGRESSION(282394@main): Flaky ASSERTION FAILED: !users.contains(pageID) on TestWebKitAPI.ProcessSwap.ConcurrentHistoryNavigations

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4651,7 +4651,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         replacedDataStoreForWebArchiveLoad
     ] (Ref<WebProcessProxy>&& processNavigatingTo, SuspendedPageProxy* destinationSuspendedPage, ASCIILiteral reason) mutable {
         // If the navigation has been destroyed, then no need to proceed.
-        if (isClosed() || !navigationState().hasNavigation(navigation->navigationID())) {
+        if (isClosed() || !navigationState().hasNavigation(navigation->navigationID()) || m_mainFrame.get() != &frame->rootFrame()) {
             receivedPolicyDecision(policyAction, navigation.ptr(), navigation->protectedWebsitePolicies().get(), WTFMove(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, WTFMove(message), WTFMove(completionHandler));
             return;
         }


### PR DESCRIPTION
#### c06e80ae3a80148fc10c5d9868d7a5426e3807a3
<pre>
REGRESSION(282394@main): Flaky ASSERTION FAILED: !users.contains(pageID) on TestWebKitAPI.ProcessSwap.ConcurrentHistoryNavigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=280888">https://bugs.webkit.org/show_bug.cgi?id=280888</a>
<a href="https://rdar.apple.com/136716513">rdar://136716513</a>

Reviewed by NOBODY (OOPS!).

The assertion happens when registering a pageID as a VisitedLinkStore client and the crash
happens if the pageID is already registered. Normally, when we construct a ProvisionalPageProxy
(for a process swap), we will register the pageID as a VisitedLinkStore client for the new
WebProcess used for the navigation. However, due to a race, the ProvisionalPageProxy sometimes
ends up using the same WebProcess as the WebPageProxy&apos;s current WebProcess. This doesn&apos;t make
sense since ProvisionalPageProxy is only supposed to be used in case of process-swap.

The race is in WebPageProxy::receivedNavigationActionPolicyDecision(), where the lambda may
sometimes run after the frame has been detached from the frame tree (the frame has been replaced).
To address the issue, we now early return in the lambda if the frame has been detached so that
we don&apos;t attempt to do a process swap in this case.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c06e80ae3a80148fc10c5d9868d7a5426e3807a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21353 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55660 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73253 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45169 "Found 7 new test failures: compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html http/tests/site-isolation/draw-after-cross-origin-navigation.html http/tests/site-isolation/load-event-after-transition.html http/tests/site-isolation/permissions-policy-nested.html http/tests/site-isolation/permissions-policy.html http/tests/site-isolation/window-properties.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60537 "Found 15 new API test failures: TestWebKitAPI.SiteIsolation.SandboxFlags, TestWebKitAPI.SiteIsolation.ChildBeingNavigatedToMainFrameDomainByParent, TestWebKitAPI.SiteIsolation.ChildBeingNavigatedToNewDomainByParent, TestWebKitAPI.SiteIsolation.WebsitePoliciesCustomUserAgentDuringCrossSiteProvisionalNavigation, TestWebKitAPI.SiteIsolation.NavigationWithIFrames, TestWebKitAPI.SiteIsolation.ChildBeingNavigatedToSameDomainByParent, TestWebKitAPI.SiteIsolation.ParentNavigatingCrossOriginIframeToSameOrigin, TestWebKitAPI.SiteIsolation.CancelProvisionalLoad, TestWebKitAPI.SiteIsolation.NavigatingCrossOriginIframeToSameOrigin, TestWebKitAPI.SiteIsolation.NavigateIframeToProvisionalNavigationFailure ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41818 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19722 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63753 "1 api test failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18315 "Found 5 new test failures: http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html http/tests/site-isolation/load-event-after-transition.html http/tests/site-isolation/permissions-policy-nested.html http/tests/site-isolation/permissions-policy.html http/tests/site-isolation/window-properties.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75991 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14412 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17553 "Found 4 new test failures: http/tests/site-isolation/load-event-after-transition.html http/tests/site-isolation/permissions-policy-nested.html http/tests/site-isolation/permissions-policy.html http/tests/site-isolation/window-properties.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63371 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63311 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11342 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4966 "Found 5 new test failures: http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html http/tests/site-isolation/load-event-after-transition.html http/tests/site-isolation/permissions-policy-nested.html http/tests/site-isolation/permissions-policy.html http/tests/site-isolation/window-properties.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46469 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->