### PR TITLE
Port more StorageArea identifiers to ObjectIdentifier

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -778,7 +778,7 @@ void NetworkStorageManager::clearStorageForWebPage(WebPageProxyIdentifier pageId
         assertIsCurrent(workQueue());
         for (auto& manager : m_originStorageManagers.values()) {
             if (auto* sessionStorageManager = manager->existingSessionStorageManager())
-                sessionStorageManager->removeNamespace(LegacyNullableObjectIdentifier<StorageNamespaceIdentifierType>(pageIdentifier.toUInt64()));
+                sessionStorageManager->removeNamespace(ObjectIdentifier<StorageNamespaceIdentifierType>(pageIdentifier.toUInt64()));
         }
     });
 }
@@ -790,7 +790,7 @@ void NetworkStorageManager::cloneSessionStorageForWebPage(WebPageProxyIdentifier
 
     protectedWorkQueue()->dispatch([this, protectedThis = Ref { *this }, fromIdentifier, toIdentifier]() mutable {
         assertIsCurrent(workQueue());
-        cloneSessionStorageNamespace(LegacyNullableObjectIdentifier<StorageNamespaceIdentifierType>(fromIdentifier.toUInt64()), LegacyNullableObjectIdentifier<StorageNamespaceIdentifierType>(toIdentifier.toUInt64()));
+        cloneSessionStorageNamespace(ObjectIdentifier<StorageNamespaceIdentifierType>(fromIdentifier.toUInt64()), ObjectIdentifier<StorageNamespaceIdentifierType>(toIdentifier.toUInt64()));
     });
 }
 

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
@@ -72,8 +72,6 @@ void StorageAreaBase::notifyListenersAboutClear()
 
 void StorageAreaBase::dispatchEvents(IPC::Connection::UniqueID sourceConnection, StorageAreaImplIdentifier sourceImplIdentifier, const String& key, const String& oldValue, const String& newValue, const String& urlString) const
 {
-    ASSERT(sourceImplIdentifier);
-
     for (auto& [connection, identifier] : m_listeners) {
         std::optional<StorageAreaImplIdentifier> implIdentifier;
         if (connection == sourceConnection)

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -89,9 +89,6 @@ template: enum class WebKit::RetrieveRecordResponseBodyCallbackIdentifierType
 template: enum class WebKit::SampleBufferDisplayLayerIdentifierType
 template: enum class WebKit::ScriptMessageHandlerIdentifierType
 template: enum class WebKit::ShapeDetectionIdentifierType
-template: enum class WebKit::StorageAreaImplIdentifierType
-template: enum class WebKit::StorageAreaMapIdentifierType
-template: enum class WebKit::StorageNamespaceIdentifierType
 template: enum class WebKit::UserScriptIdentifierType
 template: enum class WebKit::UserStyleSheetIdentifierType
 template: enum class WebKit::WCLayerTreeHostIdentifierType
@@ -142,6 +139,9 @@ template: enum class WebCore::SharedWorkerIdentifierType
 template: enum class WebCore::WindowIdentifierType
 template: enum class WebCore::WorkletGlobalScopeIdentifierType
 template: enum class WebKit::DownloadIdentifierType
+template: enum class WebKit::StorageAreaImplIdentifierType
+template: enum class WebKit::StorageAreaMapIdentifierType
+template: enum class WebKit::StorageNamespaceIdentifierType
 template: enum class WebKit::VisitedLinkTableIdentifierType
 template: struct WebCore::FrameIdentifierType
 template: struct WebCore::NavigationIdentifierType

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -115,7 +115,7 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
         return true;
     }
     if (decoder.messageReceiverName() == Messages::StorageAreaMap::messageReceiverName()) {
-        if (auto storageAreaMap = WebProcess::singleton().storageAreaMap(LegacyNullableObjectIdentifier<StorageAreaMapIdentifierType>(decoder.destinationID())))
+        if (auto storageAreaMap = WebProcess::singleton().storageAreaMap(ObjectIdentifier<StorageAreaMapIdentifierType>(decoder.destinationID())))
             storageAreaMap->didReceiveMessage(connection, decoder);
         return true;
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPageInlines.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageInlines.h
@@ -43,7 +43,7 @@ inline WebCore::IntRect WebPage::bounds() const
 
 inline StorageNamespaceIdentifier WebPage::sessionStorageNamespaceIdentifier() const
 {
-    return LegacyNullableObjectIdentifier<StorageNamespaceIdentifierType>(m_webPageProxyIdentifier.toUInt64());
+    return ObjectIdentifier<StorageNamespaceIdentifierType>(m_webPageProxyIdentifier.toUInt64());
 }
 
 inline void WebPage::setHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds limit)

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaImplIdentifier.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaImplIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class StorageAreaImplIdentifierType { };
-using StorageAreaImplIdentifier = LegacyNullableObjectIdentifier<StorageAreaImplIdentifierType>;
+using StorageAreaImplIdentifier = ObjectIdentifier<StorageAreaImplIdentifierType>;
 
 }

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMapIdentifier.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMapIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebKit {
 
 enum class StorageAreaMapIdentifierType { };
-using StorageAreaMapIdentifier = LegacyNullableObjectIdentifier<StorageAreaMapIdentifierType>;
+using StorageAreaMapIdentifier = ObjectIdentifier<StorageAreaMapIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceIdentifier.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class StorageNamespaceIdentifierType { };
-using StorageNamespaceIdentifier = LegacyNullableObjectIdentifier<StorageNamespaceIdentifierType>;
+using StorageNamespaceIdentifier = ObjectIdentifier<StorageNamespaceIdentifierType>;
 
 }


### PR DESCRIPTION
#### 1de9b8f4d5532456c5f399ad4224839a68068b18
<pre>
Port more StorageArea identifiers to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=280904">https://bugs.webkit.org/show_bug.cgi?id=280904</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::clearStorageForWebPage):
(WebKit::NetworkStorageManager::cloneSessionStorageForWebPage):
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp:
(WebKit::StorageAreaBase::dispatchEvents const):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/WebPage/WebPageInlines.h:
(WebKit::WebPage::sessionStorageNamespaceIdentifier const):
* Source/WebKit/WebProcess/WebStorage/StorageAreaImplIdentifier.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMapIdentifier.h:
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceIdentifier.h:

Canonical link: <a href="https://commits.webkit.org/284708@main">https://commits.webkit.org/284708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2d7bf5da92cbc8fe30723f9c222373798ce20cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21417 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41860 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76055 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17594 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63346 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5003 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10752 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45455 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->