### PR TITLE
JavaScriptCore/jit/GPRInfo.h: fix typo in RISCV64Registers

### DIFF
--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -779,16 +779,16 @@ public:
     static constexpr GPRReg wasmBaseMemoryPointer = regCS3;
     static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS4;
 
-    static constexpr GPRReg regWS0 = RICSV64Registers::x6;
-    static constexpr GPRReg regWS1 = RICSV64Registers::x7;
-    static constexpr GPRReg regWA0 = RICSV64Registers::x10;
-    static constexpr GPRReg regWA1 = RICSV64Registers::x11;
-    static constexpr GPRReg regWA2 = RICSV64Registers::x12;
-    static constexpr GPRReg regWA3 = RICSV64Registers::x13;
-    static constexpr GPRReg regWA4 = RICSV64Registers::x14;
-    static constexpr GPRReg regWA5 = RICSV64Registers::x15;
-    static constexpr GPRReg regWA6 = RICSV64Registers::x16;
-    static constexpr GPRReg regWA7 = RICSV64Registers::x17;
+    static constexpr GPRReg regWS0 = RISCV64Registers::x6;
+    static constexpr GPRReg regWS1 = RISCV64Registers::x7;
+    static constexpr GPRReg regWA0 = RISCV64Registers::x10;
+    static constexpr GPRReg regWA1 = RISCV64Registers::x11;
+    static constexpr GPRReg regWA2 = RISCV64Registers::x12;
+    static constexpr GPRReg regWA3 = RISCV64Registers::x13;
+    static constexpr GPRReg regWA4 = RISCV64Registers::x14;
+    static constexpr GPRReg regWA5 = RISCV64Registers::x15;
+    static constexpr GPRReg regWA6 = RISCV64Registers::x16;
+    static constexpr GPRReg regWA7 = RISCV64Registers::x17;
 
     static constexpr GPRReg patchpointScratchRegister = RISCV64Registers::x30; // Should match dataTempRegister
 


### PR DESCRIPTION
RICSV64Registers -> RISCV64Registers

This was introduced in:
https://github.com/WebKit/WebKit/commit/e41732697b999464e80dc3fe1c95900c6c438888<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f69282c9271c76e8783412766a50477288e5888

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70307 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49713 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23071 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74396 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21485 "Failed to checkout and rebase branch from PR 34727") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57513 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21325 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/74396 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/21485 "Failed to checkout and rebase branch from PR 34727") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73373 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/57513 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/23071 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/74396 "Failed to checkout and rebase branch from PR 34727") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/57513 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/23071 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19846 "Failed to checkout and rebase branch from PR 34727") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63428 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/57513 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/23071 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76115 "Failed to checkout and rebase branch from PR 34727") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69554 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14533 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/21325 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/76115 "Failed to checkout and rebase branch from PR 34727") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14575 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/23071 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/76115 "Failed to checkout and rebase branch from PR 34727") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/23071 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91336 "Failed to checkout and rebase branch from PR 34727") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11068 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45515 "Failed to checkout and rebase branch from PR 34727") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/282 "Failed to checkout and rebase branch from PR 34727") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/91336 "Failed to checkout and rebase branch from PR 34727") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46589 "Failed to checkout and rebase branch from PR 34727") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47866 "Failed to checkout and rebase branch from PR 34727") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46331 "Failed to checkout and rebase branch from PR 34727") | | | 
<!--EWS-Status-Bubble-End-->