### PR TITLE
Unreviewed. Update safer C++ expectations.

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -17,7 +17,6 @@ Modules/screen-wake-lock/NavigatorScreenWakeLock.h
 Modules/screen-wake-lock/WakeLockManager.h
 Modules/storage/StorageManager.cpp
 Modules/webaudio/AudioNodeInput.h
-Modules/webaudio/AudioNodeOutput.h
 Modules/webaudio/AudioWorkletNode.h
 Modules/webaudio/AudioWorkletProcessor.h
 Modules/webdatabase/DatabaseTask.h

--- a/Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -5,5 +5,3 @@ WebProcess/GPU/media/MediaPlayerPrivateRemote.h
 WebProcess/GPU/media/RemoteImageDecoderAVF.h
 WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
 WebProcess/GPU/media/RemoteMediaResourceProxy.h
-WebProcess/GPU/webrtc/MediaRecorderProvider.h
-WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -12,7 +12,6 @@ Shared/API/c/cg/WKImageCG.cpp
 Shared/APIWebArchive.mm
 Shared/Cocoa/APIObject.mm
 Shared/ContextMenuContextData.cpp
-Shared/SessionState.cpp
 Shared/WebBackForwardListItem.cpp
 Shared/WebContextMenuItem.cpp
 Shared/WebHitTestResultData.cpp
@@ -71,7 +70,6 @@ WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
-WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
 WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
 WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
 WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -101,7 +99,6 @@ WebProcess/Network/WebSocketChannel.cpp
 WebProcess/Network/WebTransportSession.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp
-WebProcess/Network/webrtc/LibWebRTCSocket.cpp
 WebProcess/Network/webrtc/WebMDNSRegister.cpp
 WebProcess/Notifications/WebNotificationManager.cpp
 WebProcess/Plugins/PDF/PDFIncrementalLoader.mm


### PR DESCRIPTION
#### 8180494786c3764b91eba65f4f90dabbb7654441
<pre>
Unreviewed. Update safer C++ expectations after migrating bots to macOS Tahoe.

* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebGPU/SaferCPPExpectations/NoDeleteCheckerExpectations: Added.
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations: Added.
</pre>