### PR TITLE
RELEASE_ASSERT that ImageIO could install all the supported image decoders

### DIFF
--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -46,6 +46,8 @@ namespace WebCore {
 const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageTypes()
 {
     static NeverDestroyed defaultSupportedImageTypes = [] {
+        // Changes to supported formats may require updates in Info.plist
+        // accepted formats for macOS clients such as Safari or MiniBrowse.
         static constexpr std::array defaultSupportedImageTypes = {
             "com.compuserve.gif"_s,
             "com.microsoft.bmp"_s,

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -146,8 +146,14 @@ bool isDeclaredUTI(const String& UTI)
 void setImageSourceAllowableTypes(const Vector<String>& supportedImageTypes)
 {
 #if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
-    auto allowableTypes = createNSArray(supportedImageTypes);
-    CGImageSourceSetAllowableTypes((__bridge CFArrayRef)allowableTypes.get());
+    // A WebPage might be reinitialized. So restrict ImageIO to the default and
+    // the additional supported image formats only once.
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [supportedImageTypes] {
+        auto allowableTypes = createNSArray(supportedImageTypes);
+        auto status = CGImageSourceSetAllowableTypes((__bridge CFArrayRef)allowableTypes.get());
+        RELEASE_ASSERT_WITH_MESSAGE(supportedImageTypes.isEmpty() || status == noErr, "CGImageSourceSetAllowableTypes() returned error: %d.", status);
+    });
 #else
     UNUSED_PARAM(supportedImageTypes);
 #endif


### PR DESCRIPTION
#### 71298373ddaca1efef24adf5f3bf18fb2876db47
<pre>
RELEASE_ASSERT that ImageIO could install all the supported image decoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=280990">https://bugs.webkit.org/show_bug.cgi?id=280990</a>
<a href="https://rdar.apple.com/135375243">rdar://135375243</a>

Reviewed by Simon Fraser.

We needs to check the return value of CGImageSourceSetAllowableTypes().

If CGImageSourceSetAllowableTypes() could not install all the supported image
decoders for any reason, we should halt the process launch and fail its creation
safely.

Because the WebPage can be reinitialized (WTR for example), it is important to
call GImageSourceSetAllowableTypes() only once and only when a WebProcess is
initialized.

* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::defaultSupportedImageTypes):
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::setImageSourceAllowableTypes):

Canonical link: <a href="https://commits.webkit.org/284850@main">https://commits.webkit.org/284850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dd14671d4e9decd16ce7de4d87c602926c22185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21722 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/55986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14454 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60956 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42216 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76512 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17954 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5363 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/683 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->