### PR TITLE
Adopt smart pointers in more GPUProcess files

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -323,8 +323,9 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     // Use this flag to force synchronous messages to be treated as asynchronous messages in the WebProcess.
     // Otherwise, the WebProcess would process incoming synchronous IPC while waiting for a synchronous IPC
     // reply from the GPU process, which would be unsafe.
-    m_connection->setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(true);
-    m_connection->open(*this);
+    Ref connection = m_connection;
+    connection->setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(true);
+    connection->open(*this);
 
 #if ENABLE(VP9)
     bool hasVP9HardwareDecoder;
@@ -364,7 +365,7 @@ GPUConnectionToWebProcess::~GPUConnectionToWebProcess()
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
-    m_connection->invalidate();
+    protectedConnection()->invalidate();
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     protectedSampleBufferDisplayLayerManager()->close();
@@ -414,7 +415,7 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #endif
 #if ENABLE(VIDEO)
     protectedVideoFrameObjectHeap()->close();
-    m_remoteMediaPlayerManagerProxy->clear();
+    protectedRemoteMediaPlayerManagerProxy()->clear();
 #endif
     // RemoteRenderingBackend objects ref their GPUConnectionToWebProcess so we need to make sure
     // to break the reference cycle by destroying them.
@@ -436,8 +437,8 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
     m_libWebRTCCodecsProxy = nullptr;
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    if (m_cdmFactoryProxy)
-        m_cdmFactoryProxy->clear();
+    if (RefPtr cdmFactoryProxy = m_cdmFactoryProxy)
+        cdmFactoryProxy->clear();
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
@@ -574,8 +575,8 @@ void GPUConnectionToWebProcess::terminateWebProcess()
 
 void GPUConnectionToWebProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)
 {
-    if (m_sharedResourceCache)
-        m_sharedResourceCache->lowMemoryHandler();
+    if (RefPtr sharedResourceCache = m_sharedResourceCache)
+        sharedResourceCache->lowMemoryHandler();
 #if ENABLE(VIDEO)
     protectedVideoFrameObjectHeap()->lowMemoryHandler();
 #endif
@@ -1254,7 +1255,7 @@ void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPrefe
 {
     m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess);
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
-    m_libWebRTCCodecsProxy->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+    protectedLibWebRTCCodecsProxy()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -268,8 +268,6 @@ public:
 private:
     GPUConnectionToWebProcess(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
 
-    Ref<IPC::Connection> protectedConnection() const { return m_connection.copyRef(); }
-
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
     Ref<LibWebRTCCodecsProxy> protectedLibWebRTCCodecsProxy() const;
 #endif

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
@@ -90,7 +90,7 @@ void RemoteSharedResourceCache::releaseSerializedImageBuffer(WebCore::RenderingR
 void RemoteSharedResourceCache::lowMemoryHandler()
 {
 #if HAVE(IOSURFACE)
-    m_ioSurfacePool->discardAllSurfaces();
+    Ref { m_ioSurfacePool }->discardAllSurfaces();
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
@@ -64,7 +64,7 @@ void RemoteFaceDetector::detect(WebCore::RenderingResourceIdentifier renderingRe
         return;
     }
 
-    m_backing->detect(*sourceImage, WTFMove(completionHandler));
+    Ref { m_backing }->detect(*sourceImage, WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -84,6 +84,9 @@ private:
     RemoteBuffer& operator=(RemoteBuffer&&) = delete;
 
     WebCore::WebGPU::Buffer& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::Buffer> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -45,24 +45,29 @@ RemoteRenderBundle::RemoteRenderBundle(WebCore::WebGPU::RenderBundle& renderBund
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteRenderBundle::~RemoteRenderBundle() = default;
 
 void RemoteRenderBundle::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteRenderBundle::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteRenderBundle::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemoteRenderBundle::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -76,6 +76,8 @@ private:
 
     WebCore::WebGPU::RenderBundle& backing() { return m_backing; }
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -84,7 +84,7 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
     }
     auto textureView = protectedBacking()->createView(convertedDescriptor);
     MESSAGE_CHECK(textureView);
-    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), Ref { m_gpu.get() }, identifier);
+    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), objectHeap, m_streamConnection.copyRef(), Ref { m_gpu.get() }, identifier);
     objectHeap->addObject(identifier, remoteTextureView);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
@@ -73,7 +73,7 @@ Ref<RemoteGPU> RemoteXRBinding::protectedGPU()
 
 void RemoteXRBinding::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteXRBinding::createProjectionLayer(WebCore::WebGPU::TextureFormat colorFormat, std::optional<WebCore::WebGPU::TextureFormat> depthStencilFormat, WebCore::WebGPU::TextureUsageFlags textureUsage, double scaleFactor, WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -145,13 +145,13 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
 {
     String sceneIdentifier;
     std::optional<AudioSession::SoundStageSize> maxSize;
-    for (auto& proxy : m_proxies) {
-        if (!proxy.isActive())
+    for (Ref proxy : m_proxies) {
+        if (!proxy->isActive())
             continue;
 
-        if (!maxSize || proxy.soundStageSize() > *maxSize) {
-            maxSize = proxy.soundStageSize();
-            sceneIdentifier = proxy.sceneIdentifier();
+        if (!maxSize || proxy->soundStageSize() > *maxSize) {
+            maxSize = proxy->soundStageSize();
+            sceneIdentifier = proxy->sceneIdentifier();
         }
     }
 
@@ -161,8 +161,8 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
 
 bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude)
 {
-    for (auto& proxy : m_proxies) {
-        if (proxy.isActive() && &proxy != &proxyToExclude)
+    for (Ref proxy : m_proxies) {
+        if (proxy->isActive() && proxy.ptr() != &proxyToExclude)
             return true;
     }
     return false;
@@ -170,8 +170,8 @@ bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionP
 
 bool RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy()
 {
-    for (auto& proxy : m_proxies) {
-        if (proxy.isActive() && !proxy.isInterrupted())
+    for (Ref proxy : m_proxies) {
+        if (proxy->isActive() && !proxy->isInterrupted())
             return true;
     }
     return false;

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,16 +1,9 @@
 AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
-GPUProcess/GPUConnectionToWebProcess.cpp
-GPUProcess/RemoteSharedResourceCache.cpp
-GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
 GPUProcess/graphics/RemoteDisplayListRecorder.h
 GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
 GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
-GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
-GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
-GPUProcess/graphics/WebGPU/RemoteTexture.cpp
-GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
 GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
 GPUProcess/media/RemoteAudioTrackProxy.h
 GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -398,7 +391,6 @@ WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/GPUProcessConnection.cpp
 WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
-WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
 WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-GPUProcess/media/RemoteAudioSessionProxyManager.cpp
 NetworkProcess/NetworkLoadScheduler.cpp
 NetworkProcess/NetworkSession.cpp
 NetworkProcess/PingLoad.h

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -56,12 +56,17 @@ RemoteFaceDetectorProxy::RemoteFaceDetectorProxy(Ref<IPC::StreamClientConnection
 
 RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy()
 {
-    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier);
+    protectedStreamClientConnection()->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier);
 }
 
 void RemoteFaceDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
+    protectedStreamClientConnection()->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
+}
+
+Ref<IPC::StreamClientConnection> RemoteFaceDetectorProxy::protectedStreamClientConnection() const
+{
+    return m_streamClientConnection;
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -64,6 +64,8 @@ private:
 
     ShapeDetectionIdentifier backing() const { return m_backing; }
 
+    Ref<IPC::StreamClientConnection> protectedStreamClientConnection() const;
+
     void detect(Ref<WebCore::ImageBuffer>&&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&) final;
 
     ShapeDetectionIdentifier m_backing;


### PR DESCRIPTION
#### 697816712dab2d91eff5343d0511586edad9cd97
<pre>
Adopt smart pointers in more GPUProcess files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280988">https://bugs.webkit.org/show_bug.cgi?id=280988</a>
<a href="https://rdar.apple.com/137437166">rdar://137437166</a>

Reviewed by Ryosuke Niwa and Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::~GPUConnectionToWebProcess):
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::lowMemoryHandler):
(WebKit::GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::protectedConnection const): Deleted.
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp:
(WebKit::RemoteSharedResourceCache::lowMemoryHandler):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp:
(WebKit::RemoteFaceDetector::detect):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::RemoteBuffer):
(WebKit::RemoteBuffer::stopListeningForIPC):
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::getMappedRange):
(WebKit::RemoteBuffer::unmap):
(WebKit::RemoteBuffer::copy):
(WebKit::RemoteBuffer::destroy):
(WebKit::RemoteBuffer::destruct):
(WebKit::RemoteBuffer::setLabel):
(WebKit::RemoteBuffer::protectedBacking):
(WebKit::RemoteBuffer::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp:
(WebKit::RemoteRenderBundle::RemoteRenderBundle):
(WebKit::RemoteRenderBundle::destruct):
(WebKit::RemoteRenderBundle::stopListeningForIPC):
(WebKit::RemoteRenderBundle::setLabel):
(WebKit::RemoteRenderBundle::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::createView):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp:
(WebKit::RemoteXRBinding::destruct):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateSpatialExperience):
(WebKit::RemoteAudioSessionProxyManager::hasOtherActiveProxyThan):
(WebKit::RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::detect):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::protectedStreamClientConnection const):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:

Canonical link: <a href="https://commits.webkit.org/284789@main">https://commits.webkit.org/284789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea18f1009e169f9c0c787505820e879429f2865

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42047 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63517 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5198 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46778 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->