### PR TITLE
Table Root should also account for `fill-available` in fixed table layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt
@@ -1,20 +1,56 @@
 Fixed Layout
 
-Checks whether fixed layout is implemented properly (width is not definite)
+Checks whether fixed layout is implemented properly
 
-This should be a 100px-wide blue square:
-Table-layout:fixed does not apply to width:auto tables
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:10px tables
 
-This should be a 100px-wide blue square:
-Table-layout:fixed does not apply to width:max-content tables
+10px
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:100% tables
 
-This should be a 100px-wide blue square:
-Table-layout:fixed does apply to width:min-content/fit-content tables
+100%
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:calc(10px + 100%) tables
 
+calc(10px + 100%)
+This should be a 100x50 cyan rectangle:
+Table-layout:fixed does NOT apply to width:auto tables
 
-PASS Table-layout:fixed is not applied when width is auto
-PASS Table-layout:fixed reports fixed when width is auto
-PASS Table-layout:fixed is not applied when width is max-content
-PASS Table-layout:fixed reports fixed when width is max-content
-FAIL Table-layout:fixed is applied when width is min-content assert_equals: expected 100 but got 0
+auto
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:min-content tables
+
+min-content
+This should be a 100x50 cyan rectangle:
+Table-layout:fixed does NOT apply to width:max-content tables
+
+max-content
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:fit-content tables
+
+fit-content
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:-webkit-fill-available tables
+
+-webkit-fill-available
+This should be a 100x50 cyan rectangle:
+Table-layout:fixed does NOT apply to width:intrinsic tables
+
+intrinsic
+This should be a 100x50 cyan rectangle:
+Table-layout:fixed does NOT apply to width:min-intrinsic tables
+
+min-intrinsic
+
+PASS 10px
+PASS 100%
+PASS calc(10px + 100%)
+PASS auto
+PASS min-content
+PASS max-content
+PASS fit-content
+PASS -webkit-fill-available
+PASS intrinsic
+PASS min-intrinsic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2.html
@@ -1,84 +1,116 @@
-<!doctype html>
-<script src='/resources/testharness.js'></script>
-<script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='./support/base.css' />
+<!DOCTYPE html>
+<title>table-layout:fixed with various widths</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#in-fixed-mode">
-<main>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10937">
+<link rel="stylesheet" href="./support/base.css">
 
-    <h1>Fixed Layout</h1>
-    <p>Checks whether fixed layout is implemented properly (width is not definite)</p>
+<style>
+.wrapper {
+  width: 0;
+}
+x-table {
+  table-layout: fixed;
+  border-spacing: 0px;
+}
+x-td:first-child {
+  padding: 0;
+  background: cyan;
+  width: 50px;
+  height: 50px;
+}
+x-td + x-td {
+  padding: 0;
+  height: 50px;
+}
+x-td > div {
+  width: 100px;
+}
+</style>
 
-    <hr/>
-    <p>This should be a 100px-wide blue square:</p>
-    <p>Table-layout:fixed does not apply to width:auto tables</p>
-    <x-table style="table-layout: fixed; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 100px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0"></x-td>
-        </x-tr>
-    </x-table>
-
-    <hr/>
-    <p>This should be a 100px-wide blue square:</p>
-    <p>Table-layout:fixed does not apply to width:max-content tables</p>
-    <x-table style="table-layout: fixed; width: max-content; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 100px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0"></x-td>
-        </x-tr>
-    </x-table>
-
-    <hr/>
-    <p>This should be a 100px-wide blue square:</p>
-    <p>Table-layout:fixed does apply to width:min-content/fit-content tables</p>
-    <x-table style="table-layout: fixed; width: fit-content; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 50px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0"></x-td>
-        </x-tr>
-    </x-table>
-    <x-table style="table-layout: fixed; width: min-content; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 50px;width:100px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0;height:50px"><div style="width: 100px"></div></x-td>
-        </x-tr>
-    </x-table>
-
+<main id="main">
+  <h1>Fixed Layout</h1>
+  <p>Checks whether fixed layout is implemented properly</p>
 </main>
 
