### PR TITLE
[Skia] Add build option to toggle SK_DEBUG

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -771,6 +771,7 @@ add_library(Skia STATIC
     src/sksl/SkSLUtil.cpp
     src/sksl/analysis/SkSLCanExitWithoutReturningValue.cpp
     src/sksl/analysis/SkSLCheckProgramStructure.cpp
+    src/sksl/analysis/SkSLCheckSymbolTableCorrectness.cpp
     src/sksl/analysis/SkSLFinalizationChecks.cpp
     src/sksl/analysis/SkSLGetLoopControlFlowInfo.cpp
     src/sksl/analysis/SkSLGetLoopUnrollInfo.cpp
@@ -937,6 +938,12 @@ target_compile_definitions(Skia PRIVATE
     SK_GAMMA_APPLY_TO_A8
 )
 
+# SK_DEBUG enables consistency checks. Most of the time this will not be
+# useful to develop WebKit, but provide a toggle that developers may flip
+# nevertheless to help catch incorrect Skia API uses when desired.
+option(SKIA_DEBUG "Enable internal Skia consistency checks" OFF)
+mark_as_advanced(SKIA_DEBUG)
+
 target_compile_definitions(Skia PUBLIC
     SK_DISABLE_LEGACY_GL_MAKE_NATIVE_INTERFACE
     SK_DISABLE_LEGACY_IMAGE_READBUFFER
@@ -949,10 +956,7 @@ target_compile_definitions(Skia PUBLIC
 
     SK_R32_SHIFT=16
 
-    # Use SK_RELEASE for all build types, even "Debug". The alternative
-    # is SK_DEBUG, which enables consistency checks useful to develop
-    # Skia itself, but not so much for WebKit development.
-    SK_RELEASE
+    $<IF:$<BOOL:${SKIA_DEBUG}>,SK_DEBUG,SK_RELEASE>
 )
 
 #


### PR DESCRIPTION
#### 480ca73104459953a95b269b0a40a6ebd27fe732
<pre>
[Skia] Add build option to toggle SK_DEBUG
<a href="https://bugs.webkit.org/show_bug.cgi?id=280945">https://bugs.webkit.org/show_bug.cgi?id=280945</a>

Reviewed by Nikolas Zimmermann.

Add a SKIA_DEBUG option to the Skia CMake build recipe, which toggles
between SK_RELEASE (when disabled) and SK_DEBUG (when enabled).

* Source/ThirdParty/skia/CMakeLists.txt: Add build option and list
  additional source file containing the implementation of an internal
  Skia check.

Canonical link: <a href="https://commits.webkit.org/284742@main">https://commits.webkit.org/284742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c4a8332d10189853e7c04b0220c258985218d7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21549 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55764 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14235 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36226 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19910 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76179 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63484 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63421 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5093 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/346 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->