### PR TITLE
Factor out gradient code out into strongly typed CSS/Style values

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -846,11 +846,31 @@ template<ByteType T, typename U> constexpr auto byteCast(const U& value)
 }
 
 // This is like std::invocable but it takes the expected signature rather than just the arguments.
-template<typename Functor, typename Signature>
-concept Invocable = requires(std::decay_t<Functor>&& f, std::function<Signature> expected)
-{
+template<typename Functor, typename Signature> concept Invocable = requires(std::decay_t<Functor>&& f, std::function<Signature> expected) {
     { expected = std::move(f) };
 };
+
+// Concept for constraining to user-defined "Tuple-like" types.
+//
+// Based on exposition-only text in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2165r3.pdf
+// and https://stackoverflow.com/questions/68443804/c20-concept-to-check-tuple-like-types.
+
+template<class T, std::size_t N> concept HasTupleElement = requires(T t) {
+    typename std::tuple_element_t<N, std::remove_const_t<T>>;
+    { get<N>(t) } -> std::convertible_to<std::tuple_element_t<N, T>&>;
+};
+
+template<class T> concept TupleLike = !std::is_reference_v<T>
+    && requires(T t) {
+        typename std::tuple_size<T>::type;
+        requires std::derived_from<
+          std::tuple_size<T>,
+          std::integral_constant<std::size_t, std::tuple_size_v<T>>
+        >;
+      }
+    && []<std::size_t... N>(std::index_sequence<N...>) {
+        return (HasTupleElement<T, N> && ...);
+    }(std::make_index_sequence<std::tuple_size_v<T>>());
 
 // This is like std::apply, but works with user-defined "Tuple-like" types as well as the
 // standard ones. The only real difference between its implementation and the standard one

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -907,7 +907,6 @@ css/CSSFontStyleRangeValue.h
 css/CSSFontStyleWithAngleValue.cpp
 css/CSSFontValue.cpp
 css/CSSGradientValue.cpp
-css/CSSGradientValue.h
 css/CSSGridIntegerRepeatValue.cpp
 css/CSSGridLineValue.cpp
 css/CSSGroupingRule.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -681,7 +681,6 @@ css/CSSFontFace.cpp
 css/CSSFontFaceSet.cpp
 css/CSSFontFaceSource.cpp
 css/CSSFontSelector.cpp
-css/CSSGradientValue.cpp
 css/CSSGroupingRule.cpp
 css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1117,6 +1117,7 @@ css/typedom/transform/CSSSkewY.cpp
 css/typedom/transform/CSSTransformComponent.cpp
 css/typedom/transform/CSSTransformValue.cpp
 css/typedom/transform/CSSTranslate.cpp
+css/values/CSSGradient.cpp
 css/values/CSSPosition.cpp
 css/values/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp
 css/values/CSSPrimitiveNumericTypes+Serialization.cpp
@@ -3052,6 +3053,7 @@ style/StyleUpdate.cpp
 style/Styleable.cpp
 style/TransformOperationsBuilder.cpp
 style/UserAgentStyle.cpp
+style/values/StyleGradient.cpp
 style/values/StylePosition.cpp
 style/values/StylePrimitiveNumericTypes.cpp
 style/values/StylePrimitiveNumericTypes+Conversions.cpp

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -344,7 +344,7 @@ static FontSelectionRequest computeFontSelectionRequest(CSSPropertyParserHelpers
             // FIXME: Figure out correct behavior when conversion data is required.
             if (requiresConversionData(weight))
                 return normalWeightValue();
-            return FontSelectionValue(clampTo<float>(CSS::toStyleNoConversionDataRequired(weight, CSSCalcSymbolTable { }).value, 1, 1000));
+            return FontSelectionValue(clampTo<float>(Style::toStyleNoConversionDataRequired(weight).value, 1, 1000));
         }
     );
 
@@ -356,7 +356,7 @@ static FontSelectionRequest computeFontSelectionRequest(CSSPropertyParserHelpers
             // FIXME: Figure out correct behavior when conversion data is required.
             if (requiresConversionData(percent))
                 return normalStretchValue();
-            return FontSelectionValue::clampFloat(CSS::toStyleNoConversionDataRequired(percent, CSSCalcSymbolTable { }).value);
+            return FontSelectionValue::clampFloat(Style::toStyleNoConversionDataRequired(percent).value);
         }
     );
 
@@ -378,7 +378,7 @@ static FontSelectionRequest computeFontSelectionRequest(CSSPropertyParserHelpers
             // FIXME: Figure out correct behavior when conversion data is required.
             if (requiresConversionData(angle))
                 return std::nullopt;
-            return normalizedFontItalicValue(CSS::toStyleNoConversionDataRequired(angle, CSSCalcSymbolTable { }).value);
+            return normalizedFontItalicValue(Style::toStyleNoConversionDataRequired(angle).value);
         }
     );
 

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -26,1029 +26,248 @@
 #include "config.h"
 #include "CSSGradientValue.h"
 
-#include "CSSCalcSymbolTable.h"
-#include "CSSCalcValue.h"
-#include "CSSPrimitiveNumericTypes+Serialization.h"
-#include "CSSPrimitiveValueMappings.h"
-#include "CSSValueKeywords.h"
-#include "CalculationValue.h"
 #include "ColorInterpolation.h"
-#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
 #include "StyleGradientImage.h"
-#include "StylePosition.h"
-#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+namespace CSS {
+namespace {
 
-template<CSS::RawNumeric T> static inline bool styleImageIsUncacheable(const T&);
-template<typename T> static bool styleImageIsUncacheable(const std::optional<T>&);
-template<typename T> static bool styleImageIsUncacheable(const CSS::UnevaluatedCalc<T>&);
-template<typename T> static bool styleImageIsUncacheable(const CSS::PrimitiveNumeric<T>&);
-template<typename T1, typename T2> static bool styleImageIsUncacheable(const std::pair<T1, T2>&);
-template<typename... Ts> static inline bool styleImageIsUncacheable(const CSS::SpaceSeparatedTuple<Ts...>&);
-template<typename... Ts> static inline bool styleImageIsUncacheable(const std::variant<Ts...>&);
+template<typename> struct StyleImageIsUncacheable;
 
-static inline bool styleImageIsUncacheable(CSSUnitType unit)
+template<typename CSSType> static bool styleImageIsUncacheable(const CSSType& value)
 {
-    return conversionToCanonicalUnitRequiresConversionData(unit);
+    return StyleImageIsUncacheable<CSSType>()(value);
 }
 
-static inline bool styleImageIsUncacheable(const CSSPrimitiveValue& value)
+template<typename TupleLike> static bool styleImageIsUncacheableOnTupleLike(const TupleLike& tupleLike)
 {
-    if (auto* calc = value.cssCalcValue())
-        return calc->requiresConversionData();
-    return styleImageIsUncacheable(value.primitiveType());
+    return WTF::apply([&](const auto& ...x) { return (styleImageIsUncacheable(x) || ...); }, tupleLike);
 }
 
-static inline bool styleImageIsUncacheable(const CSSValue& value)
-{
-    if (const CSSPrimitiveValue* primitive = dynamicDowncast<CSSPrimitiveValue>(value))
-        return styleImageIsUncacheable(*primitive);
-    return false;
-}
+template<typename CSSType> struct StyleImageIsUncacheable<std::optional<CSSType>> {
+    bool operator()(const std::optional<CSSType>& value) { return value && styleImageIsUncacheable(*value); }
+};
 
-constexpr bool styleImageIsUncacheable(const CSS::Left&)
-{
-    return false;
-}
+template<typename CSSType, size_t inlineCapacity> struct StyleImageIsUncacheable<SpaceSeparatedVector<CSSType, inlineCapacity>> {
+    bool operator()(const SpaceSeparatedVector<CSSType, inlineCapacity>& value) { return std::ranges::any_of(value, [](auto& element) { return styleImageIsUncacheable(element); }); }
+};
 
-constexpr bool styleImageIsUncacheable(const CSS::Right&)
-{
-    return false;
-}
+template<typename CSSType, size_t inlineCapacity> struct StyleImageIsUncacheable<CommaSeparatedVector<CSSType, inlineCapacity>> {
+    bool operator()(const CommaSeparatedVector<CSSType, inlineCapacity>& value) { return std::ranges::any_of(value, [](auto& element) { return styleImageIsUncacheable(element); }); }
+};
 
-constexpr bool styleImageIsUncacheable(const CSS::Top&)
-{
-    return false;
-}
+template<typename... CSSTypes> struct StyleImageIsUncacheable<SpaceSeparatedTuple<CSSTypes...>> {
+    bool operator()(const SpaceSeparatedTuple<CSSTypes...>& value) { return styleImageIsUncacheableOnTupleLike(value); }
+};
 
-constexpr bool styleImageIsUncacheable(const CSS::Bottom&)
-{
-    return false;
-}
+template<typename... CSSTypes> struct StyleImageIsUncacheable<CommaSeparatedTuple<CSSTypes...>> {
+    bool operator()(const CommaSeparatedTuple<CSSTypes...>& value) { return styleImageIsUncacheableOnTupleLike(value); }
+};
 
-constexpr bool styleImageIsUncacheable(const CSS::Center&)
-{
-    return false;
-}
+template<typename... CSSTypes> struct StyleImageIsUncacheable<std::variant<CSSTypes...>> {
+    bool operator()(const std::variant<CSSTypes...>& value) { return WTF::switchOn(value, [](const auto& alternative) { return styleImageIsUncacheable(alternative); }); }
+};
 
-static inline bool styleImageIsUncacheable(const CSS::Position& position)
-{
-    return styleImageIsUncacheable(position.value);
-}
+template<> struct StyleImageIsUncacheable<CSSUnitType> {
+    bool operator()(const CSSUnitType& value) { return conversionToCanonicalUnitRequiresConversionData(value); }
+};
 
-template<CSS::RawNumeric T> static inline bool styleImageIsUncacheable(const T& raw)
-{
-    return styleImageIsUncacheable(raw.type);
-}
+template<RawNumeric CSSType> struct StyleImageIsUncacheable<CSSType> {
+    constexpr bool operator()(const CSSType& value) { return styleImageIsUncacheable(value.type); }
+};
 
-template<typename T> static bool styleImageIsUncacheable(const std::optional<T>& optional)
-{
-    return optional && styleImageIsUncacheable(*optional);
-}
+template<RawNumeric CSSType> struct StyleImageIsUncacheable<UnevaluatedCalc<CSSType>> {
+    constexpr bool operator()(const UnevaluatedCalc<CSSType>& value) { return value.calc->requiresConversionData(); }
+};
 
-template<typename T> static bool styleImageIsUncacheable(const CSS::UnevaluatedCalc<T>& calc)
-{
-    return calc.calc->requiresConversionData();
-}
+template<RawNumeric CSSType> struct StyleImageIsUncacheable<PrimitiveNumeric<CSSType>> {
+    constexpr bool operator()(const PrimitiveNumeric<CSSType>& value) { return styleImageIsUncacheable(value.value); }
+};
 
-template<typename T> static bool styleImageIsUncacheable(const CSS::PrimitiveNumeric<T>& numeric)
-{
-    return styleImageIsUncacheable(numeric.value);
-}
+template<CSSValueID C> struct StyleImageIsUncacheable<Constant<C>> {
+    constexpr bool operator()(const Constant<C>&) { return false; }
+};
 
-template<typename T1, typename T2> static bool styleImageIsUncacheable(const std::pair<T1, T2>& pair)
-{
-    return styleImageIsUncacheable(pair.first) || styleImageIsUncacheable(pair.second);
-}
+template<> struct StyleImageIsUncacheable<GradientColorInterpolationMethod> {
+    constexpr bool operator()(const GradientColorInterpolationMethod&) { return false; }
+};
 
-template<typename... Ts> static inline bool styleImageIsUncacheable(const CSS::SpaceSeparatedTuple<Ts...>& tuple)
-{
-    return WTF::apply([&](const auto& ...x) { return (styleImageIsUncacheable(x) || ...); }, tuple);
-}
+template<> struct StyleImageIsUncacheable<GradientRepeat> {
+    constexpr bool operator()(const GradientRepeat&) { return false; }
+};
 
-template<typename... Ts> static inline bool styleImageIsUncacheable(const std::variant<Ts...>& variant)
-{
-    return WTF::switchOn(variant, [](const auto& value) { return styleImageIsUncacheable(value); });
-}
+template<> struct StyleImageIsUncacheable<Position> {
+    bool operator()(const Position& value) { return styleImageIsUncacheable(value.value); }
+};
 
-template<typename Stop> static bool styleImageIsUncacheable(const CSSGradientColorStopList<Stop>& stops)
-{
-    for (auto& stop : stops) {
-        if (styleImageIsUncacheable(stop.position))
+template<typename CSSType> struct StyleImageIsUncacheable<GradientColorStop<CSSType>> {
+    bool operator()(const GradientColorStop<CSSType>& value)
+    {
+        if (styleImageIsUncacheable(value.position))
             return true;
-        if (stop.color && Style::BuilderState::isColorFromPrimitiveValueDerivedFromElement(*stop.color))
+        if (value.color && Style::BuilderState::isColorFromPrimitiveValueDerivedFromElement(*value.color))
             return true;
+        return false;
     }
-    return false;
-}
+};
 
-static inline std::optional<StyleColor> computeStopColor(const RefPtr<CSSPrimitiveValue>& color, Style::BuilderState& state)
-{
-    if (!color)
-        return std::nullopt;
-    return state.colorFromPrimitiveValue(*color);
-}
+template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct StyleImageIsUncacheable<CSSType> {
+    bool operator()(const CSSType& value) { return styleImageIsUncacheableOnTupleLike(value); }
+};
 
-static inline std::optional<Style::LengthPercentage> computeStopPosition(const CSSGradientLinearColorStop::Position& position, Style::BuilderState& state)
-{
-    return CSS::toStyle(position, state);
-}
-
-static inline std::optional<Style::AnglePercentage> computeStopPosition(const CSSGradientAngularColorStop::Position& position, Style::BuilderState& state)
-{
-    return CSS::toStyle(position, state);
-}
-
-static inline Style::Number computeStopPosition(const CSSGradientDeprecatedColorStop::Position& position, Style::BuilderState& state)
-{
-    return WTF::switchOn(position,
-        [&](const CSS::Number& number) {
-            return CSS::toStyle(number, state);
-        },
-        [&](const CSS::Percentage& percentage) {
-            return Style::Number { CSS::toStyle(percentage, state).value / 100.0f };
-        }
-    );
-}
-
-static decltype(auto) toStyle(const CSSGradientLinearColorStopList& stops, Style::BuilderState& state)
-{
-    return stops.map([&](auto& stop) -> StyleGradientImageLinearColorStop {
-        return { computeStopColor(stop.color, state), computeStopPosition(stop.position, state) };
-    });
-}
-
-static decltype(auto) toStyle(const CSSGradientAngularColorStopList& stops, Style::BuilderState& state)
-{
-    return stops.map([&](auto& stop) -> StyleGradientImageAngularColorStop {
-        return { computeStopColor(stop.color, state), computeStopPosition(stop.position, state) };
-    });
-}
-
-static decltype(auto) toStyle(const CSSGradientDeprecatedColorStopList& stops, Style::BuilderState& state)
-{
-    return stops.map([&](auto& stop) -> StyleGradientImageDeprecatedColorStop {
-        return { computeStopColor(stop.color, state), computeStopPosition(stop.position, state) };
-    });
-}
+} // namespace (anonymous)
+} // namespace CSS
 
 // MARK: -
 
-RefPtr<StyleImage> CSSLinearGradientValue::createStyleImage(Style::BuilderState& state) const
+template<typename T> RefPtr<StyleImage> getOrCreateStyleImage(const T& gradient, RefPtr<StyleImage>& cachedStyleImage, Style::BuilderState& state)
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto gradientLine = WTF::switchOn(m_data.gradientLine,
-        [&](const CSS::Angle& value) -> StyleGradientImage::LinearData::GradientLine {
-            return CSS::toStyle(value, state);
-        },
-        [&](const auto& value) -> StyleGradientImage::LinearData::GradientLine {
-            return value;
-        }
-    );
+    if (cachedStyleImage)
+        return cachedStyleImage;
 
     auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::LinearData {
-            WTFMove(gradientLine),
-            m_repeating,
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
+        Style::toStyle(gradient, state)
     );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
+    if (!CSS::styleImageIsUncacheable(gradient))
+        cachedStyleImage = styleImage.ptr();
 
     return styleImage;
