### PR TITLE
Regression (284080@main): ScreenCaptureKitCaptureSource may fail capture due to the whenReady callback being called before totally stopping capture

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -76,7 +76,7 @@ public:
 private:
     // DisplayCaptureSourceCocoa::Capturer
     bool start() final;
-    void stop() final;
+    void stop() final { stopInternal([] { }); }
     void end() final;
     DisplayCaptureSourceCocoa::DisplayFrameType generateFrame() final;
     CaptureDevice::DeviceType deviceType() const final;
@@ -92,6 +92,7 @@ private:
     void sessionFilterDidChange(SCContentFilter*) final;
     void sessionStreamDidEnd(SCStream*) final;
 
+    void stopInternal(CompletionHandler<void()>&&);
     void startContentStream();
     void findShareableContent();
     RetainPtr<SCStreamConfiguration> streamConfiguration();


### PR DESCRIPTION
#### 76398a9a4508d5b249c6544c5c79fcc6824b43e3
<pre>
Regression (284080@main): ScreenCaptureKitCaptureSource may fail capture due to the whenReady callback being called before totally stopping capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=280964">https://bugs.webkit.org/show_bug.cgi?id=280964</a>
<a href="https://rdar.apple.com/problem/137414283">rdar://problem/137414283</a>

Reviewed by Jean-Yves Avenard.

284080@main added a way to get the initial capture size by starting the capture, getting a first frame and stopping the capture.
Once stopping the capture, the source is said to be ready and we synchronously send an IPC message to WebProcess.
WebProcess will then send back an IPC message to start the capture.

The issue is that stopping the capture is asynchronous.
Stopping the capture after the first frame might not be finished when receiving the IPC message to restart capture.
If that is the case, stopping the capture will fail, which fails the whole capture.

To prevent this race before the WebProcess IPC message and stopping the capture, we wait for stopping the capture to finish before stating that the source is ready.
Manually tested as there is no ScreenCaptureKitCaptureSource mock.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::whenReady):
(WebCore::ScreenCaptureKitCaptureSource::stopInternal):
(WebCore::ScreenCaptureKitCaptureSource::stop): Deleted.

Canonical link: <a href="https://commits.webkit.org/284891@main">https://commits.webkit.org/284891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e62daafc14bc784014bed9578d9fd9e9c1a530

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21859 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18068 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63749 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5473 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/820 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->