### PR TITLE
Copy files provided by WKWebView clients on iOS that implement runOpenPanel instead of moving them

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -878,8 +878,9 @@ bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFr
         RetainPtr<NSFileCoordinator> uploadFileCoordinator = adoptNS([[NSFileCoordinator alloc] init]);
         RetainPtr<NSFileManager> uploadFileManager = adoptNS([[NSFileManager alloc] init]);
         for (NSURL *url in URLs) {
-            auto [maybeMovedURL, temporaryURL] = [WKFileUploadPanel _copyToNewTemporaryDirectory:url fileCoordinator:uploadFileCoordinator.get() fileManager:uploadFileManager.get()];
-            filenames.append(maybeMovedURL.get().path);
+            auto [operationResult, maybeMovedURL, temporaryURL] = [WKFileUploadPanel _moveToNewTemporaryDirectory:url fileCoordinator:uploadFileCoordinator.get() fileManager:uploadFileManager.get() asCopy:YES];
+            if (operationResult == WebKit::MovedSuccessfully::Yes)
+                filenames.append(maybeMovedURL.get().path);
         }
 #else
         for (NSURL *url in URLs)

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
@@ -37,6 +37,13 @@ class OpenPanelParameters;
 namespace WebKit {
 class WebOpenPanelResultListenerProxy;
 enum class PickerDismissalReason : uint8_t;
+enum class MovedSuccessfully : bool { No, Yes };
+
+struct TemporaryFileMoveResults {
+    MovedSuccessfully operationResult;
+    RetainPtr<NSURL> maybeMovedURL;
+    RetainPtr<NSURL> temporaryDirectoryURL;
+};
 }
 
 @interface WKFileUploadPanel : UIViewController
@@ -53,7 +60,7 @@ enum class PickerDismissalReason : uint8_t;
 - (NSArray<NSString *> *)currentAvailableActionTitles;
 - (NSArray<NSString *> *)acceptedTypeIdentifiers;
 
-+ (std::pair<RetainPtr<NSURL>, RetainPtr<NSURL>>)_copyToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager;
++ (WebKit::TemporaryFileMoveResults)_moveToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager asCopy:(BOOL)asCopy;
 @end
 
 @protocol WKFileUploadPanelDelegate <NSObject>

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -974,7 +974,7 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
             // If the file hasn't already been imported by UIKit, we must import it into a new temporary directory ourselves
             // and leave the original intact. If it has been imported by UIKit, we must move the imported file into a new temporary
             // directory as a workaround for rdar://136776473.
-            auto [maybeMovedURL, temporaryURL] = [WKFileUploadPanel _copyToNewTemporaryDirectory:url fileCoordinator:retainedSelf->_uploadFileCoordinator.get() fileManager:retainedSelf->_uploadFileManager.get()];
+            auto [operationResult, maybeMovedURL, temporaryURL] = [WKFileUploadPanel _moveToNewTemporaryDirectory:url fileCoordinator:retainedSelf->_uploadFileCoordinator.get() fileManager:retainedSelf->_uploadFileManager.get() asCopy:!filesImportedByUIKit];
 
             if (!filesImportedByUIKit)
                 [url stopAccessingSecurityScopedResource];
@@ -982,9 +982,7 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
             // If the selected item was initially imported by UIKit, we have some copy of it to try to upload regardless
             // of whether or not the move operation succeeded. If the file hadn't already been imported and doing so
             // ourselves was unsuccessful, we have no copy to upload.
-            if (maybeMovedURL && filesImportedByUIKit) {
-                [maybeMovedURLs addObject:maybeMovedURL.get()];
-            } else if (maybeMovedURL && ![maybeMovedURL isEqual:url])
+            if (maybeMovedURL && (filesImportedByUIKit || operationResult == WebKit::MovedSuccessfully::Yes))
                 [maybeMovedURLs addObject:maybeMovedURL.get()];
 
             if (temporaryURL)
@@ -1144,7 +1142,7 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
                 return;
             }
 
-            auto [maybeMovedURL, temporaryURL] = [WKFileUploadPanel _copyToNewTemporaryDirectory:url fileCoordinator:_uploadFileCoordinator.get() fileManager:_uploadFileManager.get()];
+            auto [operationResult, maybeMovedURL, temporaryURL] = [WKFileUploadPanel _moveToNewTemporaryDirectory:url fileCoordinator:_uploadFileCoordinator.get() fileManager:_uploadFileManager.get() asCopy:NO];
             self->_temporaryUploadedFileURLs.append(WTFMove(temporaryURL));
 
             successBlock(adoptNS([[_WKVideoFileUploadItem alloc] initWithFileURL:maybeMovedURL.get()]).get());
@@ -1175,7 +1173,7 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
             return;
         }
 
-        auto [maybeMovedURL, temporaryURL] = [WKFileUploadPanel _copyToNewTemporaryDirectory:url fileCoordinator:_uploadFileCoordinator.get() fileManager:_uploadFileManager.get()];
+        auto [operationResult, maybeMovedURL, temporaryURL] = [WKFileUploadPanel _moveToNewTemporaryDirectory:url fileCoordinator:_uploadFileCoordinator.get() fileManager:_uploadFileManager.get() asCopy:NO];
         self->_temporaryUploadedFileURLs.append(WTFMove(temporaryURL));
 
         successBlock(adoptNS([[_WKImageFileUploadItem alloc] initWithFileURL:maybeMovedURL.get()]).get());
@@ -1334,33 +1332,40 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
 
 #endif
 
