### PR TITLE
Reduce use of LegacyNullableObjectIdentifier

### DIFF
--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -211,7 +211,7 @@ void SpellChecker::didCheck(TextCheckingRequestIdentifier identifier, const Vect
 
     protectedDocument()->editor().markAndReplaceFor(*m_processingRequest, results);
 
-    if (m_lastProcessedIdentifier.toUInt64() < identifier.toUInt64())
+    if (!m_lastProcessedIdentifier || *m_lastProcessedIdentifier < identifier)
         m_lastProcessedIdentifier = identifier;
 
     m_processingRequest = nullptr;

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -31,6 +31,7 @@
 #include "TextChecking.h"
 #include "Timer.h"
 #include <wtf/Deque.h>
+#include <wtf/Markable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -90,8 +91,8 @@ public:
 
     void requestCheckingFor(Ref<SpellCheckRequest>&&);
 
-    TextCheckingRequestIdentifier lastRequestIdentifier() const { return m_lastRequestIdentifier; }
-    TextCheckingRequestIdentifier lastProcessedIdentifier() const { return m_lastProcessedIdentifier; }
+    std::optional<TextCheckingRequestIdentifier> lastRequestIdentifier() const { return m_lastRequestIdentifier; }
+    std::optional<TextCheckingRequestIdentifier> lastProcessedIdentifier() const { return m_lastProcessedIdentifier; }
 
 private:
     bool canCheckAsynchronously(const SimpleRange&) const;
@@ -106,8 +107,8 @@ private:
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
-    TextCheckingRequestIdentifier m_lastRequestIdentifier;
-    TextCheckingRequestIdentifier m_lastProcessedIdentifier;
+    Markable<TextCheckingRequestIdentifier> m_lastRequestIdentifier;
+    Markable<TextCheckingRequestIdentifier> m_lastProcessedIdentifier;
 
     Timer m_timerToProcessQueuedRequest;
 

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -32,6 +32,7 @@
 #include "TextManipulationItem.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Markable.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
@@ -116,8 +117,6 @@ private:
 
     Vector<ExclusionRule> m_exclusionRules;
     HashMap<TextManipulationItemIdentifier, ManipulationItemData> m_items;
-    TextManipulationItemIdentifier m_itemIdentifier;
-    TextManipulationTokenIdentifier m_tokenIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/TextManipulationControllerManipulationFailure.h
+++ b/Source/WebCore/editing/TextManipulationControllerManipulationFailure.h
@@ -40,7 +40,7 @@ struct TextManipulationControllerManipulationFailure {
     };
 
     FrameIdentifier frameID;
-    TextManipulationItemIdentifier identifier;
+    Markable<TextManipulationItemIdentifier> identifier;
     uint64_t index;
     Type type;
 };

--- a/Source/WebCore/editing/TextManipulationItem.h
+++ b/Source/WebCore/editing/TextManipulationItem.h
@@ -35,7 +35,7 @@ struct TextManipulationItem {
     Markable<FrameIdentifier> frameID;
     bool isSubframe { false };
     bool isCrossSiteSubframe { false };
-    TextManipulationItemIdentifier identifier;
+    Markable<TextManipulationItemIdentifier> identifier;
     Vector<TextManipulationToken> tokens;
 };
 

