### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for NavigatorGamepad

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.h
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class Gamepad;
 class LocalDOMWindow;
-class NavigatorGamepad;
+class Navigator;
 class WeakPtrImplWithEventTargetData;
 
 class GamepadManager : public GamepadProviderClient {
@@ -50,8 +50,8 @@ public:
     void platformGamepadDisconnected(PlatformGamepad&) final;
     void platformGamepadInputActivity(EventMakesGamepadsVisible) final;
 
-    void registerNavigator(NavigatorGamepad&);
-    void unregisterNavigator(NavigatorGamepad&);
+    void registerNavigator(Navigator&);
+    void unregisterNavigator(Navigator&);
     void registerDOMWindow(LocalDOMWindow&);
     void unregisterDOMWindow(LocalDOMWindow&);
 
@@ -62,25 +62,25 @@ public:
 private:
     GamepadManager();
 
-    void makeGamepadVisible(PlatformGamepad&, WeakHashSet<NavigatorGamepad>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
+    void makeGamepadVisible(PlatformGamepad&, WeakHashSet<Navigator>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
     void dispatchGamepadEvent(const AtomString& eventName, PlatformGamepad&);
 
     void maybeStartMonitoringGamepads();
     void maybeStopMonitoringGamepads();
 
 #if PLATFORM(VISION)
-    void findUnquarantinedNavigatorsAndWindows(WeakHashSet<NavigatorGamepad>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
+    void findUnquarantinedNavigatorsAndWindows(WeakHashSet<Navigator>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
 #endif
 
     bool m_isMonitoringGamepads;
 
-    WeakHashSet<NavigatorGamepad> m_navigators;
-    WeakHashSet<NavigatorGamepad> m_gamepadBlindNavigators;
+    WeakHashSet<Navigator> m_navigators;
+    WeakHashSet<Navigator> m_gamepadBlindNavigators;
     WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_domWindows;
     WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_gamepadBlindDOMWindows;
 
 #if PLATFORM(VISION)
-    WeakHashSet<NavigatorGamepad> m_gamepadQuarantinedNavigators;
+    WeakHashSet<Navigator> m_gamepadQuarantinedNavigators;
     WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_gamepadQuarantinedDOMWindows;
 #endif
 };

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -32,15 +32,9 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class NavigatorGamepad;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::NavigatorGamepad> : std::true_type { };
 }
 
 namespace WebCore {
@@ -51,13 +45,15 @@ class Page;
 class PlatformGamepad;
 template<typename> class ExceptionOr;
 
-class NavigatorGamepad : public Supplement<Navigator>, public CanMakeWeakPtr<NavigatorGamepad> {
+class NavigatorGamepad : public Supplement<Navigator> {
     WTF_MAKE_TZONE_ALLOCATED(NavigatorGamepad);
 public:
     explicit NavigatorGamepad(Navigator&);
     virtual ~NavigatorGamepad();
 
-    static NavigatorGamepad* from(Navigator&);
+    static NavigatorGamepad& from(Navigator&);
+
+    Navigator& navigator() const;
 
     // The array of Gamepads might be sparse.
     // Null checking each entry is necessary.
@@ -75,6 +71,7 @@ public:
 
 private:
     static ASCIILiteral supplementName();
+    Ref<Navigator> protectedNavigator() const;
 
     void gamepadsBecameVisible();
     void maybeNotifyRecentAccess();

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -387,6 +387,17 @@ GPU* Navigator::gpu()
     return m_gpuForWebGPU.get();
 }
 
+Page* Navigator::page()
+{
+    auto* frame = this->frame();
+    return frame ? frame->page() : nullptr;
+}
+
+RefPtr<Page> Navigator::protectedPage()
+{
+    return page();
+}
+
 Document* Navigator::document()
 {
     auto* frame = this->frame();

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -35,6 +35,7 @@ class Blob;
 class DeferredPromise;
 class DOMMimeTypeArray;
 class DOMPluginArray;
+class Page;
 class ShareDataReader;
 
 class Navigator final
@@ -80,6 +81,9 @@ public:
 #endif
 
     GPU* gpu();
+
+    Page* page();
+    RefPtr<Page> protectedPage();
 
     Document* document();
     RefPtr<Document> protectedDocument();


### PR DESCRIPTION
#### 74943c773af385c17afe413f43776d1eb3cfe62d
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for NavigatorGamepad
<a href="https://bugs.webkit.org/show_bug.cgi?id=281006">https://bugs.webkit.org/show_bug.cgi?id=281006</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadDisconnected):
(WebCore::GamepadManager::makeGamepadVisible):
(WebCore::GamepadManager::registerNavigator):
(WebCore::GamepadManager::unregisterNavigator):
(WebCore::GamepadManager::registerDOMWindow):
* Source/WebCore/Modules/gamepad/GamepadManager.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::NavigatorGamepad):
(WebCore::NavigatorGamepad::~NavigatorGamepad):
(WebCore::NavigatorGamepad::protectedNavigator const):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:

Canonical link: <a href="https://commits.webkit.org/284861@main">https://commits.webkit.org/284861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9446e54d52fa4b5d6f6f5cb27d32749d5aa61f5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74809 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17965 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63664 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5369 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10846 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/698 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->