### PR TITLE
Adopt more smart pointers in Source/WebKit/WebProcess/GPU

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -101,7 +101,7 @@ void RemoteResourceCacheProxy::recordDecomposedGlyphsUse(DecomposedGlyphs& decom
 {
     if (m_renderingResources.add(decomposedGlyphs.renderingResourceIdentifier(), decomposedGlyphs).isNewEntry) {
         decomposedGlyphs.addObserver(*this);
-        m_remoteRenderingBackendProxy.cacheDecomposedGlyphs(decomposedGlyphs);
+        m_remoteRenderingBackendProxy->cacheDecomposedGlyphs(decomposedGlyphs);
     }
 }
 
@@ -109,7 +109,7 @@ void RemoteResourceCacheProxy::recordGradientUse(Gradient& gradient)
 {
     if (m_renderingResources.add(gradient.renderingResourceIdentifier(), gradient).isNewEntry) {
         gradient.addObserver(*this);
-        m_remoteRenderingBackendProxy.cacheGradient(gradient);
+        m_remoteRenderingBackendProxy->cacheGradient(gradient);
     }
 }
 
@@ -117,7 +117,7 @@ void RemoteResourceCacheProxy::recordFilterUse(Filter& filter)
 {
     if (m_renderingResources.add(filter.renderingResourceIdentifier(), filter).isNewEntry) {
         filter.addObserver(*this);
-        m_remoteRenderingBackendProxy.cacheFilter(filter);
+        m_remoteRenderingBackendProxy->cacheFilter(filter);
     }
 }
 
@@ -158,7 +158,7 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
         image.replaceBackend(makeUniqueRefFromNonNullUniquePtr(WTFMove(newBackend)));
 
     // Tell the GPU process to cache this resource.
-    m_remoteRenderingBackendProxy.cacheNativeImage(WTFMove(*handle), identifier);
+    m_remoteRenderingBackendProxy->cacheNativeImage(WTFMove(*handle), identifier);
 }
 
 void RemoteResourceCacheProxy::recordFontUse(Font& font)
@@ -170,7 +170,7 @@ void RemoteResourceCacheProxy::recordFontUse(Font& font)
 
     if (result.isNewEntry) {
         auto renderingResourceIdentifier = font.platformData().customPlatformData() ? std::optional(font.platformData().customPlatformData()->m_renderingResourceIdentifier) : std::nullopt;
-        m_remoteRenderingBackendProxy.cacheFont(font.attributes(), font.platformData().attributes(), renderingResourceIdentifier);
+        m_remoteRenderingBackendProxy->cacheFont(font.attributes(), font.platformData().attributes(), renderingResourceIdentifier);
         ++m_numberOfFontsUsedInCurrentRenderingUpdate;
         return;
     }
@@ -187,7 +187,7 @@ void RemoteResourceCacheProxy::recordFontCustomPlatformDataUse(const FontCustomP
     auto result = m_fontCustomPlatformDatas.add(customPlatformData.m_renderingResourceIdentifier, m_renderingUpdateID);
 
     if (result.isNewEntry) {
-        m_remoteRenderingBackendProxy.cacheFontCustomPlatformData(customPlatformData);
+        m_remoteRenderingBackendProxy->cacheFontCustomPlatformData(customPlatformData);
         ++m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate;
         return;
     }
@@ -203,7 +203,7 @@ void RemoteResourceCacheProxy::releaseRenderingResource(RenderingResourceIdentif
 {
     bool removed = m_renderingResources.remove(renderingResourceIdentifier);
     RELEASE_ASSERT(removed);
-    m_remoteRenderingBackendProxy.releaseRenderingResource(renderingResourceIdentifier);
+    m_remoteRenderingBackendProxy->releaseRenderingResource(renderingResourceIdentifier);
 }
 
 void RemoteResourceCacheProxy::clearRenderingResourceMap()
@@ -269,7 +269,7 @@ void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
         for (auto& item : m_fonts) {
             if (renderingUpdateID - item.value >= minimumRenderingUpdateCountToKeepFontAlive) {
                 toRemove.add(item.key);
-                m_remoteRenderingBackendProxy.releaseRenderingResource(item.key);
+                m_remoteRenderingBackendProxy->releaseRenderingResource(item.key);
             }
         }
 
@@ -286,7 +286,7 @@ void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
         for (auto& item : m_fontCustomPlatformDatas) {
             if (renderingUpdateID - item.value >= minimumRenderingUpdateCountToKeepFontAlive) {
                 toRemove.add(item.key);
-                m_remoteRenderingBackendProxy.releaseRenderingResource(item.key);
+                m_remoteRenderingBackendProxy->releaseRenderingResource(item.key);
             }
         }
 
@@ -311,7 +311,7 @@ void RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed()
         auto protectedImageBuffer = weakImageBuffer.get();
         if (!protectedImageBuffer)
             continue;
-        m_remoteRenderingBackendProxy.createRemoteImageBuffer(*protectedImageBuffer);
+        m_remoteRenderingBackendProxy->createRemoteImageBuffer(*protectedImageBuffer);
     }
 
     clearRenderingResourceMap();
@@ -325,13 +325,13 @@ void RemoteResourceCacheProxy::releaseMemory()
     clearFontMap();
     clearFontCustomPlatformDataMap();
 
-    m_remoteRenderingBackendProxy.releaseAllDrawingResources();
+    m_remoteRenderingBackendProxy->releaseAllDrawingResources();
 }
 
 void RemoteResourceCacheProxy::releaseAllImageResources()
 {
     clearNativeImageMap();
-    m_remoteRenderingBackendProxy.releaseAllImageResources();
+    m_remoteRenderingBackendProxy->releaseAllImageResources();
 }
 
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -29,6 +29,7 @@
 
 #include "RenderingUpdateID.h"
 #include <WebCore/RenderingResource.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
@@ -98,7 +99,7 @@ private:
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
     unsigned m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate { 0 };
 
-    RemoteRenderingBackendProxy& m_remoteRenderingBackendProxy;
+    CheckedRef<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     uint64_t m_renderingUpdateID;
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -123,7 +123,7 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
         MediaEngineSupportParameters parameters;
         parameters.isMediaSource = true;
         parameters.type = contentType;
-        if (m_mimeTypeCache.supportsTypeAndCodecs(parameters) == MediaPlayer::SupportsType::IsNotSupported) {
+        if (m_mimeTypeCache->supportsTypeAndCodecs(parameters) == MediaPlayer::SupportsType::IsNotSupported) {
             returnedStatus = AddStatus::NotSupported;
             return;
         }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -36,6 +36,7 @@
 #include <WebCore/MediaSourcePrivateClient.h>
 #include <WebCore/SourceBufferPrivate.h>
 #include <atomic>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
@@ -115,7 +116,7 @@ private:
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     Ref<MessageReceiver> m_receiver;
     RemoteMediaSourceIdentifier m_identifier;
-    RemoteMediaPlayerMIMETypeCache& m_mimeTypeCache;
+    CheckedRef<RemoteMediaPlayerMIMETypeCache> m_mimeTypeCache;
     ThreadSafeWeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
     std::atomic<bool> m_shutdown { false };
     std::atomic<WebCore::MediaPlayer::ReadyState> m_mediaPlayerReadyState { WebCore::MediaPlayer::ReadyState::HaveNothing };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
@@ -57,7 +57,12 @@ RemoteImageDecoderAVF::RemoteImageDecoderAVF(RemoteImageDecoderAVFManager& manag
 
 RemoteImageDecoderAVF::~RemoteImageDecoderAVF()
 {
-    m_manager.deleteRemoteImageDecoder(m_identifier);
+    protectedManager()->deleteRemoteImageDecoder(m_identifier);
+}
+
+Ref<RemoteImageDecoderAVFManager> RemoteImageDecoderAVF::protectedManager() const
+{
+    return m_manager.get().releaseNonNull();
 }
 
 bool RemoteImageDecoderAVF::canDecodeType(const String& mimeType)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
@@ -85,8 +85,10 @@ public:
     void encodedDataStatusChanged(size_t frameCount, const WebCore::IntSize&, bool hasTrack);
 
 private:
+    Ref<RemoteImageDecoderAVFManager> protectedManager() const;
+
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
-    RemoteImageDecoderAVFManager& m_manager;
+    ThreadSafeWeakPtr<RemoteImageDecoderAVFManager> m_manager; // Cannot be null.
     WebCore::ImageDecoderIdentifier m_identifier;
 
     String m_mimeType;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -59,7 +59,7 @@ HashSet<String>& RemoteMediaPlayerMIMETypeCache::supportedTypes()
 {
     ASSERT(isMainRunLoop());
     if (!m_hasPopulatedSupportedTypesCacheFromGPUProcess) {
-        auto sendResult = m_manager.gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::GetSupportedTypes(m_engineIdentifier), 0);
+        auto sendResult = protectedManager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::GetSupportedTypes(m_engineIdentifier), 0);
         if (sendResult.succeeded()) {
             auto& [types] = sendResult.reply();
             addSupportedTypes(types);
@@ -86,12 +86,17 @@ MediaPlayerEnums::SupportsType RemoteMediaPlayerMIMETypeCache::supportsTypeAndCo
     if (!m_supportsTypeAndCodecsCache)
         m_supportsTypeAndCodecsCache = HashMap<SupportedTypesAndCodecsKey, MediaPlayerEnums::SupportsType> { };
 
-    auto sendResult = m_manager.gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::SupportsTypeAndCodecs(m_engineIdentifier, parameters), 0);
+    auto sendResult = protectedManager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::SupportsTypeAndCodecs(m_engineIdentifier, parameters), 0);
     auto [result] = sendResult.takeReplyOr(MediaPlayerEnums::SupportsType::IsNotSupported);
     if (sendResult.succeeded())
         m_supportsTypeAndCodecsCache->add(searchKey, result);
 
     return result;
+}
+
+Ref<RemoteMediaPlayerManager> RemoteMediaPlayerMIMETypeCache::protectedManager() const
+{
+    return m_manager.get().releaseNonNull();
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -28,9 +28,11 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 #include <WebCore/MediaPlayerEnums.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -41,8 +43,9 @@ namespace WebKit {
 
 class RemoteMediaPlayerManager;
 
-class RemoteMediaPlayerMIMETypeCache {
+class RemoteMediaPlayerMIMETypeCache final : public CanMakeThreadSafeCheckedPtr<RemoteMediaPlayerMIMETypeCache> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaPlayerMIMETypeCache);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteMediaPlayerMIMETypeCache);
 public:
     RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayerManager&, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
     ~RemoteMediaPlayerMIMETypeCache() = default;
@@ -53,7 +56,9 @@ public:
     bool isEmpty() const;
 
 private:
-    RemoteMediaPlayerManager& m_manager;
+    Ref<RemoteMediaPlayerManager> protectedManager() const;
+
+    ThreadSafeWeakPtr<RemoteMediaPlayerManager> m_manager; // Cannot be null.
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_engineIdentifier;
 
     using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool, bool>;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -66,17 +66,17 @@ public:
 
     Ref<MediaPlayerPrivateInterface> createMediaEnginePlayer(MediaPlayer* player) const final
     {
-        return m_manager.createRemoteMediaPlayer(player, m_remoteEngineIdentifier);
+        return protectedManager()->createRemoteMediaPlayer(player, m_remoteEngineIdentifier);
     }
 
     void getSupportedTypes(HashSet<String>& types) const final
     {
-        return m_manager.getSupportedTypes(m_remoteEngineIdentifier, types);
+        return protectedManager()->getSupportedTypes(m_remoteEngineIdentifier, types);
     }
 
     MediaPlayer::SupportsType supportsTypeAndCodecs(const MediaEngineSupportParameters& parameters) const final
     {
-        return m_manager.supportsTypeAndCodecs(m_remoteEngineIdentifier, parameters);
+        return protectedManager()->supportsTypeAndCodecs(m_remoteEngineIdentifier, parameters);
     }
 
     HashSet<SecurityOriginData> originsInMediaCache(const String& path) const final
@@ -97,12 +97,14 @@ public:
 
     bool supportsKeySystem(const String& keySystem, const String& mimeType) const final
     {
-        return m_manager.supportsKeySystem(m_remoteEngineIdentifier, keySystem, mimeType);
+        return protectedManager()->supportsKeySystem(m_remoteEngineIdentifier, keySystem, mimeType);
     }
 
 private:
+    Ref<RemoteMediaPlayerManager> protectedManager() const { return m_manager.get().releaseNonNull(); }
+
     MediaPlayerEnums::MediaEngineIdentifier m_remoteEngineIdentifier;
-    RemoteMediaPlayerManager& m_manager;
+    ThreadSafeWeakPtr<RemoteMediaPlayerManager> m_manager; // Cannot be null.
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManager);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
@@ -53,8 +53,11 @@ private:
     void loadFailed(WebCore::PlatformMediaResource&, const WebCore::ResourceError&) final;
     void loadFinished(WebCore::PlatformMediaResource&, const WebCore::NetworkLoadMetrics&) final;
 
+    Ref<WebCore::PlatformMediaResource> protectedMediaResource() const;
+    Ref<IPC::Connection> protectedConnection() const { return m_connection; }
+
     Ref<IPC::Connection> m_connection;
-    WebCore::PlatformMediaResource& m_platformMediaResource;
+    ThreadSafeWeakPtr<WebCore::PlatformMediaResource> m_platformMediaResource; // Cannot be null.
     RemoteMediaResourceIdentifier m_id;
 };
 


### PR DESCRIPTION
#### 20a0941e24f6c707fd09dc95d904059d1b1e72f3
<pre>
Adopt more smart pointers in Source/WebKit/WebProcess/GPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=280951">https://bugs.webkit.org/show_bug.cgi?id=280951</a>

Reviewed by Darin Adler.

* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordDecomposedGlyphsUse):
(WebKit::RemoteResourceCacheProxy::recordGradientUse):
(WebKit::RemoteResourceCacheProxy::recordFilterUse):
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
(WebKit::RemoteResourceCacheProxy::recordFontUse):
(WebKit::RemoteResourceCacheProxy::recordFontCustomPlatformDataUse):
(WebKit::RemoteResourceCacheProxy::releaseRenderingResource):
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
(WebKit::RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
(WebKit::RemoteResourceCacheProxy::releaseAllImageResources):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHeld const):
(WebKit::MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote):
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::protectedManager const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::addSourceBuffer):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp:
(WebKit::RemoteImageDecoderAVF::~RemoteImageDecoderAVF):
(WebKit::RemoteImageDecoderAVF::protectedManager const):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
(WebKit::RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs):
(WebKit::RemoteMediaPlayerMIMETypeCache::protectedManager const):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp:
(WebKit::RemoteMediaResourceProxy::protectedMediaResource const):
(WebKit::RemoteMediaResourceProxy::responseReceived):
(WebKit::RemoteMediaResourceProxy::redirectReceived):
(WebKit::RemoteMediaResourceProxy::dataSent):
(WebKit::RemoteMediaResourceProxy::dataReceived):
(WebKit::RemoteMediaResourceProxy::accessControlCheckFailed):
(WebKit::RemoteMediaResourceProxy::loadFailed):
(WebKit::RemoteMediaResourceProxy::loadFinished):
(WebKit::RemoteMediaResourceProxy::~RemoteMediaResourceProxy): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/284768@main">https://commits.webkit.org/284768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db649f002b0e916beadc0167e9550bdc70327d7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21631 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55833 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42011 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19992 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17756 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63556 "Found 9 new test failures: imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-animated-001.html webanimations/accelerated-animation-addition-lower-in-effect-stack.html webanimations/accelerated-animation-after-forward-filling-animation.html webanimations/accelerated-animation-opacity-animation-begin-time-after-scale-animation-ends.html webanimations/accelerated-animation-renderer-change.html webanimations/accelerated-animation-slot-invalidation.html webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html webanimations/accelerated-transform-animation-to-scale-zero-with-implicit-from-keyframe.html webanimations/relative-ordering-of-translate-and-scale-properties-accelerated.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63490 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5164 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10790 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->