### PR TITLE
SWRegistrationStore and WebRegistrationStore should be ref counted

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationStore.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationStore.h
@@ -36,7 +36,7 @@ class ServiceWorkerRegistrationKey;
 
 struct ServiceWorkerContextData;
 
-class SWRegistrationStore {
+class SWRegistrationStore : public RefCountedAndCanMakeWeakPtr<SWRegistrationStore> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SWRegistrationStore);
 public:
     virtual ~SWRegistrationStore() = default;
@@ -46,6 +46,9 @@ public:
     virtual void importRegistrations(CompletionHandler<void(std::optional<Vector<ServiceWorkerContextData>>)>&&) = 0;
     virtual void updateRegistration(const ServiceWorkerContextData&) = 0;
     virtual void removeRegistration(const ServiceWorkerRegistrationKey&) = 0;
+
+protected:
+    SWRegistrationStore() = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -356,7 +356,7 @@ private:
     MemoryCompactRobinHoodHashMap<String, ScriptExecutionContextIdentifier> m_visibleClientIdToInternalClientIdMap;
 
     UniqueRef<SWOriginStore> m_originStore;
-    std::unique_ptr<SWRegistrationStore> m_registrationStore;
+    RefPtr<SWRegistrationStore> m_registrationStore;
     HashMap<RegistrableDomain, Vector<ServiceWorkerContextData>> m_pendingContextDatas;
     HashMap<RegistrableDomain, HashMap<ServiceWorkerIdentifier, Vector<RunServiceWorkerCallback>>> m_serviceWorkerRunRequests;
     PAL::SessionID m_sessionID;

--- a/Source/WebCore/workers/service/server/SWServerDelegate.h
+++ b/Source/WebCore/workers/service/server/SWServerDelegate.h
@@ -67,7 +67,7 @@ public:
     virtual void requestBackgroundFetchPermission(const ClientOrigin&, CompletionHandler<void(bool)>&&) = 0;
     virtual RefPtr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoaderClient&, const BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&) = 0;
     virtual Ref<BackgroundFetchStore> createBackgroundFetchStore() = 0;
-    virtual std::unique_ptr<SWRegistrationStore> createUniqueRegistrationStore(SWServer&) = 0;
+    virtual RefPtr<SWRegistrationStore> createRegistrationStore(SWServer&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -809,12 +809,12 @@ void NetworkSession::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier w
     m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies), LoadedWebArchive::No, [] { });
 }
 
-std::unique_ptr<SWRegistrationStore> NetworkSession::createUniqueRegistrationStore(WebCore::SWServer& server)
+RefPtr<SWRegistrationStore> NetworkSession::createRegistrationStore(WebCore::SWServer& server)
 {
     if (m_sessionID.isEphemeral())
         return nullptr;
 
-    return makeUnique<WebSWRegistrationStore>(server, m_storageManager.get());
+    return WebSWRegistrationStore::create(server, m_storageManager.get());
 }
 
 RefPtr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFetchRecordLoader(BackgroundFetchRecordLoaderClient& client, const WebCore::BackgroundFetchRequest& request, size_t responseDataSize, const ClientOrigin& clientOrigin)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -288,7 +288,7 @@ protected:
     void createContextConnection(const WebCore::RegistrableDomain&, std::optional<WebCore::ProcessIdentifier>, std::optional<WebCore::ScriptExecutionContextIdentifier>, CompletionHandler<void()>&&) final;
     void appBoundDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&) final;
     void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, std::optional<WebCore::ProcessIdentifier>, WebCore::RegistrableDomain&&) final;
-    std::unique_ptr<WebCore::SWRegistrationStore> createUniqueRegistrationStore(WebCore::SWServer&) final;
+    RefPtr<WebCore::SWRegistrationStore> createRegistrationStore(WebCore::SWServer&) final;
     void requestBackgroundFetchPermission(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&) final;
     RefPtr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoaderClient&, const WebCore::BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&) final;
     Ref<WebCore::BackgroundFetchStore> createBackgroundFetchStore() final;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -34,6 +34,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWRegistrationStore);
 
+Ref<WebSWRegistrationStore> WebSWRegistrationStore::create(WebCore::SWServer& server, NetworkStorageManager& manager)
+{
+    return adoptRef(*new WebSWRegistrationStore(server, manager));
+}
+
 WebSWRegistrationStore::WebSWRegistrationStore(WebCore::SWServer& server, NetworkStorageManager& manager)
     : m_server(server)
     , m_manager(manager)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -35,11 +35,6 @@ namespace WebKit {
 class WebSWRegistrationStore;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebSWRegistrationStore> : std::true_type { };
-}
-
 namespace WebCore {
 class SWServer;
 }
@@ -48,12 +43,14 @@ namespace WebKit {
 
 class NetworkStorageManager;
 
-class WebSWRegistrationStore final : public WebCore::SWRegistrationStore, public CanMakeWeakPtr<WebSWRegistrationStore> {
+class WebSWRegistrationStore final : public WebCore::SWRegistrationStore {
     WTF_MAKE_TZONE_ALLOCATED(WebSWRegistrationStore);
 public:
-    WebSWRegistrationStore(WebCore::SWServer&, NetworkStorageManager&);
+    static Ref<WebSWRegistrationStore> create(WebCore::SWServer&, NetworkStorageManager&);
 
 private:
+    WebSWRegistrationStore(WebCore::SWServer&, NetworkStorageManager&);
+
     // WebCore::SWRegistrationStore
     void clearAll(CompletionHandler<void()>&&);
     void flushChanges(CompletionHandler<void()>&&);


### PR DESCRIPTION
#### c592945a30a96721ad40fec9be8d6777909ace97
<pre>
SWRegistrationStore and WebRegistrationStore should be ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=280993">https://bugs.webkit.org/show_bug.cgi?id=280993</a>

Reviewed by Sihui Liu.

Make SWRegistrationStore and WebSWRegistrationStore ref counted as they also support WeakPtr.

* Source/WebCore/workers/service/server/SWRegistrationStore.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::removeRegistration):
(WebCore::SWServer::storeRegistrationsOnDisk):
(WebCore::SWServer::clearAll):
(WebCore::SWServer::clearInternal):
(WebCore::SWServer::SWServer):
(WebCore::SWServer::storeRegistrationForWorker):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerDelegate.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::createRegistrationStore): Renamed.
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::create):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:

Canonical link: <a href="https://commits.webkit.org/284810@main">https://commits.webkit.org/284810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dee4e3b2d0065e19009918327511288bd2a867f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55891 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76341 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63543 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5228 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10813 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/507 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->