### PR TITLE
Reduce further use of LegacyNullableObjectIdentifier in WebKit/

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -67,17 +67,17 @@ static CDMFactory* factoryForKeySystem(const String& keySystem)
     return factories[foundIndex];
 }
 
-void RemoteCDMFactoryProxy::createCDM(const String& keySystem, CompletionHandler<void(RemoteCDMIdentifier&&, RemoteCDMConfiguration&&)>&& completion)
+void RemoteCDMFactoryProxy::createCDM(const String& keySystem, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&& completion)
 {
     auto factory = factoryForKeySystem(keySystem);
     if (!factory) {
-        completion({ }, { });
+        completion(std::nullopt, { });
         return;
     }
 
     auto privateCDM = factory->createCDM(keySystem, *this);
     if (!privateCDM) {
-        completion({ }, { });
+        completion(std::nullopt, { });
         return;
     }
 
@@ -95,40 +95,52 @@ void RemoteCDMFactoryProxy::supportsKeySystem(const String& keySystem, Completio
 
 void RemoteCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (RefPtr proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
-        proxy->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<RemoteCDMIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (RefPtr proxy = m_proxies.get(ObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
+            proxy->didReceiveMessage(connection, decoder);
+    }
 }
 
 void RemoteCDMFactoryProxy::didReceiveCDMInstanceMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* instance = m_instances.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
-        instance->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<RemoteCDMInstanceIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* instance = m_instances.get(ObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
+            instance->didReceiveMessage(connection, decoder);
+    }
 }
 
 void RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
+            session->didReceiveMessage(connection, decoder);
+    }
 }
 
 bool RemoteCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (RefPtr proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
-        return proxy->didReceiveSyncMessage(connection, decoder, encoder);
+    if (ObjectIdentifier<RemoteCDMIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (RefPtr proxy = m_proxies.get(ObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
+            return proxy->didReceiveSyncMessage(connection, decoder, encoder);
+    }
     return false;
 }
 
 bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* instance = m_instances.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
-        return instance->didReceiveSyncMessage(connection, decoder, encoder);
+    if (ObjectIdentifier<RemoteCDMInstanceIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* instance = m_instances.get(ObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
+            return instance->didReceiveSyncMessage(connection, decoder, encoder);
+    }
     return false;
 }
 
 bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        return session->didReceiveSyncMessage(connection, decoder, encoder);
+    if (ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
+            return session->didReceiveSyncMessage(connection, decoder, encoder);
+    }
     return false;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -96,7 +96,7 @@ private:
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
-    void createCDM(const String& keySystem, CompletionHandler<void(RemoteCDMIdentifier&&, RemoteCDMConfiguration&&)>&&);
+    void createCDM(const String& keySystem, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&&);
     void supportsKeySystem(const String& keySystem, CompletionHandler<void(bool)>&&);
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
@@ -27,7 +27,7 @@
 
 [EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMFactoryProxy NotRefCounted {
-    CreateCDM(String keySystem) -> (WebKit::RemoteCDMIdentifier identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
+    CreateCDM(String keySystem) -> (std::optional<WebKit::RemoteCDMIdentifier> identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
     SupportsKeySystem(String keySystem) -> (bool result) Synchronous
     RemoveInstance(WebKit::RemoteCDMInstanceIdentifier identifier)
     RemoveSession(WebKit::RemoteCDMInstanceSessionIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -108,11 +108,11 @@ void RemoteCDMInstanceProxy::setStorageDirectory(const String& directory)
         protectedInstance()->setStorageDirectory(directory);
 }
 
-void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHandler<void(const RemoteCDMInstanceSessionIdentifier&)>&& completion)
+void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHandler<void(std::optional<RemoteCDMInstanceSessionIdentifier>)>&& completion)
 {
     auto privSession = protectedInstance()->createSession();
     if (!privSession || !m_cdm || !m_cdm->factory()) {
-        completion({ });
+        completion(std::nullopt);
         return;
     }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -85,7 +85,7 @@ private:
     void initializeWithConfiguration(const WebCore::CDMKeySystemConfiguration&, AllowDistinctiveIdentifiers, AllowPersistentState, CompletionHandler<void(SuccessValue)>&&);
     void setServerCertificate(Ref<WebCore::SharedBuffer>&&, CompletionHandler<void(SuccessValue)>&&);
     void setStorageDirectory(const String&);
-    void createSession(uint64_t logIdentifier, CompletionHandler<void(const RemoteCDMInstanceSessionIdentifier&)>&&);
+    void createSession(uint64_t logIdentifier, CompletionHandler<void(std::optional<RemoteCDMInstanceSessionIdentifier>)>&&);
 
     RefPtr<RemoteCDMProxy> protectedCdm() const;
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in
@@ -27,7 +27,7 @@
 
 [EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMInstanceProxy NotRefCounted {
-    CreateSession(uint64_t logIdentifier) -> (WebKit::RemoteCDMInstanceSessionIdentifier identifier) Synchronous
+    CreateSession(uint64_t logIdentifier) -> (std::optional<WebKit::RemoteCDMInstanceSessionIdentifier> identifier) Synchronous
     InitializeWithConfiguration(struct WebCore::CDMKeySystemConfiguration configuration, enum:bool WebCore::CDMInstance::AllowDistinctiveIdentifiers distinctiveIdentifiersAllowed, enum:bool WebCore::CDMInstance::AllowPersistentState persistentStateAllowed) -> (enum:bool WebCore::CDMInstance::SuccessValue success)
     SetServerCertificate(Ref<WebCore::SharedBuffer> certificate) -> (enum:bool WebCore::CDMInstance::SuccessValue success)
     SetStorageDirectory(String directory)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -86,11 +86,11 @@ void RemoteCDMProxy::getSupportedConfiguration(WebCore::CDMKeySystemConfiguratio
     m_private->getSupportedConfiguration(WTFMove(configuration), access, WTFMove(callback));
 }
 
-void RemoteCDMProxy::createInstance(CompletionHandler<void(RemoteCDMInstanceIdentifier, RemoteCDMInstanceConfiguration&&)>&& completion)
+void RemoteCDMProxy::createInstance(CompletionHandler<void(std::optional<RemoteCDMInstanceIdentifier>, RemoteCDMInstanceConfiguration&&)>&& completion)
 {
     auto privateInstance = m_private->createInstance();
     if (!privateInstance || !m_factory) {
-        completion({ }, { });
+        completion(std::nullopt, { });
         return;
     }
     auto identifier = RemoteCDMInstanceIdentifier::generate();

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -80,7 +80,7 @@ private:
 
     // Messages
     void getSupportedConfiguration(WebCore::CDMKeySystemConfiguration&&, WebCore::CDMPrivate::LocalStorageAccess, CompletionHandler<void(std::optional<WebCore::CDMKeySystemConfiguration>)>&&);
-    void createInstance(CompletionHandler<void(RemoteCDMInstanceIdentifier, RemoteCDMInstanceConfiguration&&)>&&);
+    void createInstance(CompletionHandler<void(std::optional<RemoteCDMInstanceIdentifier>, RemoteCDMInstanceConfiguration&&)>&&);
     void loadAndInitialize();
     void setLogIdentifier(uint64_t);
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in
@@ -28,7 +28,7 @@
 [EnabledBy=EncryptedMediaAPIEnabled]
 messages -> RemoteCDMProxy NotRefCounted {
     GetSupportedConfiguration(struct WebCore::CDMKeySystemConfiguration candidateConfiguration, enum:bool WebCore::CDMPrivate::LocalStorageAccess access) -> (std::optional<WebCore::CDMKeySystemConfiguration> accumulatedConfiguration)
-    CreateInstance() -> (WebKit::RemoteCDMInstanceIdentifier identifier, struct WebKit::RemoteCDMInstanceConfiguration configuration) Synchronous
+    CreateInstance() -> (std::optional<WebKit::RemoteCDMInstanceIdentifier> identifier, struct WebKit::RemoteCDMInstanceConfiguration configuration) Synchronous
     LoadAndInitialize()
     SetLogIdentifier(uint64_t logIdentifier)
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -70,11 +70,11 @@ void RemoteLegacyCDMFactoryProxy::clear()
         connection->messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMProxy::messageReceiverName(), proxy.key.toUInt64());
 }
 
-void RemoteLegacyCDMFactoryProxy::createCDM(const String& keySystem, std::optional<MediaPlayerIdentifier>&& optionalPlayerId, CompletionHandler<void(RemoteLegacyCDMIdentifier&&)>&& completion)
+void RemoteLegacyCDMFactoryProxy::createCDM(const String& keySystem, std::optional<MediaPlayerIdentifier>&& optionalPlayerId, CompletionHandler<void(std::optional<RemoteLegacyCDMIdentifier>&&)>&& completion)
 {
     auto privateCDM = LegacyCDM::create(keySystem);
     if (!privateCDM) {
-        completion({ });
+        completion(std::nullopt);
         return;
     }
 
@@ -98,27 +98,35 @@ void RemoteLegacyCDMFactoryProxy::supportsKeySystem(const String& keySystem, std
 
 void RemoteLegacyCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
-        proxy->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<RemoteLegacyCDMIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
+            proxy->didReceiveMessage(connection, decoder);
+    }
 }
 
 void RemoteLegacyCDMFactoryProxy::didReceiveCDMSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
+            session->didReceiveMessage(connection, decoder);
+    }
 }
 
 bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* proxy = m_proxies.get(LegacyNullableObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
-        return proxy->didReceiveSyncMessage(connection, decoder, encoder);
+    if (ObjectIdentifier<RemoteLegacyCDMIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
+            return proxy->didReceiveSyncMessage(connection, decoder, encoder);
+    }
     return false;
 }
 
 bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
-        return session->didReceiveSyncMessage(connection, decoder, encoder);
+    if (ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
+            return session->didReceiveSyncMessage(connection, decoder, encoder);
+    }
     return false;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -87,7 +87,7 @@ private:
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
-    void createCDM(const String& keySystem, std::optional<WebCore::MediaPlayerIdentifier>&&, CompletionHandler<void(RemoteLegacyCDMIdentifier&&)>&&);
+    void createCDM(const String& keySystem, std::optional<WebCore::MediaPlayerIdentifier>&&, CompletionHandler<void(std::optional<RemoteLegacyCDMIdentifier>&&)>&&);
     void supportsKeySystem(const String& keySystem, std::optional<String> mimeType, CompletionHandler<void(bool)>&&);
 
     WeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
@@ -25,7 +25,7 @@
 
 [EnabledBy=LegacyEncryptedMediaAPIEnabled]
 messages -> RemoteLegacyCDMFactoryProxy NotRefCounted {
-    CreateCDM(String keySystem, std::optional<WebCore::MediaPlayerIdentifier> playerId) -> (WebKit::RemoteLegacyCDMIdentifier identifier) Synchronous
+    CreateCDM(String keySystem, std::optional<WebCore::MediaPlayerIdentifier> playerId) -> (std::optional<WebKit::RemoteLegacyCDMIdentifier> identifier) Synchronous
     SupportsKeySystem(String keySystem, std::optional<String> mimeType) -> (bool result) Synchronous
     RemoveSession(WebKit::RemoteLegacyCDMSessionIdentifier identifier)
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -65,7 +65,7 @@ void RemoteLegacyCDMProxy::createSession(const String& keySystem, uint64_t logId
 {
     RefPtr factory = m_factory.get();
     if (!m_cdm || !factory) {
-        callback({ });
+        callback(std::nullopt);
         return;
     }
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -60,7 +60,7 @@ private:
     // Messages
     using SupportsMIMETypeCallback = CompletionHandler<void(bool)>;
     void supportsMIMEType(const String&, SupportsMIMETypeCallback&&);
-    using CreateSessionCallback = CompletionHandler<void(RemoteLegacyCDMSessionIdentifier&&)>;
+    using CreateSessionCallback = CompletionHandler<void(std::optional<RemoteLegacyCDMSessionIdentifier>&&)>;
     void createSession(const String&, uint64_t, CreateSessionCallback&&);
     void setPlayerId(std::optional<WebCore::MediaPlayerIdentifier>&&);
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in
@@ -26,7 +26,7 @@
 [EnabledBy=LegacyEncryptedMediaAPIEnabled]
 messages -> RemoteLegacyCDMProxy NotRefCounted {
     SupportsMIMEType(String mimeType) -> (bool supports) Synchronous
-    CreateSession(String mediaKeysStorageDirectory, uint64_t logIdentifier) -> (WebKit::RemoteLegacyCDMSessionIdentifier identifier) Synchronous
+    CreateSession(String mediaKeysStorageDirectory, uint64_t logIdentifier) -> (std::optional<WebKit::RemoteLegacyCDMSessionIdentifier> identifier) Synchronous
     SetPlayerId(std::optional<WebCore::MediaPlayerIdentifier> playerId)
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceIdentifier.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteMediaResourceIdentifierType { };
-using RemoteMediaResourceIdentifier = LegacyNullableObjectIdentifier<RemoteMediaResourceIdentifierType>;
+using RemoteMediaResourceIdentifier = ObjectIdentifier<RemoteMediaResourceIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferIdentifier.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteSourceBufferIdentifierType { };
-using RemoteSourceBufferIdentifier = LegacyNullableObjectIdentifier<RemoteSourceBufferIdentifierType>;
+using RemoteSourceBufferIdentifier = ObjectIdentifier<RemoteSourceBufferIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
@@ -51,8 +51,10 @@ RemoteMediaRecorderManager::~RemoteMediaRecorderManager()
 
 void RemoteMediaRecorderManager::didReceiveRemoteMediaRecorderMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* recorder = m_recorders.get(LegacyNullableObjectIdentifier<MediaRecorderIdentifierType>(decoder.destinationID())))
-        recorder->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<MediaRecorderIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* recorder = m_recorders.get(ObjectIdentifier<MediaRecorderIdentifierType>(decoder.destinationID())))
+            recorder->didReceiveMessage(connection, decoder);
+    }
 }
 
 void RemoteMediaRecorderManager::createRecorder(MediaRecorderIdentifier identifier, bool recordAudio, bool recordVideo, const MediaRecorderPrivateOptions& options, CompletionHandler<void(std::optional<ExceptionData>&&, String&&, unsigned, unsigned)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -76,10 +76,10 @@ void RemoteSampleBufferDisplayLayerManager::close()
 
 bool RemoteSampleBufferDisplayLayerManager::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (!decoder.destinationID())
+    if (!ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>::isValidIdentifier(decoder.destinationID()))
         return false;
 
-    auto identifier = LegacyNullableObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID());
+    auto identifier = ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID());
     Locker lock(m_layersLock);
     if (RefPtr layer = m_layers.get(identifier))
         layer->didReceiveMessage(connection, decoder);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -120,7 +120,7 @@ struct CoreIPCAuditToken;
 struct NetworkProcessConnectionParameters;
 struct WebTransportSessionIdentifierType;
 
-using WebTransportSessionIdentifier = LegacyNullableObjectIdentifier<WebTransportSessionIdentifierType>;
+using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdentifierType>;
 
 enum class PrivateRelayed : bool;
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
@@ -37,7 +37,7 @@
 
 namespace WebKit {
 struct WebTransportStreamIdentifierType;
-using WebTransportStreamIdentifier = LegacyNullableObjectIdentifier<WebTransportStreamIdentifierType>;
+using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 }
 
 namespace WebKit {

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -47,8 +47,8 @@ class NetworkTransportSendStream;
 struct WebTransportSessionIdentifierType;
 struct WebTransportStreamIdentifierType;
 
-using WebTransportSessionIdentifier = LegacyNullableObjectIdentifier<WebTransportSessionIdentifierType>;
-using WebTransportStreamIdentifier = LegacyNullableObjectIdentifier<WebTransportStreamIdentifierType>;
+using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdentifierType>;
+using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
 class NetworkTransportSession : public RefCounted<NetworkTransportSession>, public IPC::MessageReceiver, public IPC::MessageSender, public Identified<WebTransportSessionIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkTransportSession);

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -31,11 +31,11 @@
 namespace WebKit {
 
 enum class ContentWorldIdentifierType { };
-using ContentWorldIdentifier = LegacyNullableObjectIdentifier<ContentWorldIdentifierType>;
+using ContentWorldIdentifier = ObjectIdentifier<ContentWorldIdentifierType>;
 
 inline ContentWorldIdentifier pageContentWorldIdentifier()
 {
-    static NeverDestroyed<ContentWorldIdentifier> identifier(LegacyNullableObjectIdentifier<ContentWorldIdentifierType>(1));
+    static NeverDestroyed<ContentWorldIdentifier> identifier(ObjectIdentifier<ContentWorldIdentifierType>(1));
     return identifier;
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionControllerIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionControllerIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class WebExtensionControllerIdentifierType { };
-using WebExtensionControllerIdentifier = LegacyNullableObjectIdentifier<WebExtensionControllerIdentifierType>;
+using WebExtensionControllerIdentifier = ObjectIdentifier<WebExtensionControllerIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/IPCConnectionTesterIdentifier.h
+++ b/Source/WebKit/Shared/IPCConnectionTesterIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 struct IPCConnectionTesterIdentifierType;
-using IPCConnectionTesterIdentifier = LegacyNullableObjectIdentifier<IPCConnectionTesterIdentifierType>;
+using IPCConnectionTesterIdentifier = ObjectIdentifier<IPCConnectionTesterIdentifierType>;
 
 }
 

--- a/Source/WebKit/Shared/IPCStreamTesterIdentifier.h
+++ b/Source/WebKit/Shared/IPCStreamTesterIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 struct IPCStreamTesterIdentifierType;
-using IPCStreamTesterIdentifier = LegacyNullableObjectIdentifier<IPCStreamTesterIdentifierType>;
+using IPCStreamTesterIdentifier = ObjectIdentifier<IPCStreamTesterIdentifierType>;
 
 }
 

--- a/Source/WebKit/Shared/RemoteAudioDestinationIdentifier.h
+++ b/Source/WebKit/Shared/RemoteAudioDestinationIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 struct RemoteAudioDestinationIdentifierType;
-using RemoteAudioDestinationIdentifier = LegacyNullableObjectIdentifier<RemoteAudioDestinationIdentifierType>;
+using RemoteAudioDestinationIdentifier = ObjectIdentifier<RemoteAudioDestinationIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/RemoteImageBufferSetIdentifier.h
+++ b/Source/WebKit/Shared/RemoteImageBufferSetIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct RemoteImageBufferSetIdentifierType;
-using RemoteImageBufferSetIdentifier = LegacyNullableObjectIdentifier<RemoteImageBufferSetIdentifierType>;
+using RemoteImageBufferSetIdentifier = ObjectIdentifier<RemoteImageBufferSetIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/ScriptMessageHandlerIdentifier.h
+++ b/Source/WebKit/Shared/ScriptMessageHandlerIdentifier.h
@@ -28,6 +28,6 @@
 namespace WebKit {
 
 enum class ScriptMessageHandlerIdentifierType { };
-using ScriptMessageHandlerIdentifier = LegacyNullableObjectIdentifier<ScriptMessageHandlerIdentifierType>;
+using ScriptMessageHandlerIdentifier = ObjectIdentifier<ScriptMessageHandlerIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ShapeDetectionIdentifier.h
+++ b/Source/WebKit/Shared/ShapeDetectionIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class ShapeDetectionIdentifierType { };
-using ShapeDetectionIdentifier = LegacyNullableObjectIdentifier<ShapeDetectionIdentifierType>;
+using ShapeDetectionIdentifier = ObjectIdentifier<ShapeDetectionIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -66,29 +66,6 @@ template: enum class WebCore::MediaUniqueIdentifierType
 template: enum class WebCore::PushSubscriptionIdentifierType
 template: enum class WebCore::RealtimeMediaSourceIdentifierType
 template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
-template: enum class WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
-template: enum class WebKit::ContentWorldIdentifierType
-template: enum class WebKit::ImageAnalysisRequestIdentifierType
-template: enum class WebKit::MediaDevicePermissionRequestIdentifierType
-template: enum class WebKit::MediaRecorderIdentifierType
-template: enum class WebKit::RemoteAudioHardwareListenerIdentifierType
-template: enum class WebKit::RemoteAudioSessionIdentifierType
-template: enum class WebKit::RemoteCDMIdentifierType
-template: enum class WebKit::RemoteCDMInstanceIdentifierType
-template: enum class WebKit::RemoteCDMInstanceSessionIdentifierType
-template: enum class WebKit::RemoteLegacyCDMIdentifierType
-template: enum class WebKit::RemoteLegacyCDMSessionIdentifierType
-template: enum class WebKit::RemoteMediaResourceIdentifierType
-template: enum class WebKit::RemoteMediaSourceIdentifierType
-template: enum class WebKit::RemoteRemoteCommandListenerIdentifierType
-template: enum class WebKit::RemoteSourceBufferIdentifierType
-template: enum class WebKit::RetrieveRecordResponseBodyCallbackIdentifierType
-template: enum class WebKit::SampleBufferDisplayLayerIdentifierType
-template: enum class WebKit::ScriptMessageHandlerIdentifierType
-template: enum class WebKit::ShapeDetectionIdentifierType
-template: enum class WebKit::WCLayerTreeHostIdentifierType
-template: enum class WebKit::WebExtensionControllerIdentifierType
-template: enum class WebKit::XRDeviceIdentifierType
 template: struct WebCore::AttributedStringTextListIDType
 #if PLATFORM(COCOA)
 template: struct WebCore::AttributedStringTextTableBlockIDType
@@ -103,12 +80,6 @@ template: struct WebCore::ModelPlayerIdentifierType
 template: struct WebCore::PlaybackTargetClientContextIdentifierType
 template: struct WebCore::UserMediaRequestIdentifierType
 template: struct WebCore::ScrollingNodeIDType
-template: struct WebKit::IPCConnectionTesterIdentifierType
-template: struct WebKit::IPCStreamTesterIdentifierType
-template: struct WebKit::RemoteAudioDestinationIdentifierType
-template: struct WebKit::RemoteImageBufferSetIdentifierType
-template: struct WebKit::WebTransportSessionIdentifierType
-template: struct WebKit::WebTransportStreamIdentifierType
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::LegacyNullableObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
@@ -129,13 +100,36 @@ template: enum class WebCore::TextManipulationItemIdentifierType
 template: enum class WebCore::TextManipulationTokenIdentifierType
 template: enum class WebCore::WindowIdentifierType
 template: enum class WebCore::WorkletGlobalScopeIdentifierType
+template: enum class WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
+template: enum class WebKit::ContentWorldIdentifierType
 template: enum class WebKit::DownloadIdentifierType
+template: enum class WebKit::ImageAnalysisRequestIdentifierType
+template: enum class WebKit::MediaDevicePermissionRequestIdentifierType
+template: enum class WebKit::MediaRecorderIdentifierType
+template: enum class WebKit::RemoteAudioHardwareListenerIdentifierType
+template: enum class WebKit::RemoteAudioSessionIdentifierType
+template: enum class WebKit::RemoteCDMIdentifierType
+template: enum class WebKit::RemoteCDMInstanceIdentifierType
+template: enum class WebKit::RemoteCDMInstanceSessionIdentifierType
+template: enum class WebKit::RemoteLegacyCDMIdentifierType
+template: enum class WebKit::RemoteLegacyCDMSessionIdentifierType
+template: enum class WebKit::RemoteMediaResourceIdentifierType
+template: enum class WebKit::RemoteMediaSourceIdentifierType
+template: enum class WebKit::RemoteRemoteCommandListenerIdentifierType
+template: enum class WebKit::RemoteSourceBufferIdentifierType
+template: enum class WebKit::RetrieveRecordResponseBodyCallbackIdentifierType
+template: enum class WebKit::SampleBufferDisplayLayerIdentifierType
+template: enum class WebKit::ScriptMessageHandlerIdentifierType
+template: enum class WebKit::ShapeDetectionIdentifierType
 template: enum class WebKit::StorageAreaImplIdentifierType
 template: enum class WebKit::StorageAreaMapIdentifierType
 template: enum class WebKit::StorageNamespaceIdentifierType
 template: enum class WebKit::UserScriptIdentifierType
 template: enum class WebKit::UserStyleSheetIdentifierType
 template: enum class WebKit::VisitedLinkTableIdentifierType
+template: enum class WebKit::WCLayerTreeHostIdentifierType
+template: enum class WebKit::WebExtensionControllerIdentifierType
+template: enum class WebKit::XRDeviceIdentifierType
 template: struct WebCore::BackForwardItemIdentifierType
 template: struct WebCore::FrameIdentifierType
 template: struct WebCore::NavigationIdentifierType
@@ -148,10 +142,14 @@ template: struct WebKit::DataTaskIdentifierType
 template: struct WebKit::DisplayLinkObserverIDType
 template: struct WebKit::DrawingAreaIdentifierType
 template: struct WebKit::GeolocationIdentifierType
+template: struct WebKit::IPCConnectionTesterIdentifierType
+template: struct WebKit::IPCStreamTesterIdentifierType
 template: struct WebKit::MarkSurfacesAsVolatileRequestIdentifierType
 template: struct WebKit::NetworkResourceLoadIdentifierType
 template: struct WebKit::PDFPluginIdentifierType
 template: struct WebKit::PageGroupIdentifierType
+template: struct WebKit::RemoteAudioDestinationIdentifierType
+template: struct WebKit::RemoteImageBufferSetIdentifierType
 template: struct WebKit::TapIdentifierType
 template: struct WebKit::TextCheckerRequestType
 template: struct WebKit::UserContentControllerIdentifierType
@@ -161,6 +159,8 @@ template: struct WebKit::WebExtensionPortChannelIdentifierType
 template: struct WebKit::WebExtensionTabIdentifierType
 template: struct WebKit::WebExtensionWindowIdentifierType
 template: struct WebKit::WebPageProxyIdentifierType
+template: struct WebKit::WebTransportSessionIdentifierType
+template: struct WebKit::WebTransportStreamIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }

--- a/Source/WebKit/Shared/XR/XRDeviceIdentifier.h
+++ b/Source/WebKit/Shared/XR/XRDeviceIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class XRDeviceIdentifierType { };
-using XRDeviceIdentifier = LegacyNullableObjectIdentifier<XRDeviceIdentifierType>;
+using XRDeviceIdentifier = ObjectIdentifier<XRDeviceIdentifierType>;
 
 }
 

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -42,9 +42,9 @@ Ref<XRDeviceProxy> XRDeviceProxy::create(XRDeviceInfo&& deviceInfo, PlatformXRSy
 }
 
 XRDeviceProxy::XRDeviceProxy(XRDeviceInfo&& deviceInfo, PlatformXRSystemProxy& xrSystem)
-    : m_xrSystem(xrSystem)
+    : m_identifier(deviceInfo.identifier)
+    , m_xrSystem(xrSystem)
 {
-    m_identifier = deviceInfo.identifier;
     m_supportsStereoRendering = deviceInfo.supportsStereoRendering;
     m_supportsOrientationTracking = deviceInfo.supportsOrientationTracking;
     m_recommendedResolution = deviceInfo.recommendedResolution;

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -51,8 +51,7 @@ ContentWorld* ContentWorld::worldForIdentifier(WebKit::ContentWorldIdentifier id
     return sharedWorldIdentifierMap().get(identifier);
 }
 
-ContentWorld::ContentWorld(const WTF::String& name)
-    : m_name(name)
+static WebKit::ContentWorldIdentifier generateIdentifier()
 {
     static std::once_flag once;
     std::call_once(once, [] {
@@ -61,8 +60,13 @@ ContentWorld::ContentWorld(const WTF::String& name)
         auto identifier = WebKit::ContentWorldIdentifier::generate();
         ASSERT_UNUSED(identifier, identifier.toUInt64() >= WebKit::pageContentWorldIdentifier().toUInt64());
     });
+    return WebKit::ContentWorldIdentifier::generate();
+}
 
-    m_identifier = WebKit::ContentWorldIdentifier::generate();
+ContentWorld::ContentWorld(const WTF::String& name)
+    : m_identifier(generateIdentifier())
+    , m_name(name)
+{
     auto addResult = sharedWorldIdentifierMap().add(m_identifier, *this);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -77,15 +77,13 @@ WebExtensionController::~WebExtensionController()
 
 WebExtensionControllerParameters WebExtensionController::parameters() const
 {
-    WebExtensionControllerParameters parameters;
-
-    parameters.identifier = identifier();
-    parameters.testingMode = inTestingMode();
-    parameters.contextParameters = WTF::map(extensionContexts(), [](auto& context) {
-        return context->parameters();
-    });
-
-    return parameters;
+    return {
+        .identifier = identifier(),
+        .testingMode = inTestingMode(),
+        .contextParameters = WTF::map(extensionContexts(), [](auto& context) {
+            return context->parameters();
+        })
+    };
 }
 
 WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses() const

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -63,7 +63,7 @@ namespace WebKit {
 class WebPageProxy;
 
 enum class MediaDevicePermissionRequestIdentifierType { };
-using MediaDevicePermissionRequestIdentifier = LegacyNullableObjectIdentifier<MediaDevicePermissionRequestIdentifierType>;
+using MediaDevicePermissionRequestIdentifier = ObjectIdentifier<MediaDevicePermissionRequestIdentifierType>;
 
 class UserMediaPermissionRequestManagerProxy final
     : public RefCountedAndCanMakeWeakPtr<UserMediaPermissionRequestManagerProxy>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -294,7 +294,7 @@ enum class DynamicImageAnalysisContextMenuState : uint8_t {
 };
 
 enum class ImageAnalysisRequestIdentifierType { };
-using ImageAnalysisRequestIdentifier = LegacyNullableObjectIdentifier<ImageAnalysisRequestIdentifierType>;
+using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIdentifierType>;
 
 struct ImageAnalysisContextMenuActionData {
     bool hasSelectableText { false };

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/WCLayerTreeHostIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/WCLayerTreeHostIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class WCLayerTreeHostIdentifierType { };
-using WCLayerTreeHostIdentifier = LegacyNullableObjectIdentifier<WCLayerTreeHostIdentifierType>;
+using WCLayerTreeHostIdentifier = ObjectIdentifier<WCLayerTreeHostIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1010,12 +1010,13 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
         || (platformStrategies()->mediaStrategy().mockMediaSourceEnabled() && m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::MockMSE)) {
 
         RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateRemote>(client.mediaSourcePrivate());
-        RemoteMediaSourceIdentifier identifier;
-        if (mediaSourcePrivate) {
-            mediaSourcePrivate->setPlayer(this);
-            identifier = mediaSourcePrivate->identifier();
-        } else
-            identifier = RemoteMediaSourceIdentifier::generate();
+        RemoteMediaSourceIdentifier identifier = [&] {
+            if (mediaSourcePrivate) {
+                mediaSourcePrivate->setPlayer(this);
+                return mediaSourcePrivate->identifier();
+            }
+            return RemoteMediaSourceIdentifier::generate();
+        }();
         connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::LoadMediaSource(url, contentType, DeprecatedGlobalSettings::webMParserEnabled(), identifier), [weakThis = ThreadSafeWeakPtr { *this }, this](RemoteMediaPlayerConfiguration&& configuration) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -111,14 +111,13 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
         return AddStatus::NotSupported;
 
     AddStatus returnedStatus;
-    RemoteSourceBufferIdentifier returnedIdentifier;
     RefPtr<SourceBufferPrivate> returnedSourceBuffer;
     DEBUG_LOG(LOGIDENTIFIER, contentType);
 
     // the sendSync() call requires us to run on the connection's dispatcher, which is the main thread.
     // FIXME: Uses a new Connection for remote playback, and not the main GPUProcessConnection's one.
     // FIXME: m_mimeTypeCache is a main-thread only object.
-    callOnMainRunLoopAndWait([this, &returnedStatus, &returnedIdentifier, contentTypeString = contentType.raw().isolatedCopy(), &returnedSourceBuffer, gpuProcessConnection] {
+    callOnMainRunLoopAndWait([this, &returnedStatus, contentTypeString = contentType.raw().isolatedCopy(), &returnedSourceBuffer, gpuProcessConnection] {
         ContentType contentType { contentTypeString };
         MediaEngineSupportParameters parameters;
         parameters.isMediaSource = true;
@@ -133,7 +132,6 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
 
         if (status == AddStatus::Ok) {
             ASSERT(remoteSourceBufferIdentifier.has_value());
-            returnedIdentifier = * remoteSourceBufferIdentifier;
             returnedSourceBuffer = SourceBufferPrivateRemote::create(*gpuProcessConnection, *remoteSourceBufferIdentifier, *this);
         }
         returnedStatus = status;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -161,7 +161,7 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
             frameCountHandle = m_frameCount->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
         }
         RELEASE_ASSERT(frameCountHandle.has_value());
-        gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::CreateAudioDestination(m_destinationID, m_inputDeviceId, m_numberOfInputChannels, m_outputBus->numberOfChannels(), sampleRate(), m_remoteSampleRate, m_renderSemaphore, WTFMove(*frameCountHandle)), 0);
+        gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::CreateAudioDestination(*m_destinationID, m_inputDeviceId, m_numberOfInputChannels, m_outputBus->numberOfChannels(), sampleRate(), m_remoteSampleRate, m_renderSemaphore, WTFMove(*frameCountHandle)), 0);
 
 #if PLATFORM(COCOA)
         m_currentFrame = 0;
@@ -171,7 +171,7 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
         RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
         auto [ringBuffer, handle] = WTFMove(*result);
         m_ringBuffer = WTFMove(ringBuffer);
-        gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle) }, 0);
+        gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { *m_destinationID, WTFMove(handle) }, 0);
         m_audioBufferList = makeUnique<WebCore::WebAudioBufferList>(streamFormat);
         m_audioBufferList->setSampleCount(maxAudioBufferListSampleCount);
 #endif
@@ -190,7 +190,7 @@ IPC::Connection* RemoteAudioDestinationProxy::existingConnection()
 RemoteAudioDestinationProxy::~RemoteAudioDestinationProxy()
 {
     if (auto gpuProcessConnection = m_gpuProcessConnection.get(); gpuProcessConnection && m_destinationID)
-        gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::DeleteAudioDestination(m_destinationID), 0);
+        gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::DeleteAudioDestination(*m_destinationID), 0);
     stopRenderingThread();
 }
 
@@ -205,7 +205,7 @@ void RemoteAudioDestinationProxy::startRendering(CompletionHandler<void(bool)>&&
         return;
     }
 
-    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StartAudioDestination(m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
+    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StartAudioDestination(*m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
         protectedThis->setIsPlaying(isPlaying);
         completionHandler(isPlaying);
     });
@@ -222,7 +222,7 @@ void RemoteAudioDestinationProxy::stopRendering(CompletionHandler<void(bool)>&& 
         return;
     }
 
-    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StopAudioDestination(m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
+    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StopAudioDestination(*m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
         protectedThis->setIsPlaying(isPlaying);
         completionHandler(!isPlaying);
     });
@@ -261,7 +261,7 @@ void RemoteAudioDestinationProxy::gpuProcessConnectionDidClose(GPUProcessConnect
 {
     stopRenderingThread();
     m_gpuProcessConnection = nullptr;
-    m_destinationID = { };
+    m_destinationID = std::nullopt;
 
     if (isPlaying())
         startRendering([](bool) { });

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -79,7 +79,7 @@ private:
 
     uint32_t totalFrameCount() const;
 
-    RemoteAudioDestinationIdentifier m_destinationID; // Call destinationID() getter to make sure the destinationID is valid.
+    Markable<RemoteAudioDestinationIdentifier> m_destinationID; // Call destinationID() getter to make sure the destinationID is valid.
 
     static uint8_t s_realtimeThreadCount;
     static constexpr uint8_t s_maximumConcurrentRealtimeThreads { 3 };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListenerIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListenerIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteAudioHardwareListenerIdentifierType { };
-using RemoteAudioHardwareListenerIdentifier = LegacyNullableObjectIdentifier<RemoteAudioHardwareListenerIdentifierType>;
+using RemoteAudioHardwareListenerIdentifier = ObjectIdentifier<RemoteAudioHardwareListenerIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteAudioSessionIdentifierType { };
-using RemoteAudioSessionIdentifier = LegacyNullableObjectIdentifier<RemoteAudioSessionIdentifierType>;
+using RemoteAudioSessionIdentifier = ObjectIdentifier<RemoteAudioSessionIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -121,10 +121,10 @@ RefPtr<CDMInstance> RemoteCDM::createInstance()
         return nullptr;
 
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMProxy::CreateInstance(), m_identifier);
-    auto [identifier, configuration] = sendResult.takeReplyOr(RemoteCDMInstanceIdentifier { }, RemoteCDMInstanceConfiguration { });
+    auto [identifier, configuration] = sendResult.takeReplyOr(std::nullopt, RemoteCDMInstanceConfiguration { });
     if (!identifier)
         return nullptr;
-    return RemoteCDMInstance::create(m_factory.get(), WTFMove(identifier), WTFMove(configuration));
+    return RemoteCDMInstance::create(m_factory.get(), WTFMove(*identifier), WTFMove(configuration));
 }
 
 void RemoteCDM::loadAndInitialize()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -73,10 +73,10 @@ bool RemoteCDMFactory::supportsKeySystem(const String& keySystem)
 std::unique_ptr<CDMPrivate> RemoteCDMFactory::createCDM(const String& keySystem, const CDMPrivateClient&)
 {
     auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteCDMFactoryProxy::CreateCDM(keySystem), { });
-    auto [identifier, configuration] = sendResult.takeReplyOr(RemoteCDMIdentifier { }, RemoteCDMConfiguration { });
+    auto [identifier, configuration] = sendResult.takeReplyOr(std::nullopt, RemoteCDMConfiguration { });
     if (!identifier)
         return nullptr;
-    return RemoteCDM::create(*this, WTFMove(identifier), WTFMove(configuration));
+    return RemoteCDM::create(*this, WTFMove(*identifier), WTFMove(configuration));
 }
 
 void RemoteCDMFactory::addSession(RemoteCDMInstanceSession& session)
@@ -99,8 +99,10 @@ void RemoteCDMFactory::removeInstance(RemoteCDMInstanceIdentifier identifier)
 
 void RemoteCDMFactory::didReceiveSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto session = m_sessions.get(LegacyNullableObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
+            session->didReceiveMessage(connection, decoder);
+    }
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteCDMIdentifierType { };
-using RemoteCDMIdentifier = LegacyNullableObjectIdentifier<RemoteCDMIdentifierType>;
+using RemoteCDMIdentifier = ObjectIdentifier<RemoteCDMIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
@@ -110,10 +110,10 @@ RefPtr<WebCore::CDMInstanceSession> RemoteCDMInstance::createSession()
 #endif
 
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMInstanceProxy::CreateSession(logIdentifier), m_identifier);
-    auto [identifier] = sendResult.takeReplyOr(RemoteCDMInstanceSessionIdentifier { });
+    auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
-    auto session = RemoteCDMInstanceSession::create(m_factory.get(), WTFMove(identifier));
+    auto session = RemoteCDMInstanceSession::create(m_factory.get(), WTFMove(*identifier));
     m_factory->addSession(session.copyRef());
     return session;
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteCDMInstanceIdentifierType { };
-using RemoteCDMInstanceIdentifier = LegacyNullableObjectIdentifier<RemoteCDMInstanceIdentifierType>;
+using RemoteCDMInstanceIdentifier = ObjectIdentifier<RemoteCDMInstanceIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSessionIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSessionIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteCDMInstanceSessionIdentifierType { };
-using RemoteCDMInstanceSessionIdentifier = LegacyNullableObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>;
+using RemoteCDMInstanceSessionIdentifier = ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -73,10 +73,10 @@ std::unique_ptr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCor
 #endif
 
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(storageDirectory, logIdentifier), m_identifier);
-    auto [identifier] = sendResult.takeReplyOr(RemoteLegacyCDMSessionIdentifier { });
+    auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
-    return RemoteLegacyCDMSession::create(m_factory, WTFMove(identifier), client);
+    return RemoteLegacyCDMSession::create(m_factory, WTFMove(*identifier), client);
 }
 
 void RemoteLegacyCDM::setPlayerId(MediaPlayerIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -115,11 +115,11 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
         playerId = gpuProcessConnection().mediaPlayerManager().findRemotePlayerId(player->playerPrivate());
 
     auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm->keySystem(), WTFMove(playerId)), { });
-    auto [identifier] = sendResult.takeReplyOr(RemoteLegacyCDMIdentifier { });
+    auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
-    auto remoteCDM = RemoteLegacyCDM::create(*this, identifier);
-    m_cdms.set(identifier, remoteCDM.get());
+    auto remoteCDM = RemoteLegacyCDM::create(*this, *identifier);
+    m_cdms.set(*identifier, remoteCDM.get());
     return remoteCDM;
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteLegacyCDMIdentifierType { };
-using RemoteLegacyCDMIdentifier = LegacyNullableObjectIdentifier<RemoteLegacyCDMIdentifierType>;
+using RemoteLegacyCDMIdentifier = ObjectIdentifier<RemoteLegacyCDMIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSessionIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSessionIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteLegacyCDMSessionIdentifierType { };
-using RemoteLegacyCDMSessionIdentifier = LegacyNullableObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>;
+using RemoteLegacyCDMSessionIdentifier = ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaSourceIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaSourceIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteMediaSourceIdentifierType { };
-using RemoteMediaSourceIdentifier = LegacyNullableObjectIdentifier<RemoteMediaSourceIdentifierType>;
+using RemoteMediaSourceIdentifier = ObjectIdentifier<RemoteMediaSourceIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListenerIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListenerIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RemoteRemoteCommandListenerIdentifierType { };
-using RemoteRemoteCommandListenerIdentifier = LegacyNullableObjectIdentifier<RemoteRemoteCommandListenerIdentifierType>;
+using RemoteRemoteCommandListenerIdentifier = ObjectIdentifier<RemoteRemoteCommandListenerIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class AudioMediaStreamTrackRendererInternalUnitIdentifierType { };
-using AudioMediaStreamTrackRendererInternalUnitIdentifier = LegacyNullableObjectIdentifier<AudioMediaStreamTrackRendererInternalUnitIdentifierType>;
+using AudioMediaStreamTrackRendererInternalUnitIdentifier = ObjectIdentifier<AudioMediaStreamTrackRendererInternalUnitIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -71,7 +71,6 @@ private:
     void createRemoteUnit();
 
     Client& m_client;
-    AudioMediaStreamTrackRendererInternalUnitIdentifier m_identifier;
 
     Deque<CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>> m_descriptionCallbacks;
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum class MediaRecorderIdentifierType { };
-using MediaRecorderIdentifier = LegacyNullableObjectIdentifier<MediaRecorderIdentifierType>;
+using MediaRecorderIdentifier = ObjectIdentifier<MediaRecorderIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class SampleBufferDisplayLayerIdentifierType { };
-using SampleBufferDisplayLayerIdentifier = LegacyNullableObjectIdentifier<SampleBufferDisplayLayerIdentifierType>;
+using SampleBufferDisplayLayerIdentifier = ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -39,8 +39,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SampleBufferDisplayLayerManager);
 
 void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (auto* layer = m_layers.get(LegacyNullableObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID())).get())
-        layer->didReceiveMessage(connection, decoder);
+    if (ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>::isValidIdentifier(decoder.destinationID())) {
+        if (auto* layer = m_layers.get(ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID())).get())
+            layer->didReceiveMessage(connection, decoder);
+    }
 }
 
 RefPtr<WebCore::SampleBufferDisplayLayer> SampleBufferDisplayLayerManager::createLayer(WebCore::SampleBufferDisplayLayerClient& client)

--- a/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.h
@@ -32,7 +32,7 @@ namespace WebKit {
 class WebTransportSession;
 
 struct WebTransportStreamIdentifierType;
-using WebTransportStreamIdentifier = LegacyNullableObjectIdentifier<WebTransportStreamIdentifierType>;
+using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
 class WebTransportSendStreamSink : public WebCore::WritableStreamSink {
 public:

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -42,8 +42,8 @@ class WebTransportSendStream;
 struct WebTransportStreamIdentifierType { };
 struct WebTransportSessionIdentifierType { };
 
-using WebTransportStreamIdentifier = LegacyNullableObjectIdentifier<WebTransportStreamIdentifierType>;
-using WebTransportSessionIdentifier = LegacyNullableObjectIdentifier<WebTransportSessionIdentifierType>;
+using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
+using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdentifierType>;
 
 class WebTransportSession : public WebCore::WebTransportSession, public IPC::MessageReceiver, public IPC::MessageSender, public ThreadSafeRefCounted<WebTransportSession, WTF::DestructionThread::MainRunLoop> {
 public:

--- a/Source/WebKit/WebProcess/Storage/RetrieveRecordResponseBodyCallbackIdentifier.h
+++ b/Source/WebKit/WebProcess/Storage/RetrieveRecordResponseBodyCallbackIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebKit {
 
 enum class RetrieveRecordResponseBodyCallbackIdentifierType { };
-using RetrieveRecordResponseBodyCallbackIdentifier = LegacyNullableObjectIdentifier<RetrieveRecordResponseBodyCallbackIdentifierType>;
+using RetrieveRecordResponseBodyCallbackIdentifier = ObjectIdentifier<RetrieveRecordResponseBodyCallbackIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -106,7 +106,6 @@ InjectedBundleScriptWorld* WebUserContentController::worldForIdentifier(ContentW
 
 InjectedBundleScriptWorld* WebUserContentController::addContentWorld(const std::pair<ContentWorldIdentifier, String>& world)
 {
-    ASSERT(world.first);
     if (world.first == pageContentWorldIdentifier())
         return nullptr;
     
@@ -150,7 +149,6 @@ void WebUserContentController::addContentWorlds(const Vector<std::pair<ContentWo
 void WebUserContentController::removeContentWorlds(const Vector<ContentWorldIdentifier>& worldIdentifiers)
 {
     for (auto& worldIdentifier : worldIdentifiers) {
-        ASSERT(worldIdentifier);
         ASSERT(worldIdentifier != pageContentWorldIdentifier());
 
         auto it = worldMap().find(worldIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1227,7 +1227,7 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
 
     auto& streamConnection = jsStreamConnection->connection();
     enum JSIPCStreamTesterIdentifierType { };
-    auto destination = LegacyNullableObjectIdentifier<JSIPCStreamTesterIdentifierType>(*destinationID);
+    auto destination = ObjectIdentifier<JSIPCStreamTesterIdentifierType>(*destinationID);
 
     auto sendResult = streamConnection.sendSync(Messages::IPCStreamTester::SyncCrashOnZero(value), destination);
     if (!sendResult.succeeded()) {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -162,7 +162,7 @@ struct WebsiteDataStoreParameters;
 enum class RemoteWorkerType : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
-using WebTransportSessionIdentifier = LegacyNullableObjectIdentifier<WebTransportSessionIdentifierType>;
+using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdentifierType>;
 
 #if PLATFORM(IOS_FAMILY)
 class LayerHostingContext;


### PR DESCRIPTION
#### c7745473904a1fd35710d391b778fe1b28b59fa0
<pre>
Reduce further use of LegacyNullableObjectIdentifier in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=281017">https://bugs.webkit.org/show_bug.cgi?id=281017</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::createCDM):
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMInstanceMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp:
(WebKit::RemoteCDMProxy::createInstance):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::createCDM):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveCDMMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveCDMSessionMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceIdentifier.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferIdentifier.h:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp:
(WebKit::RemoteMediaRecorderManager::didReceiveRemoteMediaRecorderMessage):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp:
(WebKit::RemoteSampleBufferDisplayLayerManager::dispatchMessage):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/Shared/ContentWorldShared.h:
(WebKit::pageContentWorldIdentifier):
* Source/WebKit/Shared/Extensions/WebExtensionControllerIdentifier.h:
* Source/WebKit/Shared/IPCConnectionTesterIdentifier.h:
* Source/WebKit/Shared/IPCStreamTesterIdentifier.h:
* Source/WebKit/Shared/RemoteAudioDestinationIdentifier.h:
* Source/WebKit/Shared/RemoteImageBufferSetIdentifier.h:
* Source/WebKit/Shared/ScriptMessageHandlerIdentifier.h:
* Source/WebKit/Shared/ShapeDetectionIdentifier.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/XR/XRDeviceIdentifier.h:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::generateIdentifier):
(API::ContentWorld::ContentWorld):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::parameters const):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/WebProcess/GPU/graphics/wc/WCLayerTreeHostIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::addSourceBuffer):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::~RemoteAudioDestinationProxy):
(WebKit::RemoteAudioDestinationProxy::startRendering):
(WebKit::RemoteAudioDestinationProxy::stopRendering):
(WebKit::RemoteAudioDestinationProxy::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListenerIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
(WebKit::RemoteCDM::createInstance):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::createCDM):
(WebKit::RemoteCDMFactory::didReceiveSessionMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp:
(WebKit::RemoteCDMInstance::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSessionIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::createCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSessionIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaSourceIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListenerIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp:
(WebKit::SampleBufferDisplayLayerManager::didReceiveLayerMessage):
* Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKit/WebProcess/Storage/RetrieveRecordResponseBodyCallbackIdentifier.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorld):
(WebKit::WebUserContentController::removeContentWorlds):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/284830@main">https://commits.webkit.org/284830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1b4d102cbb1ecb00d80ae2c1277ed38e274eaa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21783 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36380 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42129 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20144 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76414 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63586 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5280 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10822 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/581 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->