### PR TITLE
A getDisplayMedia request should cancel any previous getDisplayMedia request that is pending

### DIFF
--- a/LayoutTests/fast/mediastream/getDisplayMedia-successive-call-expected.txt
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-successive-call-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Validate that a pending getDisplayMedia is cancelled when a new getDisplayMedia call is made
+

--- a/LayoutTests/fast/mediastream/getDisplayMedia-successive-call.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-successive-call.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="resources/getDisplayMedia-utils.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async () => {
+    let isOK = false;
+    for (let i = 0; i < 100 && !isOK; i++) {
+        let promise1;
+        window.internals.withUserGesture(() => {
+            promise1 = navigator.mediaDevices.getDisplayMedia({ video: true });
+        });
+        let promise2;
+        window.internals.withUserGesture(() => {
+            promise2 = navigator.mediaDevices.getDisplayMedia({ video: true });
+        });
+
+        const results = await Promise.all([promise2, promise1.then(() => {
+            return true;
+        }, e => {
+            assert_equals(e.name, 'AbortError');
+            return true;
+        })]);
+        isOK = results[1];
+    }
+    assert_true(isOK);
+}, "Validate that a pending getDisplayMedia is cancelled when a new getDisplayMedia call is made");
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
#### 0eeec4565988a8fe615c51cc6d29373e54c39cbe
<pre>
A getDisplayMedia request should cancel any previous getDisplayMedia request that is pending
<a href="https://bugs.webkit.org/show_bug.cgi?id=280967">https://bugs.webkit.org/show_bug.cgi?id=280967</a>
<a href="https://rdar.apple.com/problem/137417312">rdar://problem/137417312</a>

Reviewed by Eric Carlson.

It may happen for the surface picker to be cancelled without notifying WebKit.
We have a 60 seconds timer that will make sure the corresponding getDisplayMedia request is denied.
During that time though, the user could make another getDisplayMedia call that we should not delay.
For that reason, we cancel a pending getDisplayMedia call if another one from the same page happens.

* LayoutTests/fast/mediastream/getDisplayMedia-successive-call-expected.txt: Added.
* LayoutTests/fast/mediastream/getDisplayMedia-successive-call.html: Added.
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::requestUserMediaPermissionForFrame):

Canonical link: <a href="https://commits.webkit.org/284881@main">https://commits.webkit.org/284881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8acf5f6df6db33963d8af2b8c360b36f45b0ead0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23591 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21843 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61052 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76633 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18050 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61115 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5452 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/804 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->