-+ (std::pair<RetainPtr<NSURL>, RetainPtr<NSURL>>)_copyToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager
++ (WebKit::TemporaryFileMoveResults)_moveToNewTemporaryDirectory:(NSURL *)originalURL fileCoordinator:(NSFileCoordinator *)fileCoordinator fileManager:(NSFileManager *)fileManager asCopy:(BOOL)asCopy
 {
     NSError *error = nil;
     NSString *temporaryDirectory = FileSystem::createTemporaryDirectory(@"WKFileUploadPanel");
     if (!temporaryDirectory) {
         LOG_ERROR("WKFileUploadPanel: Failed to make temporary directory");
-        return { originalURL, nil };
+        return { WebKit::MovedSuccessfully::No, originalURL, nil };
     }
     NSString *filePath = [temporaryDirectory stringByAppendingPathComponent:originalURL.lastPathComponent];
     auto destinationFileURL = adoptNS([[NSURL alloc] initFileURLWithPath:filePath isDirectory:NO]);
 
-    __block std::pair<RetainPtr<NSURL>, RetainPtr<NSURL>> result;
+    __block WebKit::TemporaryFileMoveResults results;
     [fileCoordinator coordinateWritingItemAtURL:originalURL options:NSFileCoordinatorWritingForMoving error:&error byAccessor:^(NSURL *coordinatedOriginalURL) {
         NSError *error = nil;
-        if (![fileManager moveItemAtURL:coordinatedOriginalURL toURL:destinationFileURL.get() error:&error] || error) {
-            // If moving fails, keep the original URL and our 60 second time limit before it is deleted. We tried our best to extend it.
-            result = { coordinatedOriginalURL, adoptNS([[NSURL alloc] initFileURLWithPath:temporaryDirectory isDirectory:YES]) };
+        BOOL didMoveOrCopy;
+
+        if (asCopy)
+            didMoveOrCopy = [fileManager copyItemAtURL:coordinatedOriginalURL toURL:destinationFileURL.get() error:&error];
+        else
+            didMoveOrCopy = [fileManager moveItemAtURL:coordinatedOriginalURL toURL:destinationFileURL.get() error:&error];
+
+        if (!didMoveOrCopy || error) {
+            // If moving/copying fails, keep the original URL and our 60 second time limit for file URLs from UIKit before it is deleted. We tried our best to extend it.
+            results = { WebKit::MovedSuccessfully::No, coordinatedOriginalURL, adoptNS([[NSURL alloc] initFileURLWithPath:temporaryDirectory isDirectory:YES]) };
         } else
-            result = { destinationFileURL, adoptNS([[NSURL alloc] initFileURLWithPath:temporaryDirectory isDirectory:YES]) };
+            results = { WebKit::MovedSuccessfully::Yes, destinationFileURL, adoptNS([[NSURL alloc] initFileURLWithPath:temporaryDirectory isDirectory:YES]) };
     }];
     if (error) {
         LOG_ERROR("WKFileUploadPanel: Failed to coordinate moving file with error %@", error);
         // If moving fails, keep the original URL and our 60 second time limit before it is deleted. We tried our best to extend it.
-        return { originalURL, adoptNS([[NSURL alloc] initFileURLWithPath:temporaryDirectory isDirectory:YES]) };
+        return { WebKit::MovedSuccessfully::No, originalURL, adoptNS([[NSURL alloc] initFileURLWithPath:temporaryDirectory isDirectory:YES]) };
     }
 
-    return result;
+    return results;
 }
 
 - (BOOL)platformSupportsPickerViewController

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm
@@ -48,8 +48,10 @@ static NSString * const expectedFileName = @"这是中文";
     EXPECT_FALSE(parameters.allowsDirectories);
     EXPECT_EQ(0ull, parameters._acceptedMIMETypes.count);
     EXPECT_EQ(0ull, parameters._acceptedFileExtensions.count);
+    [[NSFileManager defaultManager] createFileAtPath:[NSTemporaryDirectory() stringByAppendingPathComponent:expectedFileName] contents:nil attributes:nil];
     completionHandler(@[ [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:expectedFileName]] ]);
     fileSelected = true;
+    [[NSFileManager defaultManager] removeItemAtPath:[NSTemporaryDirectory() stringByAppendingPathComponent:expectedFileName] error:nil];
 }
 
 @end


### PR DESCRIPTION
#### 05f1d0ebb69cc7cb3d8d9d9afd5e51d22f801e48
<pre>
Copy files provided by WKWebView clients on iOS that implement runOpenPanel instead of moving them
<a href="https://bugs.webkit.org/show_bug.cgi?id=280847">https://bugs.webkit.org/show_bug.cgi?id=280847</a>
<a href="https://rdar.apple.com/137172156">rdar://137172156</a>

Reviewed by Wenson Hsieh.

UIDelegate::UIClient::runOpenPanel now copies the URLs provided by implementations of runOpenPanel
in WKUIDelegates rather than moving them. This ensures that the workaround for
<a href="https://bugs.webkit.org/show_bug.cgi?id=228683">https://bugs.webkit.org/show_bug.cgi?id=228683</a> will not result in files being lost if the URL
points to an original file rather than an imported copy.

TestWebKitAPI.WebKit.RunOpenPanelNonLatin1 has also been updated to now create a file at
the URL it tests since file uploads from runOpenPanel on iOS now only proceed if the file
was successfully copied, which is impossible without an actual file.

* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::runOpenPanel):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm:
(-[RunOpenPanelUIDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/284904@main">https://commits.webkit.org/284904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5918336107886f7bfd610fe5f234788616b37632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14348 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60800 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36342 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18235 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76335 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63539 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5224 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10864 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45735 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/502 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->