### PR TITLE
[cocoa] Set cookie partition identifier in network resource requests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3357,6 +3357,8 @@ webkit.org/b/3652 http/tests/misc/prefetch-purpose.html [ Skip ]
 
 # First-party-only cookie policy only supported on Cocoa platforms.
 http/tests/cookies/only-accept-first-party-cookies.html [ Skip ]
+# Enable on appropriate platforms: rdar://140222322
+http/tests/cookies/accept-partitioned-first-and-third-party-cookies.html [ Skip ]
 
 # Disabled WPT tests
 webkit.org/b/185939 imported/w3c/web-platform-tests/css/WOFF2 [ Skip ]

--- a/LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies-expected.txt
+++ b/LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies-expected.txt
@@ -1,0 +1,29 @@
+Tests that first and third-party partitioned cookies are accepted.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Cookies are: test_cookie = 1
+
+--------
+Frame: '<!--frame2-->'
+--------
+Cookies are: test_cookie = 1
+
+--------
+Frame: '<!--frame3-->'
+--------
+Cookies are: test_cookie = 1
+
+--------
+Frame: '<!--frame4-->'
+--------
+

--- a/LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies.html
+++ b/LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies.html
@@ -1,0 +1,73 @@
+<html><!-- webkit-test-runner [ IsOptInCookiePartitioningEnabled=true ] -->
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/resetCookies.js"></script>
+    <script>
+        description("Tests that first and third-party partitioned cookies are accepted.");
+        jsTestIsAsync = true;
+
+        const iframeUrls = {
+            echoCookies : "http://localhost:8000/cookies/resources/echo-cookies.py",
+            resetCookies : "http://localhost:8000/cookies/resources/reset-cookies.html"
+        };
+
+        function injectThirdPartyIframe(url) {
+            let iframeElement = document.createElement("iframe");
+            iframeElement.src = url;
+            iframeElement.onload = runNextTestOrFinish;
+            document.body.appendChild(iframeElement);
+        }
+
+        function setCookieInRedirect(hashValue) {
+            document.location.href = "http://localhost:8000/cookies/resources/set-cookie-and-redirect-back.py?isPartitioned=True&redirectBackTo=http://127.0.0.1:8000/cookies/accept-partitioned-first-and-third-party-cookies.html#" + hashValue;
+        }
+
+        function runNextTestOrFinish() {
+            if (!window.testRunner) {
+                testFailed("No testRunner.");
+                finishJSTest();
+            }
+
+            switch (document.location.hash) {
+                case "":
+                    testRunner.dumpChildFramesAsText();
+                    document.location.hash = "1";
+                    injectThirdPartyIframe(iframeUrls.resetCookies);
+                    break;
+                case "#1":
+                    setCookieInRedirect(2);
+                    break;
+                case "#2":
+                    document.location.hash = "3";
+                    // Should see one cookie.
+                    injectThirdPartyIframe(iframeUrls.echoCookies);
+                    break;
+                case "#3":
+                    document.location.hash = "4";
+                    testRunner.setOnlyAcceptFirstPartyCookies(true);
+                    // Should see one cookie.
+                    injectThirdPartyIframe(iframeUrls.echoCookies);
+                    break;
+                case "#4":
+                    document.location.hash = "5";
+                    // Should see one cookie.
+                    testRunner.setOnlyAcceptFirstPartyCookies(false);
+                    injectThirdPartyIframe(iframeUrls.echoCookies);
+                    break;
+                case "#5":
+                    document.location.hash = "6";
+                    injectThirdPartyIframe(iframeUrls.resetCookies);
+                    break;
+                case "#6":
+                    finishJSTest();
+                    break;
+                default:
+                    testFailed("Unknown location hash value.");
+                    finishJSTest();
+            }
+        }
+    </script>
+</head>
+<body onload="runNextTestOrFinish()">
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py
+++ b/LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py
@@ -7,14 +7,18 @@ from urllib.parse import parse_qs
 
 redirect_back_to = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('redirectBackTo', [''])[0]
 
+partitionedAttr = ""
+if parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('isPartitioned', [None])[0]:
+    partitionedAttr = "; Partitioned"
+
 sys.stdout.write('Content-Type: text/html\r\n')
 
 if redirect_back_to:
     expires = datetime.utcnow() + timedelta(seconds=86400)
     sys.stdout.write(
         'status: 302\r\n'
-        'Set-Cookie: test_cookie=1; expires={} GMT; Max-Age=86400\r\n'
-        'Location: {}\r\n\r\n'.format(expires.strftime('%a, %d-%b-%Y %H:%M:%S'), redirect_back_to)
+        'Set-Cookie: test_cookie=1; expires={} GMT; Max-Age=86400{}\r\n'
+        'Location: {}\r\n\r\n'.format(expires.strftime('%a, %d-%b-%Y %H:%M:%S'), partitionedAttr, redirect_back_to)
     )
 else:
     sys.stdout.write(

--- a/Source/WebCore/platform/Site.cpp
+++ b/Source/WebCore/platform/Site.cpp
@@ -52,4 +52,9 @@ bool Site::matches(const URL& url) const
     return url.protocol() == m_protocol && m_domain.matches(url);
 }
 
+String Site::string() const
+{
+    return isEmpty() ? emptyString() : makeString(m_protocol, "://"_s, m_domain.string());
+}
+
 } // namespace WebKit

--- a/Source/WebCore/platform/Site.h
+++ b/Source/WebCore/platform/Site.h
@@ -42,6 +42,7 @@ public:
 
     const String& protocol() const { return m_protocol; }
     const RegistrableDomain& domain() const { return m_domain; }
+    String string() const;
     bool isEmpty() const { return m_domain.isEmpty(); }
     WEBCORE_EXPORT bool matches(const URL&) const;
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -33,6 +33,7 @@
 #include "NotImplemented.h"
 #include "PublicSuffixStore.h"
 #include "ResourceRequest.h"
+#include "Site.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
@@ -197,6 +198,16 @@ bool NetworkStorageSession::shouldExemptDomainPairFromThirdPartyCookieBlocking(c
         return false;
 
     return topFrameDomain == resourceDomain || (m_appBoundDomains.contains(topFrameDomain) && m_appBoundDomains.contains(resourceDomain));
+}
+
+String NetworkStorageSession::cookiePartitionIdentifier(const URL& firstPartyForCookies)
+{
+    return Site { firstPartyForCookies }.string();
+}
+
+String NetworkStorageSession::cookiePartitionIdentifier(const ResourceRequest& request)
+{
+    return cookiePartitionIdentifier(request.firstPartyForCookies());
 }
 
 std::optional<Seconds> NetworkStorageSession::maxAgeCacheCap(const ResourceRequest& request)

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -230,6 +230,8 @@ public:
     WEBCORE_EXPORT bool shouldBlockThirdPartyCookies(const RegistrableDomain&) const;
     WEBCORE_EXPORT bool shouldBlockThirdPartyCookiesButKeepFirstPartyCookiesFor(const RegistrableDomain&) const;
     WEBCORE_EXPORT void setAllCookiesToSameSiteStrict(const RegistrableDomain&, CompletionHandler<void()>&&);
+    WEBCORE_EXPORT static String cookiePartitionIdentifier(const ResourceRequest&);
+    static String cookiePartitionIdentifier(const URL&);
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT static NSHTTPCookie *capExpiryOfPersistentCookie(NSHTTPCookie *, Seconds cap);
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -290,6 +290,8 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
         m_task.get()._hostOverride = adoptNS(nw_endpoint_create_host_with_numeric_port("localhost", url.port().value_or(0))).get();
 #endif
 
+    updateTaskWithStoragePartitionIdentifier(request);
+
     WTFBeginSignpost(m_task.get(), DataTask, "%" PUBLIC_LOG_STRING " %" PRIVATE_LOG_STRING " pri: %.2f preconnect: %d", request.httpMethod().utf8().data(), url.string().utf8().data(), toNSURLSessionTaskPriority(request.priority()), parameters.shouldPreconnectOnly == PreconnectOnly::Yes);
 
     switch (parameters.storedCredentialsPolicy) {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -61,6 +61,7 @@ protected:
     void blockCookies();
     void unblockCookies();
     static void updateTaskWithFirstPartyForSameSiteCookies(NSURLSessionTask*, const WebCore::ResourceRequest&);
+    void updateTaskWithStoragePartitionIdentifier(const WebCore::ResourceRequest&);
     bool needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const;
     static NSString *lastRemoteIPAddress(NSURLSessionTask *);
     static WebCore::RegistrableDomain lastCNAMEDomain(String);

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -69,6 +69,8 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
 
     readNextMessage();
     protectedChannel()->didSendHandshakeRequest(ResourceRequest { [m_task currentRequest] });
+
+    updateTaskWithStoragePartitionIdentifier(request);
 }
 
 WebSocketTask::~WebSocketTask() = default;


### PR DESCRIPTION
#### 428cc313e773a471858ac38d144d4f7ac9379fc7
<pre>
[cocoa] Set cookie partition identifier in network resource requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=280836">https://bugs.webkit.org/show_bug.cgi?id=280836</a>
<a href="https://rdar.apple.com/problem/137220553">rdar://problem/137220553</a>

Reviewed by Sihui Liu.

WebKit, on cocoa platforms, previously supported unconditional partitioned
third-party cookies. That was removed in 203318@main. We are exploring an
implementation of opt-in partitioned third-party cookie (CHIPS), which other
engines are implementing. This is a step towards adding support.

The partition key is the top-level site (i.e., schemeful registrable domain).

New test for partitioned cookies, skipped on all platforms.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies-expected.txt: Added.
* LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies.html: Added.
* LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py:
* Source/WebCore/platform/Site.cpp:
(WebCore::Site::string const):
* Source/WebCore/platform/Site.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::cookiePartitionIdentifier):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::updateTaskWithStoragePartitionIdentifier):
(WebKit::NetworkTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::WebSocketTask):

Canonical link: <a href="https://commits.webkit.org/286830@main">https://commits.webkit.org/286830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b04545750033f717e4f15331077abb93c56b55a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60475 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23745 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68751 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66220 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68007 "Found 2 new API test failures: /TestWebKit:WebKit.AboutBlankLoad, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10083 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11958 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7329 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->