### PR TITLE
REGRESSION(284791@main): wtf/RefTrackerMixin.h(112,36): warning: 'WTF::RefTrackerLoggingDisabledScope::RefTrackerLoggingDisabledScope<T>' redeclared without 'dllimport' attribute: 'dllexport' attribute added

### DIFF
--- a/Source/WTF/wtf/RefTrackerMixin.h
+++ b/Source/WTF/wtf/RefTrackerMixin.h
@@ -37,8 +37,14 @@ namespace WTF {
 template<typename T>
 struct RefTrackerLoggingDisabledScope {
     WTF_MAKE_NONCOPYABLE(RefTrackerLoggingDisabledScope);
-    WTF_EXPORT_PRIVATE RefTrackerLoggingDisabledScope();
-    WTF_EXPORT_PRIVATE ~RefTrackerLoggingDisabledScope();
+    RefTrackerLoggingDisabledScope()
+    {
+        ++T::refTrackerSingleton().loggingDisabledDepth;
+    }
+    ~RefTrackerLoggingDisabledScope()
+    {
+        --T::refTrackerSingleton().loggingDisabledDepth;
+    }
 };
 
 struct RefTracker {
@@ -107,18 +113,6 @@ struct RefTrackerMixin final {
     // This guards against seeing an unconstructed object (say, if we are zero-initialized)
     RefTrackerMixin* originalThis = nullptr;
 };
-
-template<typename T>
-RefTrackerLoggingDisabledScope<T>::RefTrackerLoggingDisabledScope()
-{
-    ++T::refTrackerSingleton().loggingDisabledDepth;
-}
-
-template<typename T>
-RefTrackerLoggingDisabledScope<T>::~RefTrackerLoggingDisabledScope()
-{
-    --T::refTrackerSingleton().loggingDisabledDepth;
-}
 
 #define REFTRACKER_DECL(T) \
     struct T final { \


### PR DESCRIPTION
#### e4dbf952205ee07df27025f263bd35db06c9149c
<pre>
REGRESSION(284791@main): wtf/RefTrackerMixin.h(112,36): warning: &apos;WTF::RefTrackerLoggingDisabledScope::RefTrackerLoggingDisabledScope&lt;T&gt;&apos; redeclared without &apos;dllimport&apos; attribute: &apos;dllexport&apos; attribute added
<a href="https://bugs.webkit.org/show_bug.cgi?id=281032">https://bugs.webkit.org/show_bug.cgi?id=281032</a>

Unreviewed build fix for Windows Debug builds.
After &lt;<a href="https://commits.webkit.org/284791@main">https://commits.webkit.org/284791@main</a>&gt;, it reported an compiler warning.

&gt; wtf/RefTrackerMixin.h(112,36): warning: &apos;WTF::RefTrackerLoggingDisabledScope::RefTrackerLoggingDisabledScope&lt;T&gt;&apos; redeclared without &apos;dllimport&apos; attribute: &apos;dllexport&apos; attribute added [-Winconsistent-dllimport]

WTF_EXPORT_PRIVATE doesn&apos;t have to be applied to inline functions.

* Source/WTF/wtf/RefTrackerMixin.h:
(WTF::RefTrackerLoggingDisabledScope::RefTrackerLoggingDisabledScope):
(WTF::RefTrackerLoggingDisabledScope::~RefTrackerLoggingDisabledScope):
(WTF::RefTrackerLoggingDisabledScope&lt;T&gt;::RefTrackerLoggingDisabledScope): Deleted.
(WTF::RefTrackerLoggingDisabledScope&lt;T&gt;::~RefTrackerLoggingDisabledScope): Deleted.

Canonical link: <a href="https://commits.webkit.org/284811@main">https://commits.webkit.org/284811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2063d999542a0ab27884761082a3c1807eff9759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23359 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60858 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42120 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20133 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/63715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76403 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69842 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17859 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60926 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11627 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91624 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10814 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45802 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/19974 "Found 57 jsc stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/verbose-failure-dont-graph-dump-availability-already-freed.js.default, wasm.yaml/wasm/spec-tests/throw_ref.wast.js.wasm-bbq, wasm.yaml/wasm/spec-tests/try_table.wast.js.default-wasm, wasm.yaml/wasm/spec-tests/try_table.wast.js.wasm-bbq ...") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->