### PR TITLE
[Static Analyzer CI] Enable update-safer-cpp-expectations to take in lists of files per checker

### DIFF
--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -30,23 +30,16 @@ PROJECTS = ['WebCore', 'WebKit']
 
 
 def parser():
-    parser = argparse.ArgumentParser(description='Automated tooling for updating safer CPP expectations')
-    parser.add_argument(
-        '--add-expected-failures', '-a',
-        dest='results_to_add',
-        default=None,
-        help='Path to unexpected results file. Adds unexpected failures to the expectations files in SaferCPPExpectations.'
-    )
-    parser.add_argument(
-        '--remove-expected-failures', '-r',
-        dest='results_to_remove',
-        default=None,
-        help='Path to unexpected results file. Removes unexpected failures from the expectations files in SaferCPPExpectations.'
-    )
+    parser = argparse.ArgumentParser(description='Automated tooling for updating safer CPP expectations', epilog='Example: update-safer-cpp-expectations -p WebKit --RefCntblBaseVirtualDtor platform/Scrollbar.h --UncountedCallArgsChecker platform/ScrollAnimator.h')
+
+    checkers_group = parser.add_argument_group('checker arguments', 'List files to update for each checker')
+    for checker in CHECKERS:
+        checkers_group.add_argument(f'--{checker}', type=str, nargs='+')
+
     parser.add_argument(
         '--project', '-p',
-        choices=['WebKit', 'WebCore'],
-        help='Specify which project expectations you want to update.'
+        choices=PROJECTS,
+        help='Specify which project expectations you want to update'
     )
     parser.add_argument(
         '--find-expectations', '-f',
@@ -54,10 +47,23 @@ def parser():
         default=None,
         help='Check if the given file has expected failures'
     )
+    parser.add_argument(
+        '--add-expected-failures',
+        dest='add',
+        action='store_true',
+        default=False,
+        help='OVERRIDE: Add expected failures to the expectations files in SaferCPPExpectations'
+    )
+    parser.add_argument(
+        '--unexpected-results-file', '-r',
+        dest='unexpected_results_file',
+        default=None,
+        help='Path to unexpected results file'
+    )
     return parser.parse_args()
 
 
-def modify_expectations_for_checker(checker_type, unexpected_contents, project, type):
+def modify_expectations_for_checker_from_file(checker_type, unexpected_contents, project, add=False):
     path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker_type))
     with open(path_to_expectations) as expectations_file:
         expectations = expectations_file.readlines()
@@ -65,24 +71,27 @@ def modify_expectations_for_checker(checker_type, unexpected_contents, project, 
     for line in unexpected_contents:
         if '=>' in line:
             new_checker_type = line.split()[-1]
-            modify_expectations_for_checker(new_checker_type, unexpected_contents, project, type)
+            modify_expectations_for_checker_from_file(new_checker_type, unexpected_contents, project, add)
         elif line.strip():
-            if type == 'remove':
-                expectations.remove(line)
+            if not add:
+                try:
+                    expectations.remove(line)
+                except ValueError:
+                    print(f'Error: {line.strip()} is not in {checker_type}Expectations!')
             elif line not in expectations:
                 expectations.append(line)
             else:
-                print(f'{line.strip()} already in {checker_type}Expectations!\n')
+                print(f'Error: {line.strip()} is already in {checker_type}Expectations!\n')
     with open(path_to_expectations, 'w') as expectations_file:
         expectations_file.writelines(sorted(expectations))
     print(f'Updated expectations for {checker_type}!')
-    if type == 'remove':
+    if not add:
         print(f'Removed {prev_len - len(expectations)} fixed files.\n')
     else:
         print(f'Added {len(expectations) - prev_len} files with issues.\n')
 
 
-def update_expectations(unexpected_results, project, type):
+def update_expectations_from_file(unexpected_results, project, add=False):
     filename = unexpected_results.split('/')[-1]
     if not project:
         projects = [p for p in ['WebKit', 'WebCore'] if p in filename]
@@ -91,14 +100,49 @@ def update_expectations(unexpected_results, project, type):
         else:
             print(f'Could not find a project to update. Please include the project in the filename or pass in the --project argument.')
             return
-
-    print(f"{'Adding' if type == 'add' else 'Removing'} unexpected failures in {project}...\n")
-
+    print(f"{'Adding' if add else 'Removing'} unexpected failures in {project}...\n")
     with open(unexpected_results, 'r') as unexpected_contents:
         for line in unexpected_contents:
             if '=>' in line:
                 checker_type = line.split()[-1]
-                modify_expectations_for_checker(checker_type, unexpected_contents, project, type)
+                modify_expectations_for_checker_from_file(checker_type, unexpected_contents, project, add)
+    print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
+
+
+def modify_expectations_for_checker(checker_type, unexpected_contents, project, add=False):
+    path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker_type))
+    with open(path_to_expectations) as expectations_file:
+        expectations = expectations_file.readlines()
+        prev_len = len(expectations)
+    for line in unexpected_contents:
+        if not add:
+            try:
+                expectations.remove(f'{line}\n')
+            except ValueError:
+                print(f'Error: {line} is not in {checker_type}Expectations!')
+        elif line not in expectations:
+            expectations.append(f'{line}\n')
+        else:
+            print(f'Error: {line} is already in {checker_type}Expectations!\n')
+    with open(path_to_expectations, 'w') as expectations_file:
+        expectations_file.writelines(sorted(expectations))
+    print(f'Updated expectations for {checker_type}!')
+    if not add:
+        print(f'Removed {prev_len - len(expectations)} fixed files.\n')
+    else:
+        print(f'Added {len(expectations) - prev_len} files with issues.\n')
+
+
+def update_expectations(args, project, add=False):
+    if not project:
+        print(f'Could not find a project to update. Please include the project in the filename or pass in the --project argument.')
+        return
+    print(f"{'Adding' if add else 'Removing'} unexpected failures in {project}...\n")
+    for checker_type in CHECKERS:
+        files_per_checker = args[checker_type]
+        if files_per_checker:
+            modify_expectations_for_checker(checker_type, files_per_checker, project, add)
+    print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
 
 
 '''
@@ -125,14 +169,15 @@ def is_expected_file(expected_file):
 
 def main():
     args = parser()
-    if args.results_to_add:
+    if args.add:
         print('WARNING: Adding expected failures. Please only add expected failures when you fix false negatives in our tools.')
         user_input = input('Are you sure you want to proceed? [y/N]: ') or 'N'
         if user_input[0].lower() != 'y':
             return
-        update_expectations(args.results_to_add, args.project, 'add')
-    if args.results_to_remove:
-        update_expectations(args.results_to_remove, args.project, 'remove')
+    if args.unexpected_results_file:
+        update_expectations_from_file(args.unexpected_results_file, args.project, args.add)
+    else:
+        update_expectations(vars(args), args.project, args.add)
     if args.expected_file:
         is_expected_file(args.expected_file)
 


### PR DESCRIPTION
#### b50ab39c922f4afcc0b894736c29846f1f50d065
<pre>
[Static Analyzer CI] Enable update-safer-cpp-expectations to take in lists of files per checker
<a href="https://bugs.webkit.org/show_bug.cgi?id=281068">https://bugs.webkit.org/show_bug.cgi?id=281068</a>
<a href="https://rdar.apple.com/137521171">rdar://137521171</a>

Reviewed by Ryosuke Niwa.

Modify update-safer-cpp-expectations to take in arguments for the project, checker, and files to update.
Now, we can construct a one-liner command to update expectations.

* Tools/Scripts/update-safer-cpp-expectations:
(parser): Add new arguments for each checker.
(modify_expectations_for_checker_from_file): Separate logic for updating using results file.
(update_expectations_from_file): Ditto.
(modify_expectations_for_checker): New logic for updating using checker args.
(update_expectations): Ditto.
(main):

Canonical link: <a href="https://commits.webkit.org/284901@main">https://commits.webkit.org/284901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a36f1d0973fbcd70bb1cbfa53294ca94ce0916f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23519 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21950 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21771 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21950 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73816 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45600 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60998 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18431 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20292 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64191 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/18793 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14980 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/76561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15024 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11748 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5402 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10862 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45961 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47033 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48314 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46775 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->