### PR TITLE
[scroll-animations] update animation procedures to set the "auto align start time" flag

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL animation.progress reflects the progress of a scroll animation as a number between 0 and 1 assert_equals: The current time remains null while in the pending state. expected (object) null but got (number) 0
+FAIL animation.progress reflects the progress of a scroll animation as a number between 0 and 1 assert_true: Animation is in the pending state. expected true got false
 FAIL animation.progress reflects the overall progress of a scroll animation with multiple iterations. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
 FAIL animation.progress reflects the overall progress of a scroll animation that uses a view-timeline. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"
 FAIL progresss of a view-timeline is bounded between 0 and 1. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -44,6 +44,9 @@ public:
     virtual bool isScrollTimeline() const { return false; }
     virtual bool isViewTimeline() const { return false; }
 
+    bool isMonotonic() const { return !m_duration; }
+    bool isProgressBased() const { return !isMonotonic(); }
+
     const AnimationCollection& relevantAnimations() const { return m_animations; }
 
     virtual void animationTimingDidChange(WebAnimation&);

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -209,6 +209,7 @@ private:
     double effectivePlaybackRate() const;
     void applyPendingPlaybackRate();
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
+    CSSNumberishTime timeEpsilon() const;
 
     // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;
@@ -241,6 +242,7 @@ private:
     bool m_isRelevant;
     bool m_shouldSkipUpdatingFinishedStateWhenResolving;
     bool m_hasScheduledEventsDuringTick { false };
+    bool m_autoAlignStartTime { false };
     TimeToRunPendingTask m_timeToRunPendingPlayTask { TimeToRunPendingTask::NotScheduled };
     TimeToRunPendingTask m_timeToRunPendingPauseTask { TimeToRunPendingTask::NotScheduled };
     ReplaceState m_replaceState { ReplaceState::Active };


### PR DESCRIPTION
#### 56bf78a3afaabfef23f370ab77fcbbc42cda26b7
<pre>
[scroll-animations] update animation procedures to set the &quot;auto align start time&quot; flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=280963">https://bugs.webkit.org/show_bug.cgi?id=280963</a>
<a href="https://rdar.apple.com/137414223">rdar://137414223</a>

Reviewed by Dean Jackson.

The Web Animations Level 2 specification introduces the &quot;auto align start time&quot; flag for
animations associated with a non-monotonic / progress-based timeline, such as a scroll
timeline. We update the various existing procedures to account for this new flag, in
preparation for the implementation of the &quot;auto-aligning the start time&quot; procedure
(<a href="https://drafts.csswg.org/web-animations-2/#auto-aligning-start-time)">https://drafts.csswg.org/web-animations-2/#auto-aligning-start-time)</a> in a future patch.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt:
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::isMonotonic const):
(WebCore::AnimationTimeline::isProgressBased const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimeline):
(WebCore::WebAnimation::setStartTime):
(WebCore::WebAnimation::silentlySetCurrentTime):
(WebCore::WebAnimation::setCurrentTime):
(WebCore::WebAnimation::timeEpsilon const):
(WebCore::WebAnimation::playState const):
(WebCore::WebAnimation::zeroTime const):
(WebCore::WebAnimation::resetPendingTasks):
(WebCore::WebAnimation::play):
(WebCore::WebAnimation::runPendingPlayTask):
(WebCore::WebAnimation::pause):
(WebCore::WebAnimation::runPendingPauseTask):
* Source/WebCore/animation/WebAnimation.h:

Canonical link: <a href="https://commits.webkit.org/284815@main">https://commits.webkit.org/284815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3458f372130b2cef48efba95988382943eff22c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55814 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63534 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63469 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5145 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10816 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->