### PR TITLE
[libpas] Centralize most logging flags

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator.c
@@ -52,7 +52,7 @@ bool pas_bitfit_allocator_commit_view(pas_bitfit_view* view,
                                       const pas_bitfit_page_config* config,
                                       pas_lock_hold_mode commit_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_directory* directory;
     pas_segregated_heap* heap;
@@ -224,7 +224,7 @@ pas_bitfit_view* pas_bitfit_allocator_finish_failing(pas_bitfit_allocator* alloc
                                                      size_t largest_available,
                                                      const pas_bitfit_page_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_directory* directory;
     pas_bitfit_size_class* size_class;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h
@@ -59,7 +59,7 @@ pas_bitfit_allocator_try_allocate(pas_bitfit_allocator* allocator,
                                   pas_allocation_mode allocation_mode,
                                   pas_bitfit_page_config config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_view* view;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
@@ -44,7 +44,7 @@ void pas_bitfit_directory_construct(pas_bitfit_directory* directory,
                                     const pas_bitfit_page_config* config,
                                     pas_segregated_heap* heap)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
 
     /* NOTE - this works even if the config is disabled, and produces a directory that is empty and
        does nothing. This makes sense because it makes it easy to iterate over the directories in a heap
@@ -105,7 +105,7 @@ pas_bitfit_directory_get_first_free_view(pas_bitfit_directory* directory,
                                          unsigned size,
                                          const pas_bitfit_page_config* page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
 
     PAS_ASSERT(page_config->base.is_enabled);
     
@@ -376,7 +376,7 @@ pas_page_sharing_pool_take_result pas_bitfit_directory_take_last_empty(
     pas_deferred_decommit_log* decommit_log,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_versioned_field last_empty_plus_one_value;
     size_t index;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
@@ -63,7 +63,7 @@ pas_bitfit_variant_selection pas_bitfit_heap_select_variant(size_t requested_obj
                                                             const pas_heap_config* config,
                                                             pas_heap_runtime_config* runtime_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_page_config_variant variant;
     pas_bitfit_page_config_variant best_variant;
@@ -130,7 +130,7 @@ void pas_bitfit_heap_construct_and_insert_size_class(pas_bitfit_heap* heap,
                                                      const pas_heap_config* config,
                                                      pas_heap_runtime_config* runtime_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_variant_selection best;
     pas_compact_atomic_bitfit_size_class_ptr* insertion_point;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c
@@ -38,7 +38,7 @@ void pas_bitfit_page_construct(pas_bitfit_page* page,
                                pas_bitfit_view* view,
                                const pas_bitfit_page_config* config_ptr)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_page_config config;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -57,7 +57,7 @@ static PAS_ALWAYS_INLINE bool pas_bitfit_page_allocation_satisfies_alignment(
     uintptr_t alignment,
     pas_bitfit_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     uintptr_t begin_offset;
     uintptr_t end_offset;
@@ -207,7 +207,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_finish_all
     pas_allocation_mode allocation_mode,
     pas_bitfit_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     bool did_overflow;
     uintptr_t offset_in_page;
@@ -262,7 +262,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_allocate(
     pas_lock_hold_mode commit_lock_hold_mode,
     size_t* bytes_committed)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     uintptr_t word_index;
     uint64_t* free_words;
@@ -542,7 +542,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
     pas_bitfit_page_deallocate_with_page_impl_mode mode,
     size_t new_size)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     uintptr_t offset;
     uintptr_t bit_index;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_view.c
@@ -38,7 +38,7 @@
 pas_bitfit_view* pas_bitfit_view_create(pas_bitfit_directory* directory,
                                         unsigned index)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_view* result;
 
@@ -103,7 +103,7 @@ void pas_bitfit_view_note_max_free(pas_bitfit_view* view)
 
 static pas_heap_summary compute_summary(pas_bitfit_view* view)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     const pas_bitfit_page_config* config_ptr;
     pas_bitfit_page_config config;

--- a/Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c
@@ -40,7 +40,17 @@ static pas_aligned_allocation_result bootstrap_source_allocate_aligned(size_t si
                                                                        void* arg)
 {
     PAS_UNUSED_PARAM(arg);
-    return pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment);
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BOOTSTRAP_HEAPS);
+
+    if (verbose)
+        pas_log("bootstrap heap allocating %zu\n", size);
+
+    pas_aligned_allocation_result retval = pas_enumerable_page_malloc_try_allocate_without_deallocating_padding(size, alignment);
+
+    if (verbose)
+        pas_log("bootstrap heap done allocating, returning %p.\n", retval.result);
+
+    return retval;
 }
 
 static void initialize_config(pas_large_free_heap_config* config)

--- a/Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.c
@@ -42,8 +42,18 @@ pas_allocation_result pas_bootstrap_heap_page_provider(
     PAS_UNUSED_PARAM(arg);
     PAS_UNUSED_PARAM(heap);
     PAS_UNUSED_PARAM(transaction);
-    return pas_bootstrap_free_heap_try_allocate_with_alignment(
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BOOTSTRAP_HEAPS);
+
+    if (verbose)
+        pas_log("bootstreap heap page-provider allocating %zu for %s\n", size, name);
+
+    pas_allocation_result retval = pas_bootstrap_free_heap_try_allocate_with_alignment(
         size, alignment, name, pas_delegate_allocation);
+
+    if (verbose)
+        pas_log("bootstrap heap page-provider done allocating\n");
+
+    return retval;
 }
 
 #endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_bootstrap_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_bootstrap_free_heap.c
@@ -43,7 +43,17 @@ static pas_aligned_allocation_result compact_bootstrap_source_allocate_aligned(
 {
     PAS_ASSERT(!arg);
     PAS_ASSERT(!alignment.alignment_begin);
-    return pas_compact_heap_reservation_try_allocate(size, alignment.alignment);
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BOOTSTRAP_HEAPS);
+
+    if (verbose)
+        pas_log("compact bootstrap heap allocating %zu\n", size);
+
+    pas_aligned_allocation_result retval =  pas_compact_heap_reservation_try_allocate(size, alignment.alignment);
+
+    if (verbose)
+        pas_log("compact bootstrap done allocating, returning %p\n", retval.result);
+
+    return retval;
 }
 
 static void initialize_config(pas_large_free_heap_config* config)

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -28,6 +28,21 @@
 
 #include "pas_config_prefix.h"
 
+#include "stdbool.h"
+
+#define PAS_LOG_NONE (0)
+#define PAS_LOG_HEAP_INFRASTRUCTURE (1 << 0)
+#define PAS_LOG_BOOTSTRAP_HEAPS (1 << 1)
+#define PAS_LOG_IMMORTAL_HEAPS (1 << 2)
+#define PAS_LOG_SEGREGATED_HEAPS (1 << 3)
+#define PAS_LOG_BITFIT_HEAPS (1 << 4)
+#define PAS_LOG_LARGE_HEAPS (1 << 5)
+#define PAS_LOG_JIT_HEAPS (1 << 6)
+#define PAS_LOG_OTHER (1 << 7)  /* Heap-type agnostic */
+
+#define PAS_LOG_LEVEL (PAS_LOG_NONE)
+#define PAS_SHOULD_LOG(level) (PAS_LOG_LEVEL & level)
+
 #define LIBPAS_ENABLED 1
 
 #if defined(PAS_BMALLOC)

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -122,7 +122,7 @@ bool pas_try_deallocate_slow_no_cache(void* ptr,
                                       const pas_heap_config* config_ptr,
                                       pas_deallocation_mode deallocation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     uintptr_t begin;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -190,7 +190,7 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate(void* ptr,
                                                  pas_heap_config config,
                                                  pas_deallocation_mode deallocation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
 
     pas_thread_local_cache* thread_local_cache;
     uintptr_t begin;

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c
@@ -40,7 +40,7 @@ static bool view_callback(pas_enumerator* enumerator,
                           size_t index,
                           void* arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_BITFIT_HEAPS);
     
     pas_bitfit_view* view;
     pas_bitfit_directory* directory;

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
@@ -45,7 +45,7 @@
 #include "pas_thread_local_cache_layout.h"
 #include "pas_thread_local_cache_node.h"
 
-static const bool verbose = false;
+static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
 struct enumeration_context;
 struct local_allocator_node;

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
@@ -414,7 +414,7 @@ pas_allocation_result pas_fast_large_free_heap_try_allocate(pas_fast_large_free_
                                                             pas_alignment alignment,
                                                             pas_large_free_heap_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
     pas_generic_large_free_heap_config generic_heap_config;
     if (verbose)
         pas_log("heap %p allocating %zu, alignment %zu\n", heap, size, alignment.alignment);
@@ -431,7 +431,7 @@ void pas_fast_large_free_heap_deallocate(pas_fast_large_free_heap* heap,
                                          pas_zero_mode zero_mode,
                                          pas_large_free_heap_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
     pas_generic_large_free_heap_config generic_heap_config;
     if (verbose)
         pas_log("heap %p deallocating %p of size %zu\n", heap, (void*)begin, end - begin);

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -46,7 +46,8 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
                           const pas_heap_config* config,
                           pas_heap_runtime_config* runtime_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_HEAP_INFRASTRUCTURE);
+
     pas_heap* heap;
     uintptr_t begin;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h
@@ -53,7 +53,7 @@ pas_heap_ensure_size_directory_for_size(
     unsigned* cached_index,
     pas_allocator_counts* counts)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_HEAP_INFRASTRUCTURE);
 
     pas_segregated_size_directory* result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_table.h
@@ -43,7 +43,8 @@ PAS_API void pas_heap_table_try_allocate_index(pas_large_heap* heap);
 
 static inline bool pas_heap_table_has_index(pas_large_heap* heap)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_HEAP_INFRASTRUCTURE);
+
     if (heap->table_state == pas_heap_table_state_uninitialized)
         pas_heap_table_try_allocate_index(heap);
     switch (heap->table_state) {

--- a/Source/bmalloc/libpas/src/libpas/pas_immortal_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_immortal_heap.c
@@ -52,8 +52,9 @@ void* pas_immortal_heap_allocate_with_manual_alignment(size_t size,
                                                        const char* name,
                                                        pas_allocation_kind allocation_kind)
 {
-    static const unsigned verbose = 0;
-    
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_IMMORTAL_HEAPS);
+    static const unsigned verbosity = 0;
+
     uintptr_t aligned_bump;
 
     pas_heap_lock_assert_held();
@@ -88,7 +89,7 @@ void* pas_immortal_heap_allocate_with_manual_alignment(size_t size,
 
     if (verbose) {
         pas_log("pas_immortal_heap allocated %zu for %s at %p.\n", size, name, (void*)aligned_bump);
-        if (verbose >= 2) {
+        if (verbose && verbosity >= 2) {
             pas_log("immortal heap internal size: %zu.\n", pas_immortal_heap_allocated_internal);
             pas_log("immortal heap external size: %zu.\n", pas_immortal_heap_allocated_external);
         }
@@ -104,7 +105,8 @@ void* pas_immortal_heap_allocate_with_alignment(size_t size,
                                                 const char* name,
                                                 pas_allocation_kind allocation_kind)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_IMMORTAL_HEAPS);
+
     void* result;
     result = pas_immortal_heap_allocate_with_manual_alignment(
         size, PAS_MAX(alignment, PAS_INTERNAL_MIN_ALIGN), name, allocation_kind);

--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
@@ -38,7 +38,7 @@
 
 bool pas_large_utility_free_heap_talks_to_large_sharing_pool = true;
 
-static const bool verbose = false;
+static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
 
 static pas_aligned_allocation_result large_utility_aligned_allocator(size_t size,
                                                                      pas_alignment alignment,
@@ -164,7 +164,7 @@ void pas_large_free_heap_helpers_deallocate(
     pas_will_deallocate(ptr, size, pas_large_utility_free_heap_kind, pas_object_allocation);
     if (pas_large_utility_free_heap_talks_to_large_sharing_pool) {
         if (verbose) {
-            pas_log("freeing %p...%p.\n",
+            pas_log("large free heap freeing %p...%p.\n",
                     (void*)ptr,
                     (char*)ptr + size);
         }

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -96,7 +96,7 @@ static pas_allocation_result allocate_impl(pas_large_heap* heap,
                                            const pas_heap_config* heap_config,
                                            pas_physical_memory_transaction* transaction)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
     
     pas_allocation_result result;
     const pas_heap_type* type;
@@ -117,9 +117,8 @@ static pas_allocation_result allocate_impl(pas_large_heap* heap,
     *size = pas_round_up_to_power_of_2(*size, *alignment);
     
     if (verbose) {
-        printf("Allocating large object of size %zu\n", *size);
-        printf("Cartesian tree minimum = %p\n", pas_cartesian_tree_minimum(&heap->free_heap.tree));
-        printf("Num mapped bytes = %zu\n", heap->free_heap.num_mapped_bytes);
+        printf("large heap allocating large object of size %zu\n", *size);
+        printf("large heap cartesian tree minimum = %p, num mapped bytes = %zu\n", pas_cartesian_tree_minimum(&heap->free_heap.tree), heap->free_heap.num_mapped_bytes);
     }
     
     initialize_config(&config, &data, heap, heap_config);
@@ -134,7 +133,7 @@ static pas_allocation_result allocate_impl(pas_large_heap* heap,
         return pas_allocation_result_create_failure();
 
     if (verbose)
-        pas_log("Committing the memory we allocated starting at %p.\n", (void*)result.begin);
+        pas_log("large heap committing the memory we allocated starting at %p.\n", (void*)result.begin);
     
     if (heap_config->aligned_allocator_talks_to_sharing_pool &&
         !pas_large_sharing_pool_allocate_and_commit(

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
@@ -46,7 +46,7 @@ PAS_DEFINE_LOCK(pas_local_allocator_refill_efficiency);
 void pas_local_allocator_construct(pas_local_allocator* allocator,
                                    pas_segregated_size_directory* directory)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
 
     pas_local_allocator_scavenger_data_construct(
         &allocator->scavenger_data, pas_local_allocator_allocator_kind);
@@ -149,7 +149,7 @@ static bool stop_impl(
     pas_lock_lock_mode page_lock_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_segregated_view view;
     pas_segregated_page* page;
@@ -214,7 +214,7 @@ bool pas_local_allocator_stop(
     pas_lock_lock_mode page_lock_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     bool result;
     bool is_in_use;

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -169,7 +169,7 @@ static PAS_ALWAYS_INLINE void pas_local_allocator_scan_bits_to_set_up_free_bits(
     pas_full_alloc_bits full_alloc_bits,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     unsigned* alloc_bits;
     size_t index;
@@ -423,7 +423,7 @@ pas_local_allocator_prepare_to_allocate(
     pas_segregated_size_directory* directory,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     uintptr_t page_boundary;
 
@@ -504,7 +504,7 @@ pas_local_allocator_set_up_primordial_bump(
     pas_local_allocator_primordial_bump_allocation_mode mode,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     uintptr_t page_boundary;
     unsigned object_size;
@@ -611,7 +611,7 @@ pas_local_allocator_start_allocating_in_primordial_partial_view(
     pas_segregated_size_directory* size_directory,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     unsigned size;
     unsigned alignment;
@@ -747,7 +747,7 @@ pas_local_allocator_bless_primordial_partial_view_before_stopping(
     pas_lock_hold_mode heap_lock_hold_mode,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     /* We're sitting on a still-ineligible partial view. Nobody else can do things to it. We need
        to grab the heap lock in order to allocate the full alloc bits. This is called with the
@@ -910,7 +910,7 @@ pas_local_allocator_refill_with_known_config(
     pas_allocator_counts* counts,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_segregated_view new_view;
     pas_segregated_view old_view;
@@ -1272,7 +1272,7 @@ pas_local_allocator_return_memory_to_page_for_role(
     pas_segregated_page_config page_config,
     pas_segregated_page_role role)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     uintptr_t begin;
     uintptr_t end;
@@ -1379,7 +1379,7 @@ pas_local_allocator_try_allocate_with_free_bits(
     pas_allocation_mode allocation_mode,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
 
     uintptr_t found_bit_index;
     uint64_t current_word;
@@ -1504,7 +1504,7 @@ pas_local_allocator_try_allocate_inline_cases(pas_local_allocator* allocator,
                                               pas_allocation_mode allocation_mode,
                                               pas_heap_config config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     unsigned remaining;
     unsigned object_size;
@@ -1613,7 +1613,7 @@ pas_local_allocator_try_allocate_out_of_line_cases(
     pas_allocation_mode allocation_mode,
     pas_heap_config config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_local_allocator_config_kind our_kind;
     our_kind = allocator->config_kind;
@@ -1684,7 +1684,7 @@ pas_local_allocator_try_allocate_slow_impl(pas_local_allocator* allocator,
                                            pas_heap_config config,
                                            pas_allocator_counts* counts)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
 
     if (verbose) {
         pas_log("Called try_allocate_slow with kind = %s\n",
@@ -1762,7 +1762,7 @@ pas_local_allocator_try_allocate_inline_only(pas_local_allocator* allocator,
                                              pas_heap_config config,
                                              pas_allocation_result_filter result_filter)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     pas_allocation_result result;
 
     if (verbose) {
@@ -1804,7 +1804,7 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
                                  pas_allocator_counts* counts,
                                  pas_allocation_result_filter result_filter)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     pas_allocation_result result;
 
     PAS_TESTING_ASSERT(!allocator->scavenger_data.is_in_use);

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -89,7 +89,7 @@ pas_aligned_allocation_result
 pas_page_malloc_try_allocate_without_deallocating_padding(
     size_t size, pas_alignment alignment)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     size_t aligned_size;
     size_t mapped_size;
@@ -239,7 +239,7 @@ static void decommit_impl(void* ptr, size_t size,
                           bool do_mprotect,
                           pas_mmap_capability mmap_capability)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     uintptr_t base_as_int;
     uintptr_t end_as_int;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
@@ -79,7 +79,7 @@ pas_segregated_directory_get_data_slow(pas_segregated_directory* directory,
 
 uint64_t pas_segregated_directory_get_use_epoch(pas_segregated_directory* directory)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     uintptr_t last_empty_plus_one;
     size_t index;
@@ -144,7 +144,7 @@ pas_page_sharing_participant_payload*
 pas_segregated_directory_get_sharing_payload(pas_segregated_directory* directory,
                                              pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_directory_data* data;
     pas_segregated_directory_sharing_payload_ptr* payload_ptr;
@@ -282,7 +282,7 @@ bool pas_segregated_directory_view_did_become_empty_at_index(
     pas_segregated_directory* directory,
     size_t index)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     bool did_add_first_empty;
     

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory_inlines.h
@@ -72,7 +72,7 @@ pas_segregated_directory_iterate_iterate_callback(
     void* arg,
     bool is_forward)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_directory_iterate_config* config;
     pas_segregated_directory_bitvector_segment segment;
@@ -150,7 +150,7 @@ static PAS_ALWAYS_INLINE bool
 pas_segregated_directory_iterate_forward(
     pas_segregated_directory_iterate_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_directory_data* data;
     pas_found_index found_index;
@@ -244,7 +244,7 @@ static PAS_ALWAYS_INLINE bool
 pas_segregated_directory_iterate_forward_to_take_first_eligible(
     pas_segregated_directory_iterate_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     static const bool simple_eligibility = false;
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view.c
@@ -44,7 +44,7 @@ pas_segregated_exclusive_view* pas_segregated_exclusive_view_create(
     pas_segregated_size_directory* directory,
     size_t index)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_exclusive_view* result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view_inlines.h
@@ -48,7 +48,7 @@ static PAS_ALWAYS_INLINE void pas_segregated_exclusive_view_did_start_allocating
 {
     /* This is called with the page lock held. */
 
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     PAS_UNUSED_PARAM(view);
     PAS_UNUSED_PARAM(global_directory);
@@ -78,7 +78,7 @@ static PAS_ALWAYS_INLINE void pas_segregated_exclusive_view_did_stop_allocating(
     pas_segregated_page_config page_config,
     bool should_notify_eligibility)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     unsigned view_index;
     bool should_notify_emptiness;
@@ -126,7 +126,7 @@ static PAS_ALWAYS_INLINE void pas_segregated_exclusive_view_note_eligibility(
     pas_thread_local_cache* cache,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_size_directory* size_directory;
     pas_segregated_directory* directory;
@@ -134,8 +134,11 @@ static PAS_ALWAYS_INLINE void pas_segregated_exclusive_view_note_eligibility(
     size_directory = pas_compact_segregated_size_directory_ptr_load_non_null(&view->directory);
     directory = &size_directory->base;
     
-    if (verbose)
+    if (verbose) {
+        // Without this comment the style checker gets caught in a loop here
+        // for some reason, objecting both to including and excluding braces
         pas_log("Noting eligibility in exclusive %p/%p.\n", view, page);
+    }
         
     if (page->lock_ptr)
         pas_lock_testing_assert_held(page->lock_ptr);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -89,7 +89,7 @@ static size_t min_object_size_for_heap(pas_segregated_heap* heap,
 static size_t max_object_size_for_page_config(pas_heap* parent_heap,
                                               const pas_page_base_config* page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     size_t result;
 
@@ -109,7 +109,7 @@ static size_t max_segregated_object_size_for_heap(pas_heap* parent_heap,
                                                   pas_segregated_heap* heap,
                                                   const pas_heap_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_page_config_variant variant;
     for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_DESCENDING(variant)) {
@@ -136,7 +136,7 @@ static size_t max_bitfit_object_size_for_heap(pas_heap* parent_heap,
                                               pas_segregated_heap* heap,
                                               const pas_heap_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_bitfit_page_config_variant variant;
     
@@ -356,7 +356,7 @@ medium_directory_tuple_for_index_impl(
     size_t index,
     pas_segregated_heap_medium_size_directory_search_mode search_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     unsigned begin;
     unsigned end;
@@ -469,7 +469,7 @@ pas_segregated_heap_medium_directory_tuple_for_index(
     pas_segregated_heap_medium_size_directory_search_mode search_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_heap_rare_data* rare_data;
     pas_mutation_count saved_count;
@@ -517,7 +517,7 @@ unsigned pas_segregated_heap_medium_allocator_index_for_index(
     pas_segregated_heap_medium_size_directory_search_mode search_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_heap_medium_directory_tuple* medium_directory;
     
@@ -567,7 +567,7 @@ static size_t compute_small_index_upper_bound(pas_segregated_heap* heap,
 static void ensure_size_lookup(pas_segregated_heap* heap,
                                const pas_heap_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     size_t index_upper_bound;
     pas_compact_atomic_segregated_size_directory_ptr* index_to_size_directory;
@@ -850,7 +850,7 @@ pas_segregated_heap_ensure_allocator_index(
     const pas_heap_config* config,
     unsigned* cached_index)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     size_t index;
     unsigned allocator_index;
@@ -940,7 +940,7 @@ static size_t compute_ideal_object_size(pas_segregated_heap* heap,
                                         size_t alignment,
                                         const pas_segregated_page_config* page_config_ptr)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     unsigned num_objects;
     pas_segregated_page_config page_config;
@@ -1021,7 +1021,7 @@ typedef struct {
 
 static bool check_part_of_all_heaps_callback(pas_heap* heap, void* arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     check_part_of_all_heaps_data* data;
 
@@ -1331,7 +1331,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
     unsigned* cached_index,
     pas_segregated_size_directory_creation_mode creation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     pas_heap* parent_heap;
     pas_segregated_size_directory* result;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
@@ -91,7 +91,7 @@ pas_lock* pas_segregated_page_switch_lock_slow(
     pas_lock* held_lock,
     pas_lock* page_lock)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     PAS_ASSERT(held_lock != page_lock);
     
@@ -193,7 +193,7 @@ void pas_segregated_page_construct(pas_segregated_page* page,
                                    bool was_stolen,
                                    const pas_segregated_page_config* page_config_ptr)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_page_config page_config;
     pas_segregated_page_role role;
@@ -298,7 +298,7 @@ void pas_segregated_page_construct(pas_segregated_page* page,
 
 void pas_segregated_page_note_emptiness(pas_segregated_page* page, pas_note_emptiness_action action)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     if (page->lock_ptr)
         pas_lock_testing_assert_held(page->lock_ptr);
     if (verbose) {
@@ -335,7 +335,7 @@ bool pas_segregated_page_take_empty_granules(
     pas_range_locked_mode range_locked_mode,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_page_granule_use_count* use_counts;
     pas_segregated_view owner;
@@ -434,7 +434,7 @@ void pas_segregated_page_commit_fully(
     pas_lock** held_lock,
     pas_commit_fully_lock_hold_mode lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
@@ -570,7 +570,7 @@ static bool verify_granules_live_object_callback(pas_segregated_view view,
                                                  pas_range range,
                                                  void* arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     verify_granules_data* data;
 
@@ -595,7 +595,7 @@ static bool verify_granules_live_object_callback(pas_segregated_view view,
 
 void pas_segregated_page_verify_granules(pas_segregated_page* page)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_page_config page_config;
     pas_segregated_page_role role;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.h
@@ -267,7 +267,7 @@ pas_segregated_page_number_of_objects(unsigned object_size,
                                       pas_segregated_page_config page_config,
                                       pas_segregated_page_role role)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     unsigned result;
     
     result = pas_segregated_page_useful_object_payload_size(object_size, page_config, role) / object_size;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -205,7 +205,7 @@ static PAS_ALWAYS_INLINE void pas_segregated_page_switch_lock_impl(
     pas_segregated_page* page,
     pas_lock** held_lock)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_lock* held_lock_value;
     pas_lock* page_lock;
@@ -326,7 +326,7 @@ pas_segregated_page_deallocate_with_page(pas_segregated_page* page,
                                          pas_segregated_page_config page_config,
                                          pas_segregated_page_role role)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     static const bool count_things = false;
 
     static uint64_t count_exclusive;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
@@ -44,7 +44,7 @@ pas_segregated_partial_view_create(
     pas_segregated_size_directory* directory,
     size_t index)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_partial_view* result;
 
@@ -86,7 +86,7 @@ void pas_segregated_partial_view_note_eligibility(
     pas_segregated_partial_view* view,
     pas_segregated_page* page)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     if (page->lock_ptr)
         pas_lock_assert_held(page->lock_ptr);
     PAS_ASSERT(!view->eligibility_has_been_noted);
@@ -109,7 +109,7 @@ void pas_segregated_partial_view_set_is_in_use_for_allocation(
     pas_segregated_shared_view* shared_view,
     pas_segregated_shared_handle* shared_handle)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_shared_page_directory* shared_page_directory;
     size_t index;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.c
@@ -91,7 +91,7 @@ void pas_segregated_shared_handle_destroy(pas_segregated_shared_handle* handle)
 void pas_segregated_shared_handle_note_emptiness(
     pas_segregated_shared_handle* handle)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     pas_segregated_shared_view* shared_view;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle_inlines.h
@@ -38,7 +38,7 @@ pas_segregated_shared_handle_partial_view_ptr_for_index(
     size_t index,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     index >>= page_config.sharing_shift;
     if (verbose)
@@ -63,7 +63,7 @@ pas_segregated_shared_handle_partial_view_for_object(
     uintptr_t begin,
     pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     uintptr_t offset;
     uintptr_t index;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
@@ -74,7 +74,7 @@ static PAS_ALWAYS_INLINE bool
 find_first_eligible_consider_view(
     pas_segregated_directory_iterate_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     find_first_eligible_data* data;
     pas_segregated_shared_view* view;
@@ -115,7 +115,7 @@ pas_segregated_shared_view* pas_segregated_shared_page_directory_find_first_elig
     unsigned alignment,
     pas_lock_hold_mode heap_lock_hold_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_directory* directory;
     const pas_segregated_page_config* page_config_ptr;
@@ -218,7 +218,7 @@ static bool
 take_last_empty_consider_view(
     pas_segregated_directory_iterate_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     /* We put our take_last_empty logic in consider_view because should_consider_view_parallel
        cannot really tell if a page can be taken. */

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.c
@@ -205,7 +205,7 @@ static bool compute_summary_for_each_live_object_callback(
     pas_range range,
     void* arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     compute_summary_data* data;
     unsigned index;
@@ -256,7 +256,7 @@ static bool compute_summary_for_each_live_object_callback(
 static pas_heap_summary compute_summary(pas_segregated_shared_view* view,
                                         const pas_segregated_page_config* page_config_ptr)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_page_config page_config;
     pas_segregated_page* page;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
@@ -52,7 +52,7 @@ pas_segregated_size_directory* pas_segregated_size_directory_create(
     const pas_segregated_page_config* page_config,
     pas_segregated_size_directory_creation_mode creation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_size_directory* result;
     pas_segregated_page_config_kind page_config_kind;
@@ -520,7 +520,7 @@ pas_segregated_size_directory_select_allocator_slow(
 static pas_segregated_view take_first_eligible_direct_create_new_view_callback(
     pas_segregated_directory_iterate_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_size_directory* size_directory;
     pas_segregated_view view;
@@ -571,7 +571,7 @@ static pas_segregated_view take_first_eligible_direct_create_new_view_callback(
 pas_segregated_view pas_segregated_size_directory_take_first_eligible(
     pas_segregated_size_directory* size_directory)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_directory* directory;
     pas_segregated_directory_iterate_config config;
@@ -622,7 +622,7 @@ take_last_empty_should_consider_view_parallel(
 static bool
 take_last_empty_consider_view(pas_segregated_directory_iterate_config* config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     /* We put our take_last_empty logic in consider_view because should_consider_view_parallel
        cannot really tell if a page can be taken. */

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h
@@ -116,7 +116,7 @@ static PAS_ALWAYS_INLINE pas_allocator_index
 pas_segregated_size_directory_num_allocator_indices_for_config(
     pas_segregated_page_config config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     size_t size;
 
@@ -151,7 +151,7 @@ pas_segregated_size_directory_take_first_eligible_impl(
     pas_segregated_view (*create_new_view_callback)(
         pas_segregated_directory_iterate_config* config))
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     bool did_find_something;
     const pas_segregated_page_config* page_config_ptr;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view.c
@@ -289,7 +289,7 @@ static bool for_each_live_object(
     pas_segregated_view_for_each_live_object_callback callback,
     void *arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_segregated_page_config page_config;
     pas_full_alloc_bits full_alloc_bits;
@@ -433,7 +433,7 @@ bool pas_segregated_view_for_each_live_object(
 static pas_tri_state should_be_eligible(pas_segregated_view view,
                                         const pas_segregated_page_config* page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_full_alloc_bits full_alloc_bits;
     pas_segregated_page* page;
@@ -528,7 +528,7 @@ static pas_tri_state should_be_eligible(pas_segregated_view view,
 pas_tri_state pas_segregated_view_should_be_eligible(pas_segregated_view view,
                                                      const pas_segregated_page_config* page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
     
     pas_tri_state result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
@@ -51,7 +51,7 @@ static PAS_ALWAYS_INLINE pas_segregated_view
 pas_segregated_view_will_start_allocating(pas_segregated_view view,
                                           pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     pas_segregated_exclusive_view* exclusive;
     pas_segregated_partial_view* partial;
@@ -329,7 +329,7 @@ pas_segregated_view_did_stop_allocating(pas_segregated_view view,
                                         pas_segregated_page* page,
                                         pas_segregated_page_config page_config)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_SEGREGATED_HEAPS);
 
     bool should_notify_eligibility;
     bool should_notify_emptiness;

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
@@ -37,7 +37,8 @@
 #include "pas_log.h"
 #include <stdio.h>
 
-static const unsigned verbose = 0;
+static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);
+static const unsigned verbosity = 0;
 
 #define BOOTSTRAP_FREE_LIST_CAPACITY 4
 static pas_large_free bootstrap_free_list[BOOTSTRAP_FREE_LIST_CAPACITY];
@@ -421,7 +422,7 @@ static void fix_free_list_if_necessary(pas_simple_large_free_heap* heap,
     
     new_capacity = PAS_MAX(heap->free_list_size << 1, PAS_BOOTSTRAP_FREE_LIST_MINIMUM_SIZE);
     
-    if (verbose >= 2)
+    if (verbose && verbosity >= 2)
         printf("Allocating new free list with new_capacity = %zu:\n", new_capacity);
     new_free_list = (void*)try_allocate_without_fixing(
         heap,
@@ -456,7 +457,7 @@ static void fix_free_list_if_necessary(pas_simple_large_free_heap* heap,
             config);
     }
 
-    if (verbose >= 2) {
+    if (verbose && verbosity >= 2) {
         printf("Fixed:\n");
         dump_free_list(heap);
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate.h
@@ -76,7 +76,7 @@ pas_try_allocate_impl_inline_only(
     pas_heap_config config,
     pas_try_allocate_common_fast_inline_only try_allocate_common_fast_inline_only)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_local_allocator_result allocator;
     unsigned allocator_index;

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -83,7 +83,7 @@ pas_try_allocate_common_impl_fast(
     size_t alignment,
     pas_allocation_mode allocation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_allocation_result result;
     result = pas_local_allocator_try_allocate(allocator,
@@ -110,7 +110,7 @@ pas_try_allocate_common_impl_slow(
     pas_allocator_counts* allocator_counts,
     pas_size_lookup_mode size_lookup_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_baseline_allocator_result baseline_allocator_result;
     pas_allocation_result result;
@@ -244,7 +244,7 @@ pas_try_allocate_common_impl(
     pas_allocation_result (*slow)(pas_heap_ref* heap_ref, size_t size, size_t alignment, pas_allocation_mode allocation_mode),
     pas_local_allocator_result allocator_result)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     if (verbose) {
         pas_log("heap_ref = %p allocating size = %zu, alignment = %zu.\n",

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -85,7 +85,7 @@ pas_try_allocate_intrinsic_impl_casual_case(
     pas_try_allocate_common_slow try_allocate_common_slow,
     pas_intrinsic_heap_designation_mode designation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     size_t aligned_size;
     size_t index;
@@ -185,7 +185,7 @@ pas_try_allocate_intrinsic_impl_inline_only(
     pas_try_allocate_common_fast_inline_only try_allocate_common_fast_inline_only,
     pas_intrinsic_heap_designation_mode designation_mode)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     size_t aligned_size;
     size_t index;
@@ -291,7 +291,7 @@ pas_try_allocate_intrinsic_impl_inline_only(
     \
     static PAS_ALWAYS_INLINE pas_allocation_result name(size_t size, size_t alignment, pas_allocation_mode allocation_mode) \
     { \
-        static const bool verbose = false; \
+        static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER); \
         pas_allocation_result result; \
         result = name ## _inline_only(size, alignment, allocation_mode); \
         if (PAS_LIKELY(result.did_succeed)) { \
@@ -305,7 +305,7 @@ pas_try_allocate_intrinsic_impl_inline_only(
     static PAS_UNUSED PAS_NEVER_INLINE pas_allocation_result \
     name ## _for_realloc(size_t size, pas_allocation_mode allocation_mode) \
     { \
-        static const bool verbose = false; \
+        static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER); \
         pas_allocation_result result = name(size, 1, allocation_mode); \
         if (verbose) \
             pas_log("result.begin = %p\n", (void*)result.begin); \

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -57,7 +57,7 @@ pas_try_allocate_for_reallocate_and_copy(
     pas_try_reallocate_allocate_callback allocate_callback,
     void* allocate_callback_arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_allocation_result result;
 
@@ -574,7 +574,7 @@ pas_try_reallocate_primitive_allocate_callback(
     pas_allocation_mode allocation_mode,
     void* arg)
 {
-    static const bool verbose = false;
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     pas_try_reallocate_primitive_allocate_data* data;
     pas_allocation_result result;


### PR DESCRIPTION
#### dde95ad41f4e3b5bf46336bf9e47433818a1c569
<pre>
[libpas] Centralize most logging flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=280975">https://bugs.webkit.org/show_bug.cgi?id=280975</a>
<a href="https://rdar.apple.com/137427586">rdar://137427586</a>

Reviewed by Mark Lam.

Previously, these flags had to be enabled one-by-one for each file (and
often each function) you wanted to log from. Now the most common -- at
least in my experience -- collections of log-prints can be enabled by
changing PAS_LOG_LEVEL to include whichever levels should be logged.

I didn&apos;t cover all of the verbose prints in libpas, as some of the
others are particularly spammy or would otherwise need some cleanup
before they could be used. I also left the existing verbose flags
in-place in case they&apos;re part of anyone&apos;s workflow.

* Source/bmalloc/libpas/src/libpas/jit_heap.c:
(jit_heap_add_fresh_memory):
(jit_heap_try_allocate):
(jit_heap_shrink):
(jit_heap_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator.c:
(pas_bitfit_allocator_commit_view):
(pas_bitfit_allocator_finish_failing):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h:
(pas_bitfit_allocator_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c:
(pas_bitfit_directory_construct):
(pas_bitfit_directory_get_first_free_view):
(pas_bitfit_directory_take_last_empty):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c:
(pas_bitfit_heap_select_variant):
(pas_bitfit_heap_construct_and_insert_size_class):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c:
(pas_bitfit_page_construct):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_allocation_satisfies_alignment):
(pas_bitfit_page_finish_allocation):
(pas_bitfit_page_allocate):
(pas_bitfit_page_deallocate_with_page_impl):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_view.c:
(pas_bitfit_view_create):
(compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_bootstrap_free_heap.c:
(bootstrap_source_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_bootstrap_heap_page_provider.c:
(pas_bootstrap_heap_page_provider):
* Source/bmalloc/libpas/src/libpas/pas_compact_bootstrap_free_heap.c:
(compact_bootstrap_source_allocate_aligned):
* Source/bmalloc/libpas/src/libpas/pas_config.h:
* Source/bmalloc/libpas/src/libpas/pas_deallocate.c:
(pas_try_deallocate_slow_no_cache):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c:
(view_callback):
* Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c:
(record_page_objects):
(enumerate_exclusive_view):
(enumerate_shared_view):
(enumerate_partial_view):
(consider_allocator):
* Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c:
(pas_fast_large_free_heap_try_allocate):
(pas_fast_large_free_heap_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
* Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h:
(pas_heap_ensure_size_directory_for_size):
* Source/bmalloc/libpas/src/libpas/pas_heap_table.h:
(pas_heap_table_has_index):
* Source/bmalloc/libpas/src/libpas/pas_immortal_heap.c:
(pas_immortal_heap_allocate_with_manual_alignment):
(pas_immortal_heap_allocate_with_alignment):
* Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c:
(large_utility_aligned_allocator):
(pas_large_free_heap_helpers_try_allocate_with_alignment):
(pas_large_free_heap_helpers_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(allocate_impl):
* Source/bmalloc/libpas/src/libpas/pas_large_map.c:
(pas_large_map_add):
(pas_large_map_take):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator.c:
(pas_local_allocator_construct):
(stop_impl):
(pas_local_allocator_stop):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_scan_bits_to_set_up_free_bits):
(pas_local_allocator_prepare_to_allocate):
(pas_local_allocator_set_up_primordial_bump):
(pas_local_allocator_start_allocating_in_primordial_partial_view):
(pas_local_allocator_bless_primordial_partial_view_before_stopping):
(pas_local_allocator_refill_with_known_config):
(pas_local_allocator_return_memory_to_page_for_role):
(pas_local_allocator_try_allocate_with_free_bits):
(pas_local_allocator_try_allocate_inline_cases):
(pas_local_allocator_try_allocate_out_of_line_cases):
(pas_local_allocator_try_allocate_slow_impl):
(pas_local_allocator_try_allocate_inline_only):
(pas_local_allocator_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_try_allocate_without_deallocating_padding):
(decommit_impl):
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c:
(pas_segregated_directory_get_use_epoch):
(pas_segregated_directory_get_sharing_payload):
(pas_segregated_directory_view_did_become_empty_at_index):
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory_inlines.h:
(pas_segregated_directory_iterate_iterate_callback):
(pas_segregated_directory_iterate_forward):
(pas_segregated_directory_iterate_forward_to_take_first_eligible):
* Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view.c:
(pas_segregated_exclusive_view_create):
* Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view_inlines.h:
(pas_segregated_exclusive_view_did_start_allocating):
(pas_segregated_exclusive_view_did_stop_allocating):
(pas_segregated_exclusive_view_note_eligibility):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(max_object_size_for_page_config):
(max_segregated_object_size_for_heap):
(max_bitfit_object_size_for_heap):
(medium_directory_tuple_for_index_impl):
(pas_segregated_heap_medium_directory_tuple_for_index):
(pas_segregated_heap_medium_allocator_index_for_index):
(ensure_size_lookup):
(pas_segregated_heap_ensure_allocator_index):
(compute_ideal_object_size):
(check_part_of_all_heaps_callback):
(pas_segregated_heap_ensure_size_directory_for_size):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.c:
(pas_segregated_page_switch_lock_slow):
(pas_segregated_page_construct):
(pas_segregated_page_note_emptiness):
(pas_segregated_page_take_empty_granules):
(pas_segregated_page_commit_fully):
(verify_granules_live_object_callback):
(pas_segregated_page_verify_granules):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.h:
(pas_segregated_page_number_of_objects):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h:
(pas_segregated_page_switch_lock_impl):
(pas_segregated_page_deallocate_with_page):
* Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c:
(pas_segregated_partial_view_create):
(pas_segregated_partial_view_note_eligibility):
(pas_segregated_partial_view_set_is_in_use_for_allocation):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.c:
(pas_segregated_shared_handle_note_emptiness):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle_inlines.h:
(pas_segregated_shared_handle_partial_view_ptr_for_index):
(pas_segregated_shared_handle_partial_view_for_object):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c:
(find_first_eligible_consider_view):
(pas_segregated_shared_page_directory_find_first_eligible):
(take_last_empty_consider_view):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.c:
(compute_summary_for_each_live_object_callback):
(compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c:
(pas_segregated_size_directory_create):
(take_first_eligible_direct_create_new_view_callback):
(pas_segregated_size_directory_take_first_eligible):
(take_last_empty_consider_view):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h:
(pas_segregated_size_directory_num_allocator_indices_for_config):
(pas_segregated_size_directory_take_first_eligible_impl):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view.c:
(for_each_live_object):
(should_be_eligible):
(pas_segregated_view_should_be_eligible):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h:
(pas_segregated_view_will_start_allocating):
(pas_segregated_view_did_stop_allocating):
* Source/bmalloc/libpas/src/libpas/pas_try_allocate.h:
(pas_try_allocate_impl_inline_only):
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_common_impl_fast):
(pas_try_allocate_common_impl_slow):
(pas_try_allocate_common_impl):
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h:
(pas_try_allocate_intrinsic_impl_casual_case):
(pas_try_allocate_intrinsic_impl_inline_only):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_allocate_for_reallocate_and_copy):
(pas_try_reallocate_primitive_allocate_callback):

Canonical link: <a href="https://commits.webkit.org/285358@main">https://commits.webkit.org/285358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0797dc3b1dc9124dedfc89393dd94a78f64a72b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25177 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23598 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23420 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75456 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62340 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19809 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21948 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/65518 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78237 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71643 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16630 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62355 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13003 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93424 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11108 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47608 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/20558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->