+<template id="template">
+  <hr>
+  <p></p>
+  <p></p>
+  <div class="wrapper">
+    <x-table>
+      <x-tr>
+        <x-td>
+          <div></div>
+        </x-td>
+        <x-td></x-td>
+      </x-tr>
+    </x-table>
+  </div>
+</template>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script>
-    while(true) {
-        var xtd = document.querySelector('x-td[rowspan], x-td[colspan]'); if(!xtd) break;
-        var td = document.createElement('td'); for(var i = xtd.attributes.length; i--;) { td.setAttribute(xtd.attributes[i].name,xtd.attributes[i].value) }
-        xtd.parentNode.replaceChild(td,xtd);
+let sizeData = {
+  "10px": true,
+  "100%": true,
+  "calc(10px + 100%)": true,
+  "auto": false,
+  "min-content": true,
+  "max-content": false,
+  "fit-content": true,
+  "calc-size(any, 10px + 100%)": true,
+
+  // These expectations are tentative, see https://github.com/w3c/csswg-drafts/issues/10937
+  "fit-content(0)": true,
+  "stretch": true,
+
+  // These are non-standard, expect the most popular behavior among the supporting implementations.
+  "-moz-available": true,
+  "-webkit-fill-available": true,
+  "intrinsic": false,
+  "min-intrinsic": false,
+};
+
+function checkSize(size, allowsFixed) {
+  let fragment = template.content.cloneNode(true);
+  if (allowsFixed) {
+    fragment.querySelector("p").textContent = "This should be a 50x50 cyan square:";
+    fragment.querySelector("p + p").textContent = "Table-layout:fixed does apply to width:" + size + " tables";
+  } else {
+    fragment.querySelector("p").textContent = "This should be a 100x50 cyan rectangle:";
+    fragment.querySelector("p + p").textContent = "Table-layout:fixed does NOT apply to width:" + size + " tables";
+  }
+  let table = fragment.querySelector("x-table");
+  table.style.width = size;
+  table.querySelector("div").textContent = size;
+  main.appendChild(fragment);
+
+  test(() => {
+    assert_equals(
+      getComputedStyle(table).tableLayout,
+      "fixed",
+      "The computed value is 'fixed' regardless of whether it applies"
+    );
+    if (allowsFixed) {
+      assert_equals(table.offsetWidth, 50, "Table is in fixed mode");
+    } else {
+      assert_equals(table.offsetWidth, 100, "Table is NOT in fixed mode");
     }
+  }, size);
+}
 
-    generate_tests(assert_equals, [
-        [
-            "Table-layout:fixed is not applied when width is auto",
-            document.querySelector("x-table:nth-of-type(1) > x-tr:first-child > x-td:first-child").offsetWidth,
-            100
-        ],
-        [
-            "Table-layout:fixed reports fixed when width is auto",
-            getComputedStyle(document.querySelector("x-table:nth-of-type(1)")).tableLayout,
-            'fixed'
-        ],
-        [
-            "Table-layout:fixed is not applied when width is max-content",
-            document.querySelector("x-table:nth-of-type(2) > x-tr:first-child > x-td:first-child").offsetWidth,
-            100
-        ],
-        [
-            "Table-layout:fixed reports fixed when width is max-content",
-            getComputedStyle(document.querySelector("x-table:nth-of-type(2)")).tableLayout,
-            'fixed'
-        ],
-        [
-            "Table-layout:fixed is applied when width is min-content",
-            document.querySelector("x-table:nth-of-type(3) > x-tr:first-child > x-td:first-child").offsetWidth,
-            document.querySelector("x-table:nth-of-type(4) > x-tr:first-child > x-td:first-child").offsetWidth
-        ]
-    ])
+for (let [size, allowsFixed] of Object.entries(sizeData)) {
+  if (CSS.supports("width", size)) {
+    checkSize(size, allowsFixed);
 
+    // calc-size() should have the same behavior as its basis.
+    // https://drafts.csswg.org/css-values-5/#calc-size
+    let calcSize = "calc-size(" + size + ", size)";
+    if (CSS.supports("width", calcSize)) {
+      checkSize(calcSize, allowsFixed);
+    }
+  }
+}
 </script>

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -538,7 +538,7 @@ constexpr bool RenderStyle::isDisplayGridBox(DisplayType display) { return displ
 constexpr bool RenderStyle::isDisplayInlineType() const { return isDisplayInlineType(display()); }
 constexpr bool RenderStyle::isDisplayListItemType(DisplayType display) { return display == DisplayType::ListItem; }
 constexpr bool RenderStyle::isDisplayTableOrTablePart() const { return isDisplayTableOrTablePart(display()); }
-inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isMinContent()); }
+inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isFillAvailable() || logicalWidth().isMinContent()); }
 inline bool RenderStyle::isFlippedBlocksWritingMode() const { return WebCore::isFlippedWritingMode(writingMode()); }
 inline bool RenderStyle::isFlippedLinesWritingMode() const { return WebCore::isFlippedLinesWritingMode(writingMode()); }
 inline bool RenderStyle::isFloating() const { return floating() != Float::None; }


### PR DESCRIPTION
#### 981fc1e6ce7d73d4a89cb0461853650cde226d8c
<pre>
Table Root should also account for `fill-available` in fixed table layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=280900">https://bugs.webkit.org/show_bug.cgi?id=280900</a>
<a href="https://rdar.apple.com/137297914">rdar://137297914</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

In [1], the test was updated to also ensure that fixed table layout should
also account for `fill-available` (-webkit-fill-available). It seems WebKit
was not doing it, so this patch is to account for it and progress our behavior.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/10937">https://github.com/w3c/csswg-drafts/issues/10937</a>

The patch also sync particular test from below:

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/38d6fa72d1bf19674be99ff5ee97b94a1835b2f6">https://github.com/web-platform-tests/wpt/commit/38d6fa72d1bf19674be99ff5ee97b94a1835b2f6</a>

* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isFixedTableLayout const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2.html:

Canonical link: <a href="https://commits.webkit.org/284712@main">https://commits.webkit.org/284712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4989c5cb9376b8d392c51842d7da9cfba396ac7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4988 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45433 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->