--- a/Source/WebCore/editing/TextManipulationItemIdentifier.h
+++ b/Source/WebCore/editing/TextManipulationItemIdentifier.h
@@ -28,6 +28,6 @@
 namespace WebCore {
 
 enum class TextManipulationItemIdentifierType { };
-using TextManipulationItemIdentifier = LegacyNullableObjectIdentifier<TextManipulationItemIdentifierType>;
+using TextManipulationItemIdentifier = ObjectIdentifier<TextManipulationItemIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/editing/TextManipulationToken.h
+++ b/Source/WebCore/editing/TextManipulationToken.h
@@ -27,7 +27,7 @@
 namespace WebCore {
 
 enum class TextManipulationTokenIdentifierType { };
-using TextManipulationTokenIdentifier = LegacyNullableObjectIdentifier<TextManipulationTokenIdentifierType>;
+using TextManipulationTokenIdentifier = ObjectIdentifier<TextManipulationTokenIdentifierType>;
 
 struct TextManipulationTokenInfo {
     String tagName;

--- a/Source/WebCore/history/BackForwardItemIdentifier.h
+++ b/Source/WebCore/history/BackForwardItemIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 struct BackForwardItemIdentifierType;
-using BackForwardItemIdentifier = ProcessQualified<LegacyNullableObjectIdentifier<BackForwardItemIdentifierType>>;
+using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SleepDisabler.cpp
+++ b/Source/WebCore/platform/SleepDisabler.cpp
@@ -39,7 +39,7 @@ SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type
 {
     if (sleepDisablerClient()) {
         m_identifier = SleepDisablerIdentifier::generate();
-        sleepDisablerClient()->didCreateSleepDisabler(m_identifier, reason, type == PAL::SleepDisabler::Type::Display, pageID);
+        sleepDisablerClient()->didCreateSleepDisabler(*m_identifier, reason, type == PAL::SleepDisabler::Type::Display, pageID);
         return;
     }
 
@@ -49,7 +49,7 @@ SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type
 SleepDisabler::~SleepDisabler()
 {
     if (sleepDisablerClient())
-        sleepDisablerClient()->didDestroySleepDisabler(m_identifier, m_pageID);
+        sleepDisablerClient()->didDestroySleepDisabler(*m_identifier, m_pageID);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SleepDisabler.h
+++ b/Source/WebCore/platform/SleepDisabler.h
@@ -42,7 +42,7 @@ public:
 
 private:
     std::unique_ptr<PAL::SleepDisabler> m_platformSleepDisabler;
-    SleepDisablerIdentifier m_identifier;
+    Markable<SleepDisablerIdentifier> m_identifier;
     PAL::SleepDisabler::Type m_type;
     std::optional<PageIdentifier> m_pageID;
 };

--- a/Source/WebCore/platform/SleepDisablerIdentifier.h
+++ b/Source/WebCore/platform/SleepDisablerIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 struct SleepDisablerIdentifierType { };
-using SleepDisablerIdentifier = LegacyNullableObjectIdentifier<SleepDisablerIdentifierType>;
+using SleepDisablerIdentifier = ObjectIdentifier<SleepDisablerIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/text/TextCheckingRequestIdentifier.h
+++ b/Source/WebCore/platform/text/TextCheckingRequestIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class TextCheckingRequestIdentifierType { };
-using TextCheckingRequestIdentifier = LegacyNullableObjectIdentifier<TextCheckingRequestIdentifierType>;
+using TextCheckingRequestIdentifier = ObjectIdentifier<TextCheckingRequestIdentifierType>;
 
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2560,7 +2560,8 @@ ExceptionOr<uint64_t> Internals::lastSpellCheckRequestSequence()
     if (!document || !document->frame())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    return document->editor().spellChecker().lastRequestIdentifier().toUInt64();
+    auto lastRequestIdentifier = document->editor().spellChecker().lastRequestIdentifier();
+    return lastRequestIdentifier ? lastRequestIdentifier->toUInt64() : 0;
 }
 
 ExceptionOr<uint64_t> Internals::lastSpellCheckProcessedSequence()
@@ -2569,7 +2570,8 @@ ExceptionOr<uint64_t> Internals::lastSpellCheckProcessedSequence()
     if (!document || !document->frame())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    return document->editor().spellChecker().lastProcessedIdentifier().toUInt64();
+    auto lastProcessedIdentifier = document->editor().spellChecker().lastProcessedIdentifier();
+    return lastProcessedIdentifier ? lastProcessedIdentifier->toUInt64() : 0;
 }
 
 void Internals::advanceToNextMisspelling()

--- a/Source/WebCore/workers/shared/SharedWorkerObjectIdentifier.h
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 struct SharedWorkerObjectIdentifierType;
-using SharedWorkerObjectIdentifier = ProcessQualified<LegacyNullableObjectIdentifier<SharedWorkerObjectIdentifierType>>;
+using SharedWorkerObjectIdentifier = ProcessQualified<ObjectIdentifier<SharedWorkerObjectIdentifierType>>;
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -531,7 +531,7 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
     MESSAGE_CHECK(hasCookieAccess);
 
-    CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, valueOrDefault(existingLoaderToResume).toUInt64());
+    CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
 
     if (auto* session = networkSession()) {
         if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {

--- a/Source/WebKit/Shared/DisplayLinkObserverID.h
+++ b/Source/WebKit/Shared/DisplayLinkObserverID.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct DisplayLinkObserverIDType;
-using DisplayLinkObserverID = LegacyNullableObjectIdentifier<DisplayLinkObserverIDType>;
+using DisplayLinkObserverID = ObjectIdentifier<DisplayLinkObserverIDType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/DrawingAreaInfo.h
+++ b/Source/WebKit/Shared/DrawingAreaInfo.h
@@ -49,6 +49,6 @@ enum {
 typedef uint64_t ActivityStateChangeID;
 
 struct DrawingAreaIdentifierType;
-using DrawingAreaIdentifier = LegacyNullableObjectIdentifier<DrawingAreaIdentifierType>;
+using DrawingAreaIdentifier = ObjectIdentifier<DrawingAreaIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/NetworkResourceLoadIdentifier.h
+++ b/Source/WebKit/Shared/NetworkResourceLoadIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct NetworkResourceLoadIdentifierType;
-using NetworkResourceLoadIdentifier = LegacyNullableObjectIdentifier<NetworkResourceLoadIdentifierType>;
+using NetworkResourceLoadIdentifier = ObjectIdentifier<NetworkResourceLoadIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/ProcessQualified.serialization.in
+++ b/Source/WebKit/Shared/ProcessQualified.serialization.in
@@ -21,14 +21,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-additional_forward_declaration: namespace WebCore { using BackForwardItemIdentifierID = LegacyNullableObjectIdentifier<BackForwardItemIdentifierType>; }
+additional_forward_declaration: namespace WebCore { using BackForwardItemIdentifierID = ObjectIdentifier<BackForwardItemIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using DOMCacheIdentifierID = AtomicObjectIdentifier<DOMCacheIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using FrameIdentifierID = ObjectIdentifier<FrameIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using OpaqueOriginIdentifier = AtomicObjectIdentifier<OpaqueOriginIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using PlatformLayerIdentifierID = ObjectIdentifier<PlatformLayerIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using RTCDataChannelLocalIdentifier =  AtomicObjectIdentifier<RTCDataChannelLocalIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using ScrollingNodeIdentifier = LegacyNullableObjectIdentifier<ScrollingNodeIDType>; }
-additional_forward_declaration: namespace WebCore { using SharedWorkerObjectIdentifierID = LegacyNullableObjectIdentifier<SharedWorkerObjectIdentifierType>; }
+additional_forward_declaration: namespace WebCore { using SharedWorkerObjectIdentifierID = ObjectIdentifier<SharedWorkerObjectIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using WebLockIdentifierID = AtomicObjectIdentifier<WebLockIdentifierType>; }
 
 header: <WebCore/ProcessQualified.h>

--- a/Source/WebKit/Shared/UserScriptIdentifier.h
+++ b/Source/WebKit/Shared/UserScriptIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class UserScriptIdentifierType { };
-using UserScriptIdentifier = LegacyNullableObjectIdentifier<UserScriptIdentifierType>;
+using UserScriptIdentifier = ObjectIdentifier<UserScriptIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/UserStyleSheetIdentifier.h
+++ b/Source/WebKit/Shared/UserStyleSheetIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class UserStyleSheetIdentifierType { };
-using UserStyleSheetIdentifier = LegacyNullableObjectIdentifier<UserStyleSheetIdentifierType>;
+using UserStyleSheetIdentifier = ObjectIdentifier<UserStyleSheetIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -66,9 +66,6 @@ template: enum class WebCore::MediaUniqueIdentifierType
 template: enum class WebCore::PushSubscriptionIdentifierType
 template: enum class WebCore::RealtimeMediaSourceIdentifierType
 template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
-template: enum class WebCore::TextCheckingRequestIdentifierType
-template: enum class WebCore::TextManipulationItemIdentifierType
-template: enum class WebCore::TextManipulationTokenIdentifierType
 template: enum class WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
 template: enum class WebKit::ContentWorldIdentifierType
 template: enum class WebKit::ImageAnalysisRequestIdentifierType
@@ -89,8 +86,6 @@ template: enum class WebKit::RetrieveRecordResponseBodyCallbackIdentifierType
 template: enum class WebKit::SampleBufferDisplayLayerIdentifierType
 template: enum class WebKit::ScriptMessageHandlerIdentifierType
 template: enum class WebKit::ShapeDetectionIdentifierType
-template: enum class WebKit::UserScriptIdentifierType
-template: enum class WebKit::UserStyleSheetIdentifierType
 template: enum class WebKit::WCLayerTreeHostIdentifierType
 template: enum class WebKit::WebExtensionControllerIdentifierType
 template: enum class WebKit::XRDeviceIdentifierType
@@ -99,7 +94,6 @@ template: struct WebCore::AttributedStringTextListIDType
 template: struct WebCore::AttributedStringTextTableBlockIDType
 template: struct WebCore::AttributedStringTextTableIDType
 #endif
-template: struct WebCore::BackForwardItemIdentifierType
 template: struct WebCore::DictationContextType
 template: struct WebCore::MediaKeySystemRequestIdentifierType
 template: struct WebCore::MediaPlayerIdentifierType
@@ -107,15 +101,10 @@ template: struct WebCore::MediaPlayerClientIdentifierType
 template: struct WebCore::MediaSessionIdentifierType
 template: struct WebCore::ModelPlayerIdentifierType
 template: struct WebCore::PlaybackTargetClientContextIdentifierType
-template: struct WebCore::SharedWorkerObjectIdentifierType
-template: struct WebCore::SleepDisablerIdentifierType
 template: struct WebCore::UserMediaRequestIdentifierType
 template: struct WebCore::ScrollingNodeIDType
-template: struct WebKit::DisplayLinkObserverIDType
-template: struct WebKit::DrawingAreaIdentifierType
 template: struct WebKit::IPCConnectionTesterIdentifierType
 template: struct WebKit::IPCStreamTesterIdentifierType
-template: struct WebKit::NetworkResourceLoadIdentifierType
 template: struct WebKit::RemoteAudioDestinationIdentifierType
 template: struct WebKit::RemoteImageBufferSetIdentifierType
 template: struct WebKit::WebTransportSessionIdentifierType
@@ -135,21 +124,32 @@ template: enum class WebCore::LayerHostingContextIdentifierType
 template: enum class WebCore::ProcessIdentifierType
 template: enum class WebCore::SWServerToContextConnectionIdentifierType
 template: enum class WebCore::SharedWorkerIdentifierType
+template: enum class WebCore::TextCheckingRequestIdentifierType
+template: enum class WebCore::TextManipulationItemIdentifierType
+template: enum class WebCore::TextManipulationTokenIdentifierType
 template: enum class WebCore::WindowIdentifierType
 template: enum class WebCore::WorkletGlobalScopeIdentifierType
 template: enum class WebKit::DownloadIdentifierType
 template: enum class WebKit::StorageAreaImplIdentifierType
 template: enum class WebKit::StorageAreaMapIdentifierType
 template: enum class WebKit::StorageNamespaceIdentifierType
+template: enum class WebKit::UserScriptIdentifierType
+template: enum class WebKit::UserStyleSheetIdentifierType
 template: enum class WebKit::VisitedLinkTableIdentifierType
+template: struct WebCore::BackForwardItemIdentifierType
 template: struct WebCore::FrameIdentifierType
 template: struct WebCore::NavigationIdentifierType
 template: struct WebCore::PageIdentifierType
 template: struct WebCore::PlatformLayerIdentifierType
+template: struct WebCore::SharedWorkerObjectIdentifierType
+template: struct WebCore::SleepDisablerIdentifierType
 template: struct WebKit::AuthenticationChallengeIdentifierType
 template: struct WebKit::DataTaskIdentifierType
+template: struct WebKit::DisplayLinkObserverIDType
+template: struct WebKit::DrawingAreaIdentifierType
 template: struct WebKit::GeolocationIdentifierType
 template: struct WebKit::MarkSurfacesAsVolatileRequestIdentifierType
+template: struct WebKit::NetworkResourceLoadIdentifierType
 template: struct WebKit::PDFPluginIdentifierType
 template: struct WebKit::PageGroupIdentifierType
 template: struct WebKit::TapIdentifierType

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2718,7 +2718,7 @@ struct WebCore::TextManipulationItem {
     Markable<WebCore::FrameIdentifier> frameID;
     bool isSubframe;
     bool isCrossSiteSubframe;
-    WebCore::TextManipulationItemIdentifier identifier;
+    Markable<WebCore::TextManipulationItemIdentifier> identifier;
     Vector<WebCore::TextManipulationToken> tokens;
 }
 
@@ -4359,7 +4359,7 @@ header: <WebCore/TextManipulationController.h>
 header: <WebCore/TextManipulationController.h>
 [CustomHeader] struct WebCore::TextManipulationControllerManipulationFailure {
     WebCore::FrameIdentifier frameID;
-    WebCore::TextManipulationItemIdentifier identifier;
+    Markable<WebCore::TextManipulationItemIdentifier> identifier;
     uint64_t index;
     WebCore::TextManipulationControllerManipulationFailure::Type type;
 };

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -104,7 +104,7 @@ struct WebPageCreationParameters {
     
     WebPreferencesStore store { };
     DrawingAreaType drawingAreaType { };
-    DrawingAreaIdentifier drawingAreaIdentifier { };
+    DrawingAreaIdentifier drawingAreaIdentifier;
     WebPageProxyIdentifier webPageProxyIdentifier;
     WebPageGroupData pageGroupData;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -189,7 +189,7 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
     }
 
     WebKit::ResourceLoadInfo info {
-        LegacyNullableObjectIdentifier<WebKit::NetworkResourceLoadIdentifierType>(resourceLoadID.unsignedLongLongValue),
+        ObjectIdentifier<WebKit::NetworkResourceLoadIdentifierType>(resourceLoadID.unsignedLongLongValue),
         frame->_frameHandle->frameID(),
         parentFrame ? std::optional<WebCore::FrameIdentifier>(parentFrame->_frameHandle->frameID()) : std::nullopt,
         originalURL,

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -278,7 +278,7 @@ void ProvisionalPageProxy::loadData(API::Navigation& navigation, Ref<WebCore::Sh
 
 void ProvisionalPageProxy::loadRequest(API::Navigation& navigation, WebCore::ResourceRequest&& request, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, IsPerformingHTTPFallback isPerformingHTTPFallback)
 {
-    PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "loadRequest: existingNetworkResourceLoadIdentifierToResume=%" PRIu64, valueOrDefault(existingNetworkResourceLoadIdentifierToResume).toUInt64());
+    PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "loadRequest: existingNetworkResourceLoadIdentifierToResume=%" PRIu64, existingNetworkResourceLoadIdentifierToResume ? existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
     ASSERT(shouldTreatAsContinuingLoad != WebCore::ShouldTreatAsContinuingLoad::No);
 
     // If this is a client-side redirect continuing in a new process, then the new process will overwrite the fromItem's URL. In this case,
@@ -292,7 +292,7 @@ void ProvisionalPageProxy::loadRequest(API::Navigation& navigation, WebCore::Res
 
 void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebBackForwardListItem& item, RefPtr<API::WebsitePolicies>&& websitePolicies, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
 {
-    PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "goToBackForwardItem: existingNetworkResourceLoadIdentifierToResume=%" PRIu64, valueOrDefault(existingNetworkResourceLoadIdentifierToResume).toUInt64());
+    PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "goToBackForwardItem: existingNetworkResourceLoadIdentifierToResume=%" PRIu64, existingNetworkResourceLoadIdentifierToResume ? existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
 
     auto itemStates = m_page->backForwardList().filteredItemStates([this, targetItem = Ref { item }](auto& item) {
         if (auto* backForwardCacheEntry = item.backForwardCacheEntry()) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10897,6 +10897,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     RefPtr pageClient = this->pageClient();
 
     WebPageCreationParameters parameters {
+        .drawingAreaIdentifier = drawingArea.identifier(),
         .webPageProxyIdentifier = identifier(),
         .pageGroupData = m_pageGroup->data(),
         .visitedLinkTableID = m_visitedLinkStore->identifier(),
@@ -10912,7 +10913,6 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.viewSize = pageClient ? pageClient->viewSize() : WebCore::IntSize { };
     parameters.activityState = internals().activityState;
     parameters.drawingAreaType = drawingArea.type();
-    parameters.drawingAreaIdentifier = drawingArea.identifier();
     parameters.store = preferencesStore();
     parameters.isEditable = m_isEditable;
     parameters.underlayColor = internals().underlayColor;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -334,7 +334,7 @@ using SessionID = WTF::UUID;
 template<typename> class ProcessQualified;
 template<typename> class RectEdges;
 
-using BackForwardItemIdentifier = ProcessQualified<LegacyNullableObjectIdentifier<BackForwardItemIdentifierType>>;
+using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 using DictationContext = LegacyNullableObjectIdentifier<DictationContextType>;
 using FloatBoxExtent = RectEdges<float>;
 using FramesPerSecond = unsigned;
@@ -354,7 +354,7 @@ using PointerID = uint32_t;
 using ResourceLoaderIdentifier = AtomicObjectIdentifier<ResourceLoader>;
 using SandboxFlags = OptionSet<SandboxFlag>;
 using ScrollingNodeID = ProcessQualified<LegacyNullableObjectIdentifier<ScrollingNodeIDType>>;
-using SleepDisablerIdentifier = LegacyNullableObjectIdentifier<SleepDisablerIdentifierType>;
+using SleepDisablerIdentifier = ObjectIdentifier<SleepDisablerIdentifierType>;
 using UserMediaRequestIdentifier = LegacyNullableObjectIdentifier<UserMediaRequestIdentifierType>;
 
 } // namespace WebCore
@@ -583,7 +583,7 @@ template<typename> class MonotonicObjectIdentifier;
 using ActivityStateChangeID = uint64_t;
 using GeolocationIdentifier = ObjectIdentifier<GeolocationIdentifierType>;
 using LayerHostingContextID = uint32_t;
-using NetworkResourceLoadIdentifier = LegacyNullableObjectIdentifier<NetworkResourceLoadIdentifierType>;
+using NetworkResourceLoadIdentifier = ObjectIdentifier<NetworkResourceLoadIdentifierType>;
 using PDFPluginIdentifier = ObjectIdentifier<PDFPluginIdentifierType>;
 using PlaybackSessionContextIdentifier = WebCore::HTMLMediaElementIdentifier;
 using SnapshotOptions = OptionSet<SnapshotOption>;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -536,7 +536,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     if (loadParameters.isMainFrameNavigation)
         existingNetworkResourceLoadIdentifierToResume = std::exchange(m_existingNetworkResourceLoadIdentifierToResume, std::nullopt);
-    WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64 ")", static_cast<int>(resourceLoader.request().priority()), valueOrDefault(existingNetworkResourceLoadIdentifierToResume).toUInt64());
+    WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64 ")", static_cast<int>(resourceLoader.request().priority()), existingNetworkResourceLoadIdentifierToResume ? existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
 
     if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(loadParameters, existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {
         WEBLOADERSTRATEGY_RELEASE_LOG_ERROR("scheduleLoad: Unable to schedule resource with the NetworkProcess (priority=%d)", static_cast<int>(resourceLoader.request().priority()));

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -199,7 +199,7 @@ RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCARemote
 
     if (!delegate) {
         ASSERT(!existing);
-        delegate = adoptRef(new GraphicsLayerCARemoteAsyncContentsDisplayDelegate(*WebProcess::singleton().parentProcessConnection(), protectedContext->drawingAreaIdentifier()));
+        delegate = adoptRef(new GraphicsLayerCARemoteAsyncContentsDisplayDelegate(*WebProcess::singleton().parentProcessConnection(), *protectedContext->drawingAreaIdentifier()));
     }
 
     auto layerID = setContentsToAsyncDisplayDelegate(delegate, ContentsLayerPurpose::Canvas);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -74,7 +74,7 @@ public:
     
     std::optional<WebCore::DestinationColorSpace> displayColorSpace() const;
 
-    DrawingAreaIdentifier drawingAreaIdentifier() const;
+    std::optional<DrawingAreaIdentifier> drawingAreaIdentifier() const;
 
     void buildTransaction(RemoteLayerTreeTransaction&, WebCore::PlatformCALayer& rootLayer, WebCore::FrameIdentifier);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -84,10 +84,10 @@ LayerHostingMode RemoteLayerTreeContext::layerHostingMode() const
     return m_webPage->layerHostingMode();
 }
 
-DrawingAreaIdentifier RemoteLayerTreeContext::drawingAreaIdentifier() const
+std::optional<DrawingAreaIdentifier> RemoteLayerTreeContext::drawingAreaIdentifier() const
 {
     if (!m_webPage->drawingArea())
-        return DrawingAreaIdentifier();
+        return std::nullopt;
     return m_webPage->drawingArea()->identifier();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2057,7 +2057,7 @@ void WebPage::loadDidCommitInAnotherProcess(WebCore::FrameIdentifier frameID, st
 
 void WebPage::loadRequest(LoadParameters&& loadParameters)
 {
-    WEBPAGE_RELEASE_LOG(Loading, "loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, loadParameters.navigationID ? loadParameters.navigationID->toUInt64() : 0, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), valueOrDefault(loadParameters.existingNetworkResourceLoadIdentifierToResume).toUInt64());
+    WEBPAGE_RELEASE_LOG(Loading, "loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, loadParameters.navigationID ? loadParameters.navigationID->toUInt64() : 0, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), loadParameters.existingNetworkResourceLoadIdentifierToResume ? loadParameters.existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
 
     RefPtr frame = loadParameters.frameIdentifier ? WebProcess::singleton().webFrame(*loadParameters.frameIdentifier) : m_mainFrame.ptr();
     if (!frame) {
@@ -2281,7 +2281,7 @@ void WebPage::reload(WebCore::NavigationIdentifier navigationID, OptionSet<WebCo
 
 void WebPage::goToBackForwardItem(GoToBackForwardItemParameters&& parameters)
 {
-    WEBPAGE_RELEASE_LOG(Loading, "goToBackForwardItem: navigationID=%" PRIu64 ", backForwardItemID=%s, shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, parameters.navigationID.toUInt64(), parameters.backForwardItemID.toString().utf8().data(), static_cast<unsigned>(parameters.shouldTreatAsContinuingLoad), parameters.lastNavigationWasAppInitiated, valueOrDefault(parameters.existingNetworkResourceLoadIdentifierToResume).toUInt64());
+    WEBPAGE_RELEASE_LOG(Loading, "goToBackForwardItem: navigationID=%" PRIu64 ", backForwardItemID=%s, shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, parameters.navigationID.toUInt64(), parameters.backForwardItemID.toString().utf8().data(), static_cast<unsigned>(parameters.shouldTreatAsContinuingLoad), parameters.lastNavigationWasAppInitiated, parameters.existingNetworkResourceLoadIdentifierToResume ? parameters.existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
     SendStopResponsivenessTimer stopper;
 
     m_sandboxExtensionTracker.beginLoad(WTFMove(parameters.sandboxExtensionHandle));

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -83,6 +83,7 @@
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <pal/spi/mac/NSSpellCheckerSPI.h>
 #import <wtf/MainThread.h>
+#import <wtf/Markable.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -1196,7 +1197,7 @@ void WebEditorClient::handleAcceptedCandidateWithSoftSpaces(TextCheckingResult a
 @interface WebEditorSpellCheckResponder : NSObject
 {
     WeakPtr<WebEditorClient> _client;
-    TextCheckingRequestIdentifier _identifier;
+    Markable<TextCheckingRequestIdentifier> _identifier;
     RetainPtr<NSArray> _results;
 }
 - (id)initWithClient:(WeakPtr<WebEditorClient>)client identifier:(TextCheckingRequestIdentifier)identifier results:(NSArray *)results;
@@ -1218,7 +1219,7 @@ void WebEditorClient::handleAcceptedCandidateWithSoftSpaces(TextCheckingResult a
 - (void)perform
 {
     if (_client)
-        _client->didCheckSucceed(_identifier, _results.get());
+        _client->didCheckSucceed(*_identifier, _results.get());
 }
 
 @end


### PR DESCRIPTION
#### b5bd0d309f05dcf79effd0033813a983ca08631d
<pre>
Reduce use of LegacyNullableObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=280980">https://bugs.webkit.org/show_bug.cgi?id=280980</a>

Reviewed by Sihui Liu.

* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::didCheck):
* Source/WebCore/editing/SpellChecker.h:
(WebCore::SpellChecker::lastRequestIdentifier const):
(WebCore::SpellChecker::lastProcessedIdentifier const):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::parse):
(WebCore::TextManipulationController::observeParagraphs):
(WebCore::TextManipulationController::addItem):
(WebCore::TextManipulationController::completeManipulation):
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/editing/TextManipulationControllerManipulationFailure.h:
* Source/WebCore/editing/TextManipulationItem.h:
* Source/WebCore/editing/TextManipulationItemIdentifier.h:
* Source/WebCore/editing/TextManipulationToken.h:
* Source/WebCore/history/BackForwardItemIdentifier.h:
* Source/WebCore/platform/SleepDisabler.cpp:
(WebCore::SleepDisabler::SleepDisabler):
(WebCore::SleepDisabler::~SleepDisabler):
* Source/WebCore/platform/SleepDisabler.h:
* Source/WebCore/platform/SleepDisablerIdentifier.h:
* Source/WebCore/platform/text/TextCheckingRequestIdentifier.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::lastSpellCheckRequestSequence):
(WebCore::Internals::lastSpellCheckProcessedSequence):
* Source/WebCore/workers/shared/SharedWorkerObjectIdentifier.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/Shared/DisplayLinkObserverID.h:
* Source/WebKit/Shared/DrawingAreaInfo.h:
* Source/WebKit/Shared/NetworkResourceLoadIdentifier.h:
* Source/WebKit/Shared/ProcessQualified.serialization.in:
* Source/WebKit/Shared/UserScriptIdentifier.h:
* Source/WebKit/Shared/UserStyleSheetIdentifier.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _startTextManipulationsWithConfiguration:completion:]):
(coreTextManipulationItemIdentifierFromString):
(coreTextManipulationTokenIdentifierFromString):
(-[WKWebView _completeTextManipulationForItems:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(-[_WKResourceLoadInfo initWithCoder:]):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::loadRequest):
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createAsyncContentsDisplayDelegate):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::drawingAreaIdentifier const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::goToBackForwardItem):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(-[WebEditorSpellCheckResponder perform]):

Canonical link: <a href="https://commits.webkit.org/284784@main">https://commits.webkit.org/284784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bc2067179396858e4ddf6a90b7122f09b6669d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20017 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76286 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63506 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5184 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10802 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/453 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->