### PR TITLE
[site-isolation] RenderLayerBacking::updateAfterWidgetResize needs to notify cross-process subframe RenderLayerCompositors of bounds changing.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes-expected.txt
@@ -1,0 +1,173 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 1650.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 1650.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 20.00 150.00)
+          (bounds 284.00 204.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 280.00 200.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 280.00 200.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 280.00 200.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 8.00)
+                                  (bounds 252.00 172.00)
+                                  (drawsContent 1)
+                                  (children 1
+                                    (GraphicsLayer
+                                      (position 1.00 1.00)
+                                      (children 1
+                                        (GraphicsLayer
+                                          (anchor 0.00 0.00)
+                                          (bounds 250.00 170.00)
+                                          (children 1
+                                            (GraphicsLayer
+                                              (anchor 0.00 0.00)
+                                              (children 1
+                                                (GraphicsLayer
+                                                  (anchor 0.00 0.00)
+                                                  (bounds 250.00 230.00)
+                                                  (children 1
+                                                    (GraphicsLayer
+                                                      (bounds 250.00 230.00)
+                                                      (drawsContent 1)
+                                                      (children 1
+                                                        (GraphicsLayer
+                                                          (position 18.00 10.00)
+                                                          (bounds 210.00 210.00)
+                                                          (contentsOpaque 1)
+                                                        )
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 20.00 374.00)
+          (bounds 284.00 204.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 280.00 200.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 280.00 200.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 280.00 200.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 8.00)
+                                  (bounds 252.00 172.00)
+                                  (drawsContent 1)
+                                  (children 1
+                                    (GraphicsLayer
+                                      (position 1.00 1.00)
+                                      (children 1
+                                        (GraphicsLayer
+                                          (anchor 0.00 0.00)
+                                          (bounds 250.00 170.00)
+                                          (children 1
+                                            (GraphicsLayer
+                                              (anchor 0.00 0.00)
+                                              (children 1
+                                                (GraphicsLayer
+                                                  (anchor 0.00 0.00)
+                                                  (bounds 250.00 230.00)
+                                                  (children 1
+                                                    (GraphicsLayer
+                                                      (bounds 250.00 230.00)
+                                                      (drawsContent 1)
+                                                      (children 1
+                                                        (GraphicsLayer
+                                                          (position 18.00 10.00)
+                                                          (bounds 210.00 210.00)
+                                                          (contentsOpaque 1)
+                                                        )
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 0.00 100.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 785.00 120.00)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes.html
+++ b/LayoutTests/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes.html
@@ -1,0 +1,61 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+
+<html>
+<head>
+  <style type="text/css" media="screen">
+    body {
+        height: 1500px;
+        margin: 0;
+    }
+    #banner {
+        position: fixed;
+        top: 0;
+        width: 100%;
+        height: 120px;
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+    iframe {
+        display: block;
+        margin: 20px;
+        height: 200px;
+        width: 280px;
+    }
+  </style>
+  <script type="text/javascript" charset="utf-8">
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    function doTest()
+    {
+        // For some reason this delay is required for AppKit to not short-circuit the display.
+        window.setTimeout(function() {
+          window.scrollTo(0, 100);
+          // Force a paint, and give layers a chance to update.
+          if (window.testRunner)
+            testRunner.displayAndTrackRepaints();
+          window.setTimeout(function() {
+            if (window.testRunner) {
+                document.getElementById('layers').innerHTML = window.internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+          }, 0);
+        }, 0);
+    }
+
+    window.addEventListener('load', doTest, false);
+  </script>
+</head>
+<body>
+    <div id="banner"></div>
+
+    <!-- Tests that when scrolled so that one iframe is overlapped, both iframes
+        and their contents become composited. -->
+    <iframe style="margin-top: 150px;" src="http://localhost:8000/root/compositing/iframes/resources/intermediate-frame.html"></iframe>
+    <iframe src="http://localhost:8000/root/compositing/iframes/resources/intermediate-frame.html"></iframe>
+
+    <pre id="layers">Layer tree appears here in DRT.</pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes-expected.txt
@@ -1,0 +1,173 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1650.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1650.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 20.00 150.00)
+          (bounds 284.00 204.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 280.00 200.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 280.00 200.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 280.00 200.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 8.00)
+                                  (bounds 252.00 172.00)
+                                  (drawsContent 1)
+                                  (children 1
+                                    (GraphicsLayer
+                                      (position 1.00 1.00)
+                                      (children 1
+                                        (GraphicsLayer
+                                          (anchor 0.00 0.00)
+                                          (bounds 250.00 170.00)
+                                          (children 1
+                                            (GraphicsLayer
+                                              (anchor 0.00 0.00)
+                                              (children 1
+                                                (GraphicsLayer
+                                                  (anchor 0.00 0.00)
+                                                  (bounds 250.00 230.00)
+                                                  (children 1
+                                                    (GraphicsLayer
+                                                      (bounds 250.00 230.00)
+                                                      (drawsContent 1)
+                                                      (children 1
+                                                        (GraphicsLayer
+                                                          (position 18.00 10.00)
+                                                          (bounds 210.00 210.00)
+                                                          (contentsOpaque 1)
+                                                        )
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 20.00 374.00)
+          (bounds 284.00 204.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 280.00 200.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 280.00 200.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 280.00 200.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 8.00)
+                                  (bounds 252.00 172.00)
+                                  (drawsContent 1)
+                                  (children 1
+                                    (GraphicsLayer
+                                      (position 1.00 1.00)
+                                      (children 1
+                                        (GraphicsLayer
+                                          (anchor 0.00 0.00)
+                                          (bounds 250.00 170.00)
+                                          (children 1
+                                            (GraphicsLayer
+                                              (anchor 0.00 0.00)
+                                              (children 1
+                                                (GraphicsLayer
+                                                  (anchor 0.00 0.00)
+                                                  (bounds 250.00 230.00)
+                                                  (children 1
+                                                    (GraphicsLayer
+                                                      (bounds 250.00 230.00)
+                                                      (drawsContent 1)
+                                                      (children 1
+                                                        (GraphicsLayer
+                                                          (position 18.00 10.00)
+                                                          (bounds 210.00 210.00)
+                                                          (contentsOpaque 1)
+                                                        )
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 0.00 100.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 120.00)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2793,6 +2793,17 @@ void LocalFrameView::delegatedScrollingModeDidChange()
     }
 }
 
+void LocalFrameView::compositedBoundsChanged(const IntPoint& contentsOffset)
+{
+    CheckedPtr renderView = this->renderView();
+    if (!renderView)
+        return;
+
+    RenderLayerCompositor& compositor = renderView->compositor();
+    compositor.frameViewDidChangeSize();
+    compositor.frameViewDidChangeLocation(contentsOffset);
+}
+
 #if USE(COORDINATED_GRAPHICS)
 void LocalFrameView::setFixedVisibleContentRect(const IntRect& visibleContentRect)
 {

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -124,6 +124,8 @@ public:
     void setContentsSize(const IntSize&) final;
     void updateContentsSize() final;
 
+    WEBCORE_EXPORT void compositedBoundsChanged(const IntPoint& contentsOffset) final;
+
     const LocalFrameViewLayoutContext& layoutContext() const { return m_layoutContext; }
     LocalFrameViewLayoutContext& layoutContext() { return m_layoutContext; }
     CheckedRef<const LocalFrameViewLayoutContext> checkedLayoutContext() const;

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -44,6 +44,7 @@ class RemoteFrameClient : public FrameLoaderClient {
 public:
     virtual void frameDetached() = 0;
     virtual void sizeDidChange(IntSize) = 0;
+    virtual void compositedBoundsChanged(const IntPoint& contentsOffset) = 0;
     virtual void postMessageToRemote(FrameIdentifier source, const String& sourceOrigin, FrameIdentifier target, std::optional<SecurityOriginData> targetOrigin, const MessageWithMessagePorts&) = 0;
     virtual void changeLocation(FrameLoadRequest&&) = 0;
     virtual String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>) = 0;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -47,6 +47,11 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
     FrameView::setFrameRect(newRect);
 }
 
+void RemoteFrameView::compositedBoundsChanged(const IntPoint& contentsOffset)
+{
+    m_frame->client().compositedBoundsChanged(contentsOffset);
+}
+
 // FIXME: Implement all the stubs below.
 
 bool RemoteFrameView::isScrollableOrRubberbandable()

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -68,6 +68,7 @@ private:
     void updateCompositingLayersAfterScrolling() final;
 
     void setFrameRect(const IntRect&) final;
+    void compositedBoundsChanged(const IntPoint& contentsOffset) final;
 
     const Ref<RemoteFrame> m_frame;
 };

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -172,6 +172,8 @@ public:
     // Notifies this widget that its clip rect changed.
     virtual void clipRectChanged() { }
 
+    virtual void compositedBoundsChanged(const IntPoint&) { }
+
     // Whether transforms affect the frame rect. FIXME: We get rid of this and have
     // the frame rects be the same no matter what transforms are applied.
     virtual bool transformsAffectFrameRect() { return true; }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1002,10 +1002,8 @@ void RenderLayerBacking::updateAfterWidgetResize()
     if (!renderWidget)
         return;
 
-    if (auto* innerCompositor = RenderLayerCompositor::frameContentsCompositor(*renderWidget)) {
-        innerCompositor->frameViewDidChangeSize();
-        innerCompositor->frameViewDidChangeLocation(flooredIntPoint(contentsBox().location()));
-    }
+    if (RefPtr widget = renderWidget->widget())
+        widget->compositedBoundsChanged(flooredIntPoint(contentsBox().location()));
 
     if (auto* contentsLayer = layerForContents())
         contentsLayer->setPosition(flooredIntPoint(contentsBox().location()));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6285,6 +6285,11 @@ void WebPageProxy::updateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCo
     sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateFrameSize(frameID, size));
 }
 
+void WebPageProxy::frameCompositedBoundsChanged(WebCore::FrameIdentifier frameID, WebCore::IntPoint contentsOffset)
+{
+    sendToProcessContainingFrame(frameID, Messages::WebPage::FrameCompositedBoundsChanged(frameID, contentsOffset));
+}
+
 void WebPageProxy::updateSandboxFlags(IPC::Connection& connection, WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags)
 {
     if (RefPtr frame = WebFrameProxy::webFrame(frameID)) {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2615,6 +2615,7 @@ private:
 #endif
 
     void updateRemoteFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
+    void frameCompositedBoundsChanged(WebCore::FrameIdentifier, WebCore::IntPoint);
     void updateSandboxFlags(IPC::Connection&, WebCore::FrameIdentifier, WebCore::SandboxFlags);
 
     void didDestroyNavigation(WebCore::NavigationIdentifier);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -145,6 +145,7 @@ messages -> WebPageProxy {
     DidDestroyNavigation(WebCore::NavigationIdentifier navigationID)
     UpdateSandboxFlags(WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags)
     UpdateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize size)
+    FrameCompositedBoundsChanged(WebCore::FrameIdentifier frameID, WebCore::IntPoint contentsOffset)
 
     MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture, double minScale, double maxScale)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -65,6 +65,12 @@ void WebRemoteFrameClient::sizeDidChange(IntSize size)
     m_frame->updateRemoteFrameSize(size);
 }
 
+void WebRemoteFrameClient::compositedBoundsChanged(const IntPoint& contentsOffset)
+{
+    if (RefPtr page = m_frame->page())
+        page->send(Messages::WebPageProxy::FrameCompositedBoundsChanged(m_frame->frameID(), contentsOffset));
+}
+
 void WebRemoteFrameClient::postMessageToRemote(FrameIdentifier source, const String& sourceOrigin, FrameIdentifier target, std::optional<SecurityOriginData> targetOrigin, const MessageWithMessagePorts& message)
 {
     if (auto* page = m_frame->page())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -44,6 +44,7 @@ public:
 private:
     void frameDetached() final;
     void sizeDidChange(WebCore::IntSize) final;
+    void compositedBoundsChanged(const WebCore::IntPoint& contentsOffset) final;
     void postMessageToRemote(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&) final;
     void changeLocation(WebCore::FrameLoadRequest&&) final;
     String renderTreeAsText(size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3399,6 +3399,28 @@ void WebPage::updateFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize
     }
 }
 
+void WebPage::frameCompositedBoundsChanged(WebCore::FrameIdentifier frameID, WebCore::IntPoint contentsOffset)
+{
+    if (!m_page)
+        return;
+
+    ASSERT(m_page->settings().siteIsolationEnabled());
+    RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
+    if (!webFrame)
+        return;
+
+    RefPtr frame = webFrame->coreLocalFrame();
+    if (!frame)
+        return;
+
+    RefPtr frameView = frame->view();
+    if (!frameView)
+        return;
+
+    frameView->compositedBoundsChanged(contentsOffset);
+}
+
+
 void WebPage::tryMarkLayersVolatile(CompletionHandler<void(bool)>&& completionHandler)
 {
     RefPtr drawingArea = m_drawingArea;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1040,6 +1040,7 @@ public:
     void unfreezeLayerTree(LayerTreeFreezeReason);
 
     void updateFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
+    void frameCompositedBoundsChanged(WebCore::FrameIdentifier, WebCore::IntPoint);
 
     void markLayersVolatile(CompletionHandler<void(bool)>&& completionHandler = { });
     void cancelMarkLayersVolatile();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -759,6 +759,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     UseRedirectionForCurrentNavigation(WebCore::ResourceResponse response);
 
     UpdateFrameSize(WebCore::FrameIdentifier frame, WebCore::IntSize newSize)
+    FrameCompositedBoundsChanged(WebCore::FrameIdentifier frame, WebCore::IntPoint contentsOffset)
 
     DispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier frameID)
 


### PR DESCRIPTION
#### 3f1856724b13559497e7b328658134b75cbd23a9
<pre>
[site-isolation] RenderLayerBacking::updateAfterWidgetResize needs to notify cross-process subframe RenderLayerCompositors of bounds changing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280958">https://bugs.webkit.org/show_bug.cgi?id=280958</a>
&lt;<a href="https://rdar.apple.com/137406024">rdar://137406024</a>&gt;

Reviewed by Sihui Liu.

Instead of trying to access RenderLayerCompositor for a subframe directly, notify the FrameView instead.
Implement this for a RemoteFrameView by sending it across IPC to the relevant LocalFrameView.

As with bug 280874, this test is a direct copy of an existing one, updated to be cross-origin.

* LayoutTests/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/compositing/iframes/overlapped-nested-iframes.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::compositedBoundsChanged):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::compositedBoundsChanged):
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebCore/platform/Widget.h:
(WebCore::Widget::compositedBoundsChanged):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAfterWidgetResize):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::frameCompositedBoundsChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::compositedBoundsChanged):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameCompositedBoundsChanged):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/284932@main">https://commits.webkit.org/284932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dbedf0d745271b86c6fe659af47782669bbb80f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23707 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21957 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74000 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61155 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18950 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15166 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/76753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61214 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/11901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10882 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46147 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->