### PR TITLE
[JSC] `GroupBy` should throw when the number of iterations exceed 2^53 - 1

### DIFF
--- a/Source/JavaScriptCore/builtins/MapConstructor.js
+++ b/Source/JavaScriptCore/builtins/MapConstructor.js
@@ -48,6 +48,8 @@ function groupBy(items, callback)
         @@iterator: function () { return iterator; }
     };
     for (var item of wrapper) {
+        if (k >= @MAX_SAFE_INTEGER)
+            @throwTypeError("The number of iterations exceeds 2**53 - 1");
         var key = callback.@call(@undefined, item, k);
         var group = groups.@get(key);
         if (!group) {

--- a/Source/JavaScriptCore/builtins/ObjectConstructor.js
+++ b/Source/JavaScriptCore/builtins/ObjectConstructor.js
@@ -68,6 +68,8 @@ function groupBy(items, callback)
         @@iterator: function () { return iterator; }
     };
     for (var item of wrapper) {
+        if (k >= @MAX_SAFE_INTEGER)
+            @throwTypeError("The number of iterations exceeds 2**53 - 1");
         var key = @toPropertyKey(callback.@call(@undefined, item, k));
         var group = groups[key];
         if (!group) {


### PR DESCRIPTION
#### 2da72919849f061936ab55e1b918381c662d86c7
<pre>
[JSC] `GroupBy` should throw when the number of iterations exceed 2^53 - 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=280927">https://bugs.webkit.org/show_bug.cgi?id=280927</a>

Reviewed by Yusuke Suzuki.

According to the spec[1], `GroupBy` should throw a TypeError when the number of iterations exceeds
2^53-1. Although it takes a very long time to reach this condition, it is not impossible. However,
the current JSC does not throw a TypeError in such cases.

This patch changes the behavior to conform to the specification.

[1]: <a href="https://tc39.es/ecma262/#sec-groupby">https://tc39.es/ecma262/#sec-groupby</a>

* Source/JavaScriptCore/builtins/MapConstructor.js:
(groupBy):
* Source/JavaScriptCore/builtins/ObjectConstructor.js:
(groupBy):

Canonical link: <a href="https://commits.webkit.org/284739@main">https://commits.webkit.org/284739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c886f7a5987182f139a4b1b268d38ae8660b79ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21503 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55726 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18062 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19864 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63446 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76133 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69572 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17641 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63445 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/exit-transition-with-anonymous-layout-object.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-opacity.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14593 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63382 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11422 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5054 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91354 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/300 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19912 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->