### PR TITLE
Combine the WebExtension constructors to reduce duplication.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
@@ -39,7 +39,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @param error Set to \c nil or an error instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  */
-- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error;
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
@@ -48,7 +48,18 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @discussion The URL must be a file URL that points to a directory containing a `manifest.json` file.
  */
-- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error;
+
+/*!
+ @abstract Returns a web extension initialized with a specified app extension bundle and resource base URL.
+ @param appExtensionBundle The bundle to use for the new web extension. Can be \c nil if a resource base URL is provided.
+ @param resourceBaseURL The directory URL to use for the new web extension. Can be \c nil if an app extension bundle is provided.
+ @param error Set to \c nil or an error instance if an error occurred.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @discussion Either the app extension bundle or the resource base URL must be provided. This initializer is useful when the extension resources
+ are in a different location from the app extension bundle used for native messaging.
+ */
+- (nullable instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Returns a web extension initialized with a specified manifest dictionary.

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -75,8 +75,7 @@ public:
         return adoptRef(*new WebExtension(std::forward<Args>(args)...));
     }
 
-    explicit WebExtension(NSBundle *appExtensionBundle, NSError ** = nullptr);
-    explicit WebExtension(NSURL *resourceBaseURL, NSError ** = nullptr);
+    explicit WebExtension(NSBundle *appExtensionBundle, NSURL *resourceBaseURL, NSError ** = nullptr);
     explicit WebExtension(NSDictionary *manifest, NSDictionary *resources);
     explicit WebExtension(NSDictionary *resources);
 
@@ -408,6 +407,9 @@ private:
     String m_optionsPagePath;
     String m_overrideNewTabPagePath;
 
+#if PLATFORM(MAC)
+    bool m_shouldValidateResourceData : 1 { true };
+#endif
     bool m_backgroundContentIsPersistent : 1 { false };
     bool m_backgroundContentUsesModules : 1 { false };
     bool m_parsedManifest : 1 { false };


### PR DESCRIPTION
#### 1c8031fb856c3700466ff6a5543e201831f62e80
<pre>
Combine the WebExtension constructors to reduce duplication.
<a href="https://webkit.org/b/280909">https://webkit.org/b/280909</a>
<a href="https://rdar.apple.com/137293002">rdar://137293002</a>

Reviewed by Brian Weinstein.

Combine the bundle and resource URL WebExtension constructors, since there is a lot of overlap and clients
might need to provide different values. Also decouple resource validation from having a bundle set, we can
only do validation if the bundle and resource URL are equal.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(+[WKWebExtension extensionWithAppExtensionBundle:completionHandler:]): Use the combined constructor.
(+[WKWebExtension extensionWithResourceBaseURL:completionHandler:]): Ditto.
(-[WKWebExtension _initWithAppExtensionBundle:error:]): Ditto.
(-[WKWebExtension _initWithResourceBaseURL:error:]): Ditto.
(-[WKWebExtension _initWithAppExtensionBundle:resourceBaseURL:error:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension): Combined the bundle and resource URL WebExtension constructors.
(WebKit::WebExtension::validateResourceData): Return early if m_shouldValidateResourceData is false.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:

Canonical link: <a href="https://commits.webkit.org/284716@main">https://commits.webkit.org/284716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a0ce22609569c0cdb4710fb6818ad91f8171b4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74373 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21302 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60598 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41880 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76092 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17614 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63362 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5025 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10755 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45492 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46566 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/47843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->