### PR TITLE
Match FontFaceSet font loading with spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading-expected.txt
@@ -1,0 +1,10 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didReceiveTitle: Test document.fonts.ready loading with two fonts
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+Font loading test
+
+PASS document.fonts.ready is replaced as new fonts are loaded
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Test document.fonts.ready loading with two fonts</title>
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/#fontfaceset-ready">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@font-face {
+  font-family: "AhemTest";
+  src: url("/fonts/Ahem.ttf") format("truetype");
+}
+.initial {
+  font-family: "AhemTest", sans-serif;
+  font-size: 20px;
+}
+</style>
+<div>Font loading test</div>
+<script>
+promise_test(async t => {
+  const fontSet = document.fonts;
+  const readyPromise1 = fontSet.ready;
+  await readyPromise1;
+  assert_equals(fontSet.status, "loaded", "ready promise should resolve when fonts loaded");
+
+  const dynamicFace = new FontFace("AhemTest2", "url(/fonts/Ahem.ttf)");
+  fontSet.add(dynamicFace);
+  dynamicFace.load();
+  const readyPromise2 = fontSet.ready;
+  assert_not_equals(readyPromise1, readyPromise2, "A new FontFace added should create a new document.fonts.ready promise");
+  
+  await readyPromise2;
+  assert_equals(fontSet.status, "loaded", "document.fonts.status should be 'loaded'");
+}, "document.fonts.ready is replaced as new fonts are loaded");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent-expected.txt
@@ -1,0 +1,9 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didReceiveTitle: Tests FontFaceSet loading event
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+
+PASS FontFaceSet fires correct loading event
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Tests FontFaceSet loading event</title>
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/#events">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+  const fontSet = document.fonts;
+  let loadingFired = false;
+
+  fontSet.addEventListener("loading", () => {
+    loadingFired = true;
+  });
+  
+  const TestFont = new FontFace("GoodFont", "url(/fonts/Ahem.ttf)");
+  fontSet.add(TestFont);
+  await TestFont.load();
+  await fontSet.ready;
+  assert_true(loadingFired, "The 'loading' event should have fired");
+}, "FontFaceSet fires correct loading event");
+</script>

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -31,6 +31,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentView.h"
 #include "EventLoop.h"
+#include "EventNames.h"
 #include "FontFace.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
@@ -261,7 +262,9 @@ void FontFaceSet::faceFinished(CSSFontFace& face, CSSFontFace::Status newStatus)
 
 void FontFaceSet::startedLoading()
 {
-    // FIXME: Fire a "loading" event asynchronously.
+    if (m_readyPromise->isFulfilled())
+        m_readyPromise = makeUniqueRef<ReadyPromise>(*this, &FontFaceSet::readyPromiseResolve);
+    queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().loadingEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 void FontFaceSet::documentDidFinishLoading()

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -116,7 +116,7 @@ private:
 
     const Ref<CSSFontFaceSet> m_backing;
     HashMap<RefPtr<FontFace>, Vector<Ref<PendingPromise>>> m_pendingPromises;
-    const UniqueRef<ReadyPromise> m_readyPromise;
+    UniqueRef<ReadyPromise> m_readyPromise;
 
     bool m_isDocumentLoaded { true };
 };


### PR DESCRIPTION
#### 04a74bd9c97a07e7428c2df4794ad0f3532099a8
<pre>
Match FontFaceSet font loading with spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=280954">https://bugs.webkit.org/show_bug.cgi?id=280954</a>

Reviewed by Tim Nguyen.

As per spec <a href="https://drafts.csswg.org/css-font-loading/#switch-the-fontfaceset-to-loading">https://drafts.csswg.org/css-font-loading/#switch-the-fontfaceset-to-loading</a>,
steps 3 and 4 were missing in the FontFaceSet font-loading algorithm, which caused, for example,
loading two diferrent fonts using promises to not work and not fire loading event.

* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::startedLoading):
* Source/WebCore/css/FontFaceSet.h:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html: Added.

Canonical link: <a href="https://commits.webkit.org/301471@main">https://commits.webkit.org/301471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/078e087ebfe88f404e5859a7dbb7c899bf1b7661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77874 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96002 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64101 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76491 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50195 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19718 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58547 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52048 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->