### PR TITLE
GPUCanvasContextCocoa::getConfiguration()

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
@@ -29,7 +29,9 @@
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 
 [
-    EnabledBySetting=WebGPUEnabled
+    EnabledBySetting=WebGPUEnabled,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject
 ]
 dictionary GPUCanvasConfiguration {
     required GPUDevice device;

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl
@@ -26,7 +26,9 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucanvastonemapping
 
 [
-    EnabledBySetting=WebGPUEnabled
+    EnabledBySetting=WebGPUEnabled,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject
 ]
 dictionary GPUCanvasToneMapping {
   GPUCanvasToneMappingMode mode = "standard";

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -29,7 +29,8 @@
     EnabledBySetting=WebGPUEnabled,
     ActiveDOMObject,
     Exposed=(Window,DedicatedWorker),
-    SecureContext
+    SecureContext,
+    JSGenerateToJSObject
 ]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;

--- a/Source/WebCore/bindings/js/JSDOMConvertBase.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertBase.h
@@ -45,8 +45,10 @@ namespace Detail {
 
 template<typename T> inline T* getPtrOrRef(const T* p) { return const_cast<T*>(p); }
 template<typename T> inline T& getPtrOrRef(const T& p) { return const_cast<T&>(p); }
-template<typename T> inline T* getPtrOrRef(const RefPtr<T>& p) { return p.get(); }
-template<typename T> inline T& getPtrOrRef(const Ref<T>& p) { return p.get(); }
+template<typename T, typename PtrTraits, typename RefDerefTraits> inline T* getPtrOrRef(const RefPtr<T, PtrTraits, RefDerefTraits>& p) { return p.get(); }
+template<typename T, typename PtrTraits, typename RefDerefTraits> inline T& getPtrOrRef(const Ref<T, PtrTraits, RefDerefTraits>& p) { return p.get(); }
+template<typename T, typename WeakPtrImpl, typename PtrTraits> inline T* getPtrOrRef(const WeakPtr<T, WeakPtrImpl, PtrTraits>& p) { return p.get(); }
+template<typename T, typename WeakPtrImpl> inline T& getPtrOrRef(const WeakRef<T, WeakPtrImpl>& p) { return p.get(); }
 
 }
 

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -59,6 +59,7 @@ public:
     virtual CanvasType canvas() = 0;
     virtual ExceptionOr<void> configure(GPUCanvasConfiguration&&) = 0;
     virtual void unconfigure() = 0;
+    virtual std::optional<GPUCanvasConfiguration> getConfiguration() const = 0;
     virtual ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() = 0;
 
     bool isWebGPU() const override { return true; }

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -42,5 +42,6 @@ interface GPUCanvasContext {
     undefined configure(GPUCanvasConfiguration configuration);
     undefined unconfigure();
 
+    GPUCanvasConfiguration? getConfiguration();
     GPUTexture getCurrentTexture();
 };

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -71,6 +71,7 @@ public:
     CanvasType canvas() override;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;
     void unconfigure() override;
+    std::optional<GPUCanvasConfiguration> getConfiguration() const override;
     ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -330,6 +330,24 @@ void GPUCanvasContextCocoa::unconfigure()
     ASSERT(!isConfigured());
 }
 
+std::optional<GPUCanvasConfiguration> GPUCanvasContextCocoa::getConfiguration() const
+{
+    std::optional<GPUCanvasConfiguration> configuration;
+    if (m_configuration) {
+        configuration.emplace(GPUCanvasConfiguration {
+            m_configuration->device.ptr(),
+            m_configuration->format,
+            m_configuration->usage,
+            m_configuration->viewFormats,
+            m_configuration->colorSpace,
+            m_configuration->toneMapping,
+            m_configuration->compositingAlphaMode,
+        });
+    }
+
+    return configuration;
+}
+
 ExceptionOr<RefPtr<GPUTexture>> GPUCanvasContextCocoa::getCurrentTexture()
 {
     if (!isConfigured())


### PR DESCRIPTION
#### 58d02b475262162c444b8cbce2be57edffafac60
<pre>
GPUCanvasContextCocoa::getConfiguration()
<a href="https://bugs.webkit.org/show_bug.cgi?id=281015">https://bugs.webkit.org/show_bug.cgi?id=281015</a>
<a href="https://rdar.apple.com/problem/137461371">rdar://problem/137461371</a>

Reviewed by Mike Wyrzykowski.

This new function returns the *current* configuration.
In particular, its toneMapping.mode can be forced to &quot;standard&quot;
when HDR is not supported (e.g., on some platforms, or when the
feature flag is turned off.)

* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl:
* Source/WebCore/Modules/WebGPU/GPUCanvasToneMapping.idl:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::getConfiguration const):

Canonical link: <a href="https://commits.webkit.org/284814@main">https://commits.webkit.org/284814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa49b2cbf5ef623625afe8d89b72616b1675d0d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21737 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55900 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14367 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18261 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63623 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63559 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15634 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5249 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46841 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->