### PR TITLE
WebSharedWorkerServerToContextConnection should be ref counted

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -316,8 +316,8 @@ bool NetworkConnectionToWebProcess::dispatchMessage(IPC::Connection& connection,
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebSharedWorkerServerToContextConnection::messageReceiverName()) {
-        if (m_sharedWorkerContextConnection)
-            m_sharedWorkerContextConnection->didReceiveMessage(connection, decoder);
+        if (RefPtr sharedWorkerContextConnection = m_sharedWorkerContextConnection)
+            sharedWorkerContextConnection->didReceiveMessage(connection, decoder);
         return true;
     }
 
@@ -1322,7 +1322,7 @@ void NetworkConnectionToWebProcess::establishSharedWorkerContextConnection(WebPa
     CONNECTION_RELEASE_LOG(SharedWorker, "establishSharedWorkerContextConnection:");
     auto* session = networkSession();
     if (auto* swServer = session ? session->sharedWorkerServer() : nullptr)
-        m_sharedWorkerContextConnection = makeUnique<WebSharedWorkerServerToContextConnection>(*this, WTFMove(registrableDomain), *swServer);
+        m_sharedWorkerContextConnection = WebSharedWorkerServerToContextConnection::create(*this, WTFMove(registrableDomain), *swServer);
     completionHandler();
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -484,7 +484,7 @@ private:
     WeakPtr<WebSWServerConnection> m_swConnection;
     std::unique_ptr<WebSWServerToContextConnection> m_swContextConnection;
     WeakPtr<WebSharedWorkerServerConnection> m_sharedWorkerConnection;
-    std::unique_ptr<WebSharedWorkerServerToContextConnection> m_sharedWorkerContextConnection;
+    RefPtr<WebSharedWorkerServerToContextConnection> m_sharedWorkerContextConnection;
 
 #if ENABLE(WEB_RTC)
     bool m_isRegisteredToRTCDataChannelProxy { false };

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -62,7 +62,7 @@ WebSharedWorker::WebSharedWorker(WebSharedWorkerServer& server, const WebCore::S
 
 WebSharedWorker::~WebSharedWorker()
 {
-    if (auto* connection = contextConnection()) {
+    if (RefPtr connection = contextConnection()) {
         for (auto& sharedWorkerObject : m_sharedWorkerObjects)
             connection->removeSharedWorkerObject(sharedWorkerObject.identifier);
     }
@@ -105,7 +105,7 @@ void WebSharedWorker::addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifie
 {
     ASSERT(!m_sharedWorkerObjects.contains({ sharedWorkerObjectIdentifier, { false, port } }));
     m_sharedWorkerObjects.add({ sharedWorkerObjectIdentifier, { false, port } });
-    if (auto* connection = contextConnection())
+    if (RefPtr connection = contextConnection())
         connection->addSharedWorkerObject(sharedWorkerObjectIdentifier);
 
     resumeIfNeeded();
@@ -114,7 +114,7 @@ void WebSharedWorker::addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifie
 void WebSharedWorker::removeSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)
 {
     m_sharedWorkerObjects.remove({ sharedWorkerObjectIdentifier, { } });
-    if (auto* connection = contextConnection())
+    if (RefPtr connection = contextConnection())
         connection->removeSharedWorkerObject(sharedWorkerObjectIdentifier);
 
     suspendIfNeeded();
@@ -142,7 +142,7 @@ void WebSharedWorker::suspendIfNeeded()
     }
 
     m_isSuspended = true;
-    if (auto* connection = contextConnection())
+    if (RefPtr connection = contextConnection())
         connection->suspendSharedWorker(identifier());
 }
 
@@ -162,7 +162,7 @@ void WebSharedWorker::resumeIfNeeded()
         return;
 
     m_isSuspended = false;
-    if (auto* connection = contextConnection())
+    if (RefPtr connection = contextConnection())
         connection->resumeSharedWorker(identifier());
 }
 


### PR DESCRIPTION
#### 2e560ffcdef7356a04249de68d105668ead92719
<pre>
WebSharedWorkerServerToContextConnection should be ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281027">https://bugs.webkit.org/show_bug.cgi?id=281027</a>

Reviewed by Chris Dumez.

Made WebSharedWorkerServerToContextConnection ref counted.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::dispatchMessage):
(WebKit::NetworkConnectionToWebProcess::establishSharedWorkerContextConnection):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::WebSharedWorker::~WebSharedWorker):
(WebKit::WebSharedWorker::addSharedWorkerObject):
(WebKit::WebSharedWorker::removeSharedWorkerObject):
(WebKit::WebSharedWorker::suspendIfNeeded):
(WebKit::WebSharedWorker::resumeIfNeeded):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::requestSharedWorker):
(WebKit::WebSharedWorkerServer::didFinishFetchingSharedWorkerScript):
(WebKit::WebSharedWorkerServer::addContextConnection):
(WebKit::WebSharedWorkerServer::removeContextConnection):
(WebKit::WebSharedWorkerServer::contextConnectionCreated):
(WebKit::WebSharedWorkerServer::shutDownSharedWorker):
(WebKit::WebSharedWorkerServer::terminateContextConnectionWhenPossible):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::create):
(WebKit::WebSharedWorkerServerToContextConnection::webProcessIdentifier const):
(WebKit::WebSharedWorkerServerToContextConnection::ipcConnection const):
(WebKit::WebSharedWorkerServerToContextConnection::messageSenderConnection const):
(WebKit::WebSharedWorkerServerToContextConnection::connectionIsNoLongerNeeded):
(WebKit::WebSharedWorkerServerToContextConnection::launchSharedWorker):
(WebKit::WebSharedWorkerServerToContextConnection::addSharedWorkerObject):
(WebKit::WebSharedWorkerServerToContextConnection::removeSharedWorkerObject):
(WebKit::WebSharedWorkerServerToContextConnection::protectedConnection const): Deleted.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/284874@main">https://commits.webkit.org/284874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a9c439b0b5e89fa6dd5185d2cdeda20bd4ff03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21952 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56018 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42257 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76563 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63688 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5399 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10854 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/734 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47035 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->