### PR TITLE
Remove HighlightAPIEnabled and GrammarAndSpellingPseudoElementsEnabled flags

### DIFF
--- a/LayoutTests/highlight/highlight-crash.html
+++ b/LayoutTests/highlight/highlight-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ HighlightAPIEnabled=true ] -->
+<!DOCTYPE html>
 <style>
 ::highlight { background: red }
 </style>

--- a/LayoutTests/highlight/highlight-interfaces.html
+++ b/LayoutTests/highlight/highlight-interfaces.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ HighlightAPIEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <script src="../resources/js-test.js"></script>

--- a/LayoutTests/highlight/highlight-map-and-group.html
+++ b/LayoutTests/highlight/highlight-map-and-group.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ HighlightAPIEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <script src="../resources/js-test.js"></script>
 <head>

--- a/LayoutTests/highlight/highlight-pseudo-element-style.html
+++ b/LayoutTests/highlight/highlight-pseudo-element-style.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ HighlightAPIEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <script src="../resources/js-test.js"></script>
 <style>

--- a/LayoutTests/highlight/highlight-world-leak.html
+++ b/LayoutTests/highlight/highlight-world-leak.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ HighlightAPIEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <script src="../resources/js-test-pre.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3172,20 +3172,6 @@ GoogleAntiFlickerOptimizationQuirkEnabled:
     WebCore:
       default: true
 
-GrammarAndSpellingPseudoElementsEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "::grammar-error and ::spelling-error pseudo-elements"
-  humanReadableDescription: "Enable the ::grammar-error and ::spelling-error CSS pseudo-elements"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 GraphicsContextFiltersEnabled:
    type: bool
    status: stable
@@ -3287,20 +3273,6 @@ HiddenPageDOMTimerThrottlingEnabled:
       default: false
     WebCore:
       default: false
-
-HighlightAPIEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "Highlight API"
-  humanReadableDescription: "Highlight API support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
 
 HyperlinkAuditingEnabled:
   type: bool

--- a/Source/WebCore/Modules/highlight/Highlight.idl
+++ b/Source/WebCore/Modules/highlight/Highlight.idl
@@ -30,7 +30,6 @@ enum HighlightType {
 };
 
 [
-    EnabledBySetting=HighlightAPIEnabled,
     Exposed=Window
 ] interface Highlight {
     constructor(AbstractRange... initialRanges);

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.idl
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    EnabledBySetting=HighlightAPIEnabled,
     Exposed=Window
 ] interface HighlightRegistry {
     constructor();

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -534,12 +534,9 @@
         "first-line": {
             "supports-single-colon-for-compatibility": true
         },
-        "grammar-error": {
-            "settings-flag": "grammarAndSpellingPseudoElementsEnabled"
-        },
+        "grammar-error": {},
         "highlight": {
-            "argument": "required",
-            "settings-flag": "highlightAPIEnabled"
+            "argument": "required"
         },
         "marker": {},
         "part": {
@@ -555,9 +552,7 @@
         "slotted": {
             "argument": "required"
         },
-        "spelling-error": {
-            "settings-flag": "grammarAndSpellingPseudoElementsEnabled"
-        },
+        "spelling-error": {},
         "target-text": {
             "settings-flag": "targetTextPseudoElementEnabled"
         },

--- a/Source/WebCore/css/DOMCSSNamespace.idl
+++ b/Source/WebCore/css/DOMCSSNamespace.idl
@@ -34,5 +34,5 @@
     [CallWith=CurrentDocument] boolean supports(DOMString property, DOMString value);
     [CallWith=CurrentDocument] boolean supports(DOMString conditionText);
     DOMString escape(DOMString ident);
-    [EnabledBySetting=HighlightAPIEnabled, CallWith=CurrentDocument] readonly attribute HighlightRegistry highlights;
+    [CallWith=CurrentDocument] readonly attribute HighlightRegistry highlights;
 };

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -102,8 +102,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }
     , sidewaysWritingModesEnabled { document.settings().sidewaysWritingModesEnabled() }
     , cssTextWrapPrettyEnabled { document.settings().cssTextWrapPrettyEnabled() }
-    , highlightAPIEnabled { document.settings().highlightAPIEnabled() }
-    , grammarAndSpellingPseudoElementsEnabled { document.settings().grammarAndSpellingPseudoElementsEnabled() }
     , thumbAndTrackPseudoElementsEnabled { document.settings().thumbAndTrackPseudoElementsEnabled() }
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled { document.settings().imageControlsEnabled() }
@@ -140,19 +138,17 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.popoverAttributeEnabled                   << 15
         | context.sidewaysWritingModesEnabled               << 16
         | context.cssTextWrapPrettyEnabled                  << 17
-        | context.highlightAPIEnabled                       << 18
-        | context.grammarAndSpellingPseudoElementsEnabled   << 19
-        | context.thumbAndTrackPseudoElementsEnabled        << 20
+        | context.thumbAndTrackPseudoElementsEnabled        << 18
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 21
+        | context.imageControlsEnabled                      << 19
 #endif
-        | context.colorLayersEnabled                        << 22
-        | context.lightDarkEnabled                          << 23
-        | context.contrastColorEnabled                      << 24
-        | context.targetTextPseudoElementEnabled            << 25
-        | context.viewTransitionTypesEnabled                << 26
-        | context.cssProgressFunctionEnabled                << 27
-        | (uint32_t)context.mode                            << 28; // This is multiple bits, so keep it last.
+        | context.colorLayersEnabled                        << 20
+        | context.lightDarkEnabled                          << 21
+        | context.contrastColorEnabled                      << 22
+        | context.targetTextPseudoElementEnabled            << 23
+        | context.viewTransitionTypesEnabled                << 24
+        | context.cssProgressFunctionEnabled                << 25
+        | (uint32_t)context.mode                            << 26; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -93,8 +93,6 @@ struct CSSParserContext {
     bool popoverAttributeEnabled : 1 { false };
     bool sidewaysWritingModesEnabled : 1 { false };
     bool cssTextWrapPrettyEnabled : 1 { false };
-    bool highlightAPIEnabled : 1 { false };
-    bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
     bool thumbAndTrackPseudoElementsEnabled : 1 { false };
 #if ENABLE(SERVICE_CONTROLS)
     bool imageControlsEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -35,8 +35,6 @@ namespace WebCore {
 CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
     : mode(context.mode)
     , cssNestingEnabled(context.cssNestingEnabled)
-    , grammarAndSpellingPseudoElementsEnabled(context.grammarAndSpellingPseudoElementsEnabled)
-    , highlightAPIEnabled(context.highlightAPIEnabled)
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled(context.imageControlsEnabled)
 #endif
@@ -52,8 +50,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
 CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
     , cssNestingEnabled(document.settings().cssNestingEnabled())
-    , grammarAndSpellingPseudoElementsEnabled(document.settings().grammarAndSpellingPseudoElementsEnabled())
-    , highlightAPIEnabled(document.settings().highlightAPIEnabled())
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled(document.settings().imageControlsEnabled())
 #endif
@@ -71,8 +67,6 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
     add(hasher,
         context.mode,
         context.cssNestingEnabled,
-        context.grammarAndSpellingPseudoElementsEnabled,
-        context.highlightAPIEnabled,
 #if ENABLE(SERVICE_CONTROLS)
         context.imageControlsEnabled,
 #endif

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -37,8 +37,6 @@ class Document;
 struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
     bool cssNestingEnabled : 1 { false };
-    bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
-    bool highlightAPIEnabled : 1 { false };
 #if ENABLE(SERVICE_CONTROLS)
     bool imageControlsEnabled : 1 { false };
 #endif

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -183,23 +183,22 @@ Color RenderReplaced::calculateHighlightColor() const
         }
     }
 #endif
-    if (document().settings().highlightAPIEnabled()) {
-        if (auto highlightRegistry = document().highlightRegistryIfExists()) {
-            for (auto& highlight : highlightRegistry->map()) {
-                for (auto& highlightRange : highlight.value->highlightRanges()) {
-                    if (!renderHighlight.setRenderRange(highlightRange))
-                        continue;
+    if (auto highlightRegistry = document().highlightRegistryIfExists()) {
+        for (auto& highlight : highlightRegistry->map()) {
+            for (auto& highlightRange : highlight.value->highlightRanges()) {
+                if (!renderHighlight.setRenderRange(highlightRange))
+                    continue;
 
-                    auto state = renderHighlight.highlightStateForRenderer(*this);
-                    if (!isHighlighted(state, renderHighlight))
-                        continue;
+                auto state = renderHighlight.highlightStateForRenderer(*this);
+                if (!isHighlighted(state, renderHighlight))
+                    continue;
 
-                    if (auto highlightStyle = getCachedPseudoStyle({ PseudoId::Highlight, highlight.key }, &style()))
-                        return highlightStyle->colorResolvingCurrentColor(highlightStyle->backgroundColor());
-                }
+                if (auto highlightStyle = getCachedPseudoStyle({ PseudoId::Highlight, highlight.key }, &style()))
+                    return highlightStyle->colorResolvingCurrentColor(highlightStyle->backgroundColor());
             }
         }
     }
+
     if (document().settings().scrollToTextFragmentEnabled()) {
         if (auto highlightRegistry = document().fragmentHighlightRegistryIfExists()) {
             for (auto& highlight : highlightRegistry->map()) {

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -1238,16 +1238,6 @@ bool WKPreferencesGetGamepadsEnabled(WKPreferencesRef preferencesRef)
     return toImpl(preferencesRef)->gamepadsEnabled();
 }
 
-void WKPreferencesSetHighlightAPIEnabled(WKPreferencesRef preferencesRef, bool enabled)
-{
-    toImpl(preferencesRef)->setHighlightAPIEnabled(enabled);
-}
-
-bool WKPreferencesGetHighlightAPIEnabled(WKPreferencesRef preferencesRef)
-{
-    return toImpl(preferencesRef)->highlightAPIEnabled();
-}
-
 void WKPreferencesSetMinimumZoomFontSize(WKPreferencesRef preferencesRef, double size)
 {
     toImpl(preferencesRef)->setMinimumZoomFontSize(size);
@@ -2008,6 +1998,15 @@ void WKPreferencesSetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef, bool)
 bool WKPreferencesGetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef)
 {
     return false;
+}
+
+void WKPreferencesSetHighlightAPIEnabled(WKPreferencesRef preferencesRef, bool enabled)
+{
+}
+
+bool WKPreferencesGetHighlightAPIEnabled(WKPreferencesRef preferencesRef)
+{
+    return true;
 }
 
 void WKPreferencesSetWebSQLDisabled(WKPreferencesRef, bool)

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -320,10 +320,6 @@ WK_EXPORT bool WKPreferencesGetImageControlsEnabled(WKPreferencesRef preferences
 WK_EXPORT void WKPreferencesSetGamepadsEnabled(WKPreferencesRef preferencesRef, bool enabled);
 WK_EXPORT bool WKPreferencesGetGamepadsEnabled(WKPreferencesRef preferencesRef);
 
-// Default to false.
-WK_EXPORT void WKPreferencesSetHighlightAPIEnabled(WKPreferencesRef preferencesRef, bool enabled);
-WK_EXPORT bool WKPreferencesGetHighlightAPIEnabled(WKPreferencesRef preferencesRef);
-
 // Defaults to 0. Setting this to 0 disables font autosizing on iOS.
 WK_EXPORT void WKPreferencesSetMinimumZoomFontSize(WKPreferencesRef preferencesRef, double);
 WK_EXPORT double WKPreferencesGetMinimumZoomFontSize(WKPreferencesRef preferencesRef);
@@ -522,6 +518,8 @@ WK_EXPORT void WKPreferencesSetAutostartOriginPlugInSnapshottingEnabled(WKPrefer
 WK_EXPORT bool WKPreferencesGetAutostartOriginPlugInSnapshottingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetPrimaryPlugInSnapshotDetectionEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetPrimaryPlugInSnapshotDetectionEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKPreferencesSetHighlightAPIEnabled(WKPreferencesRef preferencesRef, bool) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetHighlightAPIEnabled(WKPreferencesRef preferencesRef) WK_C_API_DEPRECATED;
 
 #ifdef __cplusplus
 }

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -233,7 +233,6 @@
 // FIXME: If these are not used anywhere, we should remove them and only use WebFeature mechanism for the preference.
 #define WebKitUserGesturePromisePropagationEnabledPreferenceKey @"WebKitUserGesturePromisePropagationEnabled"
 #define WebKitRequestIdleCallbackEnabledPreferenceKey @"WebKitRequestIdleCallbackEnabled"
-#define WebKitHighlightAPIEnabledPreferenceKey @"WebKitHighlightAPIEnabled"
 #define WebKitAsyncClipboardAPIEnabledPreferenceKey @"WebKitAsyncClipboardAPIEnabled"
 #define WebKitVisualViewportAPIEnabledPreferenceKey @"WebKitVisualViewportAPIEnabled"
 #define WebKitCSSOMViewSmoothScrollingEnabledPreferenceKey @"WebKitCSSOMViewSmoothScrollingEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -2816,16 +2816,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:flag forKey:WebKitRequestIdleCallbackEnabledPreferenceKey];
 }
 
-- (BOOL)highlightAPIEnabled
-{
-    return [self _boolValueForKey:WebKitHighlightAPIEnabledPreferenceKey];
-}
-
-- (void)setHighlightAPIEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitHighlightAPIEnabledPreferenceKey];
-}
-
 - (BOOL)asyncClipboardAPIEnabled
 {
     return [self _boolValueForKey:WebKitAsyncClipboardAPIEnabledPreferenceKey];
@@ -3283,6 +3273,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 }
 
 - (void)setCSSIndividualTransformPropertiesEnabled:(BOOL)flag
+{
+}
+
+- (BOOL)highlightAPIEnabled
+{
+    return YES;
+}
+
+- (void)setHighlightAPIEnabled:(BOOL)flag
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -296,7 +296,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @interface WebPreferences (WebPrivatePreferencesConvertedToWebFeature)
 @property (nonatomic) BOOL userGesturePromisePropagationEnabled;
 @property (nonatomic) BOOL requestIdleCallbackEnabled;
-@property (nonatomic) BOOL highlightAPIEnabled;
 @property (nonatomic) BOOL asyncClipboardAPIEnabled;
 @property (nonatomic) BOOL visualViewportAPIEnabled;
 @property (nonatomic) BOOL CSSOMViewSmoothScrollingEnabled;
@@ -352,6 +351,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL transformStreamAPIEnabled;
 @property (nonatomic) BOOL lineHeightUnitsEnabled;
 @property (nonatomic) BOOL CSSIndividualTransformPropertiesEnabled;
+@property (nonatomic) BOOL highlightAPIEnabled;
 @property (nonatomic) BOOL serverTimingEnabled;
 @property (nonatomic) BOOL offlineWebApplicationCacheEnabled;
 @property (nonatomic) int64_t applicationCacheTotalQuota;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -478,7 +478,7 @@ void testWebKitFeatures(Test* test, gconstpointer)
         // FIXME: This is enabled in UnifiedWebPreferences.yaml, but the
         // actual value ends up being disabled without an obvious reason.
         // Needs investigating.
-        if (identifier == "GrammarAndSpellingPseudoElements"_s)
+        if (identifier == "TargetTextPseudoElement"_s)
             continue;
 
         g_assert(webkit_settings_get_feature_enabled(settings.get(), feature) == webkit_feature_get_default_value(feature));


### PR DESCRIPTION
#### 0871eb9a2c025797729178bb10d20d38d82e682b
<pre>
Remove HighlightAPIEnabled and GrammarAndSpellingPseudoElementsEnabled flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=280913">https://bugs.webkit.org/show_bug.cgi?id=280913</a>
<a href="https://rdar.apple.com/137312546">rdar://137312546</a>

Reviewed by Anne van Kesteren.

These have been enabled for almost a year now. Remove them to free up bits.

* LayoutTests/highlight/highlight-crash.html:
* LayoutTests/highlight/highlight-interfaces.html:
* LayoutTests/highlight/highlight-map-and-group.html:
* LayoutTests/highlight/highlight-pseudo-element-style.html:
* LayoutTests/highlight/highlight-world-leak.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/highlight/Highlight.idl:
* Source/WebCore/Modules/highlight/HighlightRegistry.idl:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/DOMCSSNamespace.idl:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::calculateHighlightColor const):
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetHighlightAPIEnabled):
(WKPreferencesGetHighlightAPIEnabled):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences highlightAPIEnabled]):
(-[WebPreferences setHighlightAPIEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitFeatures):

Canonical link: <a href="https://commits.webkit.org/284769@main">https://commits.webkit.org/284769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee7a03669f02ed9de9a98f13ca771601b76d8892

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19993 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63575 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76262 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69701 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63559 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5165 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91484 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/429 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19944 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/throw-null-ref.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->