### PR TITLE
Adopt more smart pointers in Source/WebCore/Modules/media*

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -65,11 +65,12 @@ void ArtworkImageLoader::requestImageResource()
 {
     ASSERT(!m_cachedImage, "Can only call requestImageResource once");
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
-    options.contentSecurityPolicyImposition = m_document.isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+    Ref document = m_document.get();
+    options.contentSecurityPolicyImposition = document->isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
-    CachedResourceRequest request(ResourceRequest(m_document.completeURL(m_src)), options);
-    request.setInitiatorType(AtomString { m_document.documentURI() });
-    m_cachedImage = m_document.protectedCachedResourceLoader()->requestImage(WTFMove(request)).value_or(nullptr);
+    CachedResourceRequest request(ResourceRequest(document->completeURL(m_src)), options);
+    request.setInitiatorType(AtomString { document->documentURI() });
+    m_cachedImage = document->protectedCachedResourceLoader()->requestImage(WTFMove(request)).value_or(nullptr);
 
     if (m_cachedImage)
         m_cachedImage->addClient(*this);

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -31,6 +31,7 @@
 #include "CachedResourceHandle.h"
 #include "MediaMetadataInit.h"
 #include "MediaSession.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
@@ -42,6 +43,7 @@ namespace WebCore {
 class CachedImage;
 class Document;
 class Image;
+class WeakPtrImplWithEventTargetData;
 struct MediaImage;
 
 using MediaSessionMetadata = MediaMetadataInit;
@@ -61,7 +63,7 @@ protected:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
 private:
-    Document& m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     const String m_src;
     ArtworkImageLoaderCallback m_callback;
     CachedResourceHandle<CachedImage> m_cachedImage;

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
@@ -57,7 +57,7 @@ RefPtr<MediaSession> NavigatorMediaSession::mediaSessionIfExists(Navigator& navi
 MediaSession& NavigatorMediaSession::mediaSession()
 {
     if (!m_mediaSession)
-        m_mediaSession = MediaSession::create(m_navigator);
+        m_mediaSession = MediaSession::create(Ref { m_navigator.get() });
     return *m_mediaSession;
 }
 

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_SESSION)
 
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -52,7 +53,7 @@ private:
     static ASCIILiteral supplementName();
 
     RefPtr<MediaSession> m_mediaSession;
-    Navigator& m_navigator;
+    CheckedRef<Navigator> m_navigator;
 };
 
 }

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -123,7 +123,7 @@ PeerConnectionBackend::~PeerConnectionBackend() = default;
 void PeerConnectionBackend::createOffer(RTCOfferOptions&& options, CreateCallback&& callback)
 {
     ASSERT(!m_offerAnswerCallback);
-    ASSERT(!m_peerConnection.isClosed());
+    ASSERT(!m_peerConnection->isClosed());
 
     m_offerAnswerCallback = WTFMove(callback);
     doCreateOffer(WTFMove(options));
@@ -136,7 +136,8 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
 
     ASSERT(m_offerAnswerCallback);
     validateSDP(sdp);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Offer, sdp });
     });
 }
@@ -147,7 +148,8 @@ void PeerConnectionBackend::createOfferFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Create offer failed:", exception.message());
 
     ASSERT(m_offerAnswerCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
         callback(WTFMove(exception));
     });
 }
@@ -155,7 +157,7 @@ void PeerConnectionBackend::createOfferFailed(Exception&& exception)
 void PeerConnectionBackend::createAnswer(RTCAnswerOptions&& options, CreateCallback&& callback)
 {
     ASSERT(!m_offerAnswerCallback);
-    ASSERT(!m_peerConnection.isClosed());
+    ASSERT(!m_peerConnection->isClosed());
 
     m_offerAnswerCallback = WTFMove(callback);
     doCreateAnswer(WTFMove(options));
@@ -167,7 +169,8 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
     ALWAYS_LOG(LOGIDENTIFIER, "Create answer succeeded:\n", sdp);
 
     ASSERT(m_offerAnswerCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Answer, sdp });
     });
 }
@@ -178,14 +181,15 @@ void PeerConnectionBackend::createAnswerFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Create answer failed:", exception.message());
 
     ASSERT(m_offerAnswerCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
         callback(WTFMove(exception));
     });
 }
 
 void PeerConnectionBackend::setLocalDescription(const RTCSessionDescription* sessionDescription, Function<void(ExceptionOr<void>&&)>&& callback)
 {
-    ASSERT(!m_peerConnection.isClosed());
+    ASSERT(!m_peerConnection->isClosed());
 
     m_isProcessingLocalDescriptionAnswer = sessionDescription && (sessionDescription->type() == RTCSdpType::Answer || sessionDescription->type() == RTCSdpType::Pranswer);
     m_setDescriptionCallback = WTFMove(callback);
@@ -242,21 +246,23 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
     if (transceiverStates)
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
-        if (m_peerConnection.isClosed())
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
+        Ref peerConnection = m_peerConnection.get();
+        if (peerConnection->isClosed())
             return;
 
-        m_peerConnection.updateTransceiversAfterSuccessfulLocalDescription();
-        m_peerConnection.updateSctpBackend(WTFMove(sctpBackend), maxMessageSize);
+        peerConnection->updateTransceiversAfterSuccessfulLocalDescription();
+        peerConnection->updateSctpBackend(WTFMove(sctpBackend), maxMessageSize);
 
         if (descriptionStates) {
-            m_peerConnection.updateDescriptions(WTFMove(*descriptionStates));
-            if (m_peerConnection.isClosed())
+            peerConnection->updateDescriptions(WTFMove(*descriptionStates));
+            if (peerConnection->isClosed())
                 return;
         }
 
-        m_peerConnection.processIceTransportChanges();
-        if (m_peerConnection.isClosed())
+        peerConnection->processIceTransportChanges();
+        if (peerConnection->isClosed())
             return;
 
         if (m_isProcessingLocalDescriptionAnswer && transceiverStates) {
@@ -266,7 +272,7 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
             Vector<MediaStreamAndTrackItem> addListNoOp;
             for (auto& transceiverState : *transceiverStates) {
                 RefPtr<RTCRtpTransceiver> transceiver;
-                for (auto& item : m_peerConnection.currentTransceivers()) {
+                for (auto& item : peerConnection->currentTransceivers()) {
                     if (item->mid() == transceiverState.mid) {
                         transceiver = item;
                         break;
@@ -284,13 +290,13 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
                 track->setShouldFireMuteEventImmediately(true);
                 track->source().setMuted(true);
                 track->setShouldFireMuteEventImmediately(false);
-                if (m_peerConnection.isClosed())
+                if (peerConnection->isClosed())
                     return;
             }
 
             for (auto& pair : removeList) {
                 pair.stream->privateStream().removeTrack(pair.track->privateTrack());
-                if (m_peerConnection.isClosed())
+                if (peerConnection->isClosed())
                     return;
             }
         }
@@ -305,8 +311,9 @@ void PeerConnectionBackend::setLocalDescriptionFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Set local description failed:", exception.message());
 
     ASSERT(m_setDescriptionCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
-        if (m_peerConnection.isClosed())
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
+        if (m_peerConnection->isClosed())
             return;
 
         callback(WTFMove(exception));
@@ -315,7 +322,7 @@ void PeerConnectionBackend::setLocalDescriptionFailed(Exception&& exception)
 
 void PeerConnectionBackend::setRemoteDescription(const RTCSessionDescription& sessionDescription, Function<void(ExceptionOr<void>&&)>&& callback)
 {
-    ASSERT(!m_peerConnection.isClosed());
+    ASSERT(!m_peerConnection->isClosed());
 
     m_setDescriptionCallback = WTFMove(callback);
     doSetRemoteDescription(sessionDescription);
@@ -329,13 +336,15 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
 
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
-        if (m_peerConnection.isClosed())
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
+        Ref peerConnection = m_peerConnection.get();
+        if (peerConnection->isClosed())
             return;
 
         Vector<MediaStreamAndTrackItem> removeList;
         if (transceiverStates) {
-            for (auto& transceiver : m_peerConnection.currentTransceivers()) {
+            for (auto& transceiver : peerConnection->currentTransceivers()) {
                 if (!anyOf(*transceiverStates, [&transceiver](auto& state) { return state.mid == transceiver->mid(); })) {
                     for (auto& stream : transceiver->receiver().associatedStreams()) {
                         if (stream)
@@ -345,19 +354,19 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             }
         }
 
-        m_peerConnection.updateTransceiversAfterSuccessfulRemoteDescription();
-        m_peerConnection.updateSctpBackend(WTFMove(sctpBackend), maxMessageSize);
+        peerConnection->updateTransceiversAfterSuccessfulRemoteDescription();
+        peerConnection->updateSctpBackend(WTFMove(sctpBackend), maxMessageSize);
 
         if (descriptionStates) {
-            m_peerConnection.updateDescriptions(WTFMove(*descriptionStates));
-            if (m_peerConnection.isClosed()) {
+            peerConnection->updateDescriptions(WTFMove(*descriptionStates));
+            if (peerConnection->isClosed()) {
                 DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed after descriptions update");
                 return;
             }
         }
 
-        m_peerConnection.processIceTransportChanges();
-        if (m_peerConnection.isClosed()) {
+        peerConnection->processIceTransportChanges();
+        if (peerConnection->isClosed()) {
             DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed after ICE transport changes");
             return;
         }
@@ -369,7 +378,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             Vector<Ref<RTCTrackEvent>> trackEventList;
             for (auto& transceiverState : *transceiverStates) {
                 RefPtr<RTCRtpTransceiver> transceiver;
-                for (auto& item : m_peerConnection.currentTransceivers()) {
+                for (auto& item : peerConnection->currentTransceivers()) {
                     if (item->mid() == transceiverState.mid) {
                         transceiver = item;
                         break;
@@ -384,7 +393,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
                 track->setShouldFireMuteEventImmediately(true);
                 track->source().setMuted(true);
                 track->setShouldFireMuteEventImmediately(false);
-                if (m_peerConnection.isClosed()) {
+                if (peerConnection->isClosed()) {
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while processing muted tracks");
                     return;
                 }
@@ -393,7 +402,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             DEBUG_LOG(LOGIDENTIFIER, "Removing ", removeList.size(), " tracks");
             for (auto& pair : removeList) {
                 pair.stream->privateStream().removeTrack(pair.track->privateTrack());
-                if (m_peerConnection.isClosed()) {
+                if (peerConnection->isClosed()) {
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while removing tracks");
                     return;
                 }
@@ -402,7 +411,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             DEBUG_LOG(LOGIDENTIFIER, "Adding ", addList.size(), " tracks");
             for (auto& pair : addList) {
                 pair.stream->addTrackFromPlatform(pair.track.copyRef());
-                if (m_peerConnection.isClosed()) {
+                if (peerConnection->isClosed()) {
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while adding tracks");
                     return;
                 }
@@ -411,8 +420,8 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             DEBUG_LOG(LOGIDENTIFIER, "Dispatching ", trackEventList.size(), " track events");
             for (auto& event : trackEventList) {
                 RefPtr track = event->track();
-                m_peerConnection.dispatchEvent(event);
-                if (m_peerConnection.isClosed()) {
+                peerConnection->dispatchEvent(event);
+                if (peerConnection->isClosed()) {
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while dispatching track events");
                     return;
                 }
@@ -431,8 +440,9 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Set remote description failed:", exception.message());
 
     ASSERT(m_setDescriptionCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
-        if (m_peerConnection.isClosed())
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
+        if (m_peerConnection->isClosed())
             return;
 
         callback(WTFMove(exception));
@@ -441,13 +451,19 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
 
 void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
 {
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, state] {
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, state] {
         if (state == RTCIceGatheringState::Complete) {
             doneGatheringCandidates();
             return;
         }
-        m_peerConnection.updateIceGatheringState(state);
+        protectedPeerConnection()->updateIceGatheringState(state);
     });
+}
+
+Ref<RTCPeerConnection> PeerConnectionBackend::protectedPeerConnection() const
+{
+    return m_peerConnection.get();
 }
 
 static String extractIPAddress(StringView sdp)
@@ -475,7 +491,7 @@ static inline bool shouldIgnoreIceCandidate(const RTCIceCandidate& iceCandidate)
 
 void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Function<void(ExceptionOr<void>&&)>&& callback)
 {
-    ASSERT(!m_peerConnection.isClosed());
+    ASSERT(!m_peerConnection->isClosed());
 
     if (!iceCandidate) {
         callback({ });
@@ -491,9 +507,9 @@ void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Funct
         if (!weakThis)
             return;
 
-        auto& peerConnection = weakThis->m_peerConnection;
-        peerConnection.queueTaskKeepingObjectAlive(peerConnection, TaskSource::Networking, [&peerConnection, callback = WTFMove(callback), result = std::forward<Result>(result)] () mutable {
-            if (peerConnection.isClosed())
+        Ref peerConnection = weakThis->m_peerConnection.get();
+        peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [peerConnection, callback = WTFMove(callback), result = std::forward<Result>(result)] () mutable {
+            if (peerConnection->isClosed())
                 return;
 
             if (result.hasException()) {
@@ -503,7 +519,7 @@ void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Funct
             }
 
             if (auto descriptions = result.releaseReturnValue())
-                peerConnection.updateDescriptions(WTFMove(*descriptions));
+                peerConnection->updateDescriptions(WTFMove(*descriptions));
             callback({ });
         });
     });
@@ -534,14 +550,16 @@ void PeerConnectionBackend::validateSDP(const String& sdp) const
 
 void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned short sdpMLineIndex, String&& serverURL, std::optional<DescriptionStates>&& descriptions)
 {
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, sdp = WTFMove(sdp), mid = WTFMove(mid), sdpMLineIndex, serverURL = WTFMove(serverURL), descriptions = WTFMove(descriptions)]() mutable {
-        if (m_peerConnection.isClosed())
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, sdp = WTFMove(sdp), mid = WTFMove(mid), sdpMLineIndex, serverURL = WTFMove(serverURL), descriptions = WTFMove(descriptions)]() mutable {
+        Ref peerConnection = m_peerConnection.get();
+        if (peerConnection->isClosed())
             return;
 
         if (descriptions)
-            m_peerConnection.updateDescriptions(WTFMove(*descriptions));
+            peerConnection->updateDescriptions(WTFMove(*descriptions));
 
-        if (m_peerConnection.isClosed())
+        if (peerConnection->isClosed())
             return;
 
         UNUSED_PARAM(logSiteIdentifier);
@@ -550,18 +568,19 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
 
         ASSERT(!m_shouldFilterICECandidates || sdp.contains(".local"_s) || sdp.contains(" srflx "_s) || sdp.contains(" relay "_s));
         auto candidate = RTCIceCandidate::create(WTFMove(sdp), WTFMove(mid), sdpMLineIndex);
-        m_peerConnection.dispatchEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, WTFMove(candidate), WTFMove(serverURL)));
+        peerConnection->dispatchEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, WTFMove(candidate), WTFMove(serverURL)));
     });
 }
 
 void PeerConnectionBackend::newDataChannel(UniqueRef<RTCDataChannelHandler>&& channelHandler, String&& label, RTCDataChannelInit&& channelInit)
 {
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [connection = Ref { m_peerConnection }, label = WTFMove(label), channelHandler = WTFMove(channelHandler), channelInit = WTFMove(channelInit)]() mutable {
-        if (connection->isClosed())
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [peerConnection, label = WTFMove(label), channelHandler = WTFMove(channelHandler), channelInit = WTFMove(channelInit)]() mutable {
+        if (peerConnection->isClosed())
             return;
 
-        auto channel = RTCDataChannel::create(*connection->document(), channelHandler.moveToUniquePtr(), WTFMove(label), WTFMove(channelInit), RTCDataChannelState::Open);
-        connection->dispatchEvent(RTCDataChannelEvent::create(eventNames().datachannelEvent, Event::CanBubble::No, Event::IsCancelable::No, Ref { channel }));
+        auto channel = RTCDataChannel::create(*peerConnection->document(), channelHandler.moveToUniquePtr(), WTFMove(label), WTFMove(channelInit), RTCDataChannelState::Open);
+        peerConnection->dispatchEvent(RTCDataChannelEvent::create(eventNames().datachannelEvent, Event::CanBubble::No, Event::IsCancelable::No, Ref { channel }));
         channel->fireOpenEventIfNeeded();
     });
 }
@@ -572,8 +591,9 @@ void PeerConnectionBackend::doneGatheringCandidates()
     ALWAYS_LOG(LOGIDENTIFIER, "Finished ice candidate gathering");
     m_finishedGatheringCandidates = true;
 
-    m_peerConnection.scheduleEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, nullptr, { }));
-    m_peerConnection.updateIceGatheringState(RTCIceGatheringState::Complete);
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->scheduleEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, nullptr, { }));
+    peerConnection->updateIceGatheringState(RTCIceGatheringState::Complete);
 }
 
 void PeerConnectionBackend::stop()
@@ -586,7 +606,7 @@ void PeerConnectionBackend::stop()
 
 void PeerConnectionBackend::markAsNeedingNegotiation(uint32_t eventId)
 {
-    m_peerConnection.updateNegotiationNeededFlag(eventId);
+    protectedPeerConnection()->updateNegotiationNeededFlag(eventId);
 }
 
 ExceptionOr<Ref<RTCRtpSender>> PeerConnectionBackend::addTrack(MediaStreamTrack&, FixedVector<String>&&)
@@ -632,7 +652,7 @@ void PeerConnectionBackend::generateCertificate(Document& document, const Certif
 
 ScriptExecutionContext* PeerConnectionBackend::context() const
 {
-    return m_peerConnection.scriptExecutionContext();
+    return protectedPeerConnection()->scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -675,6 +695,16 @@ static String toJSONString(const PeerConnectionBackend::TransceiverState& transc
 static String toJSONString(const PeerConnectionBackend::TransceiverStates& transceiverStates)
 {
     return toJSONArray(transceiverStates)->toJSONString();
+}
+
+void PeerConnectionBackend::ref() const
+{
+    m_peerConnection->ref();
+}
+
+void PeerConnectionBackend::deref() const
+{
+    m_peerConnection->deref();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -48,11 +48,6 @@ namespace WebCore {
 class PeerConnectionBackend;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PeerConnectionBackend> : std::true_type { };
-}
-
 namespace WebCore {
 
 class DeferredPromise;
@@ -73,6 +68,7 @@ class RTCSctpTransportBackend;
 class RTCSessionDescription;
 class RTCStatsReport;
 class ScriptExecutionContext;
+class WeakPtrImplWithEventTargetData;
 
 struct MediaEndpointConfiguration;
 struct RTCAnswerOptions;
@@ -224,6 +220,9 @@ public:
     virtual void startGatheringStatLogs(Function<void(String&&)>&&) { }
     virtual void stopGatheringStatLogs() { }
 
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
+
 protected:
     void doneGatheringCandidates();
 
@@ -250,7 +249,8 @@ private:
     virtual void doStop() = 0;
 
 protected:
-    RTCPeerConnection& m_peerConnection;
+    Ref<RTCPeerConnection> protectedPeerConnection() const;
+    WeakRef<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_peerConnection;
 
 private:
     CreateCallback m_offerAnswerCallback;

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -133,7 +133,7 @@ public:
     RTCPeerConnectionState connectionState() const { return m_connectionState; }
     std::optional<bool> canTrickleIceCandidates() const;
 
-    void restartIce() { m_backend->restartIce(); }
+    void restartIce() { protectedBackend()->restartIce(); }
     const RTCConfiguration& getConfiguration() const { return m_configuration; }
     ExceptionOr<void> setConfiguration(RTCConfiguration&&);
     void close();
@@ -180,8 +180,8 @@ public:
 
     void scheduleEvent(Ref<Event>&&);
 
-    void disableICECandidateFiltering() { m_backend->disableICECandidateFiltering(); }
-    void enableICECandidateFiltering() { m_backend->enableICECandidateFiltering(); }
+    void disableICECandidateFiltering() { protectedBackend()->disableICECandidateFiltering(); }
+    void enableICECandidateFiltering() { protectedBackend()->enableICECandidateFiltering(); }
 
     void clearController() { m_controller = nullptr; }
 
@@ -221,7 +221,7 @@ private:
     void unregisterFromController();
 
     friend class Internals;
-    void applyRotationForOutgoingVideoSources() { m_backend->applyRotationForOutgoingVideoSources(); }
+    void applyRotationForOutgoingVideoSources() { protectedBackend()->applyRotationForOutgoingVideoSources(); }
 
     // EventTarget implementation.
     void refEventTarget() final { ref(); }
@@ -240,7 +240,7 @@ private:
     bool doClose();
     void doStop();
 
-    void getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise) { m_backend->getStats(sender, WTFMove(promise)); }
+    void getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise) { protectedBackend()->getStats(sender, WTFMove(promise)); }
 
     ExceptionOr<Vector<MediaEndpointConfiguration::CertificatePEM>> certificatesFromConfiguration(const RTCConfiguration&);
     void chainOperation(Ref<DeferredPromise>&&, Function<void(Ref<DeferredPromise>&&)>&&);
@@ -253,6 +253,8 @@ private:
     void updateTransceiverTransports();
 
     void setSignalingState(RTCSignalingState);
+
+    WEBCORE_EXPORT RefPtr<PeerConnectionBackend> protectedBackend() const;
 
     bool m_isStopped { false };
     RTCSignalingState m_signalingState { RTCSignalingState::Stable };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -94,7 +94,7 @@ private:
 
     friend class GStreamerMediaEndpoint;
     friend class GStreamerRtpSenderBackend;
-    RTCPeerConnection& connection() { return m_peerConnection; }
+    RTCPeerConnection& connection();
 
     void getStatsSucceeded(const DeferredPromise&, Ref<RTCStatsReport>&&);
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -31,6 +31,7 @@
 #include "LibWebRTCRtpSenderBackend.h"
 #include "RTCRtpReceiver.h"
 #include "Timer.h"
+#include <wtf/WeakRef.h>
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -180,7 +181,9 @@ private:
     Seconds statsLogInterval(int64_t) const;
 #endif
 
-    LibWebRTCPeerConnectionBackend& m_peerConnectionBackend;
+    Ref<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
+
+    WeakRef<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
     rtc::scoped_refptr<webrtc::PeerConnectionInterface> m_backend;
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
@@ -113,8 +113,13 @@ bool LibWebRTCRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTr
         });
     }
 
-    m_peerConnectionBackend->setSenderSourceFromTrack(*this, *track);
+    protectedPeerConnectionBackend()->setSenderSourceFromTrack(*this, *track);
     return true;
+}
+
+RefPtr<LibWebRTCPeerConnectionBackend> LibWebRTCRtpSenderBackend::protectedPeerConnectionBackend() const
+{
+    return m_peerConnectionBackend.get();
 }
 
 RTCRtpSendParameters LibWebRTCRtpSenderBackend::getParameters() const

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -83,6 +83,8 @@ private:
     void stopSource();
     bool hasSource() const;
 
+    RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
+
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     rtc::scoped_refptr<webrtc::RtpSenderInterface> m_rtcSender;
     Source m_source;


### PR DESCRIPTION
#### 05041db2a3337b59c1602f9339b941a600bf7768
<pre>
Adopt more smart pointers in Source/WebCore/Modules/media*
<a href="https://bugs.webkit.org/show_bug.cgi?id=280992">https://bugs.webkit.org/show_bug.cgi?id=280992</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::requestImageResource):
* Source/WebCore/Modules/mediasession/MediaMetadata.h:
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp:
(WebCore::NavigatorMediaSession::mediaSession):
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::createOffer):
(WebCore::PeerConnectionBackend::createOfferSucceeded):
(WebCore::PeerConnectionBackend::createOfferFailed):
(WebCore::PeerConnectionBackend::createAnswer):
(WebCore::PeerConnectionBackend::createAnswerSucceeded):
(WebCore::PeerConnectionBackend::createAnswerFailed):
(WebCore::PeerConnectionBackend::setLocalDescription):
(WebCore::PeerConnectionBackend::setLocalDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setLocalDescriptionFailed):
(WebCore::PeerConnectionBackend::setRemoteDescription):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setRemoteDescriptionFailed):
(WebCore::PeerConnectionBackend::iceGatheringStateChanged):
(WebCore::PeerConnectionBackend::protectedPeerConnection const):
(WebCore::PeerConnectionBackend::addIceCandidate):
(WebCore::PeerConnectionBackend::newICECandidate):
(WebCore::PeerConnectionBackend::newDataChannel):
(WebCore::PeerConnectionBackend::doneGatheringCandidates):
(WebCore::PeerConnectionBackend::markAsNeedingNegotiation):
(WebCore::PeerConnectionBackend::context const):
(WebCore::PeerConnectionBackend::ref const):
(WebCore::PeerConnectionBackend::deref const):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::createGStreamerPeerConnectionBackend):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::setConfiguration):
(WebCore::LibWebRTCMediaEndpoint::doSetLocalDescription):
(WebCore::LibWebRTCMediaEndpoint::doSetRemoteDescription):
(WebCore::LibWebRTCMediaEndpoint::addTrack):
(WebCore::LibWebRTCMediaEndpoint::mediaStreamFromRTCStreamId):
(WebCore::LibWebRTCMediaEndpoint::collectTransceivers):
(WebCore::LibWebRTCMediaEndpoint::createTransceiverBackends):
(WebCore::LibWebRTCMediaEndpoint::createSourceAndRTCTrack):
(WebCore::LibWebRTCMediaEndpoint::OnDataChannel):
(WebCore::LibWebRTCMediaEndpoint::OnNegotiationNeededEvent):
(WebCore::LibWebRTCMediaEndpoint::OnStandardizedIceConnectionChange):
(WebCore::LibWebRTCMediaEndpoint::OnIceGatheringChange):
(WebCore::LibWebRTCMediaEndpoint::OnIceCandidate):
(WebCore::LibWebRTCMediaEndpoint::createSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::createSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::protectedPeerConnectionBackend const):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::OnStatsDelivered):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::createLibWebRTCPeerConnectionBackend):
(WebCore::LibWebRTCPeerConnectionBackend::shouldEnableWebRTCL4S const):
(WebCore::LibWebRTCPeerConnectionBackend::setConfiguration):
(WebCore::LibWebRTCPeerConnectionBackend::createReceiver):
(WebCore::LibWebRTCPeerConnectionBackend::addTrack):
(WebCore::LibWebRTCPeerConnectionBackend::addTransceiverFromTrackOrKind):
(WebCore::LibWebRTCPeerConnectionBackend::existingTransceiver):
(WebCore::LibWebRTCPeerConnectionBackend::newRemoteTransceiver):
(WebCore::LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources):

Canonical link: <a href="https://commits.webkit.org/284841@main">https://commits.webkit.org/284841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bb2baaed824df41c1c8edf6d8be5f92a3e91672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55960 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14427 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63626 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5323 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10829 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/633 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->