### PR TITLE
[WebGPU] Minimum binding size for validation needs to be max of user specified and value in WGSL source

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/repro-281057-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/repro-281057-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/repro-281057.html
+++ b/LayoutTests/fast/webgpu/nocrash/repro-281057.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Hello Triangle</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Simple Triangle</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script>
+    async function helloTriangle() {
+        if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+            document.body.className = 'error';
+            return;
+        }
+
+        const adapter = await navigator.gpu.requestAdapter();
+        const device = await adapter.requestDevice();
+        
+        /*** Vertex Buffer Setup ***/
+        
+        /* Vertex Data */
+        const vertexStride = 8 * 4;
+        const vertexDataSize = vertexStride * 3;
+        
+        /* GPUBufferDescriptor */
+        const vertexDataBufferDescriptor = {
+            size: vertexDataSize,
+            usage: GPUBufferUsage.VERTEX
+        };
+
+        /* GPUBuffer */
+        const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+        
+        /*** Shader Setup ***/
+        const wgslSource = `
+                         @group(0) @binding(0) var<storage, read> b: array<vec2f>;
+        
+                         struct Vertex {
+                             @builtin(position) Position: vec4<f32>,
+                             @location(0) color: vec4<f32>,
+                         }
+
+                         @vertex fn vsmain(@builtin(vertex_index) VertexIndex: u32) -> Vertex
+                         {
+                             var pos: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+                                 vec2<f32>( 0.0,  0.5),
+                                 vec2<f32>(-0.5, -0.5),
+                                 vec2<f32>( 0.5, -0.5)
+                             );
+                             var vertex_out : Vertex;
+                             vertex_out.Position = vec4<f32>(pos[VertexIndex], b[110].x, 1.0);
+                             vertex_out.color = vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), b[0].x, 1.0);
+                             return vertex_out;
+                         }
+
+                         @fragment fn fsmain(in: Vertex) -> @location(0) vec4<f32>
+                         {
+                             return in.color;
+                         }
+        `;
+        const shaderModule = device.createShaderModule({ code: wgslSource });
+        
+        /* GPUPipelineStageDescriptors */
+        const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+
+        const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+        
+        /* GPURenderPipelineDescriptor */
+
+        
+        
+        const transformBufferBindGroupLayoutEntry = {
+            binding: 0, // @group(0) @binding(0)
+            visibility: GPUShaderStage.VERTEX,
+            buffer: { type: "read-only-storage" },
+        };
+        const bindGroupLayoutDescriptor = { entries: [transformBufferBindGroupLayoutEntry] };
+        const bindGroupLayout = device.createBindGroupLayout(bindGroupLayoutDescriptor);
+        
+        
+        const pipelineLayoutDescriptor = { bindGroupLayouts: [bindGroupLayout] };
+        const pipelineLayout = device.createPipelineLayout(pipelineLayoutDescriptor);
+        
+        const renderPipelineDescriptor = {
+            layout: pipelineLayout,
+            vertex: vertexStageDescriptor,
+            fragment: fragmentStageDescriptor,
+            primitive: {topology: "triangle-list" },
+        };
+        /* GPURenderPipeline */
+        const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+        
+        /*** Swap Chain Setup ***/
+        
+        const canvas = document.querySelector("canvas");
+        canvas.width = 600;
+        canvas.height = 600;
+
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+            view: renderAttachment,
+            loadOp: "clear",
+            storeOp: "store",
+            clearColor: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+        
+        /*** Rendering ***/
+        
+        const transformBuffer = device.createBuffer({size: 8, usage: GPUBufferUsage.STORAGE});  // buffer's size is 8
+        const transformBufferBinding = {
+            buffer: transformBuffer,
+            offset: 0,
+            size: 4
+        };
+        const transformBufferBindGroupEntry = {
+            binding: 0,
+            resource: transformBufferBinding
+        };
+        const bindGroupDescriptor = {
+            layout:  bindGroupLayout,
+            entries: [transformBufferBindGroupEntry]
+        };
+        const bindGroup = device.createBindGroup(bindGroupDescriptor);
+        
+        let storageBuffer = device.createBuffer({size: 8, usage: GPUBufferUsage.STORAGE});  // buffer's size is 8
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        const vertexBufferSlot = 0;
+        renderPassEncoder.setBindGroup(0, bindGroup);
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.draw(3, 1, 0, 0); // 3 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+    }
+
+    window.addEventListener("DOMContentLoaded", helloTriangle);
+
+</script>
+</body>
+</html>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -907,9 +907,9 @@ static BindGroupEntryUsage usageForBuffer(WGPUBufferBindingType bufferBindingTyp
     return BindGroupEntryUsage::Undefined;
 }
 
-static BindGroupEntryUsageData makeBindGroupEntryUsageData(BindGroupEntryUsage usage, uint32_t bindingIndex, auto& resource, uint64_t entryOffset = 0)
+static BindGroupEntryUsageData makeBindGroupEntryUsageData(BindGroupEntryUsage usage, uint32_t bindingIndex, auto& resource, uint64_t entryOffset = 0, uint64_t entrySize = 0)
 {
-    return BindGroupEntryUsageData { .usage = usage, .binding = bindingIndex, .resource = &resource, .entryOffset = entryOffset };
+    return BindGroupEntryUsageData { .usage = usage, .binding = bindingIndex, .resource = &resource, .entryOffset = entryOffset, .entrySize = entrySize };
 }
 
 constexpr ShaderStage stages[] = { ShaderStage::Vertex, ShaderStage::Fragment, ShaderStage::Compute };
@@ -1058,7 +1058,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                 }
                 if (buffer) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(buffer);
-                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer, entryOffset));
+                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer, entryOffset, entrySize));
                 }
             } else if (samplerIsPresent) {
                 auto* layoutBinding = hasBinding<WGPUSamplerBindingLayout>(bindGroupLayoutEntries, bindingIndex);

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -62,6 +62,7 @@ struct BindGroupEntryUsageData {
     using Resource = std::variant<RefPtr<Buffer>, RefPtr<const TextureView>, RefPtr<const ExternalTexture>>;
     Resource resource;
     uint64_t entryOffset { 0 };
+    uint64_t entrySize { 0 };
     static constexpr uint32_t invalidBindingIndex = INT_MAX;
     static constexpr BindGroupEntryUsage invalidBindGroupUsage = static_cast<BindGroupEntryUsage>(std::numeric_limits<std::underlying_type<BindGroupEntryUsage>::type>::max());
 };


### PR DESCRIPTION
#### 24c8f5f321a0569ad1d02ebb3d45675af50e9539
<pre>
[WebGPU] Minimum binding size for validation needs to be max of user specified and value in WGSL source
<a href="https://bugs.webkit.org/show_bug.cgi?id=281057">https://bugs.webkit.org/show_bug.cgi?id=281057</a>
<a href="https://rdar.apple.com/137262987">rdar://137262987</a>

Reviewed by Tadeu Zagallo.

Ensure entrySize is at least the size of the minimum binding size
computed in the shader parsing.

* LayoutTests/fast/webgpu/nocrash/repro-281057-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/repro-281057.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::makeBindGroupEntryUsageData):
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::errorValidatingBindGroup):

Canonical link: <a href="https://commits.webkit.org/284987@main">https://commits.webkit.org/284987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55720aae4b5173e6b03cb70415f6f81fe6f14e15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56123 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63820 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5557 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47239 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->