### PR TITLE
[ARMv7] Some simple armv7 fixes

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1073,17 +1073,16 @@ LLINT_SLOW_PATH_DECL(slow_path_instanceof)
 
     bool result = false;
     JSValue hasInstance = performLLIntGetByID(codeBlock->bytecodeIndex(pc).withCheckpoint(OpInstanceof::getHasInstance), codeBlock, globalObject, constructor, vm.propertyNames->hasInstanceSymbol, metadata.m_hasInstanceModeMetadata);
-    RETURN_IF_EXCEPTION(throwScope, { });
+    LLINT_CHECK_EXCEPTION();
     if (hasInstance != globalObject->functionProtoHasInstanceSymbolFunction() || !constructor.getObject()->structure()->typeInfo().implementsDefaultHasInstance()) {
         result = constructor.getObject()->hasInstance(globalObject, value, hasInstance);
-        RETURN_IF_EXCEPTION(throwScope, { });
     } else if (!value.isObject())
         result = false;
     else {
         JSValue prototype = performLLIntGetByID(codeBlock->bytecodeIndex(pc).withCheckpoint(OpInstanceof::getPrototype), codeBlock, globalObject, constructor, vm.propertyNames->prototype, metadata.m_prototypeModeMetadata);
-        RETURN_IF_EXCEPTION(throwScope, { });
+        LLINT_CHECK_EXCEPTION();
         bool hasInstanceResult = JSObject::defaultHasInstance(globalObject, value, prototype);
-        RETURN_IF_EXCEPTION(throwScope, { });
+        LLINT_CHECK_EXCEPTION();
         result = hasInstanceResult;
     }
 

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -547,11 +547,14 @@ end
     break
 end
 
+if ARMv7
 macro branchIfWasmException(exceptionTarget)
-    loadp JSWebAssemblyInstance::m_vm[cfr], t3
+    loadp CodeBlock[cfr], t3
+    loadp JSWebAssemblyInstance::m_vm[t3], t3
     btpz VM::m_exception[t3], .noException
     jmp exceptionTarget
 .noException:
+end
 end
 
 macro zeroExtend32ToWord(r)
@@ -586,6 +589,13 @@ op(js_to_wasm_wrapper_entry, macro ()
             emit "movz x16, #0xBAD"
             emit "movz x17, #0xBAD"
             emit "movz x18, #0xBAD"
+        elsif ARMv7
+            emit "mov r4, #0xBAD"
+            emit "mov r5, #0xBAD"
+            emit "mov r6, #0xBAD"
+            emit "mov r8, #0xBAD"
+            emit "mov r9, #0xBAD"
+            emit "mov r12, #0xBAD"
         end
     end
 
@@ -681,6 +691,10 @@ if JSVALUE64
     orp (constexpr JSValue::NativeCalleeTag), wa0
 end
     storep wa0, Callee[cfr] # CalleeBits(JSEntrypointCallee*)
+if not JSVALUE64
+    move constexpr JSValue::NativeCalleeTag, wa0
+    storep wa0, TagOffset + Callee[cfr]
+end
 
     # Instance
     loadp WebAssemblyFunction::m_instance[ws0], wasmInstance
@@ -719,12 +733,7 @@ end
     move sp, a0
     cCall3(_operationJSToWasmEntryWrapperBuildFrame)
 
-if ARMv7
-    # CodeBlock slot is not an instance yet, so use JS version.
-    branchIfException(_wasm_throw_from_slow_path_trampoline)
-else
     btpnz r1, _wasm_throw_from_slow_path_trampoline
-end
     move r0, ws0
 
     # Arguments
@@ -900,19 +909,18 @@ end
     muli ImportFunctionInfoSize, ws1
 
     # Store Callee's wasm callee for import function
-    const ImportFunctionInfoBase = constexpr (sizeof(JSWebAssemblyInstance) + 7) & (~7)
-    leap ImportFunctionInfoBase[wasmInstance], ws0
+    leap (constexpr (JSWebAssemblyInstance::offsetOfTail()))[wasmInstance], ws0
     addp ws0, ws1
     # offsetOfBoxedTargetCalleeLoadLocation
     loadp JSWebAssemblyInstance::ImportFunctionInfo::boxedTargetCalleeLoadLocation[ws1], ws0
     loadp [ws0], ws0
 
-    const addressOfCalleeCalleeFromCallerPerspectiveBase = constexpr CallFrameSlot::callee * SlotSize + PayloadOffset
+    const addressOfCalleeCalleeFromCallerPerspectiveBase = constexpr CallFrameSlot::callee * SlotSize
 if JSVALUE64
     storep ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta[sp]
 else
-    storei ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + PayloadOffset[sp]
-    storei constexpr JSValue::NativeCalleeTag, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + TagOffset[sp]
+    storep ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + PayloadOffset[sp]
+    storep constexpr JSValue::NativeCalleeTag, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + TagOffset[sp]
 end
 
     loadp JSWebAssemblyInstance::ImportFunctionInfo::wasmEntrypointLoadLocation[ws1], ws0

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3624,7 +3624,10 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addThrowRef(Value exception, Stack&)
 
     LOG_INSTRUCTION("ThrowRef", exception);
 
-    emitMove(exception, Location::fromGPR(GPRInfo::argumentGPR1));
+    if constexpr (isARM_THUMB2())
+        emitMove(exception, Location::fromGPR2(wasmScratchGPR, GPRInfo::argumentGPR1));
+    else
+        emitMove(exception, Location::fromGPR(GPRInfo::argumentGPR1));
     consume(exception);
 
     ++m_callSiteIndex;

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1027,18 +1027,17 @@ WASM_SLOW_PATH_DECL(throw_ref)
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     auto instruction = pc->as<WasmThrowRef>();
-    auto exceptionPtr = READ(instruction.m_exception).pointer();
-    EncodedJSValue exception = EncodedJSValue(exceptionPtr);
+    auto exception = READ(instruction.m_exception).jsValue();
 
-    if (JSValue::decode(exception) == jsNull())
+    if (exception == jsNull())
         WASM_THROW(Wasm::ExceptionType::NullExnReference);
 
-    throwException(globalObject, throwScope, reinterpret_cast<JSWebAssemblyException*>(exceptionPtr));
+    throwException(globalObject, throwScope, jsCast<JSWebAssemblyException*>(exception));
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);
     ASSERT(!!vm.targetMachinePCForThrow);
-    WASM_RETURN_TWO(vm.targetMachinePCForThrow, exceptionPtr);
+    WASM_RETURN_TWO(vm.targetMachinePCForThrow, jsCast<JSWebAssemblyException*>(exception));
 }
 
 WASM_SLOW_PATH_DECL(retrieve_and_clear_exception)


### PR DESCRIPTION
#### 7d7d66f0624aaa42d2a78062e1e675811837fa32
<pre>
[ARMv7] Some simple armv7 fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=280930">https://bugs.webkit.org/show_bug.cgi?id=280930</a>

Reviewed by Yusuke Suzuki.

Many recent changes have broken the ARMv7 build. This patch fixes a few more
test cases.

* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCatchTableImpl):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitMoveRegister):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):

Canonical link: <a href="https://commits.webkit.org/284771@main">https://commits.webkit.org/284771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1320aa524bdb4b000e1084b9ceabdfd7df479b14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21663 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36314 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18199 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20024 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63606 "Failed to checkout and rebase branch from PR 34735") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76293 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69732 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5189 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91515 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45693 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19950 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->