### PR TITLE
Fix iOS 18 build

### DIFF
--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -1,11 +1,8 @@
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/libxslt
-$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach.h
-$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach_error.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach_types.defs
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/machine/machine_types.defs
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/std_types.defs
-$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/task.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/Protocol.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -1,11 +1,8 @@
 $(SDK_DIR_macosx)/usr/include/readline
 $(SDK_DIR_macosx)/usr/include/libxslt
-$(SDK_DIR_macosx)/usr/include/mach/mach.h
-$(SDK_DIR_macosx)/usr/include/mach/mach_error.h
 $(SDK_DIR_macosx)/usr/include/mach/mach_types.defs
 $(SDK_DIR_macosx)/usr/include/mach/machine/machine_types.defs
 $(SDK_DIR_macosx)/usr/include/mach/std_types.defs
-$(SDK_DIR_macosx)/usr/include/mach/task.h
 $(SDK_DIR_macosx)/usr/include/objc/Protocol.h
 $(SDK_DIR_macosx)/usr/include/objc/objc-class.h
 $(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h


### PR DESCRIPTION
#### 582cd3185f4c7614f44abcb7b463e2afee121781
<pre>
Fix iOS 18 build
<a href="https://rdar.apple.com/137313704">rdar://137313704</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280915">https://bugs.webkit.org/show_bug.cgi?id=280915</a>

Reviewed by Jonathan Bedard.

Fix some additional build failures when building with the iOS 18 SDK.

Combined changes:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist:
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders.xcfilelist:

Canonical link: <a href="https://commits.webkit.org/284773@main">https://commits.webkit.org/284773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fc99a8723db49df2aa76ad1d3f54f5b54de48f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55709 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41887 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19827 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76096 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17615 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63427 "Found 18 new test failures: animations/3d/full-rotation-animation.html imported/w3c/web-platform-tests/css/css-values/vh-interpolate-pct.html imported/w3c/web-platform-tests/css/css-view-transitions/class-specificity.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-old-main.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/japanese-tag.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-opacity.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-positioned-spans.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5029 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/263 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->