### PR TITLE
[WPE][GTK][Skia] High memory usage repeatedly using putImageData on accelerated canvas

### DIFF
--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -53,6 +53,7 @@ platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
 platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
 platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
 platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+platform/graphics/skia/IntRectSkia.cpp
 platform/graphics/skia/NativeImageSkia.cpp
 platform/graphics/skia/PathSkia.cpp
 platform/graphics/skia/PatternSkia.cpp

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -47,6 +47,10 @@ typedef struct _NSRect NSRect;
 #endif
 #endif
 
+#if USE(SKIA)
+struct SkIRect;
+#endif
+
 #if PLATFORM(WIN)
 typedef struct tagRECT RECT;
 #endif
@@ -220,6 +224,11 @@ public:
 
 #if PLATFORM(MAC) && !defined(NSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES)
     WEBCORE_EXPORT operator NSRect() const;
+#endif
+
+#if USE(SKIA)
+    IntRect(const SkIRect&);
+    operator SkIRect() const;
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/skia/IntRectSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/IntRectSkia.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IntRect.h"
+
+#if USE(SKIA)
+#include <skia/core/SkRect.h>
+
+namespace WebCore {
+
+IntRect::IntRect(const SkIRect& r)
+    : m_location(r.left(), r.top())
+    , m_size(r.width(), r.height())
+{
+}
+
+IntRect::operator SkIRect() const
+{
+    return { x(), y(), maxX(), maxY() };
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)


### PR DESCRIPTION
#### 2b8b7072fa8ec617ef88bfb1d4d6b37924a3cca2
<pre>
[WPE][GTK][Skia] High memory usage repeatedly using putImageData on accelerated canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=281042">https://bugs.webkit.org/show_bug.cgi?id=281042</a>

Reviewed by Carlos Garcia Campos.

Change ImageBufferSkiaAcceleratedBackend::putPixelBuffer() to avoid
making a temporary scratch buffer with the same size as the canvas
backing SkSurface on each canvas.putImageData() invocation, which may
happen many times in between each composition.

Instead of using the ImageBufferBackend::putPixelBuffer() helper on
a temporary buffer with the same size as the canvas backing surface,
bring inline part of the source/destination rectangle calculations to
operate strictly on the part of the source PixelBuffer that will be
applied onto the backing surface. The source pixel data gets passed
directly to Skia in the rather common case where the destination
alpha mode matches that of the canvas backing surface (and Skia will
handle any other conversions, if needed); otherwise going through
a scratch buffer is still done, but its size is limited to that of
the clipped source rectangle to convert only the pixel area that
gets applied onto the canvas backing surface.

On top of reducing memory usage, this makes the MotionMark Images
test ~2.5x faster, and its Canvas putPixel/getPixel test ~1.2x faster.

* Source/WebCore/platform/SourcesSkia.txt: List IntRectSkia.cpp file.
* Source/WebCore/platform/graphics/IntRect.h: Add SkIRect forward
  declaration and operator methods to convert instances to/from
  WebCore::IntRect.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/skia/IntRectSkia.cpp: Added.
(WebCore::IntRect::IntRect):
(WebCore::IntRect::operator SkIRect const):

Canonical link: <a href="https://commits.webkit.org/285116@main">https://commits.webkit.org/285116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ab82f80ef5588abf5f9c7145d545ee5f54a97b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24401 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74693 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/61700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21173 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15861 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15904 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/12435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10975 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46840 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->