### PR TITLE
Consider delegate methods for _WKWebExtensionAction changes instead of a notification.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h
@@ -42,10 +42,6 @@
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionAction has changed properties. */
-WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionActionPropertiesDidChangeNotification NS_SWIFT_NAME(WKWebExtensionAction.propertiesDidChangeNotification) NS_SWIFT_NONISOLATED;
-
 /*!
  @abstract A ``WKWebExtensionAction`` object encapsulates the properties for an individual web extension action.
  @discussion Provides access to action properties such as popup, icon, and title, with tab-specific values.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -37,8 +37,6 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 
-NSNotificationName const WKWebExtensionActionPropertiesDidChangeNotification = @"WKWebExtensionActionPropertiesDidChange";
-
 #if USE(APPKIT)
 using CocoaMenuItem = NSMenuItem;
 #else

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
@@ -151,6 +151,16 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
 - (void)webExtensionController:(WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <WKWebExtensionTab>)tab forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<WKWebExtensionMatchPattern *> *allowedMatchPatterns, NSDate * _Nullable expirationDate))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
 
 /*!
+ @abstract Called when an action's properties are updated.
+ @param controller The web extension controller initiating the request.
+ @param action The web extension action whose properties are updated.
+ @param context The context within which the web extension is running.
+ @discussion This method is called when an action's properties are updated and should be reflected in the app's user interface.
+ The app should ensure that any visible changes, such as icons and labels, are updated accordingly.
+ */
+- (void)webExtensionController:(WKWebExtensionController *)controller didUpdateAction:(WKWebExtensionAction *)action forExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(webExtensionController(_:didUpdate:forExtensionContext:));
+
+/*!
  @abstract Called when a popup is requested to be displayed for a specific action.
  @param controller The web extension controller initiating the request.
  @param action The action for which the popup is requested.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2704,7 +2704,7 @@ Ref<WebExtensionAction> WebExtensionContext::getOrCreateAction(WebExtensionWindo
         return defaultAction();
 
     return m_actionWindowMap.ensure(*window, [&] {
-        return WebExtensionAction::create(*this);
+        return WebExtensionAction::create(*this, *window);
     }).iterator->value;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -81,6 +81,10 @@ public:
     RefPtr<WebExtensionTab> tab() const { return m_tab.value_or(nullptr).get(); }
     RefPtr<WebExtensionWindow> window() const { return m_window.value_or(nullptr).get(); }
 
+    bool isTabAction() const { return !!m_tab; }
+    bool isWindowAction() const { return !!m_window; }
+    bool isDefaultAction() const { return !m_tab && !m_window; }
+
     void clearCustomizations();
     void clearBlockedResourceCount();
 
@@ -186,6 +190,7 @@ private:
     std::optional<bool> m_hasUnreadBadgeText;
     bool m_presentsPopupWhenReady : 1 { false };
     bool m_popupPresented : 1 { false };
+    bool m_updatePending : 1 { false };
 };
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -567,8 +567,6 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: 'toolbar-48.png' })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
@@ -582,7 +580,7 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
@@ -597,8 +595,6 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: '../icons/toolbar-48.png' })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
@@ -636,7 +632,7 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
@@ -651,8 +647,6 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: { '48': 'toolbar-48.png', '96': 'toolbar-96.png', '128': 'toolbar-128.png' } })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
@@ -670,7 +664,7 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
         auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
@@ -694,8 +688,6 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: { '48': '../icons/toolbar-48.png', '96': '../icons/toolbar-96.png', '128': '../icons/toolbar-128.png' } })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
@@ -737,7 +729,7 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
         auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
@@ -766,8 +758,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageData)
 
         @"const imageData = context.getImageData(0, 0, 48, 48)",
         @"await browser.action.setIcon({ imageData })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *resources = @{
@@ -778,7 +768,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageData)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
 
         EXPECT_NOT_NULL(icon);
@@ -806,8 +796,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
         @"const imageData128 = createImageData(128, 'red')",
 
         @"await browser.action.setIcon({ imageData: { '48': imageData48, '96': imageData96, '128': imageData128 } })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *resources = @{
@@ -818,7 +806,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
         auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
@@ -852,8 +840,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithDataURL)
         @"const pngDataURL48 = canvas.toDataURL('image/png')",
 
         @"await browser.action.setIcon({ path: pngDataURL48 })",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *resources = @{
@@ -864,7 +850,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithDataURL)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
@@ -899,8 +885,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
         @"const pngDataURL96 = canvas.toDataURL('image/png')",
 
         @"await browser.action.setIcon({ path: { '48': pngDataURL48, '96': pngDataURL96 } })",
-
-        @"browser.action.openPopup();"
     ]);
 
     auto *resources = @{
@@ -911,7 +895,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon48);
         EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(48, 48)));
@@ -936,8 +920,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithVariants)
         @"        { 32: 'action-light-32.png', 64: 'action-light-64.png', 'color_schemes': [ 'light' ] }",
         @"    ]",
         @"}))",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *dark32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
@@ -957,7 +939,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithVariants)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon32 = [action iconForSize:CGSizeMake(32, 32)];
         EXPECT_NOT_NULL(icon32);
         EXPECT_TRUE(CGSizeEqualToSize(icon32.size, CGSizeMake(32, 32)));
@@ -1004,8 +986,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)
         @"        { 32: imageDataLight32, 64: imageDataLight64, 'color_schemes': [ 'light' ] }",
         @"    ]",
         @"}))",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *resources = @{
@@ -1016,7 +996,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon32 = [action iconForSize:CGSizeMake(32, 32)];
         auto *icon64 = [action iconForSize:CGSizeMake(64, 64)];
 
@@ -1097,8 +1077,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)
         @"        { '32.5': invalidImageData, 'color_schemes': ['dark'] }",
         @"    ]",
         @"}))",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *resources = @{
@@ -1109,7 +1087,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon32 = [action iconForSize:CGSizeMake(32, 32)];
         EXPECT_NOT_NULL(icon32);
         EXPECT_TRUE(CGSizeEqualToSize(icon32.size, CGSizeMake(32, 32)));
@@ -1148,8 +1126,6 @@ TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)
         @"        { any: blackSVGData, 'color_schemes': [ 'light' ] }",
         @"    ]",
         @"}))",
-
-        @"browser.action.openPopup()"
     ]);
 
     auto *resources = @{
@@ -1160,7 +1136,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+    manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *iconAnySize = [action iconForSize:CGSizeMake(48, 48)];
 
         EXPECT_NOT_NULL(iconAnySize);

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -61,6 +61,7 @@
 @property (nonatomic, copy) void (^sendMessage)(id message, NSString *applicationIdentifier, void (^)(id replyMessage, NSError *));
 @property (nonatomic, copy) void (^connectUsingMessagePort)(WKWebExtensionMessagePort *);
 
+@property (nonatomic, copy) void (^didUpdateAction)(WKWebExtensionAction *);
 @property (nonatomic, copy) void (^presentPopupForAction)(WKWebExtensionAction *);
 
 @property (nonatomic, copy) void (^presentSidebar)(_WKWebExtensionSidebar *);

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -131,6 +131,12 @@
         completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.connectNative() not implemented" }]);
 }
 
+- (void)webExtensionController:(WKWebExtensionController *)controller didUpdateAction:(WKWebExtensionAction *)action forExtensionContext:(WKWebExtensionContext *)context
+{
+    if (_didUpdateAction)
+        _didUpdateAction(action);
+}
+
 - (void)webExtensionController:(WKWebExtensionController *)controller presentPopupForAction:(WKWebExtensionAction *)action forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
     if (_presentPopupForAction) {


### PR DESCRIPTION
#### 48c566a109a63be806e989c0a0c54c16b2c09263
<pre>
Consider delegate methods for _WKWebExtensionAction changes instead of a notification.
<a href="https://webkit.org/b/268017">https://webkit.org/b/268017</a>
<a href="https://rdar.apple.com/problem/121536906">rdar://problem/121536906</a>

Reviewed by Brian Weinstein.

Add a new delegate method that get notified about any tab actions that have updated.
This will notify the app for all tab actions when a default or window action changes,
which we were missing before when it was a simple notification. Also update after a
small delay, so multiple changes in succession are only notifying the delegate once.

Some tests have been updated to use the new delegate method instead to exercise it.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::propertiesDidChange): Call the delegate on a timeout.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getOrCreateAction): Pass window to the constructor.
This was a bug, but in practice it wasn&apos;t hit.
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::isTabAction const): Added.
(WebKit::WebExtensionAction::isWindowAction const): Added.
(WebKit::WebExtensionAction::isDefaultAction const): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconSinglePath)): Use new delegate.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithImageData)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithDataURL)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithVariants)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)): Ditto.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:didUpdateAction:forExtensionContext:]): Added.

Canonical link: <a href="https://commits.webkit.org/284707@main">https://commits.webkit.org/284707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e31f6101239bd931d88ae9e1bf6ddc1cf786c74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23014 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74339 "Hash 7e31f610 for PR 34712 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21268 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/74339 "Hash 7e31f610 for PR 34712 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14178 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60577 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/74339 "Hash 7e31f610 for PR 34712 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19789 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17595 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63347 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5005 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10750 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45458 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->