### PR TITLE
[GTK][WPE] Move AcceleratedSurface handling from LayerTreeHost to ThreadedCompositor

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -46,12 +46,7 @@ class AcceleratedSurface {
     WTF_MAKE_NONCOPYABLE(AcceleratedSurface);
     WTF_MAKE_TZONE_ALLOCATED(AcceleratedSurface);
 public:
-    class Client {
-    public:
-        virtual void frameComplete() = 0;
-    };
-
-    static std::unique_ptr<AcceleratedSurface> create(WebPage&, Client&);
+    static std::unique_ptr<AcceleratedSurface> create(WebPage&, Function<void()>&& frameCompleteHandler);
     virtual ~AcceleratedSurface() = default;
 
     virtual uint64_t window() const { ASSERT_NOT_REACHED(); return 0; }
@@ -60,7 +55,6 @@ public:
     virtual void clientResize(const WebCore::IntSize&) { };
     virtual bool shouldPaintMirrored() const { return false; }
 
-    virtual void initialize() { }
     virtual void didCreateGLContext() { }
     virtual void willDestroyGLContext() { }
     virtual void finalize() { }
@@ -81,10 +75,12 @@ public:
     void clearIfNeeded();
 
 protected:
-    AcceleratedSurface(WebPage&, Client&);
+    AcceleratedSurface(WebPage&, Function<void()>&& frameCompleteHandler);
+
+    void frameComplete() const;
 
     WeakRef<WebPage> m_webPage;
-    Client& m_client;
+    Function<void()> m_frameCompleteHandler;
     WebCore::IntSize m_size;
     std::atomic<bool> m_isOpaque { true };
 };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -71,12 +71,9 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
 LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displayID)
 #endif
     : m_webPage(webPage)
-    , m_surface(AcceleratedSurface::create(webPage, *this))
     , m_viewportController(webPage.size())
     , m_layerFlushTimer(RunLoop::main(), this, &LayerTreeHost::layerFlushTimerFired)
-#if HAVE(DISPLAY_LINK)
-    , m_didRenderFrameTimer(RunLoop::main(), this, &LayerTreeHost::didRenderFrameTimerFired)
-#else
+#if !HAVE(DISPLAY_LINK)
     , m_displayID(displayID)
 #endif
 #if USE(CAIRO)
@@ -112,27 +109,12 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
             m_viewportController.didChangeContentsSize(contentsSize);
     }
 
-    IntSize scaledSize(m_webPage.size());
-    scaledSize.scale(m_webPage.deviceScaleFactor());
-    float scaleFactor = m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor();
-
-    const auto damagePropagation = ([](const WebCore::Settings& settings) {
-        if (!settings.propagateDamagingInformation())
-            return ThreadedCompositor::DamagePropagation::None;
-        if (settings.unifyDamagedRegions())
-            return ThreadedCompositor::DamagePropagation::Unified;
-        return ThreadedCompositor::DamagePropagation::Region;
-    })(m_webPage.corePage()->settings());
-
 #if HAVE(DISPLAY_LINK)
-    // FIXME: remove the displayID from ThreadedCompositor too.
-    auto displayID = m_webPage.corePage()->displayID();
-    m_compositor = ThreadedCompositor::create(*this, displayID, scaledSize, scaleFactor, m_surface->shouldPaintMirrored(), damagePropagation);
+    m_compositor = ThreadedCompositor::create(*this, m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor());
 #else
-    m_compositor = ThreadedCompositor::create(*this, *this, displayID, scaledSize, scaleFactor, m_surface->shouldPaintMirrored(), damagePropagation);
+    m_compositor = ThreadedCompositor::create(*this, *this, m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor(), displayID);
 #endif
-    m_layerTreeContext.contextID = m_surface->surfaceID();
-    m_surface->didCreateCompositingRunLoop(m_compositor->compositingRunLoop());
+    m_layerTreeContext.contextID = m_compositor->surfaceID();
 
     didChangeViewport();
 }
@@ -140,8 +122,6 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
 LayerTreeHost::~LayerTreeHost()
 {
     cancelPendingLayerFlush();
-
-    m_surface->willDestroyCompositingRunLoop();
 
     m_nicosia.sceneIntegration->invalidate();
 
@@ -160,7 +140,6 @@ LayerTreeHost::~LayerTreeHost()
 #endif
 
     m_compositor->invalidate();
-    m_surface = nullptr;
 }
 
 void LayerTreeHost::setLayerFlushSchedulingEnabled(bool layerFlushingEnabled)
@@ -379,30 +358,23 @@ void LayerTreeHost::forceRepaintAsync(CompletionHandler<void()>&& callback)
 
 void LayerTreeHost::sizeDidChange(const IntSize& size)
 {
-    if (m_surface->hostResize(size))
-        m_layerTreeContext.contextID = m_surface->surfaceID();
-
     m_rootLayer->setSize(size);
     scheduleLayerFlush();
 
     m_viewportController.didChangeViewportSize(size);
-    IntSize scaledSize(size);
-    scaledSize.scale(m_webPage.deviceScaleFactor());
-    m_compositor->setViewportSize(scaledSize, m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor());
+    m_compositor->setViewportSize(size, m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor());
     didChangeViewport();
 }
 
 void LayerTreeHost::pauseRendering()
 {
     m_isSuspended = true;
-    m_surface->visibilityDidChange(false);
     m_compositor->suspend();
 }
 
 void LayerTreeHost::resumeRendering()
 {
     m_isSuspended = false;
-    m_surface->visibilityDidChange(true);
     m_compositor->resume();
     scheduleLayerFlush();
 }
@@ -477,19 +449,14 @@ void LayerTreeHost::didChangeViewport()
 
 void LayerTreeHost::deviceOrPageScaleFactorChanged()
 {
-    if (m_surface->hostResize(m_webPage.size()))
-        m_layerTreeContext.contextID = m_surface->surfaceID();
-
     m_webPage.corePage()->pageOverlayController().didChangeDeviceScaleFactor();
-    IntSize scaledSize(m_webPage.size());
-    scaledSize.scale(m_webPage.deviceScaleFactor());
-    m_compositor->setViewportSize(scaledSize, m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor());
+    m_compositor->setViewportSize(m_webPage.size(), m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor());
     didChangeViewport();
 }
 
 void LayerTreeHost::backgroundColorDidChange()
 {
-    m_surface->backgroundColorDidChange();
+    m_compositor->backgroundColorDidChange();
 }
 
 void LayerTreeHost::detachLayer(CoordinatedGraphicsLayer* layer)
@@ -545,107 +512,7 @@ RefPtr<DisplayRefreshMonitor> LayerTreeHost::createDisplayRefreshMonitor(Platfor
     ASSERT(m_displayID == displayID);
     return Ref { m_compositor->displayRefreshMonitor() };
 }
-#endif
 
-void LayerTreeHost::commitSceneState(const RefPtr<Nicosia::Scene>& state)
-{
-    WTFEmitSignpost(this, CommitSceneState, "compositionRequestID %i", m_compositionRequestID + 1);
-    m_isWaitingForRenderer = true;
-    m_compositor->updateSceneState(state, ++m_compositionRequestID);
-}
-
-void LayerTreeHost::frameComplete()
-{
-    m_compositor->frameComplete();
-}
-
-uint64_t LayerTreeHost::nativeSurfaceHandleForCompositing()
-{
-    m_surface->initialize();
-    return m_surface->window();
-}
-
-void LayerTreeHost::didCreateGLContext()
-{
-    m_surface->didCreateGLContext();
-}
-
-void LayerTreeHost::willDestroyGLContext()
-{
-    m_surface->willDestroyGLContext();
-}
-
-void LayerTreeHost::didDestroyGLContext()
-{
-    m_surface->finalize();
-}
-
-void LayerTreeHost::resize(const IntSize& size)
-{
-    m_surface->clientResize(size);
-}
-
-void LayerTreeHost::willRenderFrame()
-{
-    RunLoop::main().dispatch([webPage = Ref { m_webPage }] {
-        if (auto* drawingArea = webPage->drawingArea())
-            drawingArea->willStartRenderingUpdateDisplay();
-    });
-    m_surface->willRenderFrame();
-}
-
-void LayerTreeHost::clearIfNeeded()
-{
-    m_surface->clearIfNeeded();
-}
-
-void LayerTreeHost::didRenderFrame(uint32_t compositionResponseID, const WebCore::Damage& damage)
-{
-    WTFEmitSignpost(this, DidRenderFrame, "compositionResponseID %i", compositionResponseID);
-
-    auto damageRegion = [&]() -> WebCore::Region {
-        if (m_scrolledSinceLastFrame || damage.isInvalid())
-            return { };
-
-        if (damage.isEmpty())
-            return { };
-
-        const auto& region = damage.region();
-        if (region.isRect() && region.contains(IntRect({ }, m_surface->size())))
-            return { };
-
-        return region;
-    }();
-
-    m_surface->didRenderFrame(WTFMove(damageRegion));
-
-    m_scrolledSinceLastFrame = false;
-
-#if HAVE(DISPLAY_LINK)
-    m_compositionResponseID = compositionResponseID;
-    if (!m_didRenderFrameTimer.isActive())
-        m_didRenderFrameTimer.startOneShot(0_s);
-#endif
-    RunLoop::main().dispatch([webPage = Ref { m_webPage }] {
-        if (auto* drawingArea = webPage->drawingArea())
-            drawingArea->didCompleteRenderingUpdateDisplay();
-    });
-}
-
-#if HAVE(DISPLAY_LINK)
-void LayerTreeHost::didRenderFrameTimerFired()
-{
-    if (!m_isWaitingForRenderer || (m_isWaitingForRenderer && m_compositionRequestID == m_compositionResponseID))
-        renderNextFrame(false);
-}
-#endif
-
-void LayerTreeHost::displayDidRefresh(PlatformDisplayID displayID)
-{
-    WebProcess::singleton().eventDispatcher().notifyScrollingTreesDisplayDidRefresh(displayID);
-}
-
-#if !HAVE(DISPLAY_LINK)
 void LayerTreeHost::requestDisplayRefreshMonitorUpdate()
 {
     // Flush layers to cause a repaint. If m_isWaitingForRenderer was true at this point, the layer
@@ -662,6 +529,33 @@ void LayerTreeHost::handleDisplayRefreshMonitorUpdate(bool hasBeenRescheduled)
     renderNextFrame(hasBeenRescheduled);
 }
 #endif
+
+void LayerTreeHost::willRenderFrame()
+{
+    if (auto* drawingArea = m_webPage.drawingArea())
+        drawingArea->willStartRenderingUpdateDisplay();
+}
+
+void LayerTreeHost::didRenderFrame()
+{
+    if (auto* drawingArea = m_webPage.drawingArea())
+        drawingArea->didCompleteRenderingUpdateDisplay();
+}
+
+#if HAVE(DISPLAY_LINK)
+void LayerTreeHost::didComposite(uint32_t compositionResponseID)
+{
+    if (!m_isWaitingForRenderer || (m_isWaitingForRenderer && m_compositionRequestID == compositionResponseID))
+        renderNextFrame(false);
+}
+#endif
+
+void LayerTreeHost::commitSceneState(const RefPtr<Nicosia::Scene>& state)
+{
+    m_isWaitingForRenderer = true;
+    m_compositionRequestID = m_compositor->requestComposition(state);
+    WTFEmitSignpost(this, CommitSceneState, "compositionRequestID %i", m_compositionRequestID);
+}
 
 void LayerTreeHost::requestUpdate()
 {
@@ -784,7 +678,7 @@ void LayerTreeHost::commitTransientZoom(double scale, FloatPoint origin)
 #if PLATFORM(WPE) && USE(GBM) && ENABLE(WPE_PLATFORM)
 void LayerTreeHost::preferredBufferFormatsDidChange()
 {
-    m_surface->preferredBufferFormatsDidChange();
+    m_compositor->preferredBufferFormatsDidChange();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -62,9 +62,9 @@ static uint64_t generateID()
     return ++identifier;
 }
 
-std::unique_ptr<AcceleratedSurfaceDMABuf> AcceleratedSurfaceDMABuf::create(WebPage& webPage, Client& client)
+std::unique_ptr<AcceleratedSurfaceDMABuf> AcceleratedSurfaceDMABuf::create(WebPage& webPage, Function<void()>&& frameCompleteHandler)
 {
-    return std::unique_ptr<AcceleratedSurfaceDMABuf>(new AcceleratedSurfaceDMABuf(webPage, client));
+    return std::unique_ptr<AcceleratedSurfaceDMABuf>(new AcceleratedSurfaceDMABuf(webPage, WTFMove(frameCompleteHandler)));
 }
 
 static bool useExplicitSync()
@@ -74,8 +74,8 @@ static bool useExplicitSync()
     return extensions.ANDROID_native_fence_sync && (display.eglCheckVersion(1, 5) || extensions.KHR_fence_sync);
 }
 
-AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf(WebPage& webPage, Client& client)
-    : AcceleratedSurface(webPage, client)
+AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf(WebPage& webPage, Function<void()>&& frameCompleteHandler)
+    : AcceleratedSurface(webPage, WTFMove(frameCompleteHandler))
     , m_id(generateID())
     , m_swapChain(m_id)
     , m_isVisible(webPage.activityState().contains(WebCore::ActivityState::IsVisible))
@@ -666,7 +666,7 @@ void AcceleratedSurfaceDMABuf::releaseBuffer(uint64_t targetID, UnixFileDescript
 
 void AcceleratedSurfaceDMABuf::frameDone()
 {
-    m_client.frameComplete();
+    frameComplete();
     m_target = nullptr;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -57,7 +57,7 @@ class WebPage;
 
 class AcceleratedSurfaceDMABuf final : public AcceleratedSurface, public IPC::MessageReceiver {
 public:
-    static std::unique_ptr<AcceleratedSurfaceDMABuf> create(WebPage&, Client&);
+    static std::unique_ptr<AcceleratedSurfaceDMABuf> create(WebPage&, Function<void()>&& frameCompleteHandler);
     ~AcceleratedSurfaceDMABuf();
 
 private:
@@ -87,7 +87,7 @@ private:
     void visibilityDidChange(bool) override;
     bool backgroundColorDidChange() override;
 
-    AcceleratedSurfaceDMABuf(WebPage&, Client&);
+    AcceleratedSurfaceDMABuf(WebPage&, Function<void()>&& frameCompleteHandler);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -39,13 +39,13 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurfaceLibWPE);
 
-std::unique_ptr<AcceleratedSurfaceLibWPE> AcceleratedSurfaceLibWPE::create(WebPage& webPage, Client& client)
+std::unique_ptr<AcceleratedSurfaceLibWPE> AcceleratedSurfaceLibWPE::create(WebPage& webPage, Function<void()>&& frameCompleteHandler)
 {
-    return std::unique_ptr<AcceleratedSurfaceLibWPE>(new AcceleratedSurfaceLibWPE(webPage, client));
+    return std::unique_ptr<AcceleratedSurfaceLibWPE>(new AcceleratedSurfaceLibWPE(webPage, WTFMove(frameCompleteHandler)));
 }
 
-AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE(WebPage& webPage, Client& client)
-    : AcceleratedSurface(webPage, client)
+AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE(WebPage& webPage, Function<void()>&& frameCompleteHandler)
+    : AcceleratedSurface(webPage, WTFMove(frameCompleteHandler))
     , m_hostFD(webPage.hostFileDescriptor())
 {
 }
@@ -55,15 +55,22 @@ AcceleratedSurfaceLibWPE::~AcceleratedSurfaceLibWPE()
     ASSERT(!m_backend);
 }
 
+void AcceleratedSurfaceLibWPE::finalize()
+{
+    wpe_renderer_backend_egl_target_destroy(m_backend);
+    m_backend = nullptr;
+}
+
 void AcceleratedSurfaceLibWPE::initialize()
 {
+    ASSERT(!m_backend);
     m_backend = wpe_renderer_backend_egl_target_create(m_hostFD.release());
     static struct wpe_renderer_backend_egl_target_client s_client = {
         // frame_complete
         [](void* data)
         {
             auto& surface = *reinterpret_cast<AcceleratedSurfaceLibWPE*>(data);
-            surface.m_client.frameComplete();
+            surface.frameComplete();
         },
         // padding
         nullptr,
@@ -76,21 +83,16 @@ void AcceleratedSurfaceLibWPE::initialize()
         std::max(1, m_size.width()), std::max(1, m_size.height()));
 }
 
-void AcceleratedSurfaceLibWPE::finalize()
-{
-    wpe_renderer_backend_egl_target_destroy(m_backend);
-    m_backend = nullptr;
-}
-
 uint64_t AcceleratedSurfaceLibWPE::window() const
 {
-    ASSERT(m_backend);
+    const_cast<AcceleratedSurfaceLibWPE*>(this)->initialize();
+
     // EGLNativeWindowType changes depending on the EGL implementation: reinterpret_cast works
     // for pointers (only if they are 64-bit wide and not for other cases), and static_cast for
     // numeric types (and when needed they get extended to 64-bit) but not for pointers. Using
     // a plain C cast expression in this one instance works in all cases.
     static_assert(sizeof(EGLNativeWindowType) <= sizeof(uint64_t), "EGLNativeWindowType must not be longer than 64 bits.");
-    return (uint64_t) wpe_renderer_backend_egl_target_get_native_window(m_backend);
+    return (uint64_t)wpe_renderer_backend_egl_target_get_native_window(m_backend);
 }
 
 uint64_t AcceleratedSurfaceLibWPE::surfaceID() const

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -41,28 +41,20 @@ class AcceleratedSurfaceLibWPE final : public AcceleratedSurface {
     WTF_MAKE_NONCOPYABLE(AcceleratedSurfaceLibWPE);
     WTF_MAKE_TZONE_ALLOCATED(AcceleratedSurfaceLibWPE);
 public:
-    static std::unique_ptr<AcceleratedSurfaceLibWPE> create(WebPage&, Client&);
+    static std::unique_ptr<AcceleratedSurfaceLibWPE> create(WebPage&, Function<void()>&& frameCompleteHandler);
     ~AcceleratedSurfaceLibWPE();
 
     uint64_t window() const override;
     uint64_t surfaceID() const override;
     void clientResize(const WebCore::IntSize&) override;
-    bool shouldPaintMirrored() const override
-    {
-#if PLATFORM(GTK) && !USE(GTK4)
-        return true;
-#else
-        return false;
-#endif
-    }
-
-    void initialize() override;
     void finalize() override;
     void willRenderFrame() override;
     void didRenderFrame(WebCore::Region&&) override;
 
 private:
-    AcceleratedSurfaceLibWPE(WebPage&, Client&);
+    AcceleratedSurfaceLibWPE(WebPage&, Function<void()>&& frameCompleteHandler);
+
+    void initialize();
 
     UnixFileDescriptor m_hostFD;
     struct wpe_renderer_backend_egl_target* m_backend { nullptr };


### PR DESCRIPTION
#### e17ffe7b5bd3105bdd72617c07655ee4f2d0fdd4
<pre>
[GTK][WPE] Move AcceleratedSurface handling from LayerTreeHost to ThreadedCompositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=281049">https://bugs.webkit.org/show_bug.cgi?id=281049</a>

Reviewed by Miguel Gomez.

The Threaded compositor has a client that is implemented by the
LayerTreeHost and is mainly used to pass messages from the
ThreadedCompositor to the AcceleratedSurface. The ThreadedCompositor
could just create the surface and call it directly instead of going
through the LayerTreeHost.

* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::create):
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::frameComplete const):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::initialize): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::~LayerTreeHost):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::pauseRendering):
(WebKit::LayerTreeHost::resumeRendering):
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged):
(WebKit::LayerTreeHost::backgroundColorDidChange):
(WebKit::LayerTreeHost::commitSceneState):
(WebKit::LayerTreeHost::preferredBufferFormatsDidChange):
(WebKit::LayerTreeHost::frameComplete): Deleted.
(WebKit::LayerTreeHost::nativeSurfaceHandleForCompositing): Deleted.
(WebKit::LayerTreeHost::didCreateGLContext): Deleted.
(WebKit::LayerTreeHost::willDestroyGLContext): Deleted.
(WebKit::LayerTreeHost::didDestroyGLContext): Deleted.
(WebKit::LayerTreeHost::resize): Deleted.
(WebKit::LayerTreeHost::willRenderFrame): Deleted.
(WebKit::LayerTreeHost::clearIfNeeded): Deleted.
(WebKit::LayerTreeHost::didRenderFrame): Deleted.
(WebKit::LayerTreeHost::didRenderFrameTimerFired): Deleted.
(WebKit::LayerTreeHost::displayDidRefresh): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::create):
(WebKit::ThreadedCompositor::ThreadedCompositor):
(WebKit::ThreadedCompositor::surfaceID const):
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::suspend):
(WebKit::ThreadedCompositor::resume):
(WebKit::ThreadedCompositor::setScrollPosition):
(WebKit::ThreadedCompositor::setViewportSize):
(WebKit::ThreadedCompositor::backgroundColorDidChange):
(WebKit::ThreadedCompositor::preferredBufferFormatsDidChange):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::requestComposition):
(WebKit::ThreadedCompositor::frameComplete):
(WebKit::ThreadedCompositor::displayUpdateFired):
(WebKit::ThreadedCompositor::sceneUpdateFinished):
(WebKit::ThreadedCompositor::~ThreadedCompositor): Deleted.
(WebKit::ThreadedCompositor::createGLContext): Deleted.
(WebKit::ThreadedCompositor::updateSceneState): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
(WebKit::ThreadedCompositor::compositingRunLoop const): Deleted.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::create):
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::frameDone):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::create):
(WebKit::AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE):
(WebKit::AcceleratedSurfaceLibWPE::finalize):
(WebKit::AcceleratedSurfaceLibWPE::window const):
(WebKit::AcceleratedSurfaceLibWPE::initialize): Deleted.
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/285007@main">https://commits.webkit.org/285007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc4c29a8b0ee9161a0d19fd8538df7853dc5783

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71046 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56174 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14648 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42493 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76870 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63870 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5624 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10917 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->