### PR TITLE
[JSC] Set.prototype methods should invoke keys() without arguments

### DIFF
--- a/JSTests/stress/set-prototype-difference.js
+++ b/JSTests/stress/set-prototype-difference.js
@@ -77,5 +77,5 @@ try {
 }
 
 let s = new Set([1]);
-assertArrayContent(Array.from(s.difference({ size:1, has(v) { return s.has(v); }, keys() { return s.keys() } })), []);
-assertArrayContent(Array.from(set2.difference({ size:1, has(v) { return s.has(v); }, keys() { return s.keys() } })), [2, 3]);
+assertArrayContent(Array.from(s.difference({ size:1, has(v) { return s.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return s.keys() } })), []);
+assertArrayContent(Array.from(set2.difference({ size:1, has(v) { return s.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return s.keys() } })), [2, 3]);

--- a/JSTests/stress/set-prototype-intersection.js
+++ b/JSTests/stress/set-prototype-intersection.js
@@ -81,5 +81,5 @@ try {
 }
 
 
-assertArrayContent(Array.from(set1.intersection({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [1]);
-assertArrayContent(Array.from(set4.intersection({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [1]);
+assertArrayContent(Array.from(set1.intersection({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } })), [1]);
+assertArrayContent(Array.from(set4.intersection({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } })), [1]);

--- a/JSTests/stress/set-prototype-isDisjointfrom.js
+++ b/JSTests/stress/set-prototype-isDisjointfrom.js
@@ -92,6 +92,6 @@ try {
         throw e;
 }
 
-assert(set1.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), false);
-assert(set4.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), false);
-assert(set6.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);
+assert(set1.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } }), false);
+assert(set4.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } }), false);
+assert(set6.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } }), true);

--- a/JSTests/stress/set-prototype-isSupersetOf.js
+++ b/JSTests/stress/set-prototype-isSupersetOf.js
@@ -86,5 +86,5 @@ try {
         throw e;
 }
 
-assert(set1.isSupersetOf({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);
-assert(set4.isSupersetOf({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);
+assert(set1.isSupersetOf({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } }), true);
+assert(set4.isSupersetOf({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } }), true);

--- a/JSTests/stress/set-prototype-symmetricDifference.js
+++ b/JSTests/stress/set-prototype-symmetricDifference.js
@@ -79,5 +79,5 @@ try {
 }
 
 
-assertArrayContent(Array.from(set1.symmetricDifference({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), []);
-assertArrayContent(Array.from(set4.symmetricDifference({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [2, 3]);
+assertArrayContent(Array.from(set1.symmetricDifference({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } })), []);
+assertArrayContent(Array.from(set4.symmetricDifference({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } })), [2, 3]);

--- a/JSTests/stress/set-prototype-union.js
+++ b/JSTests/stress/set-prototype-union.js
@@ -76,5 +76,5 @@ try {
 }
 
 
-assertArrayContent(Array.from(set1.union({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [1]);
-assertArrayContent(Array.from(set4.union({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [obj1, array1, set1, 1]);
+assertArrayContent(Array.from(set1.union({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } })), [1]);
+assertArrayContent(Array.from(set4.union({ size:1, has(v) { return set1.has(v); }, keys() { assert(arguments.length, 0, "keys() arguments.length"); return set1.keys() } })), [obj1, array1, set1, 1]);

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -85,7 +85,7 @@ function union(other)
     if (!@isCallable(keys))
         @throwTypeError("Set.prototype.union expects other.keys to be callable");
 
-    var iterator = keys.@call(other, keys);
+    var iterator = keys.@call(other);
     var wrapper = {
         @@iterator: function () { return iterator; }
     };
@@ -131,7 +131,7 @@ function intersection(other)
                 result.@add(key);
         } while (true);
     } else {
-        var iterator = keys.@call(other, keys);
+        var iterator = keys.@call(other);
         var wrapper = {
             @@iterator: function () { return iterator; }
         };
@@ -179,7 +179,7 @@ function difference(other)
                 result.@delete(key);
         }
     } else {
-        var iterator = keys.@call(other, keys);
+        var iterator = keys.@call(other);
         var wrapper = {
             @@iterator: function () { return iterator; }
         };
@@ -211,7 +211,7 @@ function symmetricDifference(other)
     if (!@isCallable(keys))
         @throwTypeError("Set.prototype.symmetricDifference expects other.keys to be callable");
 
-    var iterator = keys.@call(other, keys);
+    var iterator = keys.@call(other);
     var wrapper = {
         @@iterator: function () { return iterator; }
     };
@@ -286,7 +286,7 @@ function isSupersetOf(other)
     if (this.@size < size)
         return false;
 
-    var iterator = keys.@call(other, keys);
+    var iterator = keys.@call(other);
     var wrapper = {
         @@iterator: function () { return iterator; }
     };
@@ -331,7 +331,7 @@ function isDisjointFrom(other)
                 return false;
         } while (true);
     } else {
-        var iterator = keys.@call(other, keys);
+        var iterator = keys.@call(other);
         var wrapper = {
             @@iterator: function () { return iterator; }
         };


### PR DESCRIPTION
#### 43eed397118c9bc94293f17d9d4e272f79f478ab
<pre>
[JSC] Set.prototype methods should invoke keys() without arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=280952">https://bugs.webkit.org/show_bug.cgi?id=280952</a>
&lt;<a href="https://rdar.apple.com/problem/137395979">rdar://problem/137395979</a>&gt;

Reviewed by Keith Miller.

This change aligns JSC with the spec [1], V8, and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-getiteratorfrommethod">https://tc39.es/ecma262/#sec-getiteratorfrommethod</a> (step 1)

* JSTests/stress/set-prototype-difference.js:
* JSTests/stress/set-prototype-intersection.js:
* JSTests/stress/set-prototype-isDisjointfrom.js:
* JSTests/stress/set-prototype-isSupersetOf.js:
* JSTests/stress/set-prototype-symmetricDifference.js:
* JSTests/stress/set-prototype-union.js:
* Source/JavaScriptCore/builtins/SetPrototype.js:

Canonical link: <a href="https://commits.webkit.org/284747@main">https://commits.webkit.org/284747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/807d876cfa35762195dd58733dfea79c483ce5ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21414 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14252 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18124 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19935 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63517 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76204 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69643 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17702 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63442 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5115 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91426 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10773 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/371 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19934 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46678 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->