### PR TITLE
[scroll-animations] add support for normalizing the specified timing for an animation effect

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -66,7 +66,7 @@ public:
     virtual void animationDidChangeTimingProperties() { };
     virtual void animationWasCanceled() { };
     virtual void animationSuspensionStateDidChange(bool) { };
-    virtual void animationTimelineDidChange(AnimationTimeline*) { };
+    virtual void animationTimelineDidChange(const AnimationTimeline*);
     virtual void animationDidFinish() { };
 
     AnimationEffectTiming timing() const { return m_timing; }
@@ -116,9 +116,11 @@ protected:
 private:
     std::optional<CSSNumberishTime> localTime(std::optional<CSSNumberishTime>) const;
     double playbackRate() const;
+    void normalizeSpecifiedTiming(std::variant<double, String>);
 
     AnimationEffectTiming m_timing;
     WeakPtr<WebAnimation, WeakPtrImplWithEventTargetData> m_animation;
+    bool m_hasAutoDuration { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -84,6 +84,11 @@ CSSNumberishTime::CSSNumberishTime(const CSSNumberish& value)
     }
 }
 
+CSSNumberishTime CSSNumberishTime::fromMilliseconds(double milliseconds)
+{
+    return { Type::Time, milliseconds / 1000 };
+}
+
 CSSNumberishTime CSSNumberishTime::fromPercentage(double percentage)
 {
     return { Type::Percentage, percentage };

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -38,6 +38,7 @@ public:
     CSSNumberishTime(const Seconds&);
     CSSNumberishTime(const CSSNumberish&);
 
+    static CSSNumberishTime fromMilliseconds(double);
     static CSSNumberishTime fromPercentage(double);
 
     WEBCORE_EXPORT std::optional<Seconds> time() const;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1209,8 +1209,10 @@ void KeyframeEffect::computeStackingContextImpact()
     }
 }
 
-void KeyframeEffect::animationTimelineDidChange(AnimationTimeline* timeline)
+void KeyframeEffect::animationTimelineDidChange(const AnimationTimeline* timeline)
 {
+    AnimationEffect::animationTimelineDidChange(timeline);
+
     auto target = targetStyleable();
     if (!target)
         return;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -273,7 +273,7 @@ private:
     void animationDidChangeTimingProperties() final;
     void animationWasCanceled() final;
     void animationSuspensionStateDidChange(bool) final;
-    void animationTimelineDidChange(AnimationTimeline*) final;
+    void animationTimelineDidChange(const AnimationTimeline*) final;
     void animationDidFinish() final;
     void setAnimation(WebAnimation*) final;
     Seconds timeToNextTick(const BasicEffectTiming&) const final;


### PR DESCRIPTION
#### ff6a099cb650f08d516a3311a3901ea8a62a3db4
<pre>
[scroll-animations] add support for normalizing the specified timing for an animation effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=280962">https://bugs.webkit.org/show_bug.cgi?id=280962</a>
<a href="https://rdar.apple.com/137412959">rdar://137412959</a>

Reviewed by Anne van Kesteren.

The Web Animations Level 2 specification introduces the concept of normalizing the specified
timing (<a href="https://drafts.csswg.org/web-animations-2/#normalize-specified-timing)">https://drafts.csswg.org/web-animations-2/#normalize-specified-timing)</a> such that the
&quot;auto&quot; value can be computed based on the timeline type.

We also noticed that `animationTimelineDidChange()` did not take a `const` pointer as its
argument, although there is no reason for it not to be `const`, so we make that change.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::updateTiming):
(WebCore::AnimationEffect::normalizeSpecifiedTiming):
(WebCore::AnimationEffect::animationTimelineDidChange):
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::animationTimelineDidChange): Deleted.
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::fromMilliseconds):
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationTimelineDidChange):
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/284825@main">https://commits.webkit.org/284825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/453b8177a545a50fa51bf719db447aa8534ee9aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14405 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20167 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63614 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5298 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10821 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/604 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46910 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48187 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->