### PR TITLE
Fix smart pointer warnings in RemoteSourceBufferProxy::createInitializationSegmentInfo

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -74,6 +74,7 @@ public:
             RefPtr<MediaDescription> description;
             RefPtr<AudioTrackPrivate> track;
 
+            RefPtr<MediaDescription> protectedDescription() const { return description; }
             RefPtr<AudioTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<AudioTrackInformation> audioTracks;
@@ -82,6 +83,7 @@ public:
             RefPtr<MediaDescription> description;
             RefPtr<VideoTrackPrivate> track;
 
+            RefPtr<MediaDescription> protectedDescription() const { return description; }
             RefPtr<VideoTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<VideoTrackInformation> videoTracks;
@@ -90,6 +92,7 @@ public:
             RefPtr<MediaDescription> description;
             RefPtr<InbandTextTrackPrivate> track;
 
+            RefPtr<MediaDescription> protectedDescription() const { return description; }
             RefPtr<InbandTextTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<TextTrackInformation> textTracks;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -383,24 +383,24 @@ std::optional<InitializationSegmentInfo> RemoteSourceBufferProxy::createInitiali
     InitializationSegmentInfo segmentInfo;
     segmentInfo.duration = segment.duration;
 
-    segmentInfo.audioTracks = segment.audioTracks.map([&](auto& audioTrackInfo) {
+    segmentInfo.audioTracks = segment.audioTracks.map([&](const InitializationSegment::AudioTrackInformation& audioTrackInfo) {
         auto id = audioTrackInfo.track->id();
         remoteMediaPlayerProxy->addRemoteAudioTrackProxy(*audioTrackInfo.protectedTrack());
-        m_mediaDescriptions.try_emplace(id, *audioTrackInfo.description);
+        m_mediaDescriptions.try_emplace(id, *audioTrackInfo.protectedDescription());
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*audioTrackInfo.description), id };
     });
 
-    segmentInfo.videoTracks = segment.videoTracks.map([&](auto& videoTrackInfo) {
+    segmentInfo.videoTracks = segment.videoTracks.map([&](const InitializationSegment::VideoTrackInformation& videoTrackInfo) {
         auto id = videoTrackInfo.track->id();
         remoteMediaPlayerProxy->addRemoteVideoTrackProxy(*videoTrackInfo.protectedTrack());
-        m_mediaDescriptions.try_emplace(id, *videoTrackInfo.description);
+        m_mediaDescriptions.try_emplace(id, *videoTrackInfo.protectedDescription());
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*videoTrackInfo.description), id };
     });
 
-    segmentInfo.textTracks = segment.textTracks.map([&](auto& textTrackInfo) {
+    segmentInfo.textTracks = segment.textTracks.map([&](const InitializationSegment::TextTrackInformation& textTrackInfo) {
         auto id = textTrackInfo.track->id();
         remoteMediaPlayerProxy->addRemoteTextTrackProxy(*textTrackInfo.protectedTrack());
-        m_mediaDescriptions.try_emplace(id, *textTrackInfo.description);
+        m_mediaDescriptions.try_emplace(id, *textTrackInfo.protectedDescription());
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*textTrackInfo.description), id };
     });
 

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -14,7 +14,6 @@ GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
 GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
 GPUProcess/media/RemoteAudioTrackProxy.h
 GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
-GPUProcess/media/RemoteSourceBufferProxy.cpp
 GPUProcess/media/RemoteVideoTrackProxy.h
 JSWebExtensionAPIAction.mm
 JSWebExtensionAPIAlarms.mm


### PR DESCRIPTION
#### 7d3dcb5289b05797610da7432b2f1ca0393570c3
<pre>
Fix smart pointer warnings in RemoteSourceBufferProxy::createInitializationSegmentInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=280936">https://bugs.webkit.org/show_bug.cgi?id=280936</a>

Reviewed by Chris Dumez.

The warnings were emitted because static analyzer can&apos;t resolve the type of the &quot;auto&quot; lambda arguments.
Explicitly specify the argument type to fix this.

Also protect the media description as it was warned by the static analyzer once the type was specified.

* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation::protectedDescription const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation::protectedDescription const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::TextTrackInformation::protectedDescription const):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::createInitializationSegmentInfo):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/284753@main">https://commits.webkit.org/284753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d80e338d526996b5aee34bde991133d94e18370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55756 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14227 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76169 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63476 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63413 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5085 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10780 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45569 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->