### PR TITLE
[scroll-animations] implement `AnimationTimeline.duration`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The duration of a scroll timeline is 100%
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ScrollTimeline.duration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#dom-animationtimeline-duration">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+
+test(t => {
+  const timeline = new ScrollTimeline();
+  assert_equals(timeline.duration.toString(), '100%');
+}, 'The duration of a scroll timeline is 100%');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The duration of a view timeline is 100%
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ViewTimeline.duration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#dom-animationtimeline-duration">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+
+test(t => {
+  const timeline = new ViewTimeline();
+  assert_equals(timeline.duration.toString(), '100%');
+}, 'The duration of a view timeline is 100%');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/DocumentTimeline/duration.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/DocumentTimeline/duration.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A document timeline does not have a duration
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/DocumentTimeline/duration.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/DocumentTimeline/duration.tentative.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>DocumentTimeline.duration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#dom-animationtimeline-duration">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<script src="../../resources/timing-override.js"></script>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  const timeline = new DocumentTimeline();
+  assert_equals(timeline.duration, null);
+}, 'A document timeline does not have a duration');
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -36,7 +36,11 @@
 
 namespace WebCore {
 
-AnimationTimeline::AnimationTimeline() = default;
+AnimationTimeline::AnimationTimeline(std::optional<CSSNumberishTime> duration)
+    : m_duration(duration)
+{
+}
+
 AnimationTimeline::~AnimationTimeline() = default;
 
 void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -50,6 +50,7 @@ public:
     virtual void removeAnimation(WebAnimation&);
 
     virtual std::optional<CSSNumberishTime> currentTime() { return m_currentTime; }
+    virtual std::optional<CSSNumberishTime> duration() const { return m_duration; }
 
     virtual void detachFromDocument();
 
@@ -63,7 +64,7 @@ public:
     virtual AnimationTimelinesController* controller() const { return nullptr; }
 
 protected:
-    AnimationTimeline();
+    AnimationTimeline(std::optional<CSSNumberishTime> = std::nullopt);
 
     AnimationCollection m_animations;
 
@@ -71,6 +72,7 @@ private:
     void updateGlobalPosition(WebAnimation&);
 
     std::optional<CSSNumberishTime> m_currentTime;
+    std::optional<CSSNumberishTime> m_duration;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.idl
+++ b/Source/WebCore/animation/AnimationTimeline.idl
@@ -31,4 +31,5 @@ typedef (double or CSSNumericValue) CSSNumberish;
     Exposed=Window
 ] interface AnimationTimeline {
     readonly attribute CSSNumberish? currentTime;
+    [EnabledBySetting=ScrollDrivenAnimationsEnabled] readonly attribute CSSNumberish? duration;
 };

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -84,6 +84,11 @@ CSSNumberishTime::CSSNumberishTime(const CSSNumberish& value)
     }
 }
 
+CSSNumberishTime CSSNumberishTime::fromPercentage(double percentage)
+{
+    return { Type::Percentage, percentage };
+}
+
 std::optional<Seconds> CSSNumberishTime::time() const
 {
     if (m_type == Type::Time)

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -38,6 +38,8 @@ public:
     CSSNumberishTime(const Seconds&);
     CSSNumberishTime(const CSSNumberish&);
 
+    static CSSNumberishTime fromPercentage(double);
+
     WEBCORE_EXPORT std::optional<Seconds> time() const;
     WEBCORE_EXPORT std::optional<double> percentage() const;
 

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -74,8 +74,14 @@ Ref<ScrollTimeline> ScrollTimeline::createFromCSSValue(const CSSScrollValue& css
     return adoptRef(*new ScrollTimeline(scroller, axis));
 }
 
+// https://drafts.csswg.org/web-animations-2/#timelines
+// For a monotonic timeline, there is no upper bound on current time, and
+// timeline duration is unresolved. For a non-monotonic (e.g. scroll) timeline,
+// the duration has a fixed upper bound. In this case, the timeline is a
+// progress-based timeline, and its timeline duration is 100%.
 ScrollTimeline::ScrollTimeline(ScrollTimelineOptions&& options)
-    : m_source(WTFMove(options.source))
+    : AnimationTimeline(CSSNumberishTime::fromPercentage(100))
+    , m_source(WTFMove(options.source))
     , m_axis(options.axis)
 {
     if (m_source)
@@ -83,15 +89,17 @@ ScrollTimeline::ScrollTimeline(ScrollTimelineOptions&& options)
 }
 
 ScrollTimeline::ScrollTimeline(const AtomString& name, ScrollAxis axis)
-    : m_axis(axis)
-    , m_name(name)
+    : ScrollTimeline()
 {
+    m_axis = axis;
+    m_name = name;
 }
 
 ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
-    : m_axis(axis)
-    , m_scroller(scroller)
+    : ScrollTimeline()
 {
+    m_axis = axis;
+    m_scroller = scroller;
 }
 
 void ScrollTimeline::dump(TextStream& ts) const


### PR DESCRIPTION
#### de9e4f1d93e3502199d6bc56d08fe044d108eca6
<pre>
[scroll-animations] implement `AnimationTimeline.duration`
<a href="https://bugs.webkit.org/show_bug.cgi?id=280889">https://bugs.webkit.org/show_bug.cgi?id=280889</a>
<a href="https://rdar.apple.com/137281217">rdar://137281217</a>

Reviewed by Anne van Kesteren.

Implement the new `AnimationTimeline.duration` property.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/duration.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/DocumentTimeline/duration.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/DocumentTimeline/duration.tentative.html: Added.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::AnimationTimeline):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::duration const):
* Source/WebCore/animation/AnimationTimeline.idl:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::fromPercentage):
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::ScrollTimeline):

Canonical link: <a href="https://commits.webkit.org/284696@main">https://commits.webkit.org/284696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4edc65abc2dc6d19c84852e0d93fc3a3be1f68a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14156 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19726 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63382 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63316 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4969 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10736 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/165 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->