### PR TITLE
Overflow:hidden fails on a transformed element inside overflow scroll (affects motionpictures.org, www.bogleheads.org)

### DIFF
--- a/LayoutTests/compositing/scrolling/transformed-clipping-inside-scroller-expected.html
+++ b/LayoutTests/compositing/scrolling/transformed-clipping-inside-scroller-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 400px;
+            height: 400px;
+            border: 1px solid black;
+            overflow: scroll;
+            font-size: 36pt;
+        }
+        
+        .transformed {
+            margin: 20px;
+            overflow: hidden;
+            width: 50px;
+            border: 1px solid black;
+        }
+        
+        .spacer {
+            height: 1000px;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="transformed">CSS is awesome.</div>
+        <div class="spacer"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/scrolling/transformed-clipping-inside-scroller.html
+++ b/LayoutTests/compositing/scrolling/transformed-clipping-inside-scroller.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 400px;
+            height: 400px;
+            border: 1px solid black;
+            overflow: scroll;
+            font-size: 36pt;
+        }
+        
+        .transformed {
+            margin: 20px;
+            overflow: hidden;
+            width: 50px;
+            transform: rotate(0deg);
+            border: 1px solid black;
+        }
+        
+        .spacer {
+            height: 1000px;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="transformed">CSS is awesome.</div>
+        <div class="spacer"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/transforms/3d-transformed-fixed.html
+++ b/LayoutTests/compositing/transforms/3d-transformed-fixed.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-30">
     <style>
         body {
             perspective: 500px;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3266,7 +3266,7 @@ void RenderLayer::paintLayerWithEffects(GraphicsContext& context, const LayerPai
         GraphicsContextStateSaver stateSaver(context, false);
         RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
         if (parent()) {
-            auto options = paintFlags.contains(PaintLayerFlag::PaintingOverflowContents) ? clipRectOptionsForPaintingOverflowControls : clipRectDefaultOptions;
+            auto options = paintFlags.contains(PaintLayerFlag::PaintingOverflowContents) ? clipRectOptionsForPaintingOverflowContents : clipRectDefaultOptions;
             auto clipRectsContext = ClipRectsContext(paintingInfo.rootLayer, (paintFlags & PaintLayerFlag::TemporaryClipRects) ? TemporaryClipRects : PaintingClipRects, options);
             clipRect = backgroundClipRect(clipRectsContext);
             clipRect.intersect(paintingInfo.paintDirtyRect);
@@ -3638,7 +3638,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             // Now we need to compute the backgroundRect uncontaminated by filters, in order to clip the filtered result.
             // Note that we also use paintingInfo here, not localPaintingInfo which filters also contaminated.
             LayerFragments layerFragments;
-            auto clipRectOptions = isPaintingOverflowContents ? clipRectOptionsForPaintingOverflowControls : clipRectDefaultOptions;
+            auto clipRectOptions = isPaintingOverflowContents ? clipRectOptionsForPaintingOverflowContents : clipRectDefaultOptions;
             collectFragments(layerFragments, paintingInfo.rootLayer, paintingInfo.paintDirtyRect, ExcludeCompositedPaginatedLayers,
                 (localPaintFlags & PaintLayerFlag::TemporaryClipRects) ? TemporaryClipRects : PaintingClipRects, clipRectOptions, offsetFromRoot);
             updatePaintingInfoForFragments(layerFragments, paintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
@@ -3679,7 +3679,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
                 paintDirtyRect = clipRectRelativeToAncestor(localPaintingInfo.rootLayer, offsetFromRoot, LayoutRect::infiniteRect(), !!(localPaintFlags & PaintLayerFlag::TemporaryClipRects));
             }
 
-            auto clipRectOptions = isPaintingOverflowContents ? clipRectOptionsForPaintingOverflowControls : clipRectDefaultOptions;
+            auto clipRectOptions = isPaintingOverflowContents ? clipRectOptionsForPaintingOverflowContents : clipRectDefaultOptions;
             collectFragments(layerFragments, localPaintingInfo.rootLayer, paintDirtyRect, ExcludeCompositedPaginatedLayers,
                 (localPaintFlags & PaintLayerFlag::TemporaryClipRects) ? TemporaryClipRects : PaintingClipRects, clipRectOptions, offsetFromRoot);
             updatePaintingInfoForFragments(layerFragments, localPaintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
@@ -3800,6 +3800,9 @@ void RenderLayer::paintLayerByApplyingTransform(GraphicsContext& context, const 
     transformedPaintingInfo.rootLayer = this;
     if (!transformedPaintingInfo.paintDirtyRect.isInfinite())
         transformedPaintingInfo.paintDirtyRect = LayoutRect(encloseRectToDevicePixels(valueOrDefault(transform.inverse()).mapRect(paintingInfo.paintDirtyRect), deviceScaleFactor));
+
+    paintFlags.remove(PaintLayerFlag::PaintingOverflowContents);
+
     transformedPaintingInfo.subpixelOffset = adjustedSubpixelOffset;
     paintLayerContentsAndReflection(context, transformedPaintingInfo, paintFlags);
 
@@ -4004,7 +4007,7 @@ void RenderLayer::paintTransformedLayerIntoFragments(GraphicsContext& context, c
     RenderLayer* paginatedLayer = enclosingPaginationLayer(ExcludeCompositedPaginatedLayers);
     LayoutRect transformedExtent = transparencyClipBox(*this, paginatedLayer, PaintingTransparencyClipBox, RootOfTransparencyClipBox, paintingInfo.paintBehavior);
 
-    auto clipRectOptions = paintFlags.contains(PaintLayerFlag::PaintingOverflowContents) ? clipRectOptionsForPaintingOverflowControls : clipRectDefaultOptions;
+    auto clipRectOptions = paintFlags.contains(PaintLayerFlag::PaintingOverflowContents) ? clipRectOptionsForPaintingOverflowContents : clipRectDefaultOptions;
     paginatedLayer->collectFragments(enclosingPaginationFragments, paintingInfo.rootLayer, paintingInfo.paintDirtyRect, ExcludeCompositedPaginatedLayers,
         (paintFlags & PaintLayerFlag::TemporaryClipRects) ? TemporaryClipRects : PaintingClipRects, clipRectOptions, offsetOfPaginationLayerFromRoot, &transformedExtent);
     

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -664,7 +664,7 @@ public:
         IncludeOverlayScrollbarSize = 1 << 1,
     };
 
-    static constexpr OptionSet<ClipRectsOption> clipRectOptionsForPaintingOverflowControls = { };
+    static constexpr OptionSet<ClipRectsOption> clipRectOptionsForPaintingOverflowContents = { };
     static constexpr OptionSet<ClipRectsOption> clipRectDefaultOptions = { ClipRectsOption::RespectOverflowClip };
 
     struct ClipRectsContext {


### PR DESCRIPTION
#### b56addc7fbfd92f4d7f2ac43380703d589829fdb
<pre>
Overflow:hidden fails on a transformed element inside overflow scroll (affects motionpictures.org, www.bogleheads.org)
<a href="https://bugs.webkit.org/show_bug.cgi?id=281073">https://bugs.webkit.org/show_bug.cgi?id=281073</a>
<a href="https://rdar.apple.com/66751438">rdar://66751438</a>

Reviewed by Alan Baradlay.

When `paintLayerByApplyingTransform()` paints a layer with a transform, that layer becomes a painting
root, which means that clip rects are computed relative to it. However, `RenderLayer::calculateRects()`
has logic that is conditional on a layer being the painting root and `clipRectsContext.respectOverflowClip()`
being unset, resulting in the clip being ignored. `clipRectsContext.respectOverflowClip()` is false for all descendants
of content being painted into an overflow scroller (see `clipRectOptionsForPaintingOverflowContents`).

So a transformed and clipped element inside an overflow scroller would fail to apply the clipping.

Fix this in `paintLayerByApplyingTransform`, since that&apos;s the only place we reset the painting root,
by clearing the `PaintLayerFlag::PaintingOverflowContents` painting flag.

Also rename `clipRectOptionsForPaintingOverflowControls`, since it&apos;s about painting content inside
overflow, not about overflow controls.

* LayoutTests/compositing/scrolling/transformed-clipping-inside-scroller-expected.html: Added.
* LayoutTests/compositing/scrolling/transformed-clipping-inside-scroller.html: Added.
* LayoutTests/compositing/transforms/3d-transformed-fixed.html: Just add some pixel tolerance so it passes on my machine.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerWithEffects):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintLayerByApplyingTransform):
(WebCore::RenderLayer::paintTransformedLayerIntoFragments):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/284872@main">https://commits.webkit.org/284872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d52b6a7adea18d7f72e43e4b05b569b87087b89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14475 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76550 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63742 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63682 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15670 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11745 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5388 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->