### PR TITLE
Avoid process suspension on launch

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -352,7 +352,6 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
     m_lifetimeActivity = protect(throttler())->foregroundActivity("Lifetime Activity"_s);
-    m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
 #endif
 
     RefPtr connection = IPC::Connection::createServerConnection(WTF::move(connectionIdentifier), Thread::QOS::UserInteractive);
@@ -380,6 +379,9 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
 
 #if USE(RUNNINGBOARD)
     protect(throttler())->didConnectToProcess(*this);
+#if PLATFORM(MAC)
+    m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
+#endif
 #if USE(EXTENSIONKIT)
     ASSERT(launcher);
     if (launcher)


### PR DESCRIPTION
#### 5fe43caac18f266b616efd2a5d8ddedd5ccd575d
<pre>
Avoid process suspension on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=280969">https://bugs.webkit.org/show_bug.cgi?id=280969</a>
<a href="https://rdar.apple.com/137418855">rdar://137418855</a>

Reviewed by Chris Dumez.

Currently, the first assertion we take on process launch is the boosted jetsam assertion. This assertion
does not provide any runtime, so the system will immediately suspend the process when this assertion is
taken. To avoid this suspension, we can take a foreground assertion via the process throttler before we
take the jetsam assertion. The foreground assertion is taken async when the process throttler has been
connected to the process.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):

Canonical link: <a href="https://commits.webkit.org/308022@main">https://commits.webkit.org/308022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/921d98a287b458982442a41106c715bc944325a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98782 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d078986f-68a7-401d-a9c4-8f820624a0ae) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111598 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79999 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/838ffd86-3a27-42bb-ae36-e1c97c278783) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92496 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55ae1681-aad3-4517-a26f-8600c6774eda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11085 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122845 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156130 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119607 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128371 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73342 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15716 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6630 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81078 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17035 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17244 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->