### PR TITLE
CodeSign of TestWebKitAPI.app fails in some configurations on macOS

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/Base.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/Base.xcconfig
@@ -87,6 +87,8 @@ DEBUG_DEFINES[config=Debug] = $(WK_ENABLE_CONJECTURE_ASSERT_YES);
 
 WK_DEFAULT_GCC_OPTIMIZATION_LEVEL[config=Debug] = 0;
 
+AD_HOC_CODE_SIGNING_ALLOWED = YES;
+
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
 

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig
@@ -40,6 +40,8 @@ INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=embedded*] = YES;
 INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad[sdk=embedded*] = UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight;
 INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone[sdk=embedded*] = UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight;
 
+TARGETED_DEVICE_FAMILY = 1,2,4,7;
+
 CLANG_ENABLE_OBJC_ARC = YES;
 CLANG_ENABLE_OBJC_WEAK = YES;
 


### PR DESCRIPTION
#### 45be32b703ec845c521898d4fdda7e29d67b80a2
<pre>
CodeSign of TestWebKitAPI.app fails in some configurations on macOS
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=281033">https://bugs.webkit.org/show_bug.cgi?id=281033</a>&gt;
&lt;<a href="https://rdar.apple.com/137451687">rdar://137451687</a>&gt;

Reviewed by Jonathan Bedard.

Update TestWebKitAPI project build settings to match WebKitTestRunner.

* Tools/TestWebKitAPI/Configurations/Base.xcconfig:
(AD_HOC_CODE_SIGNING_ALLOWED): Add.
- Allow ad-hoc code signing.
* Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig:
(TARGETED_DEVICE_FAMILY): Add.
- Define which devices are allowed to build TestWebKitAPI.app.

Canonical link: <a href="https://commits.webkit.org/284832@main">https://commits.webkit.org/284832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134b8d1014a40a004aea01abd179f74be349646c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55920 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76421 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63592 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5286 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/588 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->