### PR TITLE
Suppress static analyzer false-positive warnings until they're fixed.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -63,7 +63,8 @@ public:
 
     virtual ~RemoteAdapter();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteBindGroup();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteBindGroupLayout();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -68,7 +68,8 @@ public:
 
     virtual ~RemoteBuffer();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteCommandBuffer();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -69,7 +69,8 @@ public:
 
     virtual ~RemoteCommandEncoder();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -75,7 +75,8 @@ public:
 
     virtual ~RemoteCompositorIntegration();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -60,7 +60,8 @@ public:
 
     virtual ~RemoteComputePassEncoder();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -57,7 +57,8 @@ public:
         return adoptRef(*new RemoteComputePipeline(computePipeline, objectHeap, WTFMove(streamConnection), gpu, identifier));
     }
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     virtual ~RemoteComputePipeline();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -98,7 +98,8 @@ public:
 
     ~RemoteDevice();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteExternalTexture();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemotePipelineLayout();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -62,7 +62,8 @@ public:
 
     virtual ~RemotePresentationContext();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteQuerySet();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -72,7 +72,8 @@ public:
 
     virtual ~RemoteQueue();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteRenderBundle();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -65,7 +65,8 @@ public:
 
     ~RemoteRenderBundleEncoder();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -62,7 +62,8 @@ public:
 
     ~RemoteRenderPassEncoder();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteRenderPipeline();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteSampler();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -62,7 +62,8 @@ public:
 
     virtual ~RemoteShaderModule();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -63,7 +63,8 @@ public:
 
     virtual ~RemoteTexture();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -59,7 +59,8 @@ public:
 
     virtual ~RemoteTextureView();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
 
     void stopListeningForIPC();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
@@ -65,7 +65,8 @@ public:
 
     virtual ~RemoteXRBinding();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
     void stopListeningForIPC();
 
 private:

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -78,7 +78,8 @@ public:
 
     virtual ~RemoteXRProjectionLayer();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
     void stopListeningForIPC();
 
     WebCore::WebGPU::XRProjectionLayer& backing() { return m_backing; }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
@@ -75,7 +75,8 @@ public:
 
     virtual ~RemoteXRSubImage();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
     void stopListeningForIPC();
 
 private:

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
@@ -74,7 +74,8 @@ public:
 
     virtual ~RemoteXRView();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_gpu->sharedPreferencesForWebProcess(); }
     void stopListeningForIPC();
 
 private:

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -136,7 +136,8 @@ std::optional<SharedPreferencesForWebProcess> RemoteCDMInstanceProxy::sharedPref
     if (!m_cdm)
         return std::nullopt;
 
-    return m_cdm->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_cdm->sharedPreferencesForWebProcess();
 }
 
 RefPtr<RemoteCDMProxy> RemoteCDMInstanceProxy::protectedCdm() const

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -189,7 +189,8 @@ std::optional<SharedPreferencesForWebProcess> RemoteCDMInstanceSessionProxy::sha
     if (!m_cdm)
         return std::nullopt;
 
-    return m_cdm->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_cdm->sharedPreferencesForWebProcess();
 }
 
 RefPtr<RemoteCDMProxy> RemoteCDMInstanceSessionProxy::protectedCdm() const

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -121,7 +121,8 @@ std::optional<SharedPreferencesForWebProcess> RemoteCDMProxy::sharedPreferencesF
     if (!m_factory)
         return std::nullopt;
 
-    return m_factory->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_factory->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -100,7 +100,8 @@ std::optional<SharedPreferencesForWebProcess> RemoteLegacyCDMProxy::sharedPrefer
     if (!m_factory)
         return std::nullopt;
 
-    return m_factory->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_factory->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -202,7 +202,8 @@ std::optional<SharedPreferencesForWebProcess> RemoteLegacyCDMSessionProxy::share
     if (!m_factory)
         return std::nullopt;
 
-    return m_factory->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_factory->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -1044,7 +1044,8 @@ std::optional<SharedPreferencesForWebProcess> PlaybackSessionManagerProxy::share
     if (!m_page)
         return std::nullopt;
 
-    return m_page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -895,7 +895,8 @@ std::optional<SharedPreferencesForWebProcess> VideoPresentationManagerProxy::sha
     if (!m_page)
         return std::nullopt;
 
-    return m_page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
 }
 
 #pragma mark Messages from VideoPresentationManager

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -74,7 +74,8 @@ RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 
 std::optional<SharedPreferencesForWebProcess> RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess() const
 {
-    return m_webPageProxy->legacyMainFrameProcess().sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_webPageProxy->legacyMainFrameProcess().sharedPreferencesForWebProcess();
 }
 
 void RemoteMediaSessionCoordinatorProxy::join(MediaSessionCommandCompletionHandler&& completionHandler)

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -101,7 +101,8 @@ void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::Real
 
 std::optional<SharedPreferencesForWebProcess> SpeechRecognitionRemoteRealtimeMediaSourceManager::sharedPreferencesForWebProcess() const
 {
-    return m_process->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_process->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -57,7 +57,8 @@ SpeechRecognitionServer::SpeechRecognitionServer(WebProcessProxy& process, Speec
 
 std::optional<SharedPreferencesForWebProcess> SpeechRecognitionServer::sharedPreferencesForWebProcess() const
 {
-    return m_process->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_process->sharedPreferencesForWebProcess();
 }
 
 void SpeechRecognitionServer::start(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier, String&& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&& origin, WebCore::FrameIdentifier frameIdentifier)

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -53,7 +53,8 @@ public:
     explicit WebLockRegistryProxy(WebProcessProxy&);
     ~WebLockRegistryProxy();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() { return m_process->sharedPreferencesForWebProcess(); }
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() { return m_process->sharedPreferencesForWebProcess(); }
 
     void processDidExit();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1704,7 +1704,8 @@ WebProcessProxy* WebProcessPool::webProcessProxyFromConnection(const IPC::Connec
 
 std::optional<SharedPreferencesForWebProcess> WebProcessPool::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
 {
-    return webProcessProxyFromConnection(connection)->sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return webProcessProxyFromConnection(connection)->sharedPreferencesForWebProcess();
 }
 
 void WebProcessPool::handleMessage(IPC::Connection& connection, const String& messageName, const WebKit::UserData& messageBody)

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -57,7 +57,8 @@ WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
 
 std::optional<SharedPreferencesForWebProcess> WebScreenOrientationManagerProxy::sharedPreferencesForWebProcess() const
 {
-    return m_page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
+    // FIXME: Remove SUPPRESS_UNCOUNTED_ARG once https://github.com/llvm/llvm-project/pull/111198 lands.
+    SUPPRESS_UNCOUNTED_ARG return m_page->legacyMainFrameProcess().sharedPreferencesForWebProcess();
 }
 
 void WebScreenOrientationManagerProxy::currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&& completionHandler)


### PR DESCRIPTION
#### a0b60b95688050ca27cd988d8aa9e8373828874a
<pre>
Suppress static analyzer false-positive warnings until they&apos;re fixed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280906">https://bugs.webkit.org/show_bug.cgi?id=280906</a>
<a href="https://rdar.apple.com/137304761">rdar://137304761</a>

Reviewed by Ryosuke Niwa and Mike Wyrzykowski.

Suppress false positives until they&apos;re fixed by <a href="https://github.com/llvm/llvm-project/pull/111198.">https://github.com/llvm/llvm-project/pull/111198.</a>

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp:
(WebKit::RemoteCDMProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::sharedPreferencesForWebProcess const):

Canonical link: <a href="https://commits.webkit.org/284709@main">https://commits.webkit.org/284709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1967dbdac114b1f8d6f3bc082ff6c91f6705d3b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74338 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21419 "Hash 1967dbda for PR 34711 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21267 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/21419 "Hash 1967dbda for PR 34711 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41864 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76057 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17593 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63351 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5000 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45457 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->