### PR TITLE
[JSC] Add a peephole optimization for @wrapIterator() and utilize it across built-ins

### DIFF
--- a/JSTests/microbenchmarks/array-from-iterable.js
+++ b/JSTests/microbenchmarks/array-from-iterable.js
@@ -1,0 +1,7 @@
+(function() {
+    var source = [0, 1, 2, 3, 4];
+    for (var i = 0; i < 1e6; ++i)
+        var array = Array.from(source.values());
+    if (array[4] !== 4)
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/iterator-prototype-some.js
+++ b/JSTests/microbenchmarks/iterator-prototype-some.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+(function() {
+    var source = [0, 1, 2, 3, 4];
+    for (var i = 0; i < 1e6; ++i)
+        var has4 = source.values().some(x => x === 4);
+    if (!has4)
+        throw new Error("Bad assertion!");
+})();

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -71,11 +71,7 @@ function from(items /*, mapFn, thisArg */)
         // Since for-of loop once more looks up the @@iterator property of a given iterable,
         // it could be observable if the user defines a getter for @@iterator.
         // To avoid this situation, we define a wrapper object that @@iterator just returns a given iterator.
-        var wrapper = {
-            @@iterator: function () { return iterator; }
-        };
-
-        for (var value of wrapper) {
+        for (var value of @wrapIterator(iterator)) {
             if (k >= @MAX_SAFE_INTEGER)
                 @throwTypeError("Length exceeded the maximum array length");
             if (mapFn)

--- a/Source/JavaScriptCore/builtins/IteratorHelpers.js
+++ b/Source/JavaScriptCore/builtins/IteratorHelpers.js
@@ -54,10 +54,10 @@ function performIteration(iterable)
 }
 
 @linkTimeConstant
-function wrappedIterator(iterator)
+function wrapIterator(iterator)
 {
     var wrapper = @Object.@create(null);
-    wrapper.@@iterator = function() { return iterator; }
+    wrapper.@@iterator = function() { return iterator; };
     return wrapper;
 }
 
@@ -74,7 +74,7 @@ function builtinSetIterable(set)
     // placed at `Symbol.iterator`.
     var iteratorFunction = set.@values;
     
-    return @wrappedIterator(iteratorFunction.@call(set));
+    return @wrapIterator(iteratorFunction.@call(set));
 }
 
 @linkTimeConstant
@@ -90,5 +90,5 @@ function builtinMapIterable(map)
     // placed at `Symbol.iterator`.
     var iteratorFunction = map.@entries;
 
-    return @wrappedIterator(iteratorFunction.@call(map));
+    return @wrapIterator(iteratorFunction.@call(map));
 }

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -184,19 +184,18 @@ function flatMap(mapper)
 
     var iterated = this;
     var iteratedNextMethod = iterated.next;
-    var iteratedWrapper = {
-        @@iterator: function() { return this; },
+    var methodForwardingIterator = {
         next: function() { return iteratedNextMethod.@call(iterated); },
         return: function() { return iterated.return(@undefined); },
     };
 
     var generator = (function*() {
         var counter = 0;
-        for (var item of iteratedWrapper) {
+        for (var item of @wrapIterator(methodForwardingIterator)) {
             var mapped = mapper(item, counter++);
             var innerIterator = @getIteratorFlattenable(mapped, /* rejectStrings: */ true);
 
-            for (var innerItem of { @@iterator: function() { return innerIterator; } })
+            for (var innerItem of @wrapIterator(innerIterator))
                 yield innerItem;
         }
     })();
@@ -216,9 +215,7 @@ function some(predicate)
         @throwTypeError("Iterator.prototype.some callback must be a function.");
 
     var count = 0;
-    var iterator = this;
-    var wrapper = { @@iterator: function () { return iterator; }};
-    for (var item of wrapper) {
+    for (var item of @wrapIterator(this)) {
         if (predicate(item, count++))
             return true;
     }
@@ -238,9 +235,7 @@ function every(predicate)
         @throwTypeError("Iterator.prototype.every callback must be a function.");
 
     var count = 0;
-    var iterator = this;
-    var wrapper = { @@iterator: function () { return iterator; }};
-    for (var item of wrapper) {
+    for (var item of @wrapIterator(this)) {
         if (!predicate(item, count++))
             return false;
     }
@@ -260,9 +255,7 @@ function find(predicate)
         @throwTypeError("Iterator.prototype.find callback must be a function.");
 
     var count = 0;
-    var iterator = this;
-    var wrapper = { @@iterator: function () { return iterator; }};
-    for (var item of wrapper) {
+    for (var item of @wrapIterator(this)) {
         if (predicate(item, count++))
             return item;
     }

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -86,12 +86,8 @@ function union(other)
         @throwTypeError("Set.prototype.union expects other.keys to be callable");
 
     var iterator = keys.@call(other, keys);
-    var wrapper = {
-        @@iterator: function () { return iterator; }
-    };
-
     var result = @setClone(this);
-    for (var key of wrapper)
+    for (var key of @wrapIterator(iterator))
         result.@add(key);
 
     return result;
@@ -132,11 +128,7 @@ function intersection(other)
         } while (true);
     } else {
         var iterator = keys.@call(other, keys);
-        var wrapper = {
-            @@iterator: function () { return iterator; }
-        };
-
-        for (var key of wrapper) {
+        for (var key of @wrapIterator(iterator)) {
             if (this.@has(key))
                 result.@add(key);
         }
@@ -180,11 +172,7 @@ function difference(other)
         }
     } else {
         var iterator = keys.@call(other, keys);
-        var wrapper = {
-            @@iterator: function () { return iterator; }
-        };
-
-        for (var key of wrapper) {
+        for (var key of @wrapIterator(iterator)) {
             if (this.@has(key))
                 result.@delete(key);
         }
@@ -212,12 +200,8 @@ function symmetricDifference(other)
         @throwTypeError("Set.prototype.symmetricDifference expects other.keys to be callable");
 
     var iterator = keys.@call(other, keys);
-    var wrapper = {
-        @@iterator: function () { return iterator; }
-    };
-
     var result = @setClone(this);
-    for (var key of wrapper) {
+    for (var key of @wrapIterator(iterator)) {
         if (this.@has(key))
             result.@delete(key);
         else
@@ -287,11 +271,7 @@ function isSupersetOf(other)
         return false;
 
     var iterator = keys.@call(other, keys);
-    var wrapper = {
-        @@iterator: function () { return iterator; }
-    };
-
-    for (var key of wrapper) {
+    for (var key of @wrapIterator(iterator)) {
         if (!this.@has(key))
             return false;
     }
@@ -332,11 +312,7 @@ function isDisjointFrom(other)
         } while (true);
     } else {
         var iterator = keys.@call(other, keys);
-        var wrapper = {
-            @@iterator: function () { return iterator; }
-        };
-
-        for (var key of wrapper) {
+        for (var key of @wrapIterator(iterator)) {
             if (this.@has(key))
                 return false;
         }

--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -79,10 +79,7 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
         // Since for-of loop once more looks up the @@iterator property of a given iterable,
         // it could be observable if the user defines a getter for @@iterator.
         // To avoid this situation, we define a wrapper object that @@iterator just returns a given iterator.
-        var wrapper = {};
-        wrapper.@@iterator = function() { return iterator; }
-
-        for (var value of wrapper) {
+        for (var value of @wrapIterator(iterator)) {
             @putByValDirect(accumulator, count, value);
             count++;
         }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -866,7 +866,7 @@ namespace JSC {
         void emitTryWithFinallyThatDoesNotShadowException(const ScopedLambda<void(BytecodeGenerator&)>& emitTry, const ScopedLambda<void(BytecodeGenerator&)>& emitFinally);
         void emitTryWithFinallyThatDoesNotShadowException(FinallyContext&, const ScopedLambda<void(BytecodeGenerator&)>& emitTry, const ScopedLambda<void(BytecodeGenerator&)>& emitFinally);
 
-        void emitGenericEnumeration(ThrowableExpressionData* enumerationNode, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* = nullptr, RegisterID* forLoopSymbolTable = nullptr);
+        void emitGenericEnumeration(ThrowableExpressionData* enumerationNode, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* = nullptr, RegisterID* forLoopSymbolTable = nullptr, RegisterID* iteratorPtr = nullptr);
         void emitEnumeration(ThrowableExpressionData* enumerationNode, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* = nullptr, RegisterID* forLoopSymbolTable = nullptr);
 
         RegisterID* emitGetTemplateObject(RegisterID* dst, TaggedTemplateNode*);

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -121,7 +121,7 @@ function isPrimitiveValue(value)
     
 function createIterableWithoutPrototypeFromArguments(argumentsObject) {
     let iteratorFunction = argumentsObject.@@iterator;
-    return @wrappedIterator(iteratorFunction.@call(argumentsObject));
+    return @wrapIterator(iteratorFunction.@call(argumentsObject));
 }
 
 function max(a, b) {


### PR DESCRIPTION
#### ed9f39676b3034ae2ed577cb766e9885e9467a22
<pre>
[JSC] Add a peephole optimization for @wrapIterator() and utilize it across built-ins
<a href="https://bugs.webkit.org/show_bug.cgi?id=280934">https://bugs.webkit.org/show_bug.cgi?id=280934</a>
&lt;<a href="https://rdar.apple.com/problem/137328904">rdar://problem/137328904</a>&gt;

Reviewed by NOBODY (OOPS!).

Given that non-generic BytecodeGenerator::emitEnumeration() is beneficial only when called on JSArray [1],
this patch optimizes patterns like `for (var item of @wrapIterator(this))` by &quot;inlining&quot; @wrapIterator()
to avoid creation of intermediate iterator wrapper and performing GetIterator [2], which results in 9%
speed-up of `Array.from(iterable)` and even more for a few Iterator helpers.

                                    ToT                      Patch

array-from-iterable           42.6624+-0.1969     ^     39.0824+-0.1893        ^ definitely 1.0916x faster
iterator-prototype-some       25.0081+-0.0551     ^     21.9849+-0.1285        ^ definitely 1.1375x faster

No new tests, no behavior change.

[1]: <a href="https://github.com/WebKit/WebKit/commit/02445d9ac60880854cc79ba1af2602a092d28134">https://github.com/WebKit/WebKit/commit/02445d9ac60880854cc79ba1af2602a092d28134</a>
[2]: <a href="https://tc39.es/ecma262/#sec-getiterator">https://tc39.es/ecma262/#sec-getiterator</a>

* JSTests/microbenchmarks/array-from-iterable.js: Added.
* JSTests/microbenchmarks/iterator-prototype-some.js: Added.
* Source/JavaScriptCore/builtins/ArrayConstructor.js:
(from):
(from.wrapper.iterator): Deleted.
* Source/JavaScriptCore/builtins/IteratorHelpers.js:
(linkTimeConstant.wrapIterator.wrapper.iterator):
(linkTimeConstant.wrapIterator):
(set linkTimeConstant.builtinMapIterable):
(linkTimeConstant.wrappedIterator.wrapper.iterator): Deleted.
(linkTimeConstant.wrappedIterator): Deleted.
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(flatMap.generator):
(flatMap):
(some):
(every):
(find):
(flatMap.iteratedWrapper.iterator): Deleted.
(flatMap.iteratedWrapper.next): Deleted.
(flatMap.iteratedWrapper.return): Deleted.
(flatMap.): Deleted.
(some.wrapper.iterator): Deleted.
(every.wrapper.iterator): Deleted.
(find.wrapper.iterator): Deleted.
* Source/JavaScriptCore/builtins/SetPrototype.js:
(union):
(intersection):
(difference):
(symmetricDifference):
(isSupersetOf):
(isDisjointFrom):
(union.wrapper.iterator): Deleted.
(intersection.else.wrapper.iterator): Deleted.
(difference.else.wrapper.iterator): Deleted.
(symmetricDifference.wrapper.iterator): Deleted.
(isSupersetOf.wrapper.iterator): Deleted.
(isDisjointFrom.else.wrapper.iterator): Deleted.
* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
(from):
(from.wrapper.iterator): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitGenericEnumeration):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ForOfNode::emitBytecode):
* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(createIterableWithoutPrototypeFromArguments):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::ExpressionNode::isBinaryOpNode const):
(JSC::ExpressionNode::functionCallNodeKind const):
(JSC::ExpressionNode::isFunctionCall const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed9f39676b3034ae2ed577cb766e9885e9467a22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21522 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14213 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18077 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19883 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63465 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76152 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69591 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14570 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17658 "Found 60 new test failures: accessibility/aria-expanded-supported-roles.html accessibility/aria-hidden-hides-all-elements.html accessibility/custom-elements/controls-shadow.html accessibility/custom-elements/controls.html accessibility/custom-elements/describedby-shadow.html accessibility/custom-elements/describedby.html accessibility/custom-elements/flowto-shadow.html accessibility/mac/media-role-descriptions.html accessibility/mac/text-marker-for-index.html accessibility/mac/text-marker-paragraph-nav.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63458 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63396 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5069 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45552 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/319 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19918 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->