### PR TITLE
[JSC] Add RegExpSubstringGlobalAtomCache

### DIFF
--- a/JSTests/microbenchmarks/substring-match-global-atom.js
+++ b/JSTests/microbenchmarks/substring-match-global-atom.js
@@ -1,0 +1,13 @@
+
+function test(str, regexp) {
+    str.substring(0, 50).match(regexp);
+    str.substring(0, 60).match(regexp);
+}
+noInline(test);
+
+let str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+let regexp = /aaaaaaaaaa/g;
+for (let i = 0; i < 1e4; i++) {
+    test(str, regexp);
+}
+

--- a/JSTests/stress/substring-global-atom-cache.js
+++ b/JSTests/stress/substring-global-atom-cache.js
@@ -1,0 +1,58 @@
+
+function assert(a, b) {
+    if (a === b)
+        return;
+    if (a === null || b === null || a.length != b.length)
+        throw new Error("bad, a=" + a + " b=" + b);
+    for (let i = 0; i < b.length; i++) {
+        if (a[i] != b[i])
+            throw new Error("bad, a=" + a + " b=" + b);
+    }
+}
+
+let str = "aaaaaaaaaaaaaaa";
+let verbose = false;
+
+function test(str, regexp, atomLen, unit) {
+    function expectedResult(start, end) {
+        let totalLen = end - start;
+        if (totalLen < atomLen)
+            return null;
+        let list = [];
+        while (totalLen >= atomLen) {
+            list.push(unit);
+            totalLen -= atomLen;
+        }
+        return list;
+    }    
+
+    for (let start1 = 0; start1 < str.length; start1++) {
+        for (let end1 = start1 + 1; end1 <= str.length; end1++) {
+            for (let start2 = 0; start2 < str.length; start2++) {
+                for (let end2 = start2 + 1; end2 <= str.length; end2++) {
+                    if (verbose)
+                        print(start1, end1);
+                    let m1 = str.substring(start1, end1).match(regexp);
+                    if (verbose)
+                        print(start2, end2);
+                    let m2 = str.substring(start2, end2).match(regexp);
+                    let e1 = expectedResult(start1, end1);
+                    let e2 = expectedResult(start2, end2);
+                    if (verbose)
+                        print(m1, e1, m2, e2);
+
+                    assert(m1, e1);
+                    assert(m2, e2);
+                }
+            }
+        }
+    }
+}
+noInline(test);
+
+for (let i = 0; i < 50; i++) {
+    test(str, /aaaaa/g, 5, "aaaaa");
+    test(str, /a/g, 1, "a");
+}
+
+

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1185,6 +1185,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/RegExpKey.h
     runtime/RegExpObject.h
     runtime/RegExpStringIteratorPrototype.h
+    runtime/RegExpSubstringGlobalAtomCache.h
     runtime/ResourceExhaustion.h
     runtime/RuntimeFlags.h
     runtime/RuntimeType.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2201,6 +2201,7 @@
 		FEF90A8D28AC135F00C14B84 /* APIIntegrityPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF90A8C28AC135C00C14B84 /* APIIntegrityPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEF934472B4DC61500DFA7F5 /* ExpressionInfoInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF934462B4DC61500DFA7F5 /* ExpressionInfoInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEFD6FC61D5E7992008F2F0B /* JSStringInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF3394AA2CB4944E004AFF6A /* RegExpSubstringGlobalAtomCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6090,6 +6091,8 @@
 		FEF934462B4DC61500DFA7F5 /* ExpressionInfoInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExpressionInfoInlines.h; sourceTree = "<group>"; };
 		FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringInlines.h; sourceTree = "<group>"; };
 		FF27D0E42BE2AEDB00397A8C /* OrderedHashTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OrderedHashTable.cpp; sourceTree = "<group>"; };
+		FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegExpSubstringGlobalAtomCache.h; sourceTree = "<group>"; };
+		FF3394AB2CB4948E004AFF6A /* RegExpSubstringGlobalAtomCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpSubstringGlobalAtomCache.cpp; sourceTree = "<group>"; };
 		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
 		FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaiterListManager.cpp; sourceTree = "<group>"; };
 		FFB951132C043CA800349750 /* OrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTableHelper.h; sourceTree = "<group>"; };
@@ -8704,6 +8707,8 @@
 				84925A9A22B30CBA00D1DFFF /* RegExpStringIteratorPrototype.cpp */,
 				84925A9B22B30CBA00D1DFFF /* RegExpStringIteratorPrototype.h */,
 				276B38A22A71D1B600252F4E /* RegExpStringIteratorPrototypeInlines.h */,
+				FF3394AB2CB4948E004AFF6A /* RegExpSubstringGlobalAtomCache.cpp */,
+				FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */,
 				FE9F3FBA2613C87C0069E89F /* ResourceExhaustion.cpp */,
 				FE9F3FB82613C7880069E89F /* ResourceExhaustion.h */,
 				70B0A9D01A9B66200001306A /* RuntimeFlags.h */,
@@ -11659,6 +11664,7 @@
 				BCD202C40E1706A7002C7E82 /* RegExpPrototype.h in Headers */,
 				276B38A32A71D1B600252F4E /* RegExpPrototypeInlines.h in Headers */,
 				276B38A52A71D1B600252F4E /* RegExpStringIteratorPrototypeInlines.h in Headers */,
+				FF3394AA2CB4944E004AFF6A /* RegExpSubstringGlobalAtomCache.h in Headers */,
 				BC18C45D0E16F5CD00B34460 /* Register.h in Headers */,
 				E328C6C91DA432F900D255FD /* RegisterAtOffset.h in Headers */,
 				E328C6C81DA4306100D255FD /* RegisterAtOffsetList.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1032,6 +1032,7 @@ runtime/RegExpMatchesArray.cpp
 runtime/RegExpObject.cpp
 runtime/RegExpPrototype.cpp
 runtime/RegExpStringIteratorPrototype.cpp
+runtime/RegExpSubstringGlobalAtomCache.cpp
 runtime/ResourceExhaustion.cpp
 runtime/RuntimeTZoneImpls.cpp
 runtime/RuntimeType.cpp

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -259,6 +259,11 @@ public:
     {
         return m_fiber & isRopeInPointer;
     }
+    ALWAYS_INLINE JSRopeString* asRope()
+    {
+        ASSERT(isRope());
+        return jsCast<JSRopeString*>(this);
+    }
 
     ALWAYS_INLINE bool isNonSubstringRope() const
     {
@@ -314,6 +319,8 @@ private:
 // from JSStringSubspace::
 class JSRopeString final : public JSString {
     friend class JSString;
+    friend class RegExpObject;
+    friend class RegExpSubstringGlobalAtomCache;
 public:
     static void destroy(JSCell*);
 

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -164,6 +164,8 @@ void RegExp::finishCreation(VM& vm)
         return;
     }
 
+    setAtom(WTFMove(pattern.m_atom));
+
     m_numSubpatterns = pattern.m_numSubpatterns;
     if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndices.isEmpty()) {
         m_rareData = makeUnique<RareData>();
@@ -223,6 +225,8 @@ void RegExp::byteCodeCompileIfNecessary(VM* vm)
     }
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
+    setAtom(WTFMove(pattern.m_atom));
+
     m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);
     if (!m_regExpBytecode) {
         m_state = ParseError;
@@ -240,6 +244,8 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
         return;
     }
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
+
+    setAtom(WTFMove(pattern.m_atom));
 
     if (!hasCode()) {
         ASSERT(m_state == NotCompiled);
@@ -306,6 +312,8 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
     }
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
+    setAtom(WTFMove(pattern.m_atom));
+
     if (!hasCode()) {
         ASSERT(m_state == NotCompiled);
         vm->regExpCache()->addToStrongCache(this);
@@ -364,6 +372,7 @@ void RegExp::deleteCode()
     if (!hasCode())
         return;
     m_state = NotCompiled;
+    m_atom = String();
 #if ENABLE(YARR_JIT)
     if (m_regExpJITCode)
         m_regExpJITCode->clear(locker);

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -168,6 +168,10 @@ public:
     }
 #endif
 
+    bool hasValidAtom() const { return !m_atom.isNull(); }
+    const String& atom() const { return m_atom; }
+    void setAtom(String&& atom) { m_atom = WTFMove(atom); }
+
 private:
     friend class RegExpCache;
     RegExp(VM&, const String&, OptionSet<Yarr::Flags>);
@@ -215,6 +219,7 @@ private:
     };
 
     String m_patternString;
+    String m_atom;
     RegExpState m_state { NotCompiled };
     OptionSet<Yarr::Flags> m_flags;
     Yarr::ErrorCode m_constructionErrorCode { Yarr::ErrorCode::NoError };

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.cpp
@@ -34,6 +34,7 @@ template<typename Visitor>
 void RegExpGlobalData::visitAggregateImpl(Visitor& visitor)
 {
     m_cachedResult.visitAggregate(visitor);
+    m_substringGlobalAtomCache.visitAggregate(visitor);
 }
 
 DEFINE_VISIT_AGGREGATE(RegExpGlobalData);

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RegExpCachedResult.h"
+#include "RegExpSubstringGlobalAtomCache.h"
 
 namespace JSC {
 
@@ -59,8 +60,11 @@ public:
     inline MatchResult matchResult() const;
     void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, MatchResult, Vector<int>&&);
 
+    RegExpSubstringGlobalAtomCache& substringGlobalAtomCache() { return m_substringGlobalAtomCache; }
+
 private:
     RegExpCachedResult m_cachedResult;
+    RegExpSubstringGlobalAtomCache m_substringGlobalAtomCache;
     bool m_multiline { false };
     Vector<int> m_ovector;
 };

--- a/Source/JavaScriptCore/runtime/RegExpObject.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpObject.cpp
@@ -178,6 +178,11 @@ JSValue RegExpObject::matchGlobal(JSGlobalObject* globalObject, JSString* string
     setLastIndex(globalObject, 0);
     RETURN_IF_EXCEPTION(scope, { });
 
+    if (RegExpSubstringGlobalAtomCache::hasValidPattern(string, regExp)) {
+        auto& cache = globalObject->regExpGlobalData().substringGlobalAtomCache();
+        RELEASE_AND_RETURN(scope, cache.collectMatches(globalObject, string->asRope(), regExp));
+    }
+
     auto s = string->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RegExpSubstringGlobalAtomCache.h"
+
+#include "JSGlobalObjectInlines.h"
+
+namespace JSC {
+
+template<typename Visitor>
+void RegExpSubstringGlobalAtomCache::visitAggregateImpl(Visitor& visitor)
+{
+    visitor.append(m_lastSubstringBase);
+    visitor.append(m_lastRegExp);
+}
+
+DEFINE_VISIT_AGGREGATE(RegExpSubstringGlobalAtomCache);
+
+bool RegExpSubstringGlobalAtomCache::hasValidPattern(JSString* string, RegExp* regExp)
+{
+    return string->isSubstring() && regExp->global() && regExp->hasValidAtom();
+}
+
+JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObject, JSRopeString* substring, RegExp* regExp)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Try to get the last cache if possible
+    size_t numberOfMatches = 0;
+    size_t startIndex = 0;
+    ([&]() ALWAYS_INLINE_LAMBDA {
+        if (regExp != m_lastRegExp.get())
+            return;
+        if (substring->substringBase() != m_lastSubstringBase.get())
+            return;
+        if (substring->substringOffset() != m_lastSubstringOffset)
+            return;
+        if (substring->length() < m_lastSubstringLength)
+            return;
+        numberOfMatches = m_lastNumberOfMatches;
+        startIndex = m_lastMatchEnd;
+    })();
+
+    JSString* substringBase = substring->substringBase();
+    unsigned substringOffset = substring->substringOffset();
+    unsigned substringLength = substring->length();
+    // Keep the substring info above since the following will resolve the substring to a non-rope.
+    auto input = substring->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, substring, input, startIndex);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (result) {
+        do {
+            if (numberOfMatches > MAX_STORAGE_VECTOR_LENGTH) {
+                throwOutOfMemoryError(globalObject, scope);
+                return jsUndefined();
+            }
+
+            numberOfMatches++;
+            startIndex = result.end;
+            if (result.empty())
+                startIndex++;
+
+            result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, substring, input, startIndex);
+            RETURN_IF_EXCEPTION(scope, { });
+        } while (result);
+    } else if (!numberOfMatches)
+        return jsNull();
+
+    // Construct the array
+    JSArray* array = constructEmptyArray(globalObject, nullptr, numberOfMatches);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    const String& atom = regExp->atom();
+    ASSERT(!atom.isEmpty() && !atom.isNull());
+    JSString* atomString = atom.length() == 1 ? jsSingleCharacterString(vm, atom[0]) : jsNontrivialString(vm, atom);
+    for (size_t i = 0, arrayIndex = 0; i < numberOfMatches; ++i) {
+        array->putDirectIndex(globalObject, arrayIndex++, atomString);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Cache
+    {
+        m_lastSubstringBase.setWithoutWriteBarrier(substringBase);
+        m_lastSubstringOffset = substringOffset;
+        m_lastSubstringLength = substringLength;
+
+        m_lastRegExp.setWithoutWriteBarrier(regExp);
+        m_lastNumberOfMatches = numberOfMatches;
+        m_lastMatchEnd = startIndex;
+
+        vm.writeBarrier(globalObject);
+    }
+    return array;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.h
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "MatchResult.h"
+#include "SlotVisitorMacros.h"
+#include "WriteBarrier.h"
+
+namespace JSC {
+
+class JSString;
+class JSRopeString;
+class RegExp;
+
+// This class is used to track the cached results of the last match
+// on a substring with global and atomic pattern regexp. It's
+// looking for the code pattern:
+//
+//     str.substring(0, 50).match(regExp);
+//     str.substring(0, 60).match(regExp);
+class RegExpSubstringGlobalAtomCache {
+public:
+    static bool hasValidPattern(JSString*, RegExp*);
+    JSValue collectMatches(JSGlobalObject*, JSRopeString* substring, RegExp*);
+
+    DECLARE_VISIT_AGGREGATE;
+
+private:
+    WriteBarrier<JSString> m_lastSubstringBase;
+    unsigned m_lastSubstringOffset;
+    unsigned m_lastSubstringLength;
+
+    WriteBarrier<RegExp> m_lastRegExp;
+    size_t m_lastNumberOfMatches { 0 };
+    size_t m_lastMatchEnd { 0 };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -720,6 +720,7 @@ struct YarrPattern {
     // duplicateNamedGroupId. Subsequent vector entries are the subpatternId's for that duplicateNamedGroupId.
     HashMap<String, Vector<unsigned>> m_namedGroupToParenIndices;
     Vector<unsigned> m_duplicateNamedGroupForSubpatternId;
+    String m_atom;
 
 private:
     ErrorCode compile(StringView patternString);


### PR DESCRIPTION
#### 43219930455072a522a32b1dee44857513991e3a
<pre>
[JSC] Add RegExpSubstringGlobalAtomCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=281012">https://bugs.webkit.org/show_bug.cgi?id=281012</a>
<a href="https://rdar.apple.com/137459855">rdar://137459855</a>

Reviewed by Yusuke Suzuki.

Inspired by [1], this update adds a caching mechanism to optimize
repeated matching of global atomic regular expressions on growing
substrings. By caching results, we avoid redundant work and improve
performance, particularly in scenarios where the same RegExp is applied
to overlapping or incrementally growing substrings.

MicroBenchmark Result with `--inner 10 --outer 20`:

                                       before                    after

substring-match-global-atom        3.1816+-0.0123     ^      2.4063+-0.0082        ^ definitely 1.3222x faster

[1] <a href="https://chromium-review.googlesource.com/c/v8/v8/+/5886727">https://chromium-review.googlesource.com/c/v8/v8/+/5886727</a>

* JSTests/microbenchmarks/substring-match-global-atom.js: Added.
(test):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::asRope):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
(JSC::RegExp::byteCodeCompileIfNecessary):
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
(JSC::RegExp::deleteCode):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpGlobalData.h:
(JSC::RegExpGlobalData::substringGlobalAtomCache):
* Source/JavaScriptCore/runtime/RegExpObject.cpp:
(JSC::RegExpObject::matchGlobal):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp: Added.
(JSC::RegExpSubstringGlobalAtomCache::visitAggregateImpl):
(JSC::RegExpSubstringGlobalAtomCache::hasValidPattern):
(JSC::RegExpSubstringGlobalAtomCache::tryGet):
(JSC::RegExpSubstringGlobalAtomCache::record):
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.h: Copied from Source/JavaScriptCore/runtime/RegExpGlobalData.h.
(JSC::RegExpSubstringGlobalAtomCache::lastRegExp):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::extractAtom):
(JSC::Yarr::YarrPattern::compile):
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/284859@main">https://commits.webkit.org/284859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a570b8fbdd670c62089181e879273bca9c4fcfe4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23513 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21765 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73810 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60992 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18425 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/63866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76555 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69993 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14974 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61055 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11752 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91774 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45955 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20007 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->