+}
+
+RefPtr<StyleImage> CSSLinearGradientValue::createStyleImage(Style::BuilderState& state) const
+{
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 RefPtr<StyleImage> CSSPrefixedLinearGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto gradientLine = WTF::switchOn(m_data.gradientLine,
-        [&](const CSS::Angle& value) -> StyleGradientImage::PrefixedLinearData::GradientLine {
-            return CSS::toStyle(value, state);
-        },
-        [&](const auto& value) -> StyleGradientImage::PrefixedLinearData::GradientLine {
-            return value;
-        }
-    );
-
-    auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::PrefixedLinearData {
-            WTFMove(gradientLine),
-            m_repeating,
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
-    );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
-
-    return styleImage;
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 RefPtr<StyleImage> CSSDeprecatedLinearGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::DeprecatedLinearData {
-            CSS::toStyle(m_data.first, state),
-            CSS::toStyle(m_data.second, state),
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
-    );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
-
-    return styleImage;
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 RefPtr<StyleImage> CSSRadialGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto gradientBox = WTF::switchOn(m_data.gradientBox,
-        [&](std::monostate) -> StyleGradientImage::RadialData::GradientBox {
-            return std::monostate { };
-        },
-        [&](const CSSRadialGradientValue::Shape& shape) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::Shape {
-                shape.shape,
-                CSS::toStyle(shape.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::Extent& extent) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::Extent {
-                extent.extent,
-                CSS::toStyle(extent.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::Length& length) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::Length {
-                CSS::toStyle(length.length, state),
-                CSS::toStyle(length.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::Size& size) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::Size {
-                CSS::toStyle(size.size, state),
-                CSS::toStyle(size.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::CircleOfLength& circleOfLength) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::CircleOfLength {
-                CSS::toStyle(circleOfLength.length, state),
-                CSS::toStyle(circleOfLength.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::CircleOfExtent& circleOfExtent) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::CircleOfExtent {
-                circleOfExtent.extent,
-                CSS::toStyle(circleOfExtent.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::EllipseOfSize& ellipseOfSize) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::EllipseOfSize {
-                CSS::toStyle(ellipseOfSize.size, state),
-                CSS::toStyle(ellipseOfSize.position, state)
-            };
-        },
-        [&](const CSSRadialGradientValue::EllipseOfExtent& ellipseOfExtent) -> StyleGradientImage::RadialData::GradientBox {
-            return StyleGradientImage::RadialData::EllipseOfExtent {
-                ellipseOfExtent.extent,
-                CSS::toStyle(ellipseOfExtent.position, state)
-            };
-        },
-        [&](const CSS::Position& position) -> StyleGradientImage::RadialData::GradientBox {
-            return CSS::toStyle(position, state);
-        }
-    );
-
-    auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::RadialData {
-            WTFMove(gradientBox),
-            m_repeating,
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
-    );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
-
-    return styleImage;
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 RefPtr<StyleImage> CSSPrefixedRadialGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto gradientBox = WTF::switchOn(m_data.gradientBox,
-        [&](std::monostate) -> StyleGradientImage::PrefixedRadialData::GradientBox {
-            return std::monostate { };
-        },
-        [&](const CSSPrefixedRadialGradientValue::ShapeKeyword& shape) -> StyleGradientImage::PrefixedRadialData::GradientBox {
-            return shape;
-        },
-        [&](const CSSPrefixedRadialGradientValue::ExtentKeyword& extent) -> StyleGradientImage::PrefixedRadialData::GradientBox {
-            return extent;
-        },
-        [&](const CSSPrefixedRadialGradientValue::ShapeAndExtent& shapeAndExtent) -> StyleGradientImage::PrefixedRadialData::GradientBox {
-            return shapeAndExtent;
-        },
-        [&](const CSSPrefixedRadialGradientValue::MeasuredSize& measuredSize) -> StyleGradientImage::PrefixedRadialData::GradientBox {
-            return StyleGradientImage::PrefixedRadialData::MeasuredSize {
-                CSS::toStyle(measuredSize.size, state)
-            };
-        }
-    );
-
-    auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::PrefixedRadialData {
-            WTFMove(gradientBox),
-            CSS::toStyle(m_data.position, state),
-            m_repeating,
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
-    );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
-
-    return styleImage;
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 RefPtr<StyleImage> CSSDeprecatedRadialGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto toStyleRadius = [](const CSS::Number& radius, Style::BuilderState& state) -> Style::Number {
-        return { CSS::toStyle(radius, state).value * state.cssToLengthConversionData().zoom() };
-    };
-
-    auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::DeprecatedRadialData {
-            CSS::toStyle(m_data.first, state),
-            CSS::toStyle(m_data.second, state),
-            toStyleRadius(m_data.firstRadius, state),
-            toStyleRadius(m_data.secondRadius, state),
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
-    );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
-
-    return styleImage;
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 RefPtr<StyleImage> CSSConicGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    if (m_cachedStyleImage)
-        return m_cachedStyleImage;
-
-    auto styleImage = StyleGradientImage::create(
-        StyleGradientImage::ConicData {
-            CSS::toStyle(m_data.angle, state),
-            CSS::toStyle(m_data.position, state),
-            m_repeating,
-            toStyle(m_stops, state)
-        },
-        m_colorInterpolationMethod
-    );
-    if (!styleImageIsUncacheable())
-        m_cachedStyleImage = styleImage.ptr();
-
-    return styleImage;
-}
-
-static bool appendColorInterpolationMethod(StringBuilder& builder, CSSGradientColorInterpolationMethod colorInterpolationMethod, bool needsLeadingSpace)
-{
-    return WTF::switchOn(colorInterpolationMethod.method.colorSpace,
-        [&](const ColorInterpolationMethod::OKLab&) {
-            if (colorInterpolationMethod.defaultMethod != CSSGradientColorInterpolationMethod::Default::OKLab) {
-                builder.append(needsLeadingSpace ? " "_s : ""_s, "in oklab"_s);
-                return true;
-            }
-            return false;
-        },
-        [&](const ColorInterpolationMethod::SRGB&) {
-            if (colorInterpolationMethod.defaultMethod != CSSGradientColorInterpolationMethod::Default::SRGB) {
-                builder.append(needsLeadingSpace ? " "_s : ""_s, "in srgb"_s);
-                return true;
-            }
-            return false;
-        },
-        [&]<typename MethodColorSpace> (const MethodColorSpace& methodColorSpace) {
-            builder.append(needsLeadingSpace ? " "_s : ""_s, "in "_s, serializationForCSS(methodColorSpace.interpolationColorSpace));
-            if constexpr (hasHueInterpolationMethod<MethodColorSpace>)
-                serializationForCSS(builder, methodColorSpace.hueInterpolationMethod);
-            return true;
-        }
-    );
-}
-
-static void appendColorStop(StringBuilder& builder, const CSSGradientDeprecatedColorStop& stop)
-{
-    auto appendRaw = [&](const auto& color, CSS::NumberRaw raw) {
-        if (!raw.value)
-            builder.append("from("_s, color->cssText(), ')');
-        else if (raw.value == 1)
-            builder.append("to("_s, color->cssText(), ')');
-        else {
-            builder.append("color-stop("_s);
-            serializationForCSS(builder, raw);
-            builder.append(", "_s, color->cssText(), ')');
-        }
-    };
-
-    auto appendCalc = [&](const auto& calc) {
-        builder.append("color-stop("_s, calc.calc->cssText(), ", "_s, stop.color->cssText(), ')');
-    };
-
-    WTF::switchOn(stop.position,
-        [&](const CSS::Number& number) {
-            return WTF::switchOn(number.value,
-                [&](CSS::NumberRaw raw) {
-                    appendRaw(stop.color, raw);
-                },
-                [&](const CSS::UnevaluatedCalc<CSS::NumberRaw>& calc) {
-                    appendCalc(calc);
-                }
-            );
-        },
-        [&](const CSS::Percentage& percentage) {
-            return WTF::switchOn(percentage.value,
-                [&](CSS::PercentageRaw raw) {
-                    appendRaw(stop.color, { raw.value / 100.0 });
-                },
-                [&](const CSS::UnevaluatedCalc<CSS::PercentageRaw>& calc) {
-                    appendCalc(calc);
-                }
-            );
-        }
-    );
-}
-
-template<typename T> static void appendColorStop(StringBuilder& builder, const CSSGradientColorStop<T>& stop)
-{
-    if (stop.color && stop.position) {
-        builder.append(stop.color->cssText(), ' ');
-        serializationForCSS(builder, *stop.position);
-    } else if (stop.color)
-        builder.append(stop.color->cssText());
-    else if (stop.position)
-        serializationForCSS(builder, *stop.position);
+    return getOrCreateStyleImage(m_gradient, m_cachedStyleImage, state);
 }
 
 // MARK: - Linear.
 
-static ASCIILiteral cssText(CSSLinearGradientValue::Horizontal horizontal)
-{
-    switch (horizontal) {
-    case CSSLinearGradientValue::Horizontal::Left:
-        return "left"_s;
-    case CSSLinearGradientValue::Horizontal::Right:
-        return "right"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static ASCIILiteral cssText(CSSLinearGradientValue::Vertical vertical)
-{
-    switch (vertical) {
-    case CSSLinearGradientValue::Vertical::Top:
-        return "top"_s;
-    case CSSLinearGradientValue::Vertical::Bottom:
-        return "bottom"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 String CSSLinearGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-linear-gradient("_s : "linear-gradient("_s);
-    bool wroteSomething = false;
-
-    WTF::switchOn(m_data.gradientLine,
-        [&](std::monostate) { },
-        [&](const CSS::Angle& angle) {
-            WTF::switchOn(angle.value,
-                [&](const CSS::AngleRaw& angleRaw) {
-                    if (CSSPrimitiveValue::computeDegrees(angleRaw.type, angleRaw.value) == 180)
-                        return;
-
-                    serializationForCSS(result, angleRaw);
-                    wroteSomething = true;
-                },
-                [&](const CSS::UnevaluatedCalc<CSS::AngleRaw>& angleCalc) {
-                    serializationForCSS(result, angleCalc);
-                    wroteSomething = true;
-                }
-            );
-        },
-        [&](Horizontal horizontal) {
-            result.append("to "_s, WebCore::cssText(horizontal));
-            wroteSomething = true;
-        },
-        [&](Vertical vertical) {
-            if (vertical == Vertical::Bottom)
-                return;
-    
-            result.append("to "_s, WebCore::cssText(vertical));
-            wroteSomething = true;
-        },
-        [&](const std::pair<Horizontal, Vertical>& pair) {
-            result.append("to "_s, WebCore::cssText(pair.first), ' ', WebCore::cssText(pair.second));
-            wroteSomething = true;
-        }
-    );
-
-    if (appendColorInterpolationMethod(result, m_colorInterpolationMethod, wroteSomething))
-        wroteSomething = true;
-
-    if (wroteSomething)
-        result.append(", "_s);
-
-    result.append(interleave(m_stops, appendColorStop, ", "_s), ')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSLinearGradientValue::equals(const CSSLinearGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_repeating == other.m_repeating
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSLinearGradientValue::styleImageIsUncacheable() const
-{
-    return WebCore::styleImageIsUncacheable(m_stops);
+    return m_gradient == other.m_gradient;
 }
 
 // MARK: - Prefixed Linear.
 
-static ASCIILiteral cssText(CSSPrefixedLinearGradientValue::Horizontal horizontal)
-{
-    switch (horizontal) {
-    case CSSPrefixedLinearGradientValue::Horizontal::Left:
-        return "left"_s;
-    case CSSPrefixedLinearGradientValue::Horizontal::Right:
-        return "right"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static ASCIILiteral cssText(CSSPrefixedLinearGradientValue::Vertical vertical)
-{
-    switch (vertical) {
-    case CSSPrefixedLinearGradientValue::Vertical::Top:
-        return "top"_s;
-    case CSSPrefixedLinearGradientValue::Vertical::Bottom:
-        return "bottom"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 String CSSPrefixedLinearGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "-webkit-repeating-linear-gradient("_s : "-webkit-linear-gradient("_s);
-
-    WTF::switchOn(m_data.gradientLine,
-        [&](std::monostate) {
-            result.append("top"_s);
-        },
-        [&](const CSS::Angle& angle) {
-            serializationForCSS(result, angle);
-        },
-        [&](Horizontal horizontal) {
-            result.append(WebCore::cssText(horizontal));
-        },
-        [&](Vertical vertical) {
-            result.append(WebCore::cssText(vertical));
-        },
-        [&](const std::pair<Horizontal, Vertical>& pair) {
-            result.append(WebCore::cssText(pair.first), ' ', WebCore::cssText(pair.second));
-        }
-    );
-
-    result.append(", "_s, interleave(m_stops, appendColorStop, ", "_s), ')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSPrefixedLinearGradientValue::equals(const CSSPrefixedLinearGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_repeating == other.m_repeating
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSPrefixedLinearGradientValue::styleImageIsUncacheable() const
-{
-    return WebCore::styleImageIsUncacheable(m_stops);
+    return m_gradient == other.m_gradient;
 }
 
 // MARK: - Deprecated Linear.
 
 String CSSDeprecatedLinearGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append("-webkit-gradient(linear, "_s);
-
-    serializationForCSS(result, m_data.first);
-    result.append(", "_s);
-    serializationForCSS(result, m_data.second);
-    if (!m_stops.isEmpty())
-        result.append(", "_s, interleave(m_stops, appendColorStop, ", "_s));
-    result.append(')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSDeprecatedLinearGradientValue::equals(const CSSDeprecatedLinearGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSDeprecatedLinearGradientValue::styleImageIsUncacheable() const
-{
-    return WebCore::styleImageIsUncacheable(m_stops);
+    return m_gradient == other.m_gradient;
 }
 
 // MARK: - Radial.
 
-static ASCIILiteral cssText(CSSRadialGradientValue::ExtentKeyword extent)
-{
-    switch (extent) {
-    case CSSRadialGradientValue::ExtentKeyword::ClosestCorner:
-        return "closest-corner"_s;
-    case CSSRadialGradientValue::ExtentKeyword::ClosestSide:
-        return "closest-side"_s;
-    case CSSRadialGradientValue::ExtentKeyword::FarthestCorner:
-        return "farthest-corner"_s;
-    case CSSRadialGradientValue::ExtentKeyword::FarthestSide:
-        return "farthest-side"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 String CSSRadialGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-radial-gradient("_s : "radial-gradient("_s);
-
-    bool wroteSomething = false;
-
-    auto appendPosition = [&](const CSS::Position& position) {
-        if (!CSS::isCenterPosition(position)) {
-            if (wroteSomething)
-                result.append(' ');
-            result.append("at "_s);
-            serializationForCSS(result, position);
-            wroteSomething = true;
-        }
-    };
-
-    auto appendOptionalPosition = [&](const std::optional<CSS::Position>& position) {
-        if (!position)
-            return;
-        appendPosition(*position);
-    };
-
-    WTF::switchOn(m_data.gradientBox,
-        [&](std::monostate) { },
-        [&](const Shape& data) {
-            if (data.shape != ShapeKeyword::Ellipse) {
-                result.append("circle"_s);
-                wroteSomething = true;
-            }
-            appendOptionalPosition(data.position);
-        },
-        [&](const Extent& data) {
-            if (data.extent != ExtentKeyword::FarthestCorner) {
-                result.append(WebCore::cssText(data.extent));
-                wroteSomething = true;
-            }
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const Length& data) {
-            serializationForCSS(result, data.length);
-            wroteSomething = true;
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const CircleOfLength& data) {
-            serializationForCSS(result, data.length);
-            wroteSomething = true;
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const CircleOfExtent& data) {
-            if (data.extent != ExtentKeyword::FarthestCorner)
-                result.append("circle "_s, WebCore::cssText(data.extent));
-            else
-                result.append("circle"_s);
-            wroteSomething = true;
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const Size& data) {
-            serializationForCSS(result, data.size);
-            wroteSomething = true;
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const EllipseOfSize& data) {
-            serializationForCSS(result, data.size);
-            wroteSomething = true;
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const EllipseOfExtent& data) {
-            if (data.extent != ExtentKeyword::FarthestCorner) {
-                result.append(WebCore::cssText(data.extent));
-                wroteSomething = true;
-            }
-
-            appendOptionalPosition(data.position);
-        },
-        [&](const CSS::Position& data) {
-            appendPosition(data);
-        }
-    );
-
-    if (appendColorInterpolationMethod(result, m_colorInterpolationMethod, wroteSomething))
-        wroteSomething = true;
-
-    if (wroteSomething)
-        result.append(", "_s);
-
-    result.append(interleave(m_stops, appendColorStop, ", "_s), ')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSRadialGradientValue::equals(const CSSRadialGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_repeating == other.m_repeating
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSRadialGradientValue::styleImageIsUncacheable() const
-{
-    if (WebCore::styleImageIsUncacheable(m_stops))
-        return true;
-
-    return WTF::switchOn(m_data.gradientBox,
-        [&](std::monostate) {
-            return false;
-        },
-        [&](const Shape& data) {
-            return WebCore::styleImageIsUncacheable(data.position);
-        },
-        [&](const Extent& data) {
-            return WebCore::styleImageIsUncacheable(data.position);
-        },
-        [&](const Length& data) {
-            return WebCore::styleImageIsUncacheable(data.position) || WebCore::styleImageIsUncacheable(data.length);
-        },
-        [&](const CircleOfLength& data) {
-            return WebCore::styleImageIsUncacheable(data.position) || WebCore::styleImageIsUncacheable(data.length);
-        },
-        [&](const CircleOfExtent& data) {
-            return WebCore::styleImageIsUncacheable(data.position);
-        },
-        [&](const Size& data) {
-            return WebCore::styleImageIsUncacheable(data.position) || WebCore::styleImageIsUncacheable(data.size);
-        },
-        [&](const EllipseOfSize& data) {
-            return WebCore::styleImageIsUncacheable(data.position) || WebCore::styleImageIsUncacheable(data.size);
-        },
-        [&](const EllipseOfExtent& data) {
-            return WebCore::styleImageIsUncacheable(data.position);
-        },
-        [&](const CSS::Position& data) {
-            return WebCore::styleImageIsUncacheable(data.value);
-        }
-    );
+    return m_gradient == other.m_gradient;
 }
 
 // MARK: Prefixed Radial.
 
-static ASCIILiteral cssText(CSSPrefixedRadialGradientValue::ShapeKeyword shape)
-{
-    switch (shape) {
-    case CSSPrefixedRadialGradientValue::ShapeKeyword::Circle:
-        return "circle"_s;
-    case CSSPrefixedRadialGradientValue::ShapeKeyword::Ellipse:
-        return "ellipse"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static ASCIILiteral cssText(CSSPrefixedRadialGradientValue::ExtentKeyword extent)
-{
-    switch (extent) {
-    case CSSPrefixedRadialGradientValue::ExtentKeyword::ClosestCorner:
-        return "closest-corner"_s;
-    case CSSPrefixedRadialGradientValue::ExtentKeyword::ClosestSide:
-        return "closest-side"_s;
-    case CSSPrefixedRadialGradientValue::ExtentKeyword::FarthestCorner:
-        return "farthest-corner"_s;
-    case CSSPrefixedRadialGradientValue::ExtentKeyword::FarthestSide:
-        return "farthest-side"_s;
-    case CSSPrefixedRadialGradientValue::ExtentKeyword::Contain:
-        return "contain"_s;
-    case CSSPrefixedRadialGradientValue::ExtentKeyword::Cover:
-        return "cover"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 String CSSPrefixedRadialGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "-webkit-repeating-radial-gradient("_s : "-webkit-radial-gradient("_s);
-
-    if (m_data.position)
-        serializationForCSS(result, *m_data.position);
-    else
-        result.append("center"_s);
-
-    WTF::switchOn(m_data.gradientBox,
-        [&](std::monostate) { },
-        [&](const ShapeKeyword& shape) {
-            result.append(", "_s, WebCore::cssText(shape), " cover"_s);
-        },
-        [&](const ExtentKeyword& extent) {
-            result.append(", ellipse "_s, WebCore::cssText(extent));
-        },
-        [&](const ShapeAndExtent& shapeAndExtent) {
-            result.append(", "_s, WebCore::cssText(shapeAndExtent.shape), ' ', WebCore::cssText(shapeAndExtent.extent));
-        },
-        [&](const MeasuredSize& measuredSize) {
-            result.append(", "_s);
-            serializationForCSS(result, measuredSize.size);
-        }
-    );
-
-    result.append(", "_s, interleave(m_stops, appendColorStop, ", "_s), ')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSPrefixedRadialGradientValue::equals(const CSSPrefixedRadialGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_repeating == other.m_repeating
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSPrefixedRadialGradientValue::styleImageIsUncacheable() const
-{
-    if (WebCore::styleImageIsUncacheable(m_stops))
-        return true;
-
-    if (WebCore::styleImageIsUncacheable(m_data.position))
-        return true;
-
-    return WTF::switchOn(m_data.gradientBox,
-        [&](std::monostate) {
-            return false;
-        },
-        [&](const ShapeKeyword&) {
-            return false;
-        },
-        [&](const ExtentKeyword&) {
-            return false;
-        },
-        [&](const ShapeAndExtent&) {
-            return false;
-        },
-        [&](const MeasuredSize& measuredSize) {
-            return WebCore::styleImageIsUncacheable(measuredSize.size);
-        }
-    );
+    return m_gradient == other.m_gradient;
 }
 
 // MARK: - Deprecated Radial.
 
 String CSSDeprecatedRadialGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append("-webkit-gradient(radial, "_s);
-
-    serializationForCSS(result, m_data.first);
-    result.append(", "_s);
-    serializationForCSS(result, m_data.firstRadius);
-    result.append(", "_s);
-    serializationForCSS(result, m_data.second);
-    result.append(", "_s);
-    serializationForCSS(result, m_data.secondRadius);
-    if (!m_stops.isEmpty())
-        result.append(", "_s, interleave(m_stops, appendColorStop, ", "_s));
-    result.append(')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSDeprecatedRadialGradientValue::equals(const CSSDeprecatedRadialGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSDeprecatedRadialGradientValue::styleImageIsUncacheable() const
-{
-    return WebCore::styleImageIsUncacheable(m_stops);
+    return m_gradient == other.m_gradient;
 }
 
 // MARK: - Conic
 
 String CSSConicGradientValue::customCSSText() const
 {
-    StringBuilder result;
-
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-conic-gradient("_s : "conic-gradient("_s);
-
-    bool wroteSomething = false;
-
-    if (m_data.angle) {
-        WTF::switchOn(m_data.angle->value,
-            [&](const CSS::AngleRaw& angleRaw) {
-                if (angleRaw.value) {
-                    result.append("from "_s);
-                    serializationForCSS(result, angleRaw);
-                    wroteSomething = true;
-                }
-            },
-            [&](const CSS::UnevaluatedCalc<CSS::AngleRaw>& angleCalc) {
-                result.append("from "_s);
-                serializationForCSS(result, angleCalc);
-                wroteSomething = true;
-            }
-        );
-    }
-
-    if (m_data.position && !CSS::isCenterPosition(*m_data.position)) {
-        if (wroteSomething)
-            result.append(' ');
-        result.append("at "_s);
-        serializationForCSS(result, *m_data.position);
-        wroteSomething = true;
-    }
-
-    if (appendColorInterpolationMethod(result, m_colorInterpolationMethod, wroteSomething))
-        wroteSomething = true;
-
-    if (wroteSomething)
-        result.append(", "_s);
-
-    result.append(interleave(m_stops, appendColorStop, ", "_s), ')');
-
-    return result.toString();
+    StringBuilder builder;
+    CSS::serializationForCSS(builder, m_gradient);
+    return builder.toString();
 }
 
 bool CSSConicGradientValue::equals(const CSSConicGradientValue& other) const
 {
-    return m_stops == other.m_stops
-        && m_repeating == other.m_repeating
-        && m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data;
-}
-
-bool CSSConicGradientValue::styleImageIsUncacheable() const
-{
-    return WebCore::styleImageIsUncacheable(m_stops) || WebCore::styleImageIsUncacheable(m_data.position);
+    return m_gradient == other.m_gradient;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -25,12 +25,7 @@
 
 #pragma once
 
-#include "CSSPosition.h"
-#include "CSSPrimitiveNumericTypes.h"
-#include "CSSPrimitiveValue.h"
-#include "CSSValueTypes.h"
-#include "ColorInterpolationMethod.h"
-#include "Gradient.h"
+#include "CSSGradient.h"
 #include "StyleImage.h"
 
 namespace WebCore {
@@ -39,76 +34,13 @@ namespace Style {
 class BuilderState;
 }
 
-// MARK: Gradient Repeat Definitions.
-
-enum class CSSGradientRepeat : bool { NonRepeating, Repeating };
-
-// MARK: Gradient Color Stop Definitions.
-
-template<typename T> struct CSSGradientColorStop {
-    using Position = T;
-
-    RefPtr<CSSPrimitiveValue> color;
-    Position position;
-
-    bool operator==(const CSSGradientColorStop<T>&) const;
-};
-
-template<typename T> inline bool CSSGradientColorStop<T>::operator==(const CSSGradientColorStop<Position>& other) const
-{
-    return compareCSSValuePtr(color, other.color) && position == other.position;
-}
-
-template<typename Stop> using CSSGradientColorStopList = Vector<Stop, 2>;
-
-using CSSGradientAngularColorStopPosition = std::optional<CSS::AnglePercentage>;
-using CSSGradientAngularColorStop = CSSGradientColorStop<CSSGradientAngularColorStopPosition>;
-using CSSGradientAngularColorStopList = CSSGradientColorStopList<CSSGradientAngularColorStop>;
-
-using CSSGradientLinearColorStopPosition = std::optional<CSS::LengthPercentage>;
-using CSSGradientLinearColorStop = CSSGradientColorStop<CSSGradientLinearColorStopPosition>;
-using CSSGradientLinearColorStopList = CSSGradientColorStopList<CSSGradientLinearColorStop>;
-
-using CSSGradientDeprecatedColorStopPosition = CSS::PercentageOrNumber;
-using CSSGradientDeprecatedColorStop = CSSGradientColorStop<CSSGradientDeprecatedColorStopPosition>;
-using CSSGradientDeprecatedColorStopList = CSSGradientColorStopList<CSSGradientDeprecatedColorStop>;
-
-// MARK: Gradient Color Interpolation Definitions.
-
-struct CSSGradientColorInterpolationMethod {
-    enum class Default : bool { SRGB, OKLab };
-
-    ColorInterpolationMethod method;
-    Default defaultMethod;
-    
-    static CSSGradientColorInterpolationMethod legacyMethod(AlphaPremultiplication alphaPremultiplication)
-    {
-        return { { ColorInterpolationMethod::SRGB { }, alphaPremultiplication }, Default::SRGB };
-    }
-
-    bool operator==(const CSSGradientColorInterpolationMethod&) const = default;
-};
-
-// MARK: Gradient Definitions.
-
-using CSSDeprecatedGradientPosition = CSS::SpaceSeparatedTuple<CSS::PercentageOrNumber, CSS::PercentageOrNumber>;
-
 // MARK: - Linear.
 
 class CSSLinearGradientValue final : public CSSValue {
 public:
-    enum class Horizontal : bool { Left, Right };
-    enum class Vertical : bool { Top, Bottom };
-    using GradientLine = std::variant<std::monostate, CSS::Angle, Horizontal, Vertical, std::pair<Horizontal, Vertical>>;
-
-    struct Data {
-        GradientLine gradientLine;
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSLinearGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    static Ref<CSSLinearGradientValue> create(CSS::LinearGradient&& gradient)
     {
-        return adoptRef(*new CSSLinearGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSLinearGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -117,62 +49,32 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        if (CSS::visitCSSValueChildren(m_data.gradientLine, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    CSSLinearGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    CSSLinearGradientValue(CSS::LinearGradient&& gradient)
         : CSSValue(ClassType::LinearGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_repeating(repeating)
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSLinearGradientValue(const CSSLinearGradientValue& other)
         : CSSValue(ClassType::LinearGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_repeating(other.m_repeating)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientLinearColorStopList m_stops;
-    CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::LinearGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 class CSSPrefixedLinearGradientValue final : public CSSValue {
 public:
-    enum class Horizontal : bool { Left, Right };
-    enum class Vertical : bool { Top, Bottom };
-    using GradientLine = std::variant<std::monostate, CSS::Angle, Horizontal, Vertical, std::pair<Horizontal, Vertical>>;
-
-    struct Data {
-        GradientLine gradientLine;
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSPrefixedLinearGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    static Ref<CSSPrefixedLinearGradientValue> create(CSS::PrefixedLinearGradient&& gradient)
     {
-        return adoptRef(*new CSSPrefixedLinearGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSPrefixedLinearGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -181,59 +83,32 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        if (CSS::visitCSSValueChildren(m_data.gradientLine, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    CSSPrefixedLinearGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    CSSPrefixedLinearGradientValue(CSS::PrefixedLinearGradient&& gradient)
         : CSSValue(ClassType::PrefixedLinearGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_repeating(repeating)
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSPrefixedLinearGradientValue(const CSSPrefixedLinearGradientValue& other)
         : CSSValue(ClassType::PrefixedLinearGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_repeating(other.m_repeating)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientLinearColorStopList m_stops;
-    CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::PrefixedLinearGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 class CSSDeprecatedLinearGradientValue final : public CSSValue {
 public:
-    struct Data {
-        CSSDeprecatedGradientPosition first;
-        CSSDeprecatedGradientPosition second;
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSDeprecatedLinearGradientValue> create(Data data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientDeprecatedColorStopList stops)
+    static Ref<CSSDeprecatedLinearGradientValue> create(CSS::DeprecatedLinearGradient&& gradient)
     {
-        return adoptRef(*new CSSDeprecatedLinearGradientValue(WTFMove(data), colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSDeprecatedLinearGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -242,44 +117,24 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        if (CSS::visitCSSValueChildren(m_data.first, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        if (CSS::visitCSSValueChildren(m_data.second, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    CSSDeprecatedLinearGradientValue(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientDeprecatedColorStopList stops)
+    CSSDeprecatedLinearGradientValue(CSS::DeprecatedLinearGradient&& gradient)
         : CSSValue(ClassType::DeprecatedLinearGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSDeprecatedLinearGradientValue(const CSSDeprecatedLinearGradientValue& other)
         : CSSValue(ClassType::DeprecatedLinearGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientDeprecatedColorStopList m_stops;
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::DeprecatedLinearGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
@@ -287,58 +142,9 @@ private:
 
 class CSSRadialGradientValue final : public CSSValue {
 public:
-    enum class ShapeKeyword : bool { Circle, Ellipse };
-    enum class ExtentKeyword : uint8_t { ClosestCorner, ClosestSide, FarthestCorner, FarthestSide };
-    struct Shape {
-        ShapeKeyword shape;
-        std::optional<CSS::Position> position;
-        bool operator==(const Shape&) const = default;
-    };
-    struct Extent {
-        ExtentKeyword extent;
-        std::optional<CSS::Position> position;
-        bool operator==(const Extent&) const = default;
-    };
-    struct Length {
-        CSS::Length length; // <length [0,∞]>
-        std::optional<CSS::Position> position;
-        bool operator==(const Length&) const = default;
-    };
-    struct CircleOfLength {
-        CSS::Length length; // <length [0,∞]>
-        std::optional<CSS::Position> position;
-        bool operator==(const CircleOfLength&) const = default;
-    };
-    struct CircleOfExtent {
-        ExtentKeyword extent;
-        std::optional<CSS::Position> position;
-        bool operator==(const CircleOfExtent&) const = default;
-    };
-    struct Size {
-        CSS::SpaceSeparatedTuple<CSS::LengthPercentage, CSS::LengthPercentage> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
-        std::optional<CSS::Position> position;
-        bool operator==(const Size&) const = default;
-    };
-    struct EllipseOfSize {
-        CSS::SpaceSeparatedTuple<CSS::LengthPercentage, CSS::LengthPercentage> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
-        std::optional<CSS::Position> position;
-        bool operator==(const EllipseOfSize&) const = default;
-    };
-    struct EllipseOfExtent {
-        ExtentKeyword extent;
-        std::optional<CSS::Position> position;
-        bool operator==(const EllipseOfExtent&) const = default;
-    };
-    using GradientBox = std::variant<std::monostate, Shape, Extent, Length, Size, CircleOfLength, CircleOfExtent, EllipseOfSize, EllipseOfExtent, CSS::Position>;
-
-    struct Data {
-        GradientBox gradientBox;
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSRadialGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    static Ref<CSSRadialGradientValue> create(CSS::RadialGradient&& gradient)
     {
-        return adoptRef(*new CSSRadialGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSRadialGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -347,123 +153,32 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        {
-            auto result = WTF::switchOn(m_data.gradientBox,
-                [&](const Shape& data) {
-                    return CSS::visitCSSValueChildren(data.position, func);
-                },
-                [&](const Extent& data) {
-                    return CSS::visitCSSValueChildren(data.position, func);
-                },
-                [&](const Length& data) {
-                    if (CSS::visitCSSValueChildren(data.length, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    if (CSS::visitCSSValueChildren(data.position, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    return IterationStatus::Continue;
-                },
-                [&](const Size& data) {
-                    if (CSS::visitCSSValueChildren(data.size, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    if (CSS::visitCSSValueChildren(data.position, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    return IterationStatus::Continue;
-                },
-                [&](const CircleOfLength& data) {
-                    if (CSS::visitCSSValueChildren(data.length, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    if (CSS::visitCSSValueChildren(data.position, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    return IterationStatus::Continue;
-                },
-                [&](const CircleOfExtent& data) {
-                    return CSS::visitCSSValueChildren(data.position, func);
-                },
-                [&](const EllipseOfSize& data) {
-                    if (CSS::visitCSSValueChildren(data.size, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    if (CSS::visitCSSValueChildren(data.position, func) == IterationStatus::Done)
-                        return IterationStatus::Done;
-                    return IterationStatus::Continue;
-                },
-                [&](const EllipseOfExtent& data) {
-                    return CSS::visitCSSValueChildren(data.position, func);
-                },
-                [&](const CSS::Position& data) {
-                    return CSS::visitCSSValueChildren(data, func);
-                },
-                [&](const auto&) {
-                    return IterationStatus::Continue;
-                }
-            );
-            if (result == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    CSSRadialGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    CSSRadialGradientValue(CSS::RadialGradient&& gradient)
         : CSSValue(ClassType::RadialGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_repeating(repeating)
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSRadialGradientValue(const CSSRadialGradientValue& other)
         : CSSValue(ClassType::RadialGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_repeating(other.m_repeating)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientLinearColorStopList m_stops;
-    CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::RadialGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 class CSSPrefixedRadialGradientValue final : public CSSValue {
 public:
-    enum class ShapeKeyword : bool { Circle, Ellipse };
-    enum class ExtentKeyword : uint8_t { ClosestSide, ClosestCorner, FarthestSide, FarthestCorner, Contain, Cover };
-    struct ShapeAndExtent {
-        ShapeKeyword shape;
-        ExtentKeyword extent;
-        bool operator==(const ShapeAndExtent&) const = default;
-    };
-    struct MeasuredSize {
-        CSS::SpaceSeparatedTuple<CSS::LengthPercentage, CSS::LengthPercentage> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
-        bool operator==(const MeasuredSize&) const = default;
-    };
-
-    using GradientBox = std::variant<std::monostate, ShapeKeyword, ExtentKeyword, ShapeAndExtent, MeasuredSize>;
-
-    struct Data {
-        GradientBox gradientBox;
-        std::optional<CSS::Position> position;
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSPrefixedRadialGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    static Ref<CSSPrefixedRadialGradientValue> create(CSS::PrefixedRadialGradient&& gradient)
     {
-        return adoptRef(*new CSSPrefixedRadialGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSPrefixedRadialGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -472,73 +187,32 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        {
-            auto result = WTF::switchOn(m_data.gradientBox,
-                [&](const MeasuredSize& data) {
-                    return CSS::visitCSSValueChildren(data.size, func);
-                },
-                [&](const auto&) {
-                    return IterationStatus::Continue;
-                }
-            );
-            if (result == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        if (CSS::visitCSSValueChildren(m_data.position, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    CSSPrefixedRadialGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientLinearColorStopList stops)
+    CSSPrefixedRadialGradientValue(CSS::PrefixedRadialGradient&& gradient)
         : CSSValue(ClassType::PrefixedRadialGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_repeating(repeating)
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSPrefixedRadialGradientValue(const CSSPrefixedRadialGradientValue& other)
         : CSSValue(ClassType::PrefixedRadialGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_repeating(other.m_repeating)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientLinearColorStopList m_stops;
-    CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::PrefixedRadialGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 class CSSDeprecatedRadialGradientValue final : public CSSValue {
 public:
-    struct Data {
-        CSSDeprecatedGradientPosition first;
-        CSSDeprecatedGradientPosition second;
-        CSS::Number firstRadius; // <number [0,∞]>
-        CSS::Number secondRadius; // <number [0,∞]>
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSDeprecatedRadialGradientValue> create(Data data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientDeprecatedColorStopList stops)
+    static Ref<CSSDeprecatedRadialGradientValue> create(CSS::DeprecatedRadialGradient&& gradient)
     {
-        return adoptRef(*new CSSDeprecatedRadialGradientValue(WTFMove(data), colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSDeprecatedRadialGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -547,49 +221,24 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        if (CSS::visitCSSValueChildren(m_data.first, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        if (CSS::visitCSSValueChildren(m_data.second, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        if (CSS::visitCSSValueChildren(m_data.firstRadius, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        if (CSS::visitCSSValueChildren(m_data.secondRadius, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    CSSDeprecatedRadialGradientValue(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientDeprecatedColorStopList stops)
+    CSSDeprecatedRadialGradientValue(CSS::DeprecatedRadialGradient&& gradient)
         : CSSValue(ClassType::DeprecatedRadialGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSDeprecatedRadialGradientValue(const CSSDeprecatedRadialGradientValue& other)
         : CSSValue(ClassType::DeprecatedRadialGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientDeprecatedColorStopList m_stops;
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::DeprecatedRadialGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
@@ -597,15 +246,9 @@ private:
 
 class CSSConicGradientValue final : public CSSValue {
 public:
-    struct Data {
-        std::optional<CSS::Angle> angle;
-        std::optional<CSS::Position> position;
-        bool operator==(const Data&) const = default;
-    };
-
-    static Ref<CSSConicGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientAngularColorStopList stops)
+    static Ref<CSSConicGradientValue> create(CSS::ConicGradient&& gradient)
     {
-        return adoptRef(*new CSSConicGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
+        return adoptRef(*new CSSConicGradientValue(WTFMove(gradient)));
     }
 
     String customCSSText() const;
@@ -614,47 +257,24 @@ public:
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
-        if (CSS::visitCSSValueChildren(m_data.angle, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        if (CSS::visitCSSValueChildren(m_data.position, func) == IterationStatus::Done)
-            return IterationStatus::Done;
-        for (auto& stop : m_stops) {
-            if (stop.color) {
-                if (func(*stop.color) == IterationStatus::Done)
-                    return IterationStatus::Done;
-            }
-            if (CSS::visitCSSValueChildren(stop.position, func) == IterationStatus::Done)
-                return IterationStatus::Done;
-        }
-        return IterationStatus::Continue;
+        return CSS::visitCSSValueChildren(func, m_gradient);
     }
 
 private:
-    explicit CSSConicGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientAngularColorStopList stops)
+    explicit CSSConicGradientValue(CSS::ConicGradient&& gradient)
         : CSSValue(ClassType::ConicGradient)
-        , m_data(WTFMove(data))
-        , m_stops(WTFMove(stops))
-        , m_repeating(repeating)
-        , m_colorInterpolationMethod(colorInterpolationMethod)
+        , m_gradient(WTFMove(gradient))
     {
     }
 
     CSSConicGradientValue(const CSSConicGradientValue& other)
         : CSSValue(ClassType::ConicGradient)
-        , m_data(other.m_data)
-        , m_stops(other.m_stops)
-        , m_repeating(other.m_repeating)
-        , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_gradient(other.m_gradient)
         , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
-    bool styleImageIsUncacheable() const;
-
-    Data m_data;
-    CSSGradientAngularColorStopList m_stops;
-    CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    CSS::ConicGradient m_gradient;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -36,6 +36,7 @@
 #include "CalculationValue.h"
 #include "Color.h"
 #include "ColorSerialization.h"
+#include "ComputedStyleDependencies.h"
 #include "ContainerQueryEvaluator.h"
 #include "FontCascade.h"
 #include "Length.h"

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -83,6 +83,7 @@
 #include "CSSValuePair.h"
 #include "CSSVariableReferenceValue.h"
 #include "CSSViewValue.h"
+#include "ComputedStyleDependencies.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
 #include "EventTarget.h"

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -43,20 +43,11 @@ class DeprecatedCSSOMValue;
 class Quad;
 class Rect;
 
+struct ComputedStyleDependencies;
 struct Counter;
 
 enum CSSPropertyID : uint16_t;
 enum CSSValueID : uint16_t;
-
-struct ComputedStyleDependencies {
-    Vector<CSSPropertyID> properties;
-    Vector<CSSPropertyID> rootProperties;
-    bool containerDimensions { false };
-    bool viewportDimensions { false };
-    bool anchors { false };
-
-    bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions && !anchors; }
-};
 
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);
 class CSSValue {

--- a/Source/WebCore/css/ComputedStyleDependencies.h
+++ b/Source/WebCore/css/ComputedStyleDependencies.h
@@ -1,0 +1,40 @@
+/*
+ * (C) 1999-2003 Lars Knoll (knoll@kde.org)
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+enum CSSPropertyID : uint16_t;
+
+struct ComputedStyleDependencies {
+    Vector<CSSPropertyID> properties;
+    Vector<CSSPropertyID> rootProperties;
+    bool containerDimensions { false };
+    bool viewportDimensions { false };
+    bool anchors { false };
+
+    bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions && !anchors; }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
@@ -29,7 +29,7 @@
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 #include "CSSPropertyNames.h"
 #include "CSSUnits.h"
-#include "CSSValue.h"
+#include "ComputedStyleDependencies.h"
 
 namespace WebCore {
 namespace CSSCalc {

--- a/Source/WebCore/css/color/CSSAbsoluteColorResolver.h
+++ b/Source/WebCore/css/color/CSSAbsoluteColorResolver.h
@@ -48,10 +48,10 @@ Color resolve(const CSSAbsoluteColorResolver<Descriptor>& absolute, const CSSToL
 {
     // Evaluated any calc values to their corresponding channel value.
     auto components = StyleColorParseType<Descriptor> {
-        CSS::toStyle(std::get<0>(absolute.components), conversionData, CSSCalcSymbolTable { }),
-        CSS::toStyle(std::get<1>(absolute.components), conversionData, CSSCalcSymbolTable { }),
-        CSS::toStyle(std::get<2>(absolute.components), conversionData, CSSCalcSymbolTable { }),
-        CSS::toStyle(std::get<3>(absolute.components), conversionData, CSSCalcSymbolTable { })
+        Style::toStyle(std::get<0>(absolute.components), conversionData),
+        Style::toStyle(std::get<1>(absolute.components), conversionData),
+        Style::toStyle(std::get<2>(absolute.components), conversionData),
+        Style::toStyle(std::get<3>(absolute.components), conversionData)
     };
 
     // Normalize values into their numeric form, forming a validated typed color.
@@ -69,10 +69,10 @@ Color resolveNoConversionDataRequired(const CSSAbsoluteColorResolver<Descriptor>
 
     // Evaluated any calc values to their corresponding channel value.
     auto components = StyleColorParseType<Descriptor> {
-        CSS::toStyleNoConversionDataRequired(std::get<0>(absolute.components), CSSCalcSymbolTable { }),
-        CSS::toStyleNoConversionDataRequired(std::get<1>(absolute.components), CSSCalcSymbolTable { }),
-        CSS::toStyleNoConversionDataRequired(std::get<2>(absolute.components), CSSCalcSymbolTable { }),
-        CSS::toStyleNoConversionDataRequired(std::get<3>(absolute.components), CSSCalcSymbolTable { })
+        Style::toStyleNoConversionDataRequired(std::get<0>(absolute.components)),
+        Style::toStyleNoConversionDataRequired(std::get<1>(absolute.components)),
+        Style::toStyleNoConversionDataRequired(std::get<2>(absolute.components)),
+        Style::toStyleNoConversionDataRequired(std::get<3>(absolute.components))
     };
 
     // Normalize values into their numeric form, forming a validated typed color.

--- a/Source/WebCore/css/color/CSSRelativeColorResolver.h
+++ b/Source/WebCore/css/color/CSSRelativeColorResolver.h
@@ -68,10 +68,10 @@ Color resolve(const CSSRelativeColorResolver<Descriptor>& relative, const CSSToL
 
     // Evaluated any calc values to their corresponding channel value.
     auto components = StyleColorParseType<Descriptor> {
-        CSS::toStyle(std::get<0>(componentsWithUnevaluatedCalc), conversionData, symbolTable),
-        CSS::toStyle(std::get<1>(componentsWithUnevaluatedCalc), conversionData, symbolTable),
-        CSS::toStyle(std::get<2>(componentsWithUnevaluatedCalc), conversionData, symbolTable),
-        CSS::toStyle(std::get<3>(componentsWithUnevaluatedCalc), conversionData, symbolTable)
+        Style::toStyle(std::get<0>(componentsWithUnevaluatedCalc), conversionData, symbolTable),
+        Style::toStyle(std::get<1>(componentsWithUnevaluatedCalc), conversionData, symbolTable),
+        Style::toStyle(std::get<2>(componentsWithUnevaluatedCalc), conversionData, symbolTable),
+        Style::toStyle(std::get<3>(componentsWithUnevaluatedCalc), conversionData, symbolTable)
     };
 
     // Normalize values into their numeric form, forming a validated typed color.
@@ -108,10 +108,10 @@ Color resolveNoConversionDataRequired(const CSSRelativeColorResolver<Descriptor>
 
     // Evaluated any calc values to their corresponding channel value.
     auto components = StyleColorParseType<Descriptor> {
-        CSS::toStyleNoConversionDataRequired(std::get<0>(componentsWithUnevaluatedCalc), symbolTable),
-        CSS::toStyleNoConversionDataRequired(std::get<1>(componentsWithUnevaluatedCalc), symbolTable),
-        CSS::toStyleNoConversionDataRequired(std::get<2>(componentsWithUnevaluatedCalc), symbolTable),
-        CSS::toStyleNoConversionDataRequired(std::get<3>(componentsWithUnevaluatedCalc), symbolTable)
+        Style::toStyleNoConversionDataRequired(std::get<0>(componentsWithUnevaluatedCalc), symbolTable),
+        Style::toStyleNoConversionDataRequired(std::get<1>(componentsWithUnevaluatedCalc), symbolTable),
+        Style::toStyleNoConversionDataRequired(std::get<2>(componentsWithUnevaluatedCalc), symbolTable),
+        Style::toStyleNoConversionDataRequired(std::get<3>(componentsWithUnevaluatedCalc), symbolTable)
     };
 
     // Normalize values into their numeric form, forming a validated typed color.

--- a/Source/WebCore/css/color/CSSUnresolvedColorMix.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColorMix.cpp
@@ -38,14 +38,14 @@ namespace WebCore {
 
 Style::Percentage resolveComponentPercentage(const CSSUnresolvedColorMix::Component::Percentage& percentage, const CSSToLengthConversionData& conversionData)
 {
-    return CSS::toStyle(percentage, conversionData, CSSCalcSymbolTable { });
+    return Style::toStyle(percentage, conversionData);
 }
 
 Style::Percentage resolveComponentPercentageNoConversionDataRequired(const CSSUnresolvedColorMix::Component::Percentage& percentage)
 {
     ASSERT(!requiresConversionData(percentage));
 
-    return CSS::toStyleNoConversionDataRequired(percentage, CSSCalcSymbolTable { });
+    return Style::toStyleNoConversionDataRequired(percentage);
 }
 
 static std::optional<Style::Percentage> resolveComponentPercentage(const std::optional<CSSUnresolvedColorMix::Component::Percentage>& percentage, const CSSToLengthConversionData& conversionData)

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -59,6 +59,7 @@
 #include "CSSValueList.h"
 #include "CSSVariableParser.h"
 #include "CSSViewTransitionRule.h"
+#include "ComputedStyleDependencies.h"
 #include "ContainerQueryParser.h"
 #include "Document.h"
 #include "Element.h"

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -75,6 +75,7 @@
 #include "CSSValuePair.h"
 #include "CSSVariableParser.h"
 #include "CSSVariableReferenceValue.h"
+#include "ComputedStyleDependencies.h"
 #include "FontFace.h"
 #include "ParsingUtilities.h"
 #include "Rect.h"

--- a/Source/WebCore/css/values/CSSGradient.cpp
+++ b/Source/WebCore/css/values/CSSGradient.cpp
@@ -1,0 +1,463 @@
+/*
+ * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSGradientValue.h"
+
+#include "CSSCalcSymbolTable.h"
+#include "CSSCalcValue.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSPrimitiveValueMappings.h"
+#include "CalculationValue.h"
+#include "ColorInterpolation.h"
+#include "StyleBuilderConverter.h"
+#include "StyleGradientImage.h"
+#include "StylePosition.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include <wtf/text/StringBuilder.h>
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Gradient Color Stop
+
+template<typename T> static void colorStopSerializationForCSS(StringBuilder& builder, const GradientColorStop<T>& stop)
+{
+    if (stop.color && stop.position) {
+        builder.append(stop.protectedColor()->cssText(), ' ');
+        serializationForCSS(builder, *stop.position);
+    } else if (stop.color)
+        builder.append(stop.protectedColor()->cssText());
+    else if (stop.position)
+        serializationForCSS(builder, *stop.position);
+}
+
+void Serialize<GradientAngularColorStop>::operator()(StringBuilder& builder, const GradientAngularColorStop& stop)
+{
+    colorStopSerializationForCSS(builder, stop);
+}
+
+void Serialize<GradientLinearColorStop>::operator()(StringBuilder& builder, const GradientLinearColorStop& stop)
+{
+    colorStopSerializationForCSS(builder, stop);
+}
+
+void Serialize<GradientDeprecatedColorStop>::operator()(StringBuilder& builder, const GradientDeprecatedColorStop& stop)
+{
+    auto appendRaw = [&](const auto& color, NumberRaw raw) {
+        if (!raw.value)
+            builder.append("from("_s, color->cssText(), ')');
+        else if (raw.value == 1)
+            builder.append("to("_s, color->cssText(), ')');
+        else {
+            builder.append("color-stop("_s);
+            serializationForCSS(builder, raw);
+            builder.append(", "_s, color->cssText(), ')');
+        }
+    };
+
+    auto appendCalc = [&](const auto& calc) {
+        builder.append("color-stop("_s, calc.calc->cssText(), ", "_s, stop.protectedColor()->cssText(), ')');
+    };
+
+    WTF::switchOn(stop.position,
+        [&](const Number& number) {
+            return WTF::switchOn(number.value,
+                [&](NumberRaw raw) {
+                    appendRaw(stop.color, raw);
+                },
+                [&](const UnevaluatedCalc<NumberRaw>& calc) {
+                    appendCalc(calc);
+                }
+            );
+        },
+        [&](const Percentage& percentage) {
+            return WTF::switchOn(percentage.value,
+                [&](PercentageRaw raw) {
+                    appendRaw(stop.color, { raw.value / 100.0 });
+                },
+                [&](const UnevaluatedCalc<PercentageRaw>& calc) {
+                    appendCalc(calc);
+                }
+            );
+        }
+    );
+}
+
+template<typename T> static void collectComputedStyleDependenciesOnStop(ComputedStyleDependencies& dependencies, const GradientColorStop<T>& stop)
+{
+    if (RefPtr color = stop.color)
+        color->collectComputedStyleDependencies(dependencies);
+    collectComputedStyleDependencies(dependencies, stop.position);
+}
+
+void ComputedStyleDependenciesCollector<GradientAngularColorStop>::operator()(ComputedStyleDependencies& dependencies, const GradientAngularColorStop& stop)
+{
+    collectComputedStyleDependenciesOnStop(dependencies, stop);
+}
+
+void ComputedStyleDependenciesCollector<GradientLinearColorStop>::operator()(ComputedStyleDependencies& dependencies, const GradientLinearColorStop& stop)
+{
+    collectComputedStyleDependenciesOnStop(dependencies, stop);
+}
+
+void ComputedStyleDependenciesCollector<GradientDeprecatedColorStop>::operator()(ComputedStyleDependencies& dependencies, const GradientDeprecatedColorStop& stop)
+{
+    collectComputedStyleDependenciesOnStop(dependencies, stop);
+}
+
+template<typename T> static IterationStatus visitCSSValueChildrenOnColorStop(const Function<IterationStatus(CSSValue&)>& func, const GradientColorStop<T>& stop)
+{
+    if (RefPtr color = stop.color) {
+        if (func(*color) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    return visitCSSValueChildren(func, stop.position);
+}
+
+IterationStatus CSSValueChildrenVisitor<GradientAngularColorStop>::operator()(const Function<IterationStatus(CSSValue&)>& func, const GradientAngularColorStop& stop)
+{
+    return visitCSSValueChildrenOnColorStop(func, stop);
+}
+
+IterationStatus CSSValueChildrenVisitor<GradientLinearColorStop>::operator()(const Function<IterationStatus(CSSValue&)>& func, const GradientLinearColorStop& stop)
+{
+    return visitCSSValueChildrenOnColorStop(func, stop);
+}
+
+IterationStatus CSSValueChildrenVisitor<GradientDeprecatedColorStop>::operator()(const Function<IterationStatus(CSSValue&)>& func, const GradientDeprecatedColorStop& stop)
+{
+    return visitCSSValueChildrenOnColorStop(func, stop);
+}
+
+// MARK: - Gradient Color Interpolation
+
+static bool appendColorInterpolationMethod(StringBuilder& builder, CSS::GradientColorInterpolationMethod colorInterpolationMethod, bool needsLeadingSpace)
+{
+    return WTF::switchOn(colorInterpolationMethod.method.colorSpace,
+        [&](const ColorInterpolationMethod::OKLab&) {
+            if (colorInterpolationMethod.defaultMethod != CSS::GradientColorInterpolationMethod::Default::OKLab) {
+                builder.append(needsLeadingSpace ? " "_s : ""_s, "in oklab"_s);
+                return true;
+            }
+            return false;
+        },
+        [&](const ColorInterpolationMethod::SRGB&) {
+            if (colorInterpolationMethod.defaultMethod != CSS::GradientColorInterpolationMethod::Default::SRGB) {
+                builder.append(needsLeadingSpace ? " "_s : ""_s, "in srgb"_s);
+                return true;
+            }
+            return false;
+        },
+        [&]<typename MethodColorSpace> (const MethodColorSpace& methodColorSpace) {
+            builder.append(needsLeadingSpace ? " "_s : ""_s, "in "_s, serializationForCSS(methodColorSpace.interpolationColorSpace));
+            if constexpr (hasHueInterpolationMethod<MethodColorSpace>)
+                serializationForCSS(builder, methodColorSpace.hueInterpolationMethod);
+            return true;
+        }
+    );
+}
+
+// MARK: - LinearGradient
+
+void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearGradient& gradient)
+{
+    builder.append(gradient.repeating == GradientRepeat::Repeating ? "repeating-linear-gradient("_s : "linear-gradient("_s);
+    bool wroteSomething = false;
+
+    WTF::switchOn(gradient.gradientLine,
+        [&](const Angle& angle) {
+            WTF::switchOn(angle.value,
+                [&](const AngleRaw& angleRaw) {
+                    if (CSSPrimitiveValue::computeDegrees(angleRaw.type, angleRaw.value) == 180)
+                        return;
+
+                    serializationForCSS(builder, angleRaw);
+                    wroteSomething = true;
+                },
+                [&](const UnevaluatedCalc<AngleRaw>& angleCalc) {
+                    serializationForCSS(builder, angleCalc);
+                    wroteSomething = true;
+                }
+            );
+        },
+        [&](const Horizontal& horizontal) {
+            builder.append("to "_s);
+            serializationForCSS(builder, horizontal);
+            wroteSomething = true;
+        },
+        [&](const Vertical& vertical) {
+            if (std::holds_alternative<Bottom>(vertical))
+                return;
+
+            builder.append("to "_s);
+            serializationForCSS(builder, vertical);
+            wroteSomething = true;
+        },
+        [&](const SpaceSeparatedTuple<Horizontal, Vertical>& pair) {
+            builder.append("to "_s);
+            serializationForCSS(builder, pair);
+            wroteSomething = true;
+        }
+    );
+
+    if (appendColorInterpolationMethod(builder, gradient.colorInterpolationMethod, wroteSomething))
+        wroteSomething = true;
+
+    if (wroteSomething)
+        builder.append(", "_s);
+
+    serializationForCSS(builder, gradient.stops);
+
+    builder.append(')');
+}
+
+// MARK: - PrefixedLinearGradient
+
+void Serialize<PrefixedLinearGradient>::operator()(StringBuilder& builder, const PrefixedLinearGradient& gradient)
+{
+    builder.append(gradient.repeating == GradientRepeat::Repeating ? "-webkit-repeating-linear-gradient("_s : "-webkit-linear-gradient("_s);
+    serializationForCSS(builder, gradient.gradientLine);
+    builder.append(", "_s);
+    serializationForCSS(builder, gradient.stops);
+    builder.append(')');
+}
+
+// MARK: - DeprecatedLinearGradient
+
+void Serialize<DeprecatedLinearGradient>::operator()(StringBuilder& builder, const DeprecatedLinearGradient& gradient)
+{
+    builder.append("-webkit-gradient(linear, "_s);
+
+    serializationForCSS(builder, gradient.gradientLine);
+
+    if (!gradient.stops.isEmpty()) {
+        builder.append(", "_s);
+        serializationForCSS(builder, gradient.stops);
+    }
+
+    builder.append(')');
+}
+
+// MARK: - RadialGradient
+
+void Serialize<RadialGradient::Ellipse>::operator()(StringBuilder& builder, const RadialGradient::Ellipse& ellipse)
+{
+    auto lengthBefore = builder.length();
+
+    WTF::switchOn(ellipse.size,
+        [&](const SpaceSeparatedTuple<LengthPercentage, LengthPercentage>& size) {
+            serializationForCSS(builder, size);
+        },
+        [&](const RadialGradient::Extent& extent) {
+            if (!std::holds_alternative<FarthestCorner>(extent))
+                serializationForCSS(builder, extent);
+        }
+    );
+
+    if (ellipse.position) {
+        if (!isCenterPosition(*ellipse.position)) {
+            bool wroteSomething = builder.length() != lengthBefore;
+            if (wroteSomething)
+                builder.append(' ');
+
+            builder.append("at "_s);
+            serializationForCSS(builder, *ellipse.position);
+        }
+    }
+}
+
+void Serialize<RadialGradient::Circle>::operator()(StringBuilder& builder, const RadialGradient::Circle& circle)
+{
+    WTF::switchOn(circle.size,
+        [&](const Length& length) {
+            serializationForCSS(builder, length);
+        },
+        [&](const RadialGradient::Extent& extent) {
+            if (!std::holds_alternative<FarthestCorner>(extent)) {
+                builder.append("circle "_s);
+                serializationForCSS(builder, extent);
+            } else
+                builder.append("circle"_s);
+        }
+    );
+
+    if (circle.position) {
+        if (!isCenterPosition(*circle.position)) {
+            builder.append(" at "_s);
+            serializationForCSS(builder, *circle.position);
+        }
+    }
+}
+
+void Serialize<RadialGradient>::operator()(StringBuilder& builder, const RadialGradient& gradient)
+{
+    builder.append(gradient.repeating == GradientRepeat::Repeating ? "repeating-radial-gradient("_s : "radial-gradient("_s);
+
+    auto lengthBefore = builder.length();
+    serializationForCSS(builder, gradient.gradientBox);
+    bool wroteSomething = builder.length() != lengthBefore;
+
+    if (appendColorInterpolationMethod(builder, gradient.colorInterpolationMethod, wroteSomething))
+        wroteSomething = true;
+
+    if (wroteSomething)
+        builder.append(", "_s);
+
+    serializationForCSS(builder, gradient.stops);
+
+    builder.append(')');
+}
+
+// MARK: - PrefixedRadialGradient
+
+void Serialize<PrefixedRadialGradient::Ellipse>::operator()(StringBuilder& builder, const PrefixedRadialGradient::Ellipse& ellipse)
+{
+    if (ellipse.position)
+        serializationForCSS(builder, *ellipse.position);
+    else
+        builder.append("center"_s);
+
+    if (ellipse.size) {
+        WTF::switchOn(*ellipse.size,
+            [&](const SpaceSeparatedTuple<LengthPercentage, LengthPercentage>& size) {
+                builder.append(", "_s);
+                serializationForCSS(builder, size);
+            },
+            [&](const PrefixedRadialGradient::Extent& extent) {
+                builder.append(", ellipse "_s);
+                serializationForCSS(builder, extent);
+            }
+        );
+    }
+}
+
+void Serialize<PrefixedRadialGradient::Circle>::operator()(StringBuilder& builder, const PrefixedRadialGradient::Circle& circle)
+{
+    if (circle.position)
+        serializationForCSS(builder, *circle.position);
+    else
+        builder.append("center"_s);
+
+    builder.append(", circle "_s);
+    serializationForCSS(builder, circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Cover { } }));
+}
+
+void Serialize<PrefixedRadialGradient>::operator()(StringBuilder& builder, const PrefixedRadialGradient& gradient)
+{
+    builder.append(gradient.repeating == GradientRepeat::Repeating ? "-webkit-repeating-radial-gradient("_s : "-webkit-radial-gradient("_s);
+
+    auto lengthBefore = builder.length();
+    serializationForCSS(builder, gradient.gradientBox);
+    bool wroteSomething = builder.length() != lengthBefore;
+
+    if (wroteSomething)
+        builder.append(", "_s);
+
+    serializationForCSS(builder, gradient.stops);
+
+    builder.append(')');
+}
+
+// MARK: - DeprecatedRadialGradient
+
+void Serialize<DeprecatedRadialGradient::GradientBox>::operator()(StringBuilder& builder, const DeprecatedRadialGradient::GradientBox& gradientBox)
+{
+    serializationForCSS(builder, gradientBox.first);
+    builder.append(", "_s);
+    serializationForCSS(builder, gradientBox.firstRadius);
+    builder.append(", "_s);
+    serializationForCSS(builder, gradientBox.second);
+    builder.append(", "_s);
+    serializationForCSS(builder, gradientBox.secondRadius);
+}
+
+void Serialize<DeprecatedRadialGradient>::operator()(StringBuilder& builder, const DeprecatedRadialGradient& gradient)
+{
+    builder.append("-webkit-gradient(radial, "_s);
+
+    serializationForCSS(builder, gradient.gradientBox);
+
+    if (!gradient.stops.isEmpty()) {
+        builder.append(", "_s);
+        serializationForCSS(builder, gradient.stops);
+    }
+
+    builder.append(')');
+}
+
+// MARK: - ConicGradient
+
+void Serialize<ConicGradient::GradientBox>::operator()(StringBuilder& builder, const ConicGradient::GradientBox& gradientBox)
+{
+    bool wroteSomething = false;
+
+    if (gradientBox.angle) {
+        WTF::switchOn(gradientBox.angle->value,
+            [&](const AngleRaw& angleRaw) {
+                if (angleRaw.value) {
+                    builder.append("from "_s);
+                    serializationForCSS(builder, angleRaw);
+                    wroteSomething = true;
+                }
+            },
+            [&](const UnevaluatedCalc<AngleRaw>& angleCalc) {
+                builder.append("from "_s);
+                serializationForCSS(builder, angleCalc);
+                wroteSomething = true;
+            }
+        );
+    }
+
+    if (gradientBox.position && !isCenterPosition(*gradientBox.position)) {
+        if (wroteSomething)
+            builder.append(' ');
+        builder.append("at "_s);
+        serializationForCSS(builder, *gradientBox.position);
+    }
+}
+
+void Serialize<ConicGradient>::operator()(StringBuilder& builder, const ConicGradient& gradient)
+{
+    builder.append(gradient.repeating == GradientRepeat::Repeating ? "repeating-conic-gradient("_s : "conic-gradient("_s);
+
+    auto lengthBefore = builder.length();
+    serializationForCSS(builder, gradient.gradientBox);
+    bool wroteSomething = builder.length() != lengthBefore;
+
+    if (appendColorInterpolationMethod(builder, gradient.colorInterpolationMethod, wroteSomething))
+        wroteSomething = true;
+
+    if (wroteSomething)
+        builder.append(", "_s);
+
+    serializationForCSS(builder, gradient.stops);
+
+    builder.append(')');
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/CSSGradient.h
+++ b/Source/WebCore/css/values/CSSGradient.h
@@ -1,0 +1,419 @@
+/*
+ * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPosition.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSValueTypes.h"
+#include "ColorInterpolationMethod.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Common Types
+
+using DeprecatedGradientPosition = SpaceSeparatedTuple<PercentageOrNumber, PercentageOrNumber>;
+
+using Horizontal = std::variant<Left, Right>;
+using Vertical   = std::variant<Top, Bottom>;
+
+using ClosestCorner  = Constant<CSSValueClosestCorner>;
+using ClosestSide    = Constant<CSSValueClosestSide>;
+using FarthestCorner = Constant<CSSValueFarthestCorner>;
+using FarthestSide   = Constant<CSSValueFarthestSide>;
+using Contain        = Constant<CSSValueContain>;
+using Cover          = Constant<CSSValueCover>;
+
+using RadialGradientExtent         = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide>;
+using PrefixedRadialGradientExtent = std::variant<ClosestCorner, ClosestSide, FarthestCorner, FarthestSide, Contain, Cover>;
+
+// MARK: - Gradient Repeat Definitions.
+
+enum class GradientRepeat : bool { NonRepeating, Repeating };
+
+template<> struct ComputedStyleDependenciesCollector<GradientRepeat> { constexpr void operator()(ComputedStyleDependencies&, const GradientRepeat&) { } };
+template<> struct CSSValueChildrenVisitor<GradientRepeat> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientRepeat&) { return IterationStatus::Continue; } };
+
+// MARK: - Gradient Color Interpolation Definitions.
+
+struct GradientColorInterpolationMethod {
+    enum class Default : bool { SRGB, OKLab };
+
+    ColorInterpolationMethod method;
+    Default defaultMethod;
+    
+    static GradientColorInterpolationMethod legacyMethod(AlphaPremultiplication alphaPremultiplication)
+    {
+        return { { ColorInterpolationMethod::SRGB { }, alphaPremultiplication }, Default::SRGB };
+    }
+
+    bool operator==(const GradientColorInterpolationMethod&) const = default;
+};
+
+template<> struct ComputedStyleDependenciesCollector<GradientColorInterpolationMethod> { constexpr void operator()(ComputedStyleDependencies&, const GradientColorInterpolationMethod&) { } };
+template<> struct CSSValueChildrenVisitor<GradientColorInterpolationMethod> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientColorInterpolationMethod&) { return IterationStatus::Continue; } };
+
+// MARK: - Gradient Color Stop Definitions.
+
+template<typename Stop> using GradientColorStopList = CommaSeparatedVector<Stop, 2>;
+
+template<typename T> struct GradientColorStop {
+    using Position = T;
+    using List = GradientColorStopList<GradientColorStop<T>>;
+
+    RefPtr<CSSPrimitiveValue> color;
+    Position position;
+
+    RefPtr<CSSPrimitiveValue> protectedColor() const { return color; }
+
+    bool operator==(const GradientColorStop<T>&) const;
+};
+
+template<typename T> inline bool GradientColorStop<T>::operator==(const GradientColorStop<Position>& other) const
+{
+    return compareCSSValuePtr(color, other.color) && position == other.position;
+}
+
+using GradientAngularColorStopPosition = std::optional<AnglePercentage>;
+using GradientAngularColorStop = GradientColorStop<GradientAngularColorStopPosition>;
+using GradientAngularColorStopList = GradientColorStopList<GradientAngularColorStop>;
+
+using GradientLinearColorStopPosition = std::optional<LengthPercentage>;
+using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopPosition>;
+using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
+
+using GradientDeprecatedColorStopPosition = PercentageOrNumber;
+using GradientDeprecatedColorStop = GradientColorStop<GradientDeprecatedColorStopPosition>;
+using GradientDeprecatedColorStopList = GradientColorStopList<GradientDeprecatedColorStop>;
+
+template<> struct Serialize<GradientAngularColorStop> { void operator()(StringBuilder&, const GradientAngularColorStop&); };
+template<> struct Serialize<GradientLinearColorStop> { void operator()(StringBuilder&, const GradientLinearColorStop&); };
+template<> struct Serialize<GradientDeprecatedColorStop> { void operator()(StringBuilder&, const GradientDeprecatedColorStop&); };
+
+template<> struct ComputedStyleDependenciesCollector<GradientAngularColorStop> { void operator()(ComputedStyleDependencies&, const GradientAngularColorStop&); };
+template<> struct ComputedStyleDependenciesCollector<GradientLinearColorStop> { void operator()(ComputedStyleDependencies&, const GradientLinearColorStop&); };
+template<> struct ComputedStyleDependenciesCollector<GradientDeprecatedColorStop> { void operator()(ComputedStyleDependencies&, const GradientDeprecatedColorStop&); };
+
+template<> struct CSSValueChildrenVisitor<GradientAngularColorStop> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientAngularColorStop&); };
+template<> struct CSSValueChildrenVisitor<GradientLinearColorStop> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientLinearColorStop&); };
+template<> struct CSSValueChildrenVisitor<GradientDeprecatedColorStop> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientDeprecatedColorStop&); };
+
+// MARK: - LinearGradient
+
+struct LinearGradient {
+    using GradientLine = std::variant<Angle, Horizontal, Vertical, SpaceSeparatedTuple<Horizontal, Vertical>>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientLine gradientLine;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const LinearGradient&) const = default;
+};
+
+template<> struct Serialize<LinearGradient> { void operator()(StringBuilder&, const LinearGradient&); };
+
+template<size_t I> const auto& get(const LinearGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientLine;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+// MARK: - PrefixedLinearGradient
+
+struct PrefixedLinearGradient {
+    using GradientLine = std::variant<Angle, Horizontal, Vertical, SpaceSeparatedTuple<Horizontal, Vertical>>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientLine gradientLine;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const PrefixedLinearGradient&) const = default;
+};
+
+template<> struct Serialize<PrefixedLinearGradient> { void operator()(StringBuilder&, const PrefixedLinearGradient&); };
+
+template<size_t I> const auto& get(const PrefixedLinearGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientLine;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+// MARK: - DeprecatedLinearGradient
+
+struct DeprecatedLinearGradient {
+    using GradientLine = CommaSeparatedTuple<DeprecatedGradientPosition, DeprecatedGradientPosition>;
+
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientLine gradientLine;
+    GradientDeprecatedColorStopList stops;
+
+    bool operator==(const DeprecatedLinearGradient&) const = default;
+};
+
+template<> struct Serialize<DeprecatedLinearGradient> { void operator()(StringBuilder&, const DeprecatedLinearGradient&); };
+
+template<size_t I> const auto& get(const DeprecatedLinearGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 1)
+        return gradient.gradientLine;
+    else if constexpr (I == 2)
+        return gradient.stops;
+}
+
+// MARK: - RadialGradient
+
+struct RadialGradient {
+    using Extent = RadialGradientExtent;
+    struct Ellipse {
+        using Size = SpaceSeparatedTuple<LengthPercentage, LengthPercentage>; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
+        std::variant<Size, Extent> size;
+        std::optional<Position> position;
+        bool operator==(const Ellipse&) const = default;
+    };
+    struct Circle {
+        using Length = CSS::Length; // <length [0,∞]>
+        std::variant<Length, Extent> size;
+        std::optional<Position> position;
+        bool operator==(const Circle&) const = default;
+    };
+    using GradientBox = std::variant<Ellipse, Circle>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const RadialGradient&) const = default;
+};
+
+template<> struct Serialize<RadialGradient::Ellipse> { void operator()(StringBuilder&, const RadialGradient::Ellipse&); };
+template<> struct Serialize<RadialGradient::Circle> { void operator()(StringBuilder&, const RadialGradient::Circle&); };
+template<> struct Serialize<RadialGradient> { void operator()(StringBuilder&, const RadialGradient&); };
+
+template<size_t I> const auto& get(const RadialGradient::Ellipse& ellipse)
+{
+    if constexpr (!I)
+        return ellipse.size;
+    else if constexpr (I == 1)
+        return ellipse.position;
+}
+
+template<size_t I> const auto& get(const RadialGradient::Circle& circle)
+{
+    if constexpr (!I)
+        return circle.size;
+    else if constexpr (I == 1)
+        return circle.position;
+}
+
+template<size_t I> const auto& get(const RadialGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientBox;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+// MARK: - PrefixedRadialGradient
+
+struct PrefixedRadialGradient {
+    using Extent = PrefixedRadialGradientExtent;
+    struct Ellipse {
+        using Size = SpaceSeparatedTuple<LengthPercentage, LengthPercentage>; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
+        std::optional<std::variant<Size, Extent>> size;
+        std::optional<Position> position;
+        bool operator==(const Ellipse&) const = default;
+    };
+    struct Circle {
+        std::optional<Extent> size;
+        std::optional<Position> position;
+        bool operator==(const Circle&) const = default;
+    };
+    using GradientBox = std::variant<Ellipse, Circle>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const PrefixedRadialGradient&) const = default;
+};
+
+template<> struct Serialize<PrefixedRadialGradient::Ellipse> { void operator()(StringBuilder&, const PrefixedRadialGradient::Ellipse&); };
+template<> struct Serialize<PrefixedRadialGradient::Circle> { void operator()(StringBuilder&, const PrefixedRadialGradient::Circle&); };
+template<> struct Serialize<PrefixedRadialGradient> { void operator()(StringBuilder&, const PrefixedRadialGradient&); };
+
+template<size_t I> const auto& get(const PrefixedRadialGradient::Ellipse& ellipse)
+{
+    if constexpr (!I)
+        return ellipse.size;
+    else if constexpr (I == 1)
+        return ellipse.position;
+}
+
+template<size_t I> const auto& get(const PrefixedRadialGradient::Circle& circle)
+{
+    if constexpr (!I)
+        return circle.size;
+    else if constexpr (I == 1)
+        return circle.position;
+}
+
+template<size_t I> const auto& get(const PrefixedRadialGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientBox;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+// MARK: - DeprecatedRadialGradient
+
+struct DeprecatedRadialGradient {
+    struct GradientBox {
+        DeprecatedGradientPosition first;
+        Number firstRadius; // <number [0,∞]>
+        DeprecatedGradientPosition second;
+        Number secondRadius; // <number [0,∞]>
+
+        bool operator==(const GradientBox&) const = default;
+    };
+
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientDeprecatedColorStopList stops;
+
+    bool operator==(const DeprecatedRadialGradient&) const = default;
+};
+
+template<> struct Serialize<DeprecatedRadialGradient::GradientBox> { void operator()(StringBuilder&, const DeprecatedRadialGradient::GradientBox&); };
+template<> struct Serialize<DeprecatedRadialGradient> { void operator()(StringBuilder&, const DeprecatedRadialGradient&); };
+
+template<size_t I> const auto& get(const DeprecatedRadialGradient::GradientBox& gradientBox)
+{
+    if constexpr (!I)
+        return gradientBox.first;
+    else if constexpr (I == 1)
+        return gradientBox.firstRadius;
+    else if constexpr (I == 2)
+        return gradientBox.second;
+    else if constexpr (I == 3)
+        return gradientBox.secondRadius;
+}
+
+template<size_t I> const auto& get(const DeprecatedRadialGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 1)
+        return gradient.gradientBox;
+    else if constexpr (I == 2)
+        return gradient.stops;
+}
+
+
+// MARK: - ConicGradient
+
+struct ConicGradient {
+    struct GradientBox {
+        std::optional<Angle> angle;
+        std::optional<Position> position;
+
+        bool operator==(const GradientBox&) const = default;
+    };
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientAngularColorStopList stops;
+
+    bool operator==(const ConicGradient&) const = default;
+};
+
+template<> struct Serialize<ConicGradient::GradientBox> { void operator()(StringBuilder&, const ConicGradient::GradientBox&); };
+template<> struct Serialize<ConicGradient> { void operator()(StringBuilder&, const ConicGradient&); };
+
+template<size_t I> const auto& get(const ConicGradient::GradientBox& gradientBox)
+{
+    if constexpr (!I)
+        return gradientBox.angle;
+    else if constexpr (I == 1)
+        return gradientBox.position;
+}
+
+template<size_t I> const auto& get(const ConicGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientBox;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+} // namespace CSS
+} // namespace WebCore
+
+CSS_TUPLE_LIKE_CONFORMANCE(LinearGradient, 4)
+CSS_TUPLE_LIKE_CONFORMANCE(PrefixedLinearGradient, 4)
+CSS_TUPLE_LIKE_CONFORMANCE(DeprecatedLinearGradient, 3)
+CSS_TUPLE_LIKE_CONFORMANCE(RadialGradient::Ellipse, 2)
+CSS_TUPLE_LIKE_CONFORMANCE(RadialGradient::Circle, 2)
+CSS_TUPLE_LIKE_CONFORMANCE(RadialGradient, 4)
+CSS_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Ellipse, 2)
+CSS_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Circle, 2)
+CSS_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient, 4)
+CSS_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient::GradientBox, 4)
+CSS_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient, 3)
+CSS_TUPLE_LIKE_CONFORMANCE(ConicGradient::GradientBox, 2)
+CSS_TUPLE_LIKE_CONFORMANCE(ConicGradient, 4)

--- a/Source/WebCore/css/values/CSSPosition.cpp
+++ b/Source/WebCore/css/values/CSSPosition.cpp
@@ -56,44 +56,19 @@ bool isCenterPosition(const Position& position)
     );
 }
 
-void serializationForCSS(StringBuilder& builder, const Left&)
-{
-    builder.append(nameLiteralForSerialization(CSSValueLeft));
-}
-
-void serializationForCSS(StringBuilder& builder, const Right&)
-{
-    builder.append(nameLiteralForSerialization(CSSValueRight));
-}
-
-void serializationForCSS(StringBuilder& builder, const Top&)
-{
-    builder.append(nameLiteralForSerialization(CSSValueTop));
-}
-
-void serializationForCSS(StringBuilder& builder, const Bottom&)
-{
-    builder.append(nameLiteralForSerialization(CSSValueBottom));
-}
-
-void serializationForCSS(StringBuilder& builder, const Center&)
-{
-    builder.append(nameLiteralForSerialization(CSSValueCenter));
-}
-
-void serializationForCSS(StringBuilder& builder, const Position& position)
+void Serialize<Position>::operator()(StringBuilder& builder, const Position& position)
 {
     serializationForCSS(builder, position.value);
 }
 
-void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, const Position& position)
+void ComputedStyleDependenciesCollector<Position>::operator()(ComputedStyleDependencies& dependencies, const Position& position)
 {
     collectComputedStyleDependencies(dependencies, position.value);
 }
 
-IterationStatus visitCSSValueChildren(const Position& position, const Function<IterationStatus(CSSValue&)>& func)
+IterationStatus CSSValueChildrenVisitor<Position>::operator()(const Function<IterationStatus(CSSValue&)>& func, const Position& position)
 {
-    return visitCSSValueChildren(position.value, func);
+    return visitCSSValueChildren(func, position.value);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/CSSPosition.h
+++ b/Source/WebCore/css/values/CSSPosition.h
@@ -25,15 +25,18 @@
 #pragma once
 
 #include "CSSPrimitiveNumericTypes.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 
 namespace WebCore {
 namespace CSS {
 
-struct Left   {  constexpr bool operator==(const Left&) const = default;   };
-struct Right  {  constexpr bool operator==(const Right&) const = default;  };
-struct Top    {  constexpr bool operator==(const Top&) const = default;    };
-struct Bottom {  constexpr bool operator==(const Bottom&) const = default; };
-struct Center {  constexpr bool operator==(const Center&) const = default; };
+using Left   = Constant<CSSValueLeft>;
+using Right  = Constant<CSSValueRight>;
+using Top    = Constant<CSSValueTop>;
+using Bottom = Constant<CSSValueBottom>;
+using Center = Constant<CSSValueCenter>;
 
 using TwoComponentPositionHorizontal    = std::variant<Left, Right, Center, LengthPercentage>;
 using TwoComponentPositionVertical      = std::variant<Top, Bottom, Center, LengthPercentage>;
@@ -76,21 +79,9 @@ struct Position {
 
 bool isCenterPosition(const Position&);
 
-void serializationForCSS(StringBuilder&, const Left&);
-void serializationForCSS(StringBuilder&, const Right&);
-void serializationForCSS(StringBuilder&, const Top&);
-void serializationForCSS(StringBuilder&, const Bottom&);
-void serializationForCSS(StringBuilder&, const Center&);
-void serializationForCSS(StringBuilder&, const Position&);
-
-constexpr void collectComputedStyleDependencies(ComputedStyleDependencies&, const Left&) { }
-constexpr void collectComputedStyleDependencies(ComputedStyleDependencies&, const Right&) { }
-constexpr void collectComputedStyleDependencies(ComputedStyleDependencies&, const Top&) { }
-constexpr void collectComputedStyleDependencies(ComputedStyleDependencies&, const Bottom&) { }
-constexpr void collectComputedStyleDependencies(ComputedStyleDependencies&, const Center&) { }
-void collectComputedStyleDependencies(ComputedStyleDependencies&, const Position&);
-
-IterationStatus visitCSSValueChildren(const Position&, const Function<IterationStatus(CSSValue&)>&);
+template<> struct Serialize<Position> { void operator()(StringBuilder&, const Position&); };
+template<> struct ComputedStyleDependenciesCollector<Position> { void operator()(ComputedStyleDependencies&, const Position&); };
+template<> struct CSSValueChildrenVisitor<Position> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const Position&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+CSSValueVisitation.h
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+CSSValueVisitation.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericTypes.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - CSSValue Visitation
+
+template<RawNumeric RawType> struct CSSValueChildrenVisitor<RawType> {
+    IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const RawType&)
+    {
+        return IterationStatus::Continue;
+    }
+};
+
+template<RawNumeric RawType> struct CSSValueChildrenVisitor<PrimitiveNumeric<RawType>> {
+    IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const PrimitiveNumeric<RawType>& value)
+    {
+        return visitCSSValueChildren(func, value.value);
+    }
+};
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp
@@ -25,14 +25,14 @@
 #include "config.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 
-#include "CSSValue.h"
+#include "ComputedStyleDependencies.h"
 
 namespace WebCore {
 namespace CSS {
 
 // MARK: - Computed Style Dependencies
 
-void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, CSSUnitType unit)
+void ComputedStyleDependenciesCollector<CSSUnitType>::operator()(ComputedStyleDependencies& dependencies, CSSUnitType unit)
 {
     switch (unit) {
     case CSSUnitType::CSS_RCAP:
@@ -134,12 +134,12 @@ void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, C
     }
 }
 
-void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, const LengthRaw& length)
+void ComputedStyleDependenciesCollector<LengthRaw>::operator()(ComputedStyleDependencies& dependencies, const LengthRaw& length)
 {
     collectComputedStyleDependencies(dependencies, length.type);
 }
 
-void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, const LengthPercentageRaw& lengthPercentage)
+void ComputedStyleDependenciesCollector<LengthPercentageRaw>::operator()(ComputedStyleDependencies& dependencies, const LengthPercentageRaw& lengthPercentage)
 {
     collectComputedStyleDependencies(dependencies, lengthPercentage.type);
 }

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+EvaluateCalc.h
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+EvaluateCalc.h
@@ -32,7 +32,7 @@ namespace CSS {
 
 // MARK: - Evaluation
 
-// FIXME: Remove "evaluateCalc" family of functions once color code has moved to the "CSS::toStyle" family of functions.
+// FIXME: Remove "evaluateCalc" family of functions once color code has moved to the "toStyle" family of functions.
 
 template<RawNumeric T> auto evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<T>& calc, const CSSCalcSymbolTable& symbolTable) -> T
 {

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+Serialization.cpp
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+Serialization.cpp
@@ -34,72 +34,28 @@ namespace CSS {
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder& builder, const NumberRaw& value)
+void rawNumericSerialization(StringBuilder& builder, double value, CSSUnitType type)
 {
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
+    formatCSSNumberValue(builder, value, CSSPrimitiveValue::unitTypeString(type));
 }
 
-void serializationForCSS(StringBuilder& builder, const PercentageRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const AngleRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const LengthRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const TimeRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const FrequencyRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const ResolutionRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const FlexRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const AnglePercentageRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const LengthPercentageRaw& value)
-{
-    formatCSSNumberValue(builder, value.value, CSSPrimitiveValue::unitTypeString(value.type));
-}
-
-void serializationForCSS(StringBuilder& builder, const NoneRaw&)
+void Serialize<NoneRaw>::operator()(StringBuilder& builder, const NoneRaw&)
 {
     builder.append("none"_s);
 }
 
-void serializationForCSS(StringBuilder& builder, const SymbolRaw& value)
+void Serialize<None>::operator()(StringBuilder& builder, const None&)
+{
+    builder.append("none"_s);
+}
+
+void Serialize<SymbolRaw>::operator()(StringBuilder& builder, const SymbolRaw& value)
 {
     builder.append(nameLiteralForSerialization(value.value));
 }
 
-void serializationForCSS(StringBuilder& builder, const None&)
-{
-    builder.append("none"_s);
-}
 
-void serializationForCSS(StringBuilder& builder, const Symbol& value)
+void Serialize<Symbol>::operator()(StringBuilder& builder, const Symbol& value)
 {
     builder.append(nameLiteralForSerialization(value.value));
 }

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes+Serialization.h
@@ -31,26 +31,28 @@ namespace CSS {
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder&, const NumberRaw&);
-void serializationForCSS(StringBuilder&, const PercentageRaw&);
-void serializationForCSS(StringBuilder&, const AngleRaw&);
-void serializationForCSS(StringBuilder&, const LengthRaw&);
-void serializationForCSS(StringBuilder&, const TimeRaw&);
-void serializationForCSS(StringBuilder&, const FrequencyRaw&);
-void serializationForCSS(StringBuilder&, const ResolutionRaw&);
-void serializationForCSS(StringBuilder&, const FlexRaw&);
-void serializationForCSS(StringBuilder&, const AnglePercentageRaw&);
-void serializationForCSS(StringBuilder&, const LengthPercentageRaw&);
-void serializationForCSS(StringBuilder&, const NoneRaw&);
-void serializationForCSS(StringBuilder&, const SymbolRaw&);
+// Type-erased helper to allow for shared code.
+void rawNumericSerialization(StringBuilder&, double, CSSUnitType);
 
-template<typename T> void serializationForCSS(StringBuilder& builder, const PrimitiveNumeric<T>& primitive)
-{
-    serializationForCSS(builder, primitive.value);
-}
+template<RawNumeric RawType> struct Serialize<RawType> {
+    inline void operator()(StringBuilder& builder, const RawType& value)
+    {
+        rawNumericSerialization(builder, value.value, value.type);
+    }
+};
 
-void serializationForCSS(StringBuilder&, const Symbol&);
-void serializationForCSS(StringBuilder&, const None&);
+template<RawNumeric RawType> struct Serialize<PrimitiveNumeric<RawType>> {
+    inline void operator()(StringBuilder& builder, const PrimitiveNumeric<RawType>& value)
+    {
+        serializationForCSS(builder, value.value);
+    }
+};
+
+template<> struct Serialize<NoneRaw> { void operator()(StringBuilder&, const NoneRaw&); };
+template<> struct Serialize<None> { void operator()(StringBuilder&, const None&); };
+
+template<> struct Serialize<SymbolRaw> { void operator()(StringBuilder&, const SymbolRaw&); };
+template<> struct Serialize<Symbol> { void operator()(StringBuilder&, const Symbol&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/CSSPrimitiveNumericTypes.h
@@ -235,6 +235,7 @@ using LengthPercentage = PrimitiveNumeric<LengthPercentageRaw>;
 struct None {
     using Raw = NoneRaw;
 
+    constexpr None() = default;
     constexpr None(NoneRaw&&) { }
     constexpr None(const NoneRaw&) { }
 
@@ -285,13 +286,6 @@ template<typename T> bool isUnevaluatedCalc(const PrimitiveNumeric<T>& primitive
 template<typename T> auto simplifyUnevaluatedCalc(const PrimitiveNumeric<T>& primitive, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> PrimitiveNumeric<T>
 {
     return { simplifyUnevaluatedCalc(primitive.value, conversionData, symbolTable) };
-}
-
-// MARK: - CSSValue Visitation
-
-template<typename T> IterationStatus visitCSSValueChildren(const PrimitiveNumeric<T>& primitive, const Function<IterationStatus(CSSValue&)>& func)
-{
-    return visitCSSValueChildren(primitive.value, func);
 }
 
 // MARK: - Type List Modifiers

--- a/Source/WebCore/css/values/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/CSSUnevaluatedCalc.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSValue.h"
+#include "CSSValueTypes.h"
 #include <optional>
 #include <variant>
 #include <wtf/Brigand.h>
@@ -155,24 +156,30 @@ template<typename T> decltype(auto) simplifyUnevaluatedCalc(const std::optional<
 
 // MARK: - Serialization
 
-template<typename T> void serializationForCSS(StringBuilder& builder, const UnevaluatedCalc<T>& unevaluatedCalc)
-{
-    unevaluatedCalcSerialization(builder, unevaluatedCalc.calc);
-}
+template<typename T> struct Serialize<UnevaluatedCalc<T>> {
+    inline void operator()(StringBuilder& builder, const UnevaluatedCalc<T>& value)
+    {
+        unevaluatedCalcSerialization(builder, value.calc);
+    }
+};
 
 // MARK: - Computed Style Dependencies
 
-template<typename T> void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, const UnevaluatedCalc<T>& calc)
-{
-    unevaluatedCalcCollectComputedStyleDependencies(dependencies, calc.calc);
-}
+template<typename T> struct ComputedStyleDependenciesCollector<UnevaluatedCalc<T>> {
+    inline void operator()(ComputedStyleDependencies& dependencies, const UnevaluatedCalc<T>& value)
+    {
+        unevaluatedCalcCollectComputedStyleDependencies(dependencies, value.calc);
+    }
+};
 
 // MARK: - CSSValue Visitation
 
-template<typename T> IterationStatus visitCSSValueChildren(const UnevaluatedCalc<T>& calc, const Function<IterationStatus(CSSValue&)>& func)
-{
-    return func(calc.calc.get());
-}
+template<typename T> struct CSSValueChildrenVisitor<UnevaluatedCalc<T>> {
+    inline IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const UnevaluatedCalc<T>& value)
+    {
+        return func(value.calc.get());
+    }
+};
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2272,17 +2272,15 @@ ExceptionOr<void> HTMLInputElement::setSelectionRangeForBindings(unsigned start,
 static Ref<StyleGradientImage> autoFillStrongPasswordMaskImage()
 {
     return StyleGradientImage::create(
-        StyleGradientImage::LinearData {
-            {
-                Style::Angle { 90 }
-            },
-            CSSGradientRepeat::NonRepeating,
-            {
+        Style::LinearGradient {
+            .repeating = Style::GradientRepeat::NonRepeating,
+            .colorInterpolationMethod = Style::GradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied),
+            .gradientLine = { Style::Angle { 90 } },
+            .stops = {
                 { Color::black,            Style::LengthPercentage { Style::Percentage { 50 } } },
                 { Color::transparentBlack, Style::LengthPercentage { Style::Percentage { 100 } } }
             }
-        },
-        CSSGradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied)
+        }
     );
 }
 

--- a/Source/WebCore/rendering/style/StyleGradientImage.h
+++ b/Source/WebCore/rendering/style/StyleGradientImage.h
@@ -26,165 +26,19 @@
 
 #pragma once
 
-#include "CSSGradientValue.h"
-#include "LengthSize.h"
-#include "StyleColor.h"
+#include "StyleGradient.h"
 #include "StyleGeneratedImage.h"
-#include "StylePosition.h"
-#include "StylePrimitiveNumericTypes.h"
-#include <utility>
-#include <variant>
 
 namespace WebCore {
 
-template<typename T> struct StyleGradientImageColorStop {
-    using Position = T;
-    using List = Vector<StyleGradientImageColorStop<T>>;
-
-    std::optional<StyleColor> color;
-    Position position;
-
-    bool operator==(const StyleGradientImageColorStop<T>&) const = default;
-};
-
-template<typename Stop> using StyleGradientImageColorStopList = Vector<Stop>;
-
-using StyleGradientImageAngularColorStop = StyleGradientImageColorStop<std::optional<Style::AnglePercentage>>;
-using StyleGradientImageAngularColorStopList = StyleGradientImageColorStopList<StyleGradientImageAngularColorStop>;
-
-using StyleGradientImageLinearColorStop = StyleGradientImageColorStop<std::optional<Style::LengthPercentage>>;
-using StyleGradientImageLinearColorStopList = StyleGradientImageColorStopList<StyleGradientImageLinearColorStop>;
-
-using StyleGradientImageDeprecatedColorStop = StyleGradientImageColorStop<Style::Number>;
-using StyleGradientImageDeprecatedColorStopList = StyleGradientImageColorStopList<StyleGradientImageDeprecatedColorStop>;
-
-// MARK: StyleGradientImageDeprecatedPosition
-
-using StyleGradientImageDeprecatedPosition = Style::SpaceSeparatedTuple<Style::PercentageOrNumber, Style::PercentageOrNumber>;
+class Gradient;
+class GradientColorStops;
 
 class StyleGradientImage final : public StyleGeneratedImage {
 public:
-    struct LinearData {
-        using Horizontal = CSSLinearGradientValue::Horizontal;
-        using Vertical = CSSLinearGradientValue::Vertical;
-        using GradientLine = std::variant<std::monostate, Style::Angle, Horizontal, Vertical, std::pair<Horizontal, Vertical>>;
-
-        GradientLine gradientLine;
-        CSSGradientRepeat repeating;
-        StyleGradientImageLinearColorStopList stops;
-
-        bool operator==(const LinearData&) const = default;
-    };
-    struct PrefixedLinearData {
-        using Horizontal = CSSPrefixedLinearGradientValue::Horizontal;
-        using Vertical = CSSPrefixedLinearGradientValue::Vertical;
-        using GradientLine = std::variant<std::monostate, Style::Angle, Horizontal, Vertical, std::pair<Horizontal, Vertical>>;
-
-        GradientLine gradientLine;
-        CSSGradientRepeat repeating;
-        StyleGradientImageLinearColorStopList stops;
-
-        bool operator==(const PrefixedLinearData&) const = default;
-    };
-    struct DeprecatedLinearData {
-        StyleGradientImageDeprecatedPosition first;
-        StyleGradientImageDeprecatedPosition second;
-        StyleGradientImageDeprecatedColorStopList stops;
-
-        bool operator==(const DeprecatedLinearData&) const = default;
-    };
-    struct RadialData {
-        using ShapeKeyword = CSSRadialGradientValue::ShapeKeyword;
-        using ExtentKeyword = CSSRadialGradientValue::ExtentKeyword;
-
-        struct Shape {
-            ShapeKeyword shape;
-            std::optional<Style::Position> position;
-            bool operator==(const Shape&) const = default;
-        };
-        struct Extent {
-            ExtentKeyword extent;
-            std::optional<Style::Position> position;
-            bool operator==(const Extent&) const = default;
-        };
-        struct Length {
-            Style::Length length; // <length [0,∞]>
-            std::optional<Style::Position> position;
-            bool operator==(const Length&) const = default;
-        };
-        struct CircleOfLength {
-            Style::Length length; // <length [0,∞]>
-            std::optional<Style::Position> position;
-            bool operator==(const CircleOfLength&) const = default;
-        };
-        struct CircleOfExtent {
-            ExtentKeyword extent;
-            std::optional<Style::Position> position;
-            bool operator==(const CircleOfExtent&) const = default;
-        };
-        struct Size {
-            Style::SpaceSeparatedTuple<Style::LengthPercentage, Style::LengthPercentage> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
-            std::optional<Style::Position> position;
-            bool operator==(const Size&) const = default;
-        };
-        struct EllipseOfSize {
-            Style::SpaceSeparatedTuple<Style::LengthPercentage, Style::LengthPercentage> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
-            std::optional<Style::Position> position;
-            bool operator==(const EllipseOfSize&) const = default;
-        };
-        struct EllipseOfExtent {
-            ExtentKeyword extent;
-            std::optional<Style::Position> position;
-            bool operator==(const EllipseOfExtent&) const = default;
-        };
-        using GradientBox = std::variant<std::monostate, Shape, Extent, Length, Size, CircleOfLength, CircleOfExtent, EllipseOfSize, EllipseOfExtent, Style::Position>;
-
-        GradientBox gradientBox;
-        CSSGradientRepeat repeating;
-        StyleGradientImageLinearColorStopList stops;
-
-        bool operator==(const RadialData&) const = default;
-    };
-    struct PrefixedRadialData {
-        using ShapeKeyword = CSSPrefixedRadialGradientValue::ShapeKeyword;
-        using ExtentKeyword = CSSPrefixedRadialGradientValue::ExtentKeyword;
-        using ShapeAndExtent = CSSPrefixedRadialGradientValue::ShapeAndExtent;
-        struct MeasuredSize {
-            Style::SpaceSeparatedTuple<Style::LengthPercentage, Style::LengthPercentage> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
-            bool operator==(const MeasuredSize&) const = default;
-        };
-        using GradientBox = std::variant<std::monostate, ShapeKeyword, ExtentKeyword, ShapeAndExtent, MeasuredSize>;
-
-        GradientBox gradientBox;
-        std::optional<Style::Position> position;
-        CSSGradientRepeat repeating;
-        StyleGradientImageLinearColorStopList stops;
-
-        bool operator==(const PrefixedRadialData&) const = default;
-    };
-    struct DeprecatedRadialData {
-        StyleGradientImageDeprecatedPosition first;
-        StyleGradientImageDeprecatedPosition second;
-        Style::Number firstRadius;
-        Style::Number secondRadius;
-        StyleGradientImageDeprecatedColorStopList stops;
-
-        bool operator==(const DeprecatedRadialData&) const = default;
-    };
-    struct ConicData {
-        std::optional<Style::Angle> angle;
-        std::optional<Style::Position> position;
-        CSSGradientRepeat repeating;
-        StyleGradientImageAngularColorStopList stops;
-
-        bool operator==(const ConicData&) const = default;
-    };
-
-    using Data = std::variant<LinearData, DeprecatedLinearData, PrefixedLinearData, RadialData, DeprecatedRadialData, PrefixedRadialData, ConicData>;
-
-    static Ref<StyleGradientImage> create(Data data, CSSGradientColorInterpolationMethod colorInterpolationMethod)
+    static Ref<StyleGradientImage> create(Style::Gradient gradient)
     {
-        return adoptRef(*new StyleGradientImage(WTFMove(data), colorInterpolationMethod));
+        return adoptRef(*new StyleGradientImage(WTFMove(gradient)));
     }
     virtual ~StyleGradientImage();
 
@@ -194,7 +48,7 @@ public:
     static constexpr bool isFixedSize = false;
 
 private:
-    explicit StyleGradientImage(Data&&, CSSGradientColorInterpolationMethod);
+    explicit StyleGradientImage(Style::Gradient&&);
 
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
@@ -205,19 +59,18 @@ private:
     void didAddClient(RenderElement&) final { }
     void didRemoveClient(RenderElement&) final { }
 
-    Ref<Gradient> createGradient(const LinearData&, const FloatSize&, const RenderStyle&) const;
-    Ref<Gradient> createGradient(const PrefixedLinearData&, const FloatSize&, const RenderStyle&) const;
-    Ref<Gradient> createGradient(const DeprecatedLinearData&, const FloatSize&, const RenderStyle&) const;
-    Ref<Gradient> createGradient(const RadialData&, const FloatSize&, const RenderStyle&) const;
-    Ref<Gradient> createGradient(const PrefixedRadialData&, const FloatSize&, const RenderStyle&) const;
-    Ref<Gradient> createGradient(const DeprecatedRadialData&, const FloatSize&, const RenderStyle&) const;
-    Ref<Gradient> createGradient(const ConicData&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::LinearGradient&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::PrefixedLinearGradient&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::DeprecatedLinearGradient&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::RadialGradient&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::PrefixedRadialGradient&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::DeprecatedRadialGradient&, const FloatSize&, const RenderStyle&) const;
+    Ref<WebCore::Gradient> createGradient(const Style::ConicGradient&, const FloatSize&, const RenderStyle&) const;
 
-    template<typename GradientAdapter, typename Stops> GradientColorStops computeStops(GradientAdapter&, const Stops&, const RenderStyle&, float maxLengthForRepeat, CSSGradientRepeat) const;
-    template<typename GradientAdapter, typename Stops> GradientColorStops computeStopsForDeprecatedVariants(GradientAdapter&, const Stops&, const RenderStyle&) const;
+    template<typename GradientAdapter, typename StyleGradient> WebCore::GradientColorStops computeStops(GradientAdapter&, const StyleGradient&, const RenderStyle&, float maxLengthForRepeat) const;
+    template<typename GradientAdapter, typename StyleGradient> WebCore::GradientColorStops computeStopsForDeprecatedVariants(GradientAdapter&, const StyleGradient&, const RenderStyle&) const;
 
-    Data m_data;
-    CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    Style::Gradient m_gradient;
     bool m_knownCacheableBarringFilter { false };
 };
 

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -28,6 +28,7 @@
 #include "CSSCustomPropertyValue.h"
 #include "CSSPropertyParser.h"
 #include "CSSRegisteredCustomProperty.h"
+#include "ComputedStyleDependencies.h"
 #include "Document.h"
 #include "Element.h"
 #include "KeyframeEffect.h"

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -30,6 +30,7 @@
 #include "CSSPaintImageValue.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSValuePool.h"
+#include "ComputedStyleDependencies.h"
 #include "PaintWorkletGlobalScope.h"
 #include "PropertyAllowlist.h"
 #include "StyleBuilderGenerated.h"

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -38,6 +38,7 @@
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSValuePair.h"
 #include "CSSValuePool.h"
+#include "ComputedStyleDependencies.h"
 #include "CustomPropertyRegistry.h"
 #include "Document.h"
 #include "DocumentInlines.h"

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -136,7 +136,7 @@ static FontSelectionValue fontWeightFromUnresolvedFontWeight(const CSSPropertyPa
             // FIXME: Figure out correct behavior when conversion data is required.
             if (requiresConversionData(weight))
                 return normalWeightValue();
-            return FontSelectionValue(clampTo<float>(CSS::toStyleNoConversionDataRequired(weight, CSSCalcSymbolTable { }).value, 1, 1000));
+            return FontSelectionValue(clampTo<float>(toStyleNoConversionDataRequired(weight).value, 1, 1000));
         }
     );
 }
@@ -253,7 +253,7 @@ static ResolvedFontStyle fontStyleFromUnresolvedFontStyle(const CSSPropertyParse
                 return { .italic = std::nullopt, .axis = FontStyleAxis::slnt };
 
             return {
-                .italic = normalizedFontItalicValue(CSS::toStyleNoConversionDataRequired(angle, CSSCalcSymbolTable { }).value),
+                .italic = normalizedFontItalicValue(toStyleNoConversionDataRequired(angle).value),
                 .axis = FontStyleAxis::slnt
             };
         }
@@ -336,7 +336,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                         return { .size = 0.0f, .keyword = CSSValueInvalid };
 
                     return {
-                        .size = Style::evaluate(CSS::toStyleNoConversionDataRequired(calc, CSSCalcSymbolTable { }), parentSize),
+                        .size = Style::evaluate(toStyleNoConversionDataRequired(calc), parentSize),
                         .keyword = CSSValueInvalid
                     };
                 }

--- a/Source/WebCore/style/values/StyleGradient.cpp
+++ b/Source/WebCore/style/values/StyleGradient.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleGradient.h"
+
+#include "ComputedStyleExtractor.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion: Style -> CSS
+
+static RefPtr<CSSPrimitiveValue> toCSSColorStopColor(const std::optional<StyleColor>& color, const RenderStyle& style)
+{
+    if (!color)
+        return nullptr;
+    return ComputedStyleExtractor::currentColorOrValidColor(style, *color);
+}
+
+static auto toCSSColorStopPosition(const GradientLinearColorStop::Position& position, const RenderStyle& style) -> CSS::GradientLinearColorStopPosition
+{
+    return toCSS(position, style);
+}
+
+static auto toCSSColorStopPosition(const GradientAngularColorStop::Position& position, const RenderStyle& style) -> CSS::GradientAngularColorStopPosition
+{
+    return toCSS(position, style);
+}
+
+static auto toCSSColorStopPosition(const GradientDeprecatedColorStop::Position& position, const RenderStyle&) -> CSS::GradientDeprecatedColorStopPosition
+{
+    return CSS::NumberRaw { position.value };
+}
+
+template<typename CSSStop, typename StyleStop> static auto toCSSColorStop(const StyleStop& stop, const RenderStyle& style) -> CSSStop
+{
+    return CSSStop {
+        toCSSColorStopColor(stop.color, style),
+        toCSSColorStopPosition(stop.position, style)
+    };
+}
+
+auto ToCSS<GradientAngularColorStop>::operator()(const GradientAngularColorStop& stop, const RenderStyle& style) -> CSS::GradientAngularColorStop
+{
+    return toCSSColorStop<CSS::GradientAngularColorStop>(stop, style);
+}
+
+auto ToCSS<GradientLinearColorStop>::operator()(const GradientLinearColorStop& stop, const RenderStyle& style) -> CSS::GradientLinearColorStop
+{
+    return toCSSColorStop<CSS::GradientLinearColorStop>(stop, style);
+}
+
+auto ToCSS<GradientDeprecatedColorStop>::operator()(const GradientDeprecatedColorStop& stop, const RenderStyle& style) -> CSS::GradientDeprecatedColorStop
+{
+    return toCSSColorStop<CSS::GradientDeprecatedColorStop>(stop, style);
+}
+
+// MARK: - Conversion: CSS -> Style
+
+static auto toStyleStopColor(const RefPtr<CSSPrimitiveValue>& color, BuilderState& state, const CSSCalcSymbolTable&) -> std::optional<StyleColor>
+{
+    if (!color)
+        return std::nullopt;
+    return state.colorFromPrimitiveValue(*color);
+}
+
+static auto toStyleStopPosition(const CSS::GradientLinearColorStopPosition& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStopPosition
+{
+    return toStyle(position, state, symbolTable);
+}
+
+static auto toStyleStopPosition(const CSS::GradientAngularColorStopPosition& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStopPosition
+{
+    return toStyle(position, state, symbolTable);
+}
+
+static auto toStyleStopPosition(const CSS::GradientDeprecatedColorStopPosition& position, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStopPosition
+{
+    return WTF::switchOn(position,
+        [&](const CSS::Number& number) {
+            return toStyle(number, state, symbolTable);
+        },
+        [&](const CSS::Percentage& percentage) {
+            return Number { toStyle(percentage, state, symbolTable).value / 100.0f };
+        }
+    );
+}
+
+template<typename T> decltype(auto) toStyleColorStop(const T& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+{
+    return GradientColorStop {
+        toStyleStopColor(stop.color, state, symbolTable),
+        toStyleStopPosition(stop.position, state, symbolTable)
+    };
+}
+
+auto ToStyle<CSS::GradientAngularColorStop>::operator()(const CSS::GradientAngularColorStop& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientAngularColorStop
+{
+    return toStyleColorStop(stop, state, symbolTable);
+}
+
+auto ToStyle<CSS::GradientLinearColorStop>::operator()(const CSS::GradientLinearColorStop& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientLinearColorStop
+{
+    return toStyleColorStop(stop, state, symbolTable);
+}
+
+auto ToStyle<CSS::GradientDeprecatedColorStop>::operator()(const CSS::GradientDeprecatedColorStop& stop, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> GradientDeprecatedColorStop
+{
+    return toStyleColorStop(stop, state, symbolTable);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/StyleGradient.h
+++ b/Source/WebCore/style/values/StyleGradient.h
@@ -1,0 +1,402 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGradient.h"
+#include "StyleColor.h"
+#include "StylePosition.h"
+#include "StylePrimitiveNumericTypes.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Common Types
+
+using DeprecatedGradientPosition = SpaceSeparatedTuple<PercentageOrNumber, PercentageOrNumber>;
+
+using Horizontal     = CSS::Horizontal;
+using Vertical       = CSS::Vertical;
+
+using ClosestCorner  = CSS::ClosestCorner;
+using ClosestSide    = CSS::ClosestSide;
+using FarthestCorner = CSS::FarthestCorner;
+using FarthestSide   = CSS::FarthestSide;
+using Contain        = CSS::Contain;
+using Cover          = CSS::Cover;
+
+using RadialGradientExtent         = CSS::RadialGradientExtent;
+using PrefixedRadialGradientExtent = CSS::PrefixedRadialGradientExtent;
+
+// MARK: - Gradient Repeat Definitions.
+
+using GradientRepeat = CSS::GradientRepeat;
+
+template<> inline constexpr bool TreatAsNonConverting<GradientRepeat> = true;
+
+// MARK: - Gradient Color Interpolation Definitions.
+
+using GradientColorInterpolationMethod = CSS::GradientColorInterpolationMethod;
+
+template<> inline constexpr bool TreatAsNonConverting<GradientColorInterpolationMethod> = true;
+
+// MARK: - Gradient Color Stop Definitions.
+
+template<typename Stop> using GradientColorStopList = CommaSeparatedVector<Stop, 2>;
+
+template<typename T> struct GradientColorStop {
+    using Position = T;
+    using List = GradientColorStopList<GradientColorStop<T>>;
+
+    std::optional<StyleColor> color;
+    Position position;
+
+    bool operator==(const GradientColorStop<T>&) const = default;
+};
+template<typename T> GradientColorStop(auto color, T position) -> GradientColorStop<T>;
+
+using GradientAngularColorStopPosition = std::optional<AnglePercentage>;
+using GradientAngularColorStop = GradientColorStop<GradientAngularColorStopPosition>;
+using GradientAngularColorStopList = GradientColorStopList<GradientAngularColorStop>;
+
+using GradientLinearColorStopPosition = std::optional<LengthPercentage>;
+using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopPosition>;
+using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
+
+using GradientDeprecatedColorStopPosition = Number;
+using GradientDeprecatedColorStop = GradientColorStop<GradientDeprecatedColorStopPosition>;
+using GradientDeprecatedColorStopList = GradientColorStopList<GradientDeprecatedColorStop>;
+
+template<> struct ToCSS<GradientAngularColorStop> { auto operator()(const GradientAngularColorStop&, const RenderStyle&) -> CSS::GradientAngularColorStop; };
+template<> struct ToCSS<GradientLinearColorStop> { auto operator()(const GradientLinearColorStop&, const RenderStyle&) -> CSS::GradientLinearColorStop; };
+template<> struct ToCSS<GradientDeprecatedColorStop> { auto operator()(const GradientDeprecatedColorStop&, const RenderStyle&) -> CSS::GradientDeprecatedColorStop; };
+
+template<> struct ToStyle<CSS::GradientAngularColorStop> { auto operator()(const CSS::GradientAngularColorStop&, BuilderState&, const CSSCalcSymbolTable&) -> GradientAngularColorStop; };
+template<> struct ToStyle<CSS::GradientLinearColorStop> { auto operator()(const CSS::GradientLinearColorStop&, BuilderState&, const CSSCalcSymbolTable&) -> GradientLinearColorStop; };
+template<> struct ToStyle<CSS::GradientDeprecatedColorStop> { auto operator()(const CSS::GradientDeprecatedColorStop&, BuilderState&, const CSSCalcSymbolTable&) -> GradientDeprecatedColorStop; };
+
+// MARK: - LinearGradient
+
+struct LinearGradient {
+    using GradientLine = std::variant<Angle, Horizontal, Vertical, SpaceSeparatedTuple<Horizontal, Vertical>>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientLine gradientLine;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const LinearGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const LinearGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientLine;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::LinearGradient, LinearGradient)
+
+// MARK: - PrefixedLinearGradient
+
+struct PrefixedLinearGradient {
+    using GradientLine = std::variant<Angle, Horizontal, Vertical, SpaceSeparatedTuple<Horizontal, Vertical>>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientLine gradientLine;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const PrefixedLinearGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const PrefixedLinearGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientLine;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::PrefixedLinearGradient, PrefixedLinearGradient)
+
+// MARK: - DeprecatedLinearGradient
+
+struct DeprecatedLinearGradient {
+    using GradientLine = CommaSeparatedTuple<DeprecatedGradientPosition, DeprecatedGradientPosition>;
+
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientLine gradientLine;
+    GradientDeprecatedColorStopList stops;
+
+    bool operator==(const DeprecatedLinearGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const DeprecatedLinearGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 1)
+        return gradient.gradientLine;
+    else if constexpr (I == 2)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::DeprecatedLinearGradient, DeprecatedLinearGradient)
+
+// MARK: - RadialGradient
+
+struct RadialGradient {
+    using Extent = CSS::RadialGradient::Extent;
+    struct Ellipse {
+        using Size = SpaceSeparatedTuple<LengthPercentage, LengthPercentage>; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
+        std::variant<Size, Extent> size;
+        std::optional<Position> position;
+        bool operator==(const Ellipse&) const = default;
+    };
+    struct Circle {
+        using Length = Style::Length; // <length [0,∞]>
+        std::variant<Length, Extent> size;
+        std::optional<Position> position;
+        bool operator==(const Circle&) const = default;
+    };
+    // [[ <ending-shape> || <size> ]? [ at <position> ]? ]
+    using GradientBox = std::variant<Ellipse, Circle>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const RadialGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const RadialGradient::Ellipse& ellipse)
+{
+    if constexpr (!I)
+        return ellipse.size;
+    else if constexpr (I == 1)
+        return ellipse.position;
+}
+
+template<size_t I> const auto& get(const RadialGradient::Circle& circle)
+{
+    if constexpr (!I)
+        return circle.size;
+    else if constexpr (I == 1)
+        return circle.position;
+}
+
+template<size_t I> const auto& get(const RadialGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientBox;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::RadialGradient::Ellipse, RadialGradient::Ellipse)
+DEFINE_CSS_STYLE_MAPPING(CSS::RadialGradient::Circle, RadialGradient::Circle)
+DEFINE_CSS_STYLE_MAPPING(CSS::RadialGradient, RadialGradient)
+
+// MARK: - PrefixedRadialGradient
+
+struct PrefixedRadialGradient {
+    using Extent = CSS::PrefixedRadialGradient::Extent;
+    struct Ellipse {
+        using Size = SpaceSeparatedTuple<LengthPercentage, LengthPercentage>; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
+        std::optional<std::variant<Size, Extent>> size;
+        std::optional<Position> position;
+        bool operator==(const Ellipse&) const = default;
+    };
+    struct Circle {
+        std::optional<Extent> size;
+        std::optional<Position> position;
+        bool operator==(const Circle&) const = default;
+    };
+    // [<bg-position>,]? [ [<shape> || <size>] | [<length-percentage>]{2} ,]?
+    using GradientBox = std::variant<Ellipse, Circle>;
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientLinearColorStopList stops;
+
+    bool operator==(const PrefixedRadialGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const PrefixedRadialGradient::Ellipse& ellipse)
+{
+    if constexpr (!I)
+        return ellipse.size;
+    else if constexpr (I == 1)
+        return ellipse.position;
+}
+
+template<size_t I> const auto& get(const PrefixedRadialGradient::Circle& circle)
+{
+    if constexpr (!I)
+        return circle.size;
+    else if constexpr (I == 1)
+        return circle.position;
+}
+
+template<size_t I> const auto& get(const PrefixedRadialGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientBox;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::PrefixedRadialGradient::Ellipse, PrefixedRadialGradient::Ellipse)
+DEFINE_CSS_STYLE_MAPPING(CSS::PrefixedRadialGradient::Circle, PrefixedRadialGradient::Circle)
+DEFINE_CSS_STYLE_MAPPING(CSS::PrefixedRadialGradient, PrefixedRadialGradient)
+
+// MARK: - DeprecatedRadialGradient
+
+struct DeprecatedRadialGradient {
+    struct GradientBox {
+        DeprecatedGradientPosition first;
+        Number firstRadius; // <number [0,∞]>
+        DeprecatedGradientPosition second;
+        Number secondRadius; // <number [0,∞]>
+
+        bool operator==(const GradientBox&) const = default;
+    };
+
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientDeprecatedColorStopList stops;
+
+    bool operator==(const DeprecatedRadialGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const DeprecatedRadialGradient::GradientBox& gradientBox)
+{
+    if constexpr (!I)
+        return gradientBox.first;
+    else if constexpr (I == 1)
+        return gradientBox.firstRadius;
+    else if constexpr (I == 2)
+        return gradientBox.second;
+    else if constexpr (I == 3)
+        return gradientBox.secondRadius;
+}
+
+template<size_t I> const auto& get(const DeprecatedRadialGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 1)
+        return gradient.gradientBox;
+    else if constexpr (I == 2)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::DeprecatedRadialGradient::GradientBox, DeprecatedRadialGradient::GradientBox)
+DEFINE_CSS_STYLE_MAPPING(CSS::DeprecatedRadialGradient, DeprecatedRadialGradient)
+
+// MARK: - ConicGradient
+
+struct ConicGradient {
+    struct GradientBox {
+        std::optional<Angle> angle;
+        std::optional<Position> position;
+
+        bool operator==(const GradientBox&) const = default;
+    };
+
+    GradientRepeat repeating;
+    GradientColorInterpolationMethod colorInterpolationMethod;
+    GradientBox gradientBox;
+    GradientAngularColorStopList stops;
+
+    bool operator==(const ConicGradient&) const = default;
+};
+
+template<size_t I> const auto& get(const ConicGradient::GradientBox& gradientBox)
+{
+    if constexpr (!I)
+        return gradientBox.angle;
+    else if constexpr (I == 1)
+        return gradientBox.position;
+}
+
+template<size_t I> const auto& get(const ConicGradient& gradient)
+{
+    if constexpr (!I)
+        return gradient.repeating;
+    else if constexpr (I == 1)
+        return gradient.colorInterpolationMethod;
+    else if constexpr (I == 2)
+        return gradient.gradientBox;
+    else if constexpr (I == 3)
+        return gradient.stops;
+}
+
+DEFINE_CSS_STYLE_MAPPING(CSS::ConicGradient::GradientBox, ConicGradient::GradientBox)
+DEFINE_CSS_STYLE_MAPPING(CSS::ConicGradient, ConicGradient)
+
+// MARK: - Gradient (variant)
+
+using Gradient = std::variant<LinearGradient, DeprecatedLinearGradient, PrefixedLinearGradient, RadialGradient, DeprecatedRadialGradient, PrefixedRadialGradient, ConicGradient>;
+
+} // namespace Style
+} // namespace WebCore
+
+STYLE_TUPLE_LIKE_CONFORMANCE(LinearGradient, 4)
+STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedLinearGradient, 4)
+STYLE_TUPLE_LIKE_CONFORMANCE(DeprecatedLinearGradient, 3)
+STYLE_TUPLE_LIKE_CONFORMANCE(RadialGradient::Ellipse, 2)
+STYLE_TUPLE_LIKE_CONFORMANCE(RadialGradient::Circle, 2)
+STYLE_TUPLE_LIKE_CONFORMANCE(RadialGradient, 4)
+STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Ellipse, 2)
+STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Circle, 2)
+STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient, 4)
+STYLE_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient::GradientBox, 4)
+STYLE_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient, 3)
+STYLE_TUPLE_LIKE_CONFORMANCE(ConicGradient::GradientBox, 2)
+STYLE_TUPLE_LIKE_CONFORMANCE(ConicGradient, 4)

--- a/Source/WebCore/style/values/StylePosition.h
+++ b/Source/WebCore/style/values/StylePosition.h
@@ -28,10 +28,13 @@
 #include "StylePrimitiveNumericTypes.h"
 
 namespace WebCore {
-
-class CSSCalcSymbolTable;
-
 namespace Style {
+
+using Left   = CSS::Left;
+using Right  = CSS::Right;
+using Top    = CSS::Top;
+using Bottom = CSS::Bottom;
+using Center = CSS::Center;
 
 struct Position  {
     Position(LengthPercentage&& horizontal, LengthPercentage&& vertical)
@@ -54,32 +57,15 @@ struct Position  {
     SpaceSeparatedTuple<LengthPercentage, LengthPercentage> value;
 };
 
-// MARK: Support for treating Position types as Tuple-like
-
-template<size_t I> decltype(auto) get(const Position& position)
+template<size_t I> const auto& get(const Position& position)
 {
     return get<I>(position.value);
 }
 
-// Custom `toCSS()` needed to implement simplification rules.
-CSS::Position toCSS(const Position&, const RenderStyle&);
+template<> struct ToCSS<Position> { auto operator()(const Position&, const RenderStyle&) -> CSS::Position; };
+template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&, BuilderState&, const CSSCalcSymbolTable&) -> Position; };
 
 } // namespace Style
-
-namespace CSS {
-
-// Custom `toStyle()` needed to implement simplification rules.
-Style::Position toStyle(const Position&, Style::BuilderState&, const CSSCalcSymbolTable&);
-
-}
 } // namespace WebCore
 
-namespace std {
-
-template<> class tuple_size<WebCore::Style::Position> : public std::integral_constant<size_t, 2> { };
-template<size_t I> class tuple_element<I, WebCore::Style::Position> {
-public:
-    using type = WebCore::Style::LengthPercentage;
-};
-
-}
+STYLE_TUPLE_LIKE_CONFORMANCE(Position, 2)

--- a/Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.cpp
@@ -35,7 +35,17 @@ namespace Style {
 
 // MARK: Conversions to "CSS"
 
-auto toCSS(const AnglePercentage& value, const RenderStyle& style) -> CSS::AnglePercentage
+auto ToCSS<Number>::operator()(const Number& value, const RenderStyle&) -> CSS::Number
+{
+    return { CSS::NumberRaw { value.value } };
+}
+
+auto ToCSS<Percentage>::operator()(const Percentage& value, const RenderStyle&) -> CSS::Percentage
+{
+    return { CSS::PercentageRaw { value.value } };
+}
+
+auto ToCSS<AnglePercentage>::operator()(const AnglePercentage& value, const RenderStyle& style) -> CSS::AnglePercentage
 {
     return value.value.switchOn(
         [&](Angle angle) -> CSS::AnglePercentage {
@@ -50,7 +60,7 @@ auto toCSS(const AnglePercentage& value, const RenderStyle& style) -> CSS::Angle
     );
 }
 
-auto toCSS(const LengthPercentage& value, const RenderStyle& style) -> CSS::LengthPercentage
+auto ToCSS<LengthPercentage>::operator()(const LengthPercentage& value, const RenderStyle& style) -> CSS::LengthPercentage
 {
     return value.value.switchOn(
         [&](Length length) -> CSS::LengthPercentage {
@@ -65,46 +75,94 @@ auto toCSS(const LengthPercentage& value, const RenderStyle& style) -> CSS::Leng
     );
 }
 
-auto toCSS(const PercentageOrNumber& value, const RenderStyle&) -> CSS::PercentageOrNumber
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::AnglePercentageRaw& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable&) -> AnglePercentage
 {
-    return WTF::switchOn(value,
-        [](Percentage percentage) { return WebCore::CSS::PercentageOrNumber { CSS::PercentageRaw { percentage.value } }; },
-        [](Number number) { return WebCore::CSS::PercentageOrNumber { CSS::NumberRaw { number.value } }; }
-    );
+    return AnglePercentage { canonicalize(value, conversionData) };
 }
 
-} // namespace Style
-
-namespace CSS {
-
-Style::AnglePercentage toStyle(const UnevaluatedCalc<AnglePercentageRaw>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::UnevaluatedCalc<CSS::AnglePercentageRaw>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
 {
-    return calc.calc->anglePercentageValue(conversionData, symbolTable);
+    return AnglePercentage { value.calc->anglePercentageValue(conversionData, symbolTable) };
 }
 
-Style::AnglePercentage toStyle(const UnevaluatedCalc<AnglePercentageRaw>& calc, Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::AnglePercentage& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
 {
-    return toStyle(calc, Style::conversionData<AnglePercentageRaw>(state), symbolTable);
+    return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
 }
 
-Style::AnglePercentage toStyleNoConversionDataRequired(const UnevaluatedCalc<AnglePercentageRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::AnglePercentageRaw& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
 {
-    return calc.calc->anglePercentageValueNoConversionDataRequired(symbolTable);
+    return (*this)(value, conversionData<CSS::AnglePercentageRaw>(state), symbolTable);
 }
 
-Style::LengthPercentage toStyle(const UnevaluatedCalc<LengthPercentageRaw>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::UnevaluatedCalc<CSS::AnglePercentageRaw>& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
 {
-    return calc.calc->lengthPercentageValue(conversionData, symbolTable);
+    return (*this)(value, conversionData<CSS::AnglePercentageRaw>(state), symbolTable);
 }
 
-Style::LengthPercentage toStyle(const UnevaluatedCalc<LengthPercentageRaw>& calc, Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::AnglePercentage& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
 {
-    return toStyle(calc, Style::conversionData<LengthPercentageRaw>(state), symbolTable);
+    return (*this)(value, conversionData<CSS::AnglePercentageRaw>(state), symbolTable);
 }
 
-Style::LengthPercentage toStyleNoConversionDataRequired(const UnevaluatedCalc<LengthPercentageRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::AnglePercentageRaw& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> AnglePercentage
 {
-    return calc.calc->lengthPercentageValueNoConversionDataRequired(symbolTable);
+    return AnglePercentage { canonicalizeNoConversionDataRequired(value) };
+}
+
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::UnevaluatedCalc<CSS::AnglePercentageRaw>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
+{
+    return AnglePercentage { value.calc->anglePercentageValueNoConversionDataRequired(symbolTable) };
+}
+
+auto ToStyle<CSS::AnglePercentage>::operator()(const CSS::AnglePercentage& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> AnglePercentage
+{
+    return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::LengthPercentageRaw& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable&) -> LengthPercentage
+{
+    return LengthPercentage { canonicalize(value, conversionData) };
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::UnevaluatedCalc<CSS::LengthPercentageRaw>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return LengthPercentage { value.calc->lengthPercentageValue(conversionData, symbolTable) };
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::LengthPercentage& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::LengthPercentageRaw& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return (*this)(value, conversionData<CSS::LengthPercentageRaw>(state), symbolTable);
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::UnevaluatedCalc<CSS::LengthPercentageRaw>& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return (*this)(value, conversionData<CSS::LengthPercentageRaw>(state), symbolTable);
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::LengthPercentage& value, BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return (*this)(value, conversionData<CSS::LengthPercentageRaw>(state), symbolTable);
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::LengthPercentageRaw& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> LengthPercentage
+{
+    return LengthPercentage { canonicalizeNoConversionDataRequired(value) };
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::UnevaluatedCalc<CSS::LengthPercentageRaw>& calc, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return LengthPercentage { calc.calc->lengthPercentageValueNoConversionDataRequired(symbolTable) };
+}
+
+auto ToStyle<CSS::LengthPercentage>::operator()(const CSS::LengthPercentage& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> LengthPercentage
+{
+    return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
 }
 
 } // namespace CSS

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSCalcSymbolTable.h"
+#include "CSSValueTypes.h"
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -38,6 +39,121 @@ class RenderStyle;
 namespace Style {
 
 class BuilderState;
+
+// Types can specialize this and set the value to true to be treated as "non-converting"
+// for css to style / style to css conversion algorithms. This means the type is identical
+// for both CSS and Style systems (e.g. a constant value or an enum).
+template<class> inline constexpr bool TreatAsNonConverting = false;
+
+// Types can specialize this and set the value to true to be treated as "tuple-like"
+// for css to style / style to css conversion algorithms.
+// NOTE: This gets automatically specialized when using the STYLE_TUPLE_LIKE_CONFORMANCE macro.
+template<class> inline constexpr bool TreatAsTupleLike = false;
+
+// Types that are treated as "tuple-like" can have their conversion operations defined
+// automatically by just defining their type mapping.
+template<typename> struct CSSToStyleMapping;
+template<typename> struct StyleToCSSMapping;
+
+// Macro to define two-way mapping between a CSS and Style type. This is only needed
+// for "tuple-like" types, in lieu of explicit ToCSS/ToStyle specializations.
+#define DEFINE_CSS_STYLE_MAPPING(css, style) \
+    template<> struct CSSToStyleMapping<css> { using type = style; }; \
+    template<> struct StyleToCSSMapping<style> { using type = css; }; \
+
+// All non-converting and non-tuple like conforming types must implement the following for conversions:
+//
+//    template<> struct WebCore::Style::ToCSS<StyleType> {
+//        CSSType operator()(const StyleType&, const RenderStyle&);
+//    };
+//
+//    template<> struct WebCore::Style::ToStyle<CSSType> {
+//        StyleType operator()(const CSSType&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
+//        StyleType operator()(const CSSType&, BuilderState&, const CSSCalcSymbolTable&);
+//        StyleType operator()(const CSSType&, NoConversionDataRequiredToken, const CSSCalcSymbolTable&);
+//    };
+
+// Token passed to ToStyle to indicate that the caller has checked that no conversion data is required.
+struct NoConversionDataRequiredToken { };
+
+template<typename> struct ToCSS;
+template<typename> struct ToStyle;
+
+// Types can specialize `PrimaryCSSType` to provided a "primary" type the specialized type should be converted to before conversion to Style. For
+// instance, `CSS::NumberRaw`, would specialize this as `template<> struct ToPrimaryCSSTypeMapping<CSS::NumberRaw> { using type = CSS::Number };` to
+// allow callers to use `toStyle(...)` directly on values of type `CSS::NumberRaw`.
+template<typename CSSType> struct ToPrimaryCSSTypeMapping { using type = CSSType; };
+template<typename CSSType> using PrimaryCSSType = typename ToPrimaryCSSTypeMapping<CSSType>::type;
+
+// MARK: Common Types.
+
+// Helper type used to represent a constant identifier.
+template<CSSValueID C> using Constant = CSS::Constant<C>;
+
+// Specialize TreatAsNonConverting for Constant<C>, to indicate that its type does not change from the CSS representation.
+template<CSSValueID C> inline constexpr bool TreatAsNonConverting<Constant<C>> = true;
+
+// Wraps a variable number of elements of a single type, semantically marking them as serializing as "space separated".
+template<typename T, size_t inlineCapacity = 0> struct SpaceSeparatedVector {
+    using Vector = WTF::Vector<T, inlineCapacity>;
+    using const_iterator = typename Vector::const_iterator;
+    using const_reverse_iterator = typename Vector::const_reverse_iterator;
+    using value_type = typename Vector::value_type;
+
+    SpaceSeparatedVector(std::initializer_list<T> initializerList)
+        : value { initializerList }
+    {
+    }
+
+    SpaceSeparatedVector(WTF::Vector<T, inlineCapacity>&& value)
+        : value { WTFMove(value) }
+    {
+    }
+
+    const_iterator begin() const { return value.begin(); }
+    const_iterator end() const { return value.end(); }
+    const_reverse_iterator rbegin() const { return value.rbegin(); }
+    const_reverse_iterator rend() const { return value.rend(); }
+
+    bool isEmpty() const { return value.isEmpty(); }
+    size_t size() const { return value.size(); }
+    const T& operator[](size_t i) const { return value[i]; }
+
+    bool operator==(const SpaceSeparatedVector<T, inlineCapacity>&) const = default;
+
+    WTF::Vector<T, inlineCapacity> value;
+};
+
+// Wraps a variable number of elements of a single type, semantically marking them as serializing as "comma separated".
+template<typename T, size_t inlineCapacity = 0> struct CommaSeparatedVector {
+    using Vector = WTF::Vector<T, inlineCapacity>;
+    using const_iterator = typename Vector::const_iterator;
+    using const_reverse_iterator = typename Vector::const_reverse_iterator;
+    using value_type = typename Vector::value_type;
+
+    CommaSeparatedVector(std::initializer_list<T> initializerList)
+        : value { initializerList }
+    {
+    }
+
+    CommaSeparatedVector(WTF::Vector<T, inlineCapacity>&& value)
+        : value { WTFMove(value) }
+    {
+    }
+
+    const_iterator begin() const { return value.begin(); }
+    const_iterator end() const { return value.end(); }
+    const_reverse_iterator rbegin() const { return value.rbegin(); }
+    const_reverse_iterator rend() const { return value.rend(); }
+
+    bool isEmpty() const { return value.isEmpty(); }
+    size_t size() const { return value.size(); }
+    const T& operator[](size_t i) const { return value[i]; }
+
+    bool operator==(const CommaSeparatedVector<T, inlineCapacity>&) const = default;
+
+    WTF::Vector<T, inlineCapacity> value;
+};
 
 // Wraps a variadic list of types, semantically marking them as serializing as "space separated".
 template<typename... Ts> struct SpaceSeparatedTuple {
@@ -61,104 +177,305 @@ template<typename... Ts> struct SpaceSeparatedTuple {
     std::tuple<Ts...> value;
 };
 
-// MARK: - Conversion from "Style to "CSS"
-
-template<typename StyleType> decltype(auto) toCSS(const std::optional<StyleType>& value, const RenderStyle& style)
-{
-    return value ? std::make_optional(toCSS(*value, style)) : std::nullopt;
-}
-
-template<typename... StyleTypes> decltype(auto) toCSS(const SpaceSeparatedTuple<StyleTypes...>& value, const RenderStyle& style)
-{
-    using CSSTuple = std::tuple<decltype(toCSS(std::declval<StyleTypes>(), style))...>;
-    return CSS::SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return CSSTuple { toCSS(x, style)... }; }, value.value) };
-}
-
-// MARK: Support for treating aggregate types as Tuple-like
-
 template<size_t I, typename... Ts> decltype(auto) get(const SpaceSeparatedTuple<Ts...>& tuple)
 {
     return std::get<I>(tuple.value);
 }
 
-} // namespace Style
+// Wraps a variadic list of types, semantically marking them as serializing as "comma separated".
+template<typename... Ts> struct CommaSeparatedTuple {
+    constexpr CommaSeparatedTuple(Ts&&... values)
+        : value { std::make_tuple(std::forward<Ts>(values)...) }
+    {
+    }
 
-namespace CSS {
+    constexpr CommaSeparatedTuple(const Ts&... values)
+        : value { std::make_tuple(values...) }
+    {
+    }
+
+    constexpr CommaSeparatedTuple(std::tuple<Ts...>&& tuple)
+        : value { WTFMove(tuple) }
+    {
+    }
+
+    constexpr bool operator==(const CommaSeparatedTuple<Ts...>&) const = default;
+
+    std::tuple<Ts...> value;
+};
+
+template<size_t I, typename... Ts> decltype(auto) get(const CommaSeparatedTuple<Ts...>& tuple)
+{
+    return std::get<I>(tuple.value);
+}
+
+// MARK: - Conversion from "Style to "CSS"
+
+// Conversion Invoker
+template<typename StyleType> decltype(auto) toCSS(const StyleType& styleType, const RenderStyle& style)
+{
+    return ToCSS<StyleType>{}(styleType, style);
+}
+
+template<typename To, typename From> auto toCSSOnTupleLike(const From& tupleLike, const RenderStyle& style) -> To
+{
+    return WTF::apply([&](const auto& ...x) { return To { toCSS(x, style)... }; }, tupleLike);
+}
+
+// Conversion Utility Types
+template<typename StyleType> using CSSType = std::decay_t<decltype(toCSS(std::declval<const StyleType&>(), std::declval<const RenderStyle&>()))>;
+template<typename... StyleTypes> using CSSVariant = std::variant<CSSType<StyleTypes>...>;
+template<typename... StyleTypes> using CSSTuple = std::tuple<CSSType<StyleTypes>...>;
+
+// Constrained for `TreatAsNonConverting`.
+template<typename StyleType> requires (TreatAsNonConverting<StyleType>) struct ToCSS<StyleType> {
+    constexpr decltype(auto) operator()(const StyleType& value, const RenderStyle&)
+    {
+        return value;
+    }
+};
+
+// Constrained for `TreatAsTupleLike`.
+template<typename StyleType> requires (TreatAsTupleLike<StyleType>) struct ToCSS<StyleType> {
+    decltype(auto) operator()(const StyleType& value, const RenderStyle& style)
+    {
+        return toCSSOnTupleLike<typename StyleToCSSMapping<StyleType>::type>(value, style);
+    }
+};
+
+// Specialization for `std::optional`.
+template<typename StyleType> struct ToCSS<std::optional<StyleType>> {
+    decltype(auto) operator()(const std::optional<StyleType>& value, const RenderStyle& style)
+    {
+        return value ? std::make_optional(toCSS(*value, style)) : std::nullopt;
+    }
+};
+
+// Specialization for `std::variant`.
+template<typename... StyleTypes> struct ToCSS<std::variant<StyleTypes...>> {
+    decltype(auto) operator()(const std::variant<StyleTypes...>& value, const RenderStyle& style)
+    {
+        return WTF::switchOn(value, [&](const auto& alternative) { return CSSVariant<StyleTypes...> { toCSS(alternative, style) }; });
+    }
+};
+
+// Specialization for `SpaceSeparatedVector`.
+template<typename StyleType, size_t inlineCapacity> struct ToCSS<SpaceSeparatedVector<StyleType, inlineCapacity>> {
+    using Result = CSS::SpaceSeparatedVector<CSSType<StyleType>, inlineCapacity>;
+
+    decltype(auto) operator()(const SpaceSeparatedVector<StyleType, inlineCapacity>& value, const RenderStyle& style)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toCSS(x, style); }) };
+    }
+};
+
+// Specialization for `CommaSeparatedVector`.
+template<typename StyleType, size_t inlineCapacity> struct ToCSS<CommaSeparatedVector<StyleType, inlineCapacity>> {
+    using Result = CSS::CommaSeparatedVector<CSSType<StyleType>, inlineCapacity>;
+
+    decltype(auto) operator()(const CommaSeparatedVector<StyleType, inlineCapacity>& value, const RenderStyle& style)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toCSS(x, style); }) };
+    }
+};
+
+// Specialization for `SpaceSeparatedTuple`.
+template<typename... StyleTypes> struct ToCSS<SpaceSeparatedTuple<StyleTypes...>> {
+    decltype(auto) operator()(const SpaceSeparatedTuple<StyleTypes...>& value, const RenderStyle& style)
+    {
+        return CSS::SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return CSSTuple<StyleTypes...> { toCSS(x, style)... }; }, value.value) };
+    }
+};
+
+// Specialization for `CommaSeparatedTuple`.
+template<typename... StyleTypes> struct ToCSS<CommaSeparatedTuple<StyleTypes...>> {
+    decltype(auto) operator()(const CommaSeparatedTuple<StyleTypes...>& value, const RenderStyle& style)
+    {
+        return CSS::CommaSeparatedTuple { WTF::apply([&](const auto& ...x) { return CSSTuple<StyleTypes...> { toCSS(x, style)... }; }, value.value) };
+    }
+};
 
 // MARK: - Conversion from "CSS" to "Style"
 
-template<typename... CSSTypes> decltype(auto) toStyle(const std::variant<CSSTypes...>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+// Conversion Invokers
+template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
 {
-    using StyleVariant = std::variant<std::decay_t<decltype(toStyle(std::declval<const CSSTypes&>(), conversionData, symbolTable))>...>;
-    return WTF::switchOn(value, [&](const auto& alternative) { return StyleVariant { toStyle(alternative, conversionData, symbolTable) }; });
+    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, conversionData, symbolTable);
 }
 
-template<typename... CSSTypes> decltype(auto) toStyle(const std::variant<CSSTypes...>& value, Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, const CSSToLengthConversionData& conversionData)
 {
-    using StyleVariant = std::variant<std::decay_t<decltype(toStyle(std::declval<const CSSTypes&>(), state, symbolTable))>...>;
-    return WTF::switchOn(value, [&](const auto& alternative) { return StyleVariant { toStyle(alternative, state, symbolTable) }; });
+    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, conversionData, CSSCalcSymbolTable { });
 }
 
-template<typename CSSType> decltype(auto) toStyle(const std::optional<CSSType>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
 {
-    return value ? std::make_optional(toStyle(*value, conversionData, symbolTable)) : std::nullopt;
+    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, builderState, symbolTable);
 }
 
-template<typename CSSType> decltype(auto) toStyle(const std::optional<CSSType>& value, Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType> decltype(auto) toStyle(const CSSType& cssType, BuilderState& builderState)
 {
-    return value ? std::make_optional(toStyle(*value, state, symbolTable)) : std::nullopt;
+    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, builderState, CSSCalcSymbolTable { });
 }
 
-template<typename... CSSTypes> decltype(auto) toStyle(const SpaceSeparatedTuple<CSSTypes...>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(const CSSType& cssType, const CSSCalcSymbolTable& symbolTable)
 {
-    using StyleTuple = std::tuple<std::decay_t<decltype(toStyle(std::declval<const CSSTypes&>(), conversionData, symbolTable))>...>;
-    return Style::SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple { toStyle(x, conversionData, symbolTable)... }; }, value.value) };
+    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, NoConversionDataRequiredToken { }, symbolTable);
 }
 
-template<typename... CSSTypes> decltype(auto) toStyle(const SpaceSeparatedTuple<CSSTypes...>& value, Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable)
+template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(const CSSType& cssType)
 {
-    using StyleTuple = std::tuple<std::decay_t<decltype(toStyle(std::declval<const CSSTypes&>(), state, symbolTable))>...>;
-    return Style::SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple { toStyle(x, state, symbolTable)... }; }, value.value) };
+    return ToStyle<PrimaryCSSType<CSSType>>{}(cssType, NoConversionDataRequiredToken { }, CSSCalcSymbolTable { });
 }
 
-template<typename CSSType> decltype(auto) toStyle(CSSType&& value, const CSSToLengthConversionData& conversionData)
+template<typename To, typename From, typename... Args> auto toStyleOnTupleLike(const From& tupleLike, Args&&... args) -> To
 {
-    // Fallback when no CSSCalcSymbolTable is provided.
-    return toStyle(std::forward<CSSType>(value), conversionData, CSSCalcSymbolTable { });
+    return WTF::apply([&](const auto& ...x) { return To { toStyle(x, args...)... }; }, tupleLike);
 }
 
-template<typename CSSType> decltype(auto) toStyle(CSSType&& value, Style::BuilderState& state)
+template<typename To, typename From, typename... Args> auto toStyleNoConversionDataRequiredOnTupleLike(const From& tupleLike, Args&&... args) -> To
 {
-    // Fallback when no CSSCalcSymbolTable is provided.
-    return toStyle(std::forward<CSSType>(value), state, CSSCalcSymbolTable { });
+    return WTF::apply([&](const auto& ...x) { return To { toStyleNoConversionDataRequired(x, args...)... }; }, tupleLike);
 }
 
-// MARK: - Conversion from "CSS" to "Style" (no conversion data required)
+// Conversion Utility Types
+template<typename CSSType> using StyleType = std::decay_t<decltype(toStyle(std::declval<const CSSType&>(), std::declval<BuilderState&>(), std::declval<const CSSCalcSymbolTable&>()))>;
+template<typename... CSSTypes> using StyleVariant = std::variant<StyleType<CSSTypes>...>;
+template<typename... CSSTypes> using StyleTuple = std::tuple<StyleType<CSSTypes>...>;
 
-template<typename... CSSTypes> decltype(auto) toStyleNoConversionDataRequired(const std::variant<CSSTypes...>& value, const CSSCalcSymbolTable& symbolTable)
-{
-    using StyleVariant = std::variant<std::decay_t<decltype(toStyleNoConversionDataRequired(std::declval<const CSSTypes&>(), symbolTable))>...>;
-    return WTF::switchOn(value, [&](const auto& alternative) { return StyleVariant { toStyleNoConversionDataRequired(alternative, symbolTable) }; });
-}
+// Constrained for `TreatAsNonConverting`.
+template<typename CSSType> requires (TreatAsNonConverting<CSSType>) struct ToStyle<CSSType> {
+    constexpr decltype(auto) operator()(const CSSType& value, const CSSToLengthConversionData&, const CSSCalcSymbolTable&)
+    {
+        return value;
+    }
+    constexpr decltype(auto) operator()(const CSSType& value, BuilderState&, const CSSCalcSymbolTable&)
+    {
+        return value;
+    }
+    constexpr decltype(auto) operator()(const CSSType& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable&)
+    {
+        return value;
+    }
+};
 
-template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(const std::optional<CSSType>& value, const CSSCalcSymbolTable& symbolTable)
-{
-    return value ? std::make_optional(toStyleNoConversionDataRequired(*value, symbolTable)) : std::nullopt;
-}
+// Constrained for `TreatAsTupleLike`.
+template<typename CSSType> requires (CSS::TreatAsTupleLike<CSSType>) struct ToStyle<CSSType> {
+    decltype(auto) operator()(const CSSType& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return toStyleOnTupleLike<typename CSSToStyleMapping<CSSType>::type>(value, conversionData, symbolTable);
+    }
+    decltype(auto) operator()(const CSSType& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return toStyleOnTupleLike<typename CSSToStyleMapping<CSSType>::type>(value, builderState, symbolTable);
+    }
+    decltype(auto) operator()(const CSSType& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return toStyleNoConversionDataRequiredOnTupleLike<typename CSSToStyleMapping<CSSType>::type>(value, symbolTable);
+    }
+};
 
-template<typename... CSSTypes> decltype(auto) toStyleNoConversionDataRequired(const SpaceSeparatedTuple<CSSTypes...>& value, const CSSCalcSymbolTable& symbolTable)
-{
-    using StyleTuple = std::tuple<std::decay_t<decltype(toStyleNoConversionDataRequired(std::declval<const CSSTypes&>()))>...>;
-    return SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple { toStyleNoConversionDataRequired(x, symbolTable)... }; }, value.value) };
-}
+// Specialization for `std::optional`.
+template<typename CSSType> struct ToStyle<std::optional<CSSType>> {
+    decltype(auto) operator()(const std::optional<CSSType>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return value ? std::make_optional(toStyle(*value, conversionData, symbolTable)) : std::nullopt;
+    }
+    decltype(auto) operator()(const std::optional<CSSType>& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return value ? std::make_optional(toStyle(*value, builderState, symbolTable)) : std::nullopt;
+    }
+    decltype(auto) operator()(const std::optional<CSSType>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return value ? std::make_optional(toStyleNoConversionDataRequired(*value, symbolTable)) : std::nullopt;
+    }
+};
 
-template<typename CSSType> decltype(auto) toStyleNoConversionDataRequired(CSSType&& value)
-{
-    // Fallback when no CSSCalcSymbolTable is provided.
-    return toStyleNoConversionDataRequired(std::forward<CSSType>(value), CSSCalcSymbolTable { });
-}
+// Specialization for `std::variant`.
+template<typename... CSSTypes> struct ToStyle<std::variant<CSSTypes...>> {
+    decltype(auto) operator()(const std::variant<CSSTypes...>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return WTF::switchOn(value, [&](const auto& alternative) { return StyleVariant<CSSTypes...> { toStyle(alternative, conversionData, symbolTable) }; });
+    }
+    decltype(auto) operator()(const std::variant<CSSTypes...>& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return WTF::switchOn(value, [&](const auto& alternative) { return StyleVariant<CSSTypes...> { toStyle(alternative, builderState, symbolTable) }; });
+    }
+    decltype(auto) operator()(const std::variant<CSSTypes...>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return WTF::switchOn(value, [&](const auto& alternative) { return StyleVariant<CSSTypes...> { toStyleNoConversionDataRequired(alternative, symbolTable) }; });
+    }
+};
 
-} // namespace CSS
+// Specialization for `SpaceSeparatedVector`.
+template<typename CSSType, size_t inlineCapacity> struct ToStyle<CSS::SpaceSeparatedVector<CSSType, inlineCapacity>> {
+    using Result = SpaceSeparatedVector<StyleType<CSSType>, inlineCapacity>;
+
+    decltype(auto) operator()(const CSS::SpaceSeparatedVector<CSSType, inlineCapacity>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, conversionData, symbolTable); }) };
+    }
+    decltype(auto) operator()(const CSS::SpaceSeparatedVector<CSSType, inlineCapacity>& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, builderState, symbolTable); }) };
+    }
+    decltype(auto) operator()(const CSS::SpaceSeparatedVector<CSSType, inlineCapacity>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyleNoConversionDataRequired(x, symbolTable); }) };
+    }
+};
+
+// Specialization for `CommaSeparatedVector`.
+template<typename CSSType, size_t inlineCapacity> struct ToStyle<CSS::CommaSeparatedVector<CSSType, inlineCapacity>> {
+    using Result = CommaSeparatedVector<StyleType<CSSType>, inlineCapacity>;
+
+    decltype(auto) operator()(const CSS::CommaSeparatedVector<CSSType, inlineCapacity>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, conversionData, symbolTable); }) };
+    }
+    decltype(auto) operator()(const CSS::CommaSeparatedVector<CSSType, inlineCapacity>& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyle(x, builderState, symbolTable); }) };
+    }
+    decltype(auto) operator()(const CSS::CommaSeparatedVector<CSSType, inlineCapacity>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return Result { value.value.template map<typename Result::Vector>([&](const auto& x) { return toStyleNoConversionDataRequired(x, symbolTable); }) };
+    }
+};
+
+// Specialization for `SpaceSeparatedTuple`.
+template<typename... CSSTypes> struct ToStyle<CSS::SpaceSeparatedTuple<CSSTypes...>> {
+    decltype(auto) operator()(const CSS::SpaceSeparatedTuple<CSSTypes...>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple<CSSTypes...> { toStyle(x, conversionData, symbolTable)... }; }, value.value) };
+    }
+    decltype(auto) operator()(const CSS::SpaceSeparatedTuple<CSSTypes...>& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple<CSSTypes...> { toStyle(x, builderState, symbolTable)... }; }, value.value) };
+    }
+    decltype(auto) operator()(const CSS::SpaceSeparatedTuple<CSSTypes...>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return SpaceSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple<CSSTypes...> { toStyleNoConversionDataRequired(x, symbolTable)... }; }, value.value) };
+    }
+};
+
+// Specialization for `CommaSeparatedTuple`.
+template<typename... CSSTypes> struct ToStyle<CSS::CommaSeparatedTuple<CSSTypes...>> {
+    decltype(auto) operator()(const CSS::CommaSeparatedTuple<CSSTypes...>& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable)
+    {
+        return CommaSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple<CSSTypes...> { toStyle(x, conversionData, symbolTable)... }; }, value.value) };
+    }
+    decltype(auto) operator()(const CSS::CommaSeparatedTuple<CSSTypes...>& value, BuilderState& builderState, const CSSCalcSymbolTable& symbolTable)
+    {
+        return CommaSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple<CSSTypes...> { toStyle(x, builderState, symbolTable)... }; }, value.value) };
+    }
+    decltype(auto) operator()(const CSS::CommaSeparatedTuple<CSSTypes...>& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable)
+    {
+        return CommaSeparatedTuple { WTF::apply([&](const auto& ...x) { return StyleTuple<CSSTypes...> { toStyleNoConversionDataRequired(x, symbolTable)... }; }, value.value) };
+    }
+};
+
+} // namespace Style
 } // namespace WebCore
 
 namespace std {
@@ -168,5 +485,22 @@ template<size_t I, typename... Ts> class tuple_element<I, WebCore::Style::SpaceS
 public:
     using type = tuple_element_t<I, tuple<Ts...>>;
 };
+
+template<typename... Ts> class tuple_size<WebCore::Style::CommaSeparatedTuple<Ts...>> : public std::integral_constant<size_t, sizeof...(Ts)> { };
+template<size_t I, typename... Ts> class tuple_element<I, WebCore::Style::CommaSeparatedTuple<Ts...>> {
+public:
+    using type = tuple_element_t<I, tuple<Ts...>>;
+};
+
+#define STYLE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
+    namespace std { \
+        template<> class tuple_size<WebCore::Style::t> : public std::integral_constant<size_t, numberOfArguments> { }; \
+        template<size_t I> class tuple_element<I, WebCore::Style::t> { \
+        public: \
+            using type = decltype(WebCore::Style::get<I>(std::declval<WebCore::Style::t>())); \
+        }; \
+    } \
+    template<> inline constexpr bool WebCore::Style::TreatAsTupleLike<WebCore::Style::t> = true; \
+\
 
 } // namespace std


### PR DESCRIPTION
#### b95f33ec7bcec3053fe9f27e1872644e8db12bfd
<pre>
Factor out gradient code out into strongly typed CSS/Style values
<a href="https://bugs.webkit.org/show_bug.cgi?id=280901">https://bugs.webkit.org/show_bug.cgi?id=280901</a>

Reviewed by Darin Adler.

Factors CSS and Style gradient code into their own top level types,
retaining the existing CSSGradient*Value and StyleGradientImage types
as thin wrappers.

Transitions overload based customization points use for CSS/Style type
operations to instead use template specialization based customization
points. This allows for either to understand error messages and does not
require ADL wizardry to get right. It also allows us to separate the
signature of the customization point from the signature of the call that
invokes the customization point, making it easier for default values.

To reduce duplicate code, default implementations of some of the customization
points (VisitCSSValueChildren, ComputedStyleDependenciesCollector, conversions)
have default implementations for &quot;tuple-like&quot; types (those that implement the
&quot;tuple-like&quot; pseudo protocol). For the conversions, an additional step of
defining the mapping between the types is needed and a helper macro is provided.

* Source/WTF/wtf/StdLibExtras.h:
    Add concept for &quot;tuple-like&quot;.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add files.
* Source/WebCore/css/CSSFontFaceSet.cpp:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/color/CSSAbsoluteColorResolver.h:
* Source/WebCore/css/color/CSSUnresolvedColorMix.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/values/CSSGradient.cpp: Added.
* Source/WebCore/css/values/CSSGradient.h: Added.
* Source/WebCore/css/values/CSSPosition.cpp:
* Source/WebCore/css/values/CSSPosition.h:
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+CSSValueVisitation.h: Added.
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp:
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h:
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+Serialization.cpp:
* Source/WebCore/css/values/CSSPrimitiveNumericTypes+Serialization.h:
* Source/WebCore/css/values/CSSPrimitiveNumericTypes.h:
* Source/WebCore/css/values/CSSUnevaluatedCalc.h:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
* Source/WebCore/rendering/style/StyleGradientImage.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/values/StyleGradient.cpp: Added.
* Source/WebCore/style/values/StyleGradient.h: Added.
* Source/WebCore/style/values/StylePosition.cpp:
* Source/WebCore/style/values/StylePosition.h:
* Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.cpp:
* Source/WebCore/style/values/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/StyleValueTypes.h:

Canonical link: <a href="https://commits.webkit.org/285038@main">https://commits.webkit.org/285038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caa05d8730cdb4c13a7f4b193aed96428e347443

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71198 "136 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14749 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20743 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64323 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77025 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70447 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63977 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15782 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5751 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92227 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1190 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20107 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->