### PR TITLE
[JSC] Array.from() and friends should invoke `document.all` passed as a mapper

### DIFF
--- a/JSTests/stress/regress-281037.js
+++ b/JSTests/stress/regress-281037.js
@@ -1,0 +1,24 @@
+load("./resources/typedarray-test-helper-functions.js", "caller relative");
+
+function shouldBeArray(actual, expected) {
+    const isEqual = actual.length === expected.length && actual.every((item, index) => item === expected[index]);
+    if (!isEqual)
+        throw new Error(`Expected [${actual.map(String)}] to equal [${expected.map(String)}]`);
+}
+
+shouldBeArray(Array.from([0, 1, 2], makeMasquerader()), [null, null, null]);
+shouldBeArray(Array.from([0, 1, 2].values(), makeMasquerader()), [null, null, null]);
+shouldBeArray(Array.from({0:0, 1:1, 2:2, length: 3}, makeMasquerader()), [null, null, null]);
+
+for (const TypedArray of typedArrays) {
+    shouldBeArray(TypedArray.from([0, 1, 2], makeMasquerader()), [0, 0, 0]);
+    shouldBeArray(TypedArray.from([0, 1, 2].values(), makeMasquerader()), [0, 0, 0]);
+    shouldBeArray(TypedArray.from({0:0, 1:1, 2:2, length: 3}, makeMasquerader()), [0, 0, 0]);
+}
+
+(async function() {
+    shouldBeArray(await Array.fromAsync([0, 1, 2], makeMasquerader()), [null, null, null]);
+    shouldBeArray(await Array.fromAsync([0, 1, 2].values(), makeMasquerader()), [null, null, null]);
+    shouldBeArray(await Array.fromAsync({0:0, 1:1, 2:2, length: 3}, makeMasquerader()), [null, null, null]);
+})().catch(err => { $vm.abort(err); });
+drainMicrotasks();

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -52,7 +52,7 @@ function from(items /*, mapFn, thisArg */)
 
     var arrayLike = @toObject(items, "Array.from requires an array-like object - not null or undefined");
 
-    if (!mapFn) {
+    if (mapFn === @undefined) {
         var fastResult = @arrayFromFastFillWithUndefined(this, arrayLike);
         if (fastResult)
             return fastResult;
@@ -78,10 +78,10 @@ function from(items /*, mapFn, thisArg */)
         for (var value of wrapper) {
             if (k >= @MAX_SAFE_INTEGER)
                 @throwTypeError("Length exceeded the maximum array length");
-            if (mapFn)
-                @putByValDirect(result, k, thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k));
-            else
+            if (mapFn === @undefined)
                 @putByValDirect(result, k, value);
+            else
+                @putByValDirect(result, k, thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k));
             k += 1;
         }
 
@@ -96,10 +96,10 @@ function from(items /*, mapFn, thisArg */)
     var k = 0;
     while (k < arrayLikeLength) {
         var value = arrayLike[k];
-        if (mapFn)
-            @putByValDirect(result, k, thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k));
-        else
+        if (mapFn === @undefined)
             @putByValDirect(result, k, value);
+        else
+            @putByValDirect(result, k, thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k));
         k += 1;
     }
 
@@ -138,10 +138,10 @@ async function defaultAsyncFromAsyncIterator(iterator, mapFn, thisArg)
     for await (var value of wrapper) {
         if (k >= @MAX_SAFE_INTEGER)
             @throwTypeError("Length exceeded the maximum array length");
-        if (mapFn)
-            @putByValDirect(result, k, await (thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k)));
-        else
+        if (mapFn === @undefined)
             @putByValDirect(result, k, value);
+        else
+            @putByValDirect(result, k, await (thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k)));
         k += 1;
     }
 
@@ -164,10 +164,10 @@ async function defaultAsyncFromAsyncArrayLike(asyncItems, mapFn, thisArg)
     var k = 0;
     while (k < arrayLikeLength) {
         var value = await arrayLike[k];
-        if (mapFn)
-            @putByValDirect(result, k, await (thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k)));
-        else
+        if (mapFn === @undefined)
             @putByValDirect(result, k, value);
+        else
+            @putByValDirect(result, k, await (thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k)));
         k += 1;
     }
 

--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -60,7 +60,7 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
 
     var arrayLike = @toObject(items, "TypedArray.from requires an array-like object - not null or undefined");
 
-    if (!mapFn) {
+    if (mapFn === @undefined) {
         var fastResult = @typedArrayFromFast(this, arrayLike);
         if (fastResult)
             return fastResult;
@@ -93,10 +93,10 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
 
         for (var k = 0; k < count; k++) {
             var value = accumulator[k];
-            if (mapFn)
-                result[k] = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
-            else
+            if (mapFn === @undefined)
                 result[k] = value;
+            else
+                result[k] = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
         }
 
         return result;
@@ -110,10 +110,10 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
 
     for (var k = 0; k < arrayLikeLength; k++) {
         var value = arrayLike[k];
-        if (mapFn)
-            result[k] = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
-        else
+        if (mapFn === @undefined)
             result[k] = value;
+        else
+            result[k] = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
     }
 
     return result;


### PR DESCRIPTION
#### 5a71a33b9e2231e6721b8398946acc01896ff24f
<pre>
[JSC] Array.from() and friends should invoke `document.all` passed as a mapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=281037">https://bugs.webkit.org/show_bug.cgi?id=281037</a>
&lt;<a href="https://rdar.apple.com/problem/137490201">rdar://problem/137490201</a>&gt;

Reviewed by Yijia Huang.

After the parameter validation, Array.from() and friends deal with either callable `mapFn` or `undefined`.
However, the assumption that all callable objects are truthy is incorrect because of `document.all` [1].
This patch tightens the checks to use strict equality, aligning JSC with the spec, V8, and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-to-boolean">https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-to-boolean</a>

* JSTests/stress/regress-281037.js: Added.
* Source/JavaScriptCore/builtins/ArrayConstructor.js:
(from):
(linkTimeConstant.visibility.PrivateRecursive.async defaultAsyncFromAsyncIterator):
(linkTimeConstant.visibility.PrivateRecursive.async defaultAsyncFromAsyncArrayLike):
* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
(from):

Canonical link: <a href="https://commits.webkit.org/284868@main">https://commits.webkit.org/284868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fd1a6095e68520357500653cef871ef3c366bca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/70791 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/50201 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/23560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/57999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/21812 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/73857 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/57999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/23560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/57999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/23560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/63913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/57999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/23560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/70040 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/15021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/21812 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/76602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/15065 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/23560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/23560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/91821 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10850 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/46002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/91821 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->