### PR TITLE
[WebGPU] RenderBundleEncoder with very large command count can result in ICB allocation to fail

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/RenderBundle_WRITE-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/RenderBundle_WRITE-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/RenderBundle_WRITE.html
+++ b/LayoutTests/fast/webgpu/nocrash/RenderBundle_WRITE.html
@@ -1,0 +1,50 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = globalThis.$vm?.print ?? console.log;
+
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice();
+    let module = device.createShaderModule({
+      code: `
+@vertex fn v() -> @builtin(position) vec4f { return vec4(); }
+@fragment fn f() {}
+`,
+    });
+    let pipeline = device.createRenderPipeline({
+      layout: 'auto', vertex: {module},
+      fragment: {module, targets: [{format, writeMask: 0}]},
+    });
+    let vertexBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.VERTEX});
+    let renderBundleEncoder = device.createRenderBundleEncoder({colorFormats: [format]});
+    renderBundleEncoder.setVertexBuffer(0, vertexBuffer);
+    renderBundleEncoder.setPipeline(pipeline);
+    for (let i = 0; i < 5_000_000; ++i) {
+      renderBundleEncoder.draw(0);
+    }
+    await 0;
+    // $vm.gc();
+    let pipeline2 = device.createRenderPipeline({
+      layout: 'auto', vertex: {module},
+      fragment: {module, targets: [{format, writeMask: 0}]},
+    });
+    let vertexBuffer2 = device.createBuffer({size: 4, usage: GPUBufferUsage.VERTEX});
+    renderBundleEncoder.setVertexBuffer(0, vertexBuffer);
+    renderBundleEncoder.setVertexBuffer(0, vertexBuffer2);
+    renderBundleEncoder.setPipeline(pipeline2);
+    let renderBundleEncoder2 = device.createRenderBundleEncoder({colorFormats: [format]});
+    renderBundleEncoder2.setVertexBuffer(0, vertexBuffer);
+    renderBundleEncoder2.setVertexBuffer(0, vertexBuffer2);
+    renderBundleEncoder2.setPipeline(pipeline);
+    await device.queue.onSubmittedWorkDone();
+    renderBundleEncoder2.draw(1);
+    await device.queue.onSubmittedWorkDone();
+    renderBundleEncoder2.finish();
+    renderBundleEncoder.finish();
+    await device.queue.onSubmittedWorkDone();
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
+  };
+</script>


### PR DESCRIPTION
#### f134376a48ae3a757d6353034170fd34ee4a5506
<pre>
[WebGPU] RenderBundleEncoder with very large command count can result in ICB allocation to fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=281067">https://bugs.webkit.org/show_bug.cgi?id=281067</a>
<a href="https://rdar.apple.com/137416848">rdar://137416848</a>

Reviewed by Tadeu Zagallo.

Metal doesn&apos;t specify the maximum number of commands which can be used in a
single ICB, but large numbers around 2 million seem to cause allocation failures.

Split the ICB and compute a number based on the maximum buffer size so it adapts to iOS and devices
where we can allocate less memory.

* LayoutTests/fast/webgpu/nocrash/RenderBundle_WRITE-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/RenderBundle_WRITE.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::finalizeRenderCommand):
(WebGPU::RenderBundleEncoder::endCurrentICB):

Canonical link: <a href="https://commits.webkit.org/284924@main">https://commits.webkit.org/284924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7a43f4c96be899cda7ccc49562d90ba27445df8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21874 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55981 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20234 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63648 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5355 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45903 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->