### PR TITLE
Pack SecurityOrigin.h bool members to bits

### DIFF
--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -225,13 +225,14 @@ private:
     SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
-    bool m_universalAccess { false };
-    bool m_domainWasSetInDOM { false };
-    bool m_canLoadLocalResources { false };
-    bool m_enforcesFilePathSeparation { false };
-    bool m_needsStorageAccessFromFileURLsQuirk { false };
+    bool m_universalAccess : 1 { false };
+    bool m_domainWasSetInDOM : 1 { false };
+    bool m_canLoadLocalResources : 1 { false };
+    bool m_enforcesFilePathSeparation : 1 { false };
+    bool m_needsStorageAccessFromFileURLsQuirk : 1 { false };
+    bool m_isLocal : 1 { false };
     mutable std::optional<bool> m_isPotentiallyTrustworthy;
-    bool m_isLocal { false };
+
 };
 
 WEBCORE_EXPORT bool shouldTreatAsPotentiallyTrustworthy(const URL&);


### PR DESCRIPTION
#### 02d52e5c680fc9027de2d37227477d681d8a6e89
<pre>
Pack SecurityOrigin.h bool members to bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=280923">https://bugs.webkit.org/show_bug.cgi?id=280923</a>

Reviewed by NOBODY (OOPS!).

Pack SecurityOrigin.h bool members to bits

* Source/WebCore/page/SecurityOrigin.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02d52e5c680fc9027de2d37227477d681d8a6e89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70312 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49718 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23076 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74401 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21490 "Hash 02d52e5c for PR 34728 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72429 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57518 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21330 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/74401 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/21490 "Hash 02d52e5c for PR 34728 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73378 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/57518 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/23076 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/74401 "Hash 02d52e5c for PR 34728 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/57518 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/23076 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19851 "Hash 02d52e5c for PR 34728 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/57518 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/23076 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76120 "Hash 02d52e5c for PR 34728 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14538 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/21330 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/76120 "Hash 02d52e5c for PR 34728 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14580 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/23076 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/76120 "Hash 02d52e5c for PR 34728 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/23076 "Hash 02d52e5c for PR 34728 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45520 "Hash 02d52e5c for PR 34728 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/287 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46594 "Hash 02d52e5c for PR 34728 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47871 "Hash 02d52e5c for PR 34728 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46336 "Hash 02d52e5c for PR 34728 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->