### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for WebSocketChannelClient

### DIFF
--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
@@ -36,6 +36,7 @@
 #include "WorkerThreadableWebSocketChannel.h"
 #include <memory>
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -44,7 +45,7 @@ namespace WebCore {
 class ScriptExecutionContext;
 class WebSocketChannelClient;
 
-class ThreadableWebSocketChannelClientWrapper : public ThreadSafeRefCounted<ThreadableWebSocketChannelClientWrapper> {
+class ThreadableWebSocketChannelClientWrapper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ThreadableWebSocketChannelClientWrapper> {
 public:
     static Ref<ThreadableWebSocketChannelClientWrapper> create(ScriptExecutionContext&, WebSocketChannelClient&);
 
@@ -53,7 +54,7 @@ public:
     bool syncMethodDone() const;
 
     WorkerThreadableWebSocketChannel::Peer* peer() const;
-    void didCreateWebSocketChannel(WorkerThreadableWebSocketChannel::Peer*);
+    void didCreateWebSocketChannel(Ref<WorkerThreadableWebSocketChannel::Peer>&&);
     void clearPeer();
 
     bool failedWebSocketChannelCreation() const;
@@ -91,8 +92,8 @@ private:
     void processPendingTasks();
 
     WeakPtr<ScriptExecutionContext> m_context;
-    WebSocketChannelClient* m_client;
-    WorkerThreadableWebSocketChannel::Peer* m_peer;
+    ThreadSafeWeakPtr<WebSocketChannelClient> m_client;
+    RefPtr<WorkerThreadableWebSocketChannel::Peer> m_peer;
     bool m_failedWebSocketChannelCreation;
     bool m_syncMethodDone;
     // ThreadSafeRefCounted must not have String member variables.

--- a/Source/WebCore/Modules/websockets/WebSocketChannelClient.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelClient.h
@@ -31,20 +31,11 @@
 #pragma once
 
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class WebSocketChannelClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::WebSocketChannelClient> : std::true_type { };
-}
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
-class WebSocketChannelClient : public CanMakeWeakPtr<WebSocketChannelClient> {
+class WebSocketChannelClient : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebSocketChannelClient, WTF::DestructionThread::Main> {
 public:
     virtual ~WebSocketChannelClient() = default;
     virtual void didConnect() = 0;

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -152,12 +152,17 @@ void WorkerThreadableWebSocketChannel::resume()
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WorkerThreadableWebSocketChannelPeer, WorkerThreadableWebSocketChannel::Peer);
 
 WorkerThreadableWebSocketChannel::Peer::Peer(Ref<ThreadableWebSocketChannelClientWrapper>&& clientWrapper, ScriptExecutionContext& context, ScriptExecutionContextIdentifier workerContextIdentifier, const String& taskMode, SocketProvider& provider)
-    : m_workerClientWrapper(WTFMove(clientWrapper))
+    : m_workerClientWrapper(clientWrapper.ptr())
     , m_mainWebSocketChannel(ThreadableWebSocketChannel::create(downcast<Document>(context), *this, provider))
     , m_taskMode(taskMode)
     , m_workerContextIdentifier(workerContextIdentifier)
 {
     ASSERT(isMainThread());
+}
+
+Ref<WorkerThreadableWebSocketChannel::Peer> WorkerThreadableWebSocketChannel::Peer::create(Ref<ThreadableWebSocketChannelClientWrapper>&& clientWrapper, ScriptExecutionContext& context, ScriptExecutionContextIdentifier workerContextIdentifier, const String& taskMode, SocketProvider& provider)
+{
+    return adoptRef(*new Peer(WTFMove(clientWrapper), context, workerContextIdentifier, taskMode, provider));
 }
 
 WorkerThreadableWebSocketChannel::Peer::~Peer()
@@ -181,8 +186,12 @@ void WorkerThreadableWebSocketChannel::Peer::send(CString&& message)
     if (!m_mainWebSocketChannel)
         return;
 
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
     ThreadableWebSocketChannel::SendResult sendRequestResult = m_mainWebSocketChannel->send(WTFMove(message));
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, sendRequestResult](ScriptExecutionContext&) mutable {
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), sendRequestResult](ScriptExecutionContext&) mutable {
         workerClientWrapper->setSendRequestResult(sendRequestResult);
     }, m_taskMode);
 }
@@ -193,8 +202,12 @@ void WorkerThreadableWebSocketChannel::Peer::send(const ArrayBuffer& binaryData)
     if (!m_mainWebSocketChannel)
         return;
 
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
     ThreadableWebSocketChannel::SendResult sendRequestResult = m_mainWebSocketChannel->send(binaryData, 0, binaryData.byteLength());
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, sendRequestResult](ScriptExecutionContext&) mutable {
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), sendRequestResult](ScriptExecutionContext&) mutable {
         workerClientWrapper->setSendRequestResult(sendRequestResult);
     }, m_taskMode);
 }
@@ -205,8 +218,12 @@ void WorkerThreadableWebSocketChannel::Peer::send(Blob& binaryData)
     if (!m_mainWebSocketChannel)
         return;
 
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
     ThreadableWebSocketChannel::SendResult sendRequestResult = m_mainWebSocketChannel->send(binaryData);
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, sendRequestResult](ScriptExecutionContext&) mutable {
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), sendRequestResult](ScriptExecutionContext&) mutable {
         workerClientWrapper->setSendRequestResult(sendRequestResult);
     }, m_taskMode);
 }
@@ -217,8 +234,12 @@ void WorkerThreadableWebSocketChannel::Peer::bufferedAmount()
     if (!m_mainWebSocketChannel)
         return;
 
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
     unsigned bufferedAmount = m_mainWebSocketChannel->bufferedAmount();
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, bufferedAmount](ScriptExecutionContext& context) mutable {
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), bufferedAmount](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->setBufferedAmount(bufferedAmount);
     }, m_taskMode);
@@ -269,9 +290,13 @@ void WorkerThreadableWebSocketChannel::Peer::didConnect()
 {
     ASSERT(isMainThread());
 
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
     String subprotocol = m_mainWebSocketChannel->subprotocol();
     String extensions = m_mainWebSocketChannel->extensions();
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, subprotocol = WTFMove(subprotocol).isolatedCopy(), extensions = WTFMove(extensions).isolatedCopy()](ScriptExecutionContext& context) mutable {
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), subprotocol = WTFMove(subprotocol).isolatedCopy(), extensions = WTFMove(extensions).isolatedCopy()](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->setSubprotocol(subprotocol);
         workerClientWrapper->setExtensions(extensions);
@@ -283,7 +308,11 @@ void WorkerThreadableWebSocketChannel::Peer::didReceiveMessage(String&& message)
 {
     ASSERT(isMainThread());
 
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, message = WTFMove(message).isolatedCopy()](ScriptExecutionContext& context) mutable {
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), message = WTFMove(message).isolatedCopy()](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didReceiveMessage(WTFMove(message));
     }, m_taskMode);
@@ -293,7 +322,11 @@ void WorkerThreadableWebSocketChannel::Peer::didReceiveBinaryData(Vector<uint8_t
 {
     ASSERT(isMainThread());
 
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, binaryData = WTFMove(binaryData)](ScriptExecutionContext& context) mutable {
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), binaryData = WTFMove(binaryData)](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didReceiveBinaryData(WTFMove(binaryData));
     }, m_taskMode);
@@ -303,7 +336,11 @@ void WorkerThreadableWebSocketChannel::Peer::didUpdateBufferedAmount(unsigned bu
 {
     ASSERT(isMainThread());
 
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, bufferedAmount](ScriptExecutionContext& context) mutable {
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), bufferedAmount](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didUpdateBufferedAmount(bufferedAmount);
     }, m_taskMode);
@@ -313,7 +350,11 @@ void WorkerThreadableWebSocketChannel::Peer::didStartClosingHandshake()
 {
     ASSERT(isMainThread());
 
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper](ScriptExecutionContext& context) mutable {
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull()](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didStartClosingHandshake();
     }, m_taskMode);
@@ -324,7 +365,11 @@ void WorkerThreadableWebSocketChannel::Peer::didClose(unsigned unhandledBuffered
     ASSERT(isMainThread());
     m_mainWebSocketChannel = nullptr;
 
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, unhandledBufferedAmount, closingHandshakeCompletion, code, reason = reason.isolatedCopy()](ScriptExecutionContext& context) mutable {
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), unhandledBufferedAmount, closingHandshakeCompletion, code, reason = reason.isolatedCopy()](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didClose(unhandledBufferedAmount, closingHandshakeCompletion, code, reason);
     }, m_taskMode);
@@ -334,7 +379,11 @@ void WorkerThreadableWebSocketChannel::Peer::didReceiveMessageError(String&& rea
 {
     ASSERT(isMainThread());
 
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper, reason = WTFMove(reason).isolatedCopy()](ScriptExecutionContext& context) mutable {
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
+
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull(), reason = WTFMove(reason).isolatedCopy()](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didReceiveMessageError(WTFMove(reason));
     }, m_taskMode);
@@ -343,8 +392,12 @@ void WorkerThreadableWebSocketChannel::Peer::didReceiveMessageError(String&& rea
 void WorkerThreadableWebSocketChannel::Peer::didUpgradeURL()
 {
     ASSERT(isMainThread());
+
+    RefPtr workerClientWrapper = m_workerClientWrapper.get();
+    if (!workerClientWrapper)
+        return;
     
-    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = m_workerClientWrapper](ScriptExecutionContext& context) mutable {
+    ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_workerContextIdentifier, [workerClientWrapper = workerClientWrapper.releaseNonNull()](ScriptExecutionContext& context) mutable {
         ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         workerClientWrapper->didUpgradeURL();
     }, m_taskMode);
@@ -377,25 +430,17 @@ void WorkerThreadableWebSocketChannel::Bridge::mainThreadInitialize(ScriptExecut
 
     workerRunLoop.postTaskForMode({
         ScriptExecutionContext::Task::CleanupTask,
-        [clientWrapper, peer = makeUnique<Peer>(clientWrapper.copyRef(), context, workerContextIdentifier, taskMode, WTFMove(provider))](auto& context) mutable {
-            ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
-            if (clientWrapper->failedWebSocketChannelCreation()) {
-                // If Bridge::initialize() quitted earlier, we need to kick mainThreadDestroy() to delete the peer.
-                if (auto* workerLoaderProxy = downcast<WorkerOrWorkletGlobalScope>(context).workerOrWorkletThread()->workerLoaderProxy()) {
-                    workerLoaderProxy->postTaskToLoader([peer = WTFMove(peer)](ScriptExecutionContext& context) {
-                        ASSERT(isMainThread());
-                        ASSERT_UNUSED(context, context.isDocument());
-                    });
-                }
-            } else
-                clientWrapper->didCreateWebSocketChannel(peer.release());
+        [clientWrapper, peer = Peer::create(clientWrapper.copyRef(), context, workerContextIdentifier, taskMode, WTFMove(provider))](auto& context) mutable {
+            ASSERT_UNUSED(context, context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
+            if (!clientWrapper->failedWebSocketChannelCreation())
+                clientWrapper->didCreateWebSocketChannel(WTFMove(peer));
         }
     }, taskMode);
 }
 
 void WorkerThreadableWebSocketChannel::Bridge::initialize(WorkerGlobalScope& scope)
 {
-    ASSERT(!m_peer);
+    ASSERT(!m_peer.get());
     setMethodNotCompleted();
     Ref<Bridge> protectedThis(*this);
 
@@ -406,18 +451,18 @@ void WorkerThreadableWebSocketChannel::Bridge::initialize(WorkerGlobalScope& sco
 
     // m_peer may be null when the nested runloop exited before a peer has created.
     m_peer = m_workerClientWrapper->peer();
-    if (!m_peer)
+    if (!m_peer.get())
         m_workerClientWrapper->setFailedWebSocketChannelCreation();
 }
 
 void WorkerThreadableWebSocketChannel::Bridge::connect(const URL& url, const String& protocol)
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return;
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, url = url.isolatedCopy(), protocol = protocol.isolatedCopy()](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull(), url = url.isolatedCopy(), protocol = protocol.isolatedCopy()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
-        ASSERT(peer);
 
         auto& document = downcast<Document>(context);
         
@@ -433,14 +478,14 @@ void WorkerThreadableWebSocketChannel::Bridge::connect(const URL& url, const Str
 
 ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge::send(CString&& message)
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return ThreadableWebSocketChannel::SendFail;
     setMethodNotCompleted();
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, message = WTFMove(message)](ScriptExecutionContext& context) mutable {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull(), message = WTFMove(message)](ScriptExecutionContext& context) mutable {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->send(WTFMove(message));
     });
@@ -452,7 +497,8 @@ ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge:
 
 ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge::send(const ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return ThreadableWebSocketChannel::SendFail;
 
     // ArrayBuffer isn't thread-safe, hence the content of ArrayBuffer is copied into Vector<uint8_t>.
@@ -461,10 +507,9 @@ ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge:
         memcpySpan(data.mutableSpan(), binaryData.span().subspan(byteOffset, byteLength));
     setMethodNotCompleted();
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, data = WTFMove(data)](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull(), data = WTFMove(data)](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         auto arrayBuffer = ArrayBuffer::create(data.span());
         peer->send(arrayBuffer);
@@ -477,14 +522,14 @@ ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge:
 
 ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge::send(Blob& binaryData)
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return ThreadableWebSocketChannel::SendFail;
     setMethodNotCompleted();
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, url = binaryData.url().isolatedCopy(), type = binaryData.type().isolatedCopy(), size = binaryData.size(), memoryCost = binaryData.memoryCost()](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull(), url = binaryData.url().isolatedCopy(), type = binaryData.type().isolatedCopy(), size = binaryData.size(), memoryCost = binaryData.memoryCost()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->send(Blob::deserialize(&context, url, type, size, memoryCost, { }));
     });
@@ -496,14 +541,15 @@ ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge:
 
 unsigned WorkerThreadableWebSocketChannel::Bridge::bufferedAmount()
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return 0;
+
     setMethodNotCompleted();
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->bufferedAmount();
     });
@@ -515,13 +561,13 @@ unsigned WorkerThreadableWebSocketChannel::Bridge::bufferedAmount()
 
 void WorkerThreadableWebSocketChannel::Bridge::close(int code, const String& reason)
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return;
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, code, reason = reason.isolatedCopy()](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull(), code, reason = reason.isolatedCopy()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->close(code, reason);
     });
@@ -529,13 +575,13 @@ void WorkerThreadableWebSocketChannel::Bridge::close(int code, const String& rea
 
 void WorkerThreadableWebSocketChannel::Bridge::fail(String&& reason)
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return;
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, reason = WTFMove(reason).isolatedCopy()](ScriptExecutionContext& context) mutable {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull(), reason = WTFMove(reason).isolatedCopy()](ScriptExecutionContext& context) mutable {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->fail(WTFMove(reason));
     });
@@ -544,25 +590,19 @@ void WorkerThreadableWebSocketChannel::Bridge::fail(String&& reason)
 void WorkerThreadableWebSocketChannel::Bridge::disconnect()
 {
     clearClientWrapper();
-    if (m_peer) {
-        m_loaderProxy.postTaskToLoader([peer = std::unique_ptr<Peer>(m_peer)](ScriptExecutionContext& context) {
-            ASSERT(isMainThread());
-            ASSERT_UNUSED(context, context.isDocument());
-        });
-        m_peer = nullptr;
-    }
+    m_peer = nullptr;
     m_workerGlobalScope = nullptr;
 }
 
 void WorkerThreadableWebSocketChannel::Bridge::suspend()
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return;
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->suspend();
     });
@@ -570,13 +610,13 @@ void WorkerThreadableWebSocketChannel::Bridge::suspend()
 
 void WorkerThreadableWebSocketChannel::Bridge::resume()
 {
-    if (!m_peer)
+    RefPtr peer = m_peer.get();
+    if (!peer)
         return;
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = peer.releaseNonNull()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
-        ASSERT(peer);
 
         peer->resume();
     });

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h
@@ -75,7 +75,7 @@ public:
         WTF_MAKE_TZONE_ALLOCATED(Peer);
         WTF_MAKE_NONCOPYABLE(Peer);
     public:
-        Peer(Ref<ThreadableWebSocketChannelClientWrapper>&&, ScriptExecutionContext&, ScriptExecutionContextIdentifier, const String& taskMode, SocketProvider&);
+        static Ref<Peer> create(Ref<ThreadableWebSocketChannelClientWrapper>&&, ScriptExecutionContext&, ScriptExecutionContextIdentifier, const String& taskMode, SocketProvider&);
         ~Peer();
 
         ConnectStatus connect(const URL&, const String& protocol);
@@ -100,7 +100,9 @@ public:
         void didUpgradeURL() final;
 
     private:
-        Ref<ThreadableWebSocketChannelClientWrapper> m_workerClientWrapper;
+        Peer(Ref<ThreadableWebSocketChannelClientWrapper>&&, ScriptExecutionContext&, ScriptExecutionContextIdentifier, const String& taskMode, SocketProvider&);
+
+        ThreadSafeWeakPtr<ThreadableWebSocketChannelClientWrapper> m_workerClientWrapper;
         RefPtr<ThreadableWebSocketChannel> m_mainWebSocketChannel;
         String m_taskMode;
         ScriptExecutionContextIdentifier m_workerContextIdentifier;
@@ -154,7 +156,7 @@ private:
         RefPtr<WorkerGlobalScope> m_workerGlobalScope;
         WorkerLoaderProxy& m_loaderProxy;
         String m_taskMode;
-        Peer* m_peer { nullptr };
+        ThreadSafeWeakPtr<Peer> m_peer;
         Ref<SocketProvider> m_socketProvider;
     };
 

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -108,7 +108,7 @@ private:
     const WebCore::ResourceResponse& serverHandshakeResponse() const final { return m_handshakeResponse; }
 
     WeakPtr<WebCore::Document, WebCore::WeakPtrImplWithEventTargetData> m_document;
-    WeakPtr<WebCore::WebSocketChannelClient> m_client;
+    ThreadSafeWeakPtr<WebCore::WebSocketChannelClient> m_client;
     URL m_url;
     String m_subprotocol;
     String m_extensions;

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -179,8 +179,10 @@ private:
         BlobLoaderFailed
     };
 
+    RefPtr<WebSocketChannelClient> protectedClient() const;
+
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    WeakPtr<WebSocketChannelClient> m_client;
+    ThreadSafeWeakPtr<WebSocketChannelClient> m_client;
     std::unique_ptr<WebSocketHandshake> m_handshake;
     RefPtr<SocketStreamHandle> m_handle;
     Vector<uint8_t> m_buffer;


### PR DESCRIPTION
#### 8d994270641cbb5ff5ce2a87d079546a7e33bcff
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for WebSocketChannelClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=281081">https://bugs.webkit.org/show_bug.cgi?id=281081</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp:
(WebCore::ThreadableWebSocketChannelClientWrapper::ThreadableWebSocketChannelClientWrapper):
(WebCore::ThreadableWebSocketChannelClientWrapper::peer const):
(WebCore::ThreadableWebSocketChannelClientWrapper::didCreateWebSocketChannel):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h:
* Source/WebCore/Modules/websockets/WebSocketChannelClient.h:
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Peer::Peer):
(WebCore::WorkerThreadableWebSocketChannel::Peer::create):
(WebCore::WorkerThreadableWebSocketChannel::Peer::send):
(WebCore::WorkerThreadableWebSocketChannel::Peer::bufferedAmount):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didConnect):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didReceiveMessage):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didReceiveBinaryData):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didUpdateBufferedAmount):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didStartClosingHandshake):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didClose):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didReceiveMessageError):
(WebCore::WorkerThreadableWebSocketChannel::Peer::didUpgradeURL):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::mainThreadInitialize):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::initialize):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::connect):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::send):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::bufferedAmount):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::close):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::fail):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::disconnect):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::suspend):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::resume):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.h:
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::connect):
(WebKit::WebSocketChannel::increaseBufferedAmount):
(WebKit::WebSocketChannel::decreaseBufferedAmount):
(WebKit::WebSocketChannel::close):
(WebKit::WebSocketChannel::fail):
(WebKit::WebSocketChannel::didConnect):
(WebKit::WebSocketChannel::didReceiveText):
(WebKit::WebSocketChannel::didReceiveBinaryData):
(WebKit::WebSocketChannel::didClose):
(WebKit::WebSocketChannel::didReceiveMessageError):
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::connect):
(WebCore::WebSocketChannel::fail):
(WebCore::WebSocketChannel::resume):
(WebCore::WebSocketChannel::didCloseSocketStream):
(WebCore::WebSocketChannel::didReceiveSocketStreamData):
(WebCore::WebSocketChannel::didUpdateBufferedAmount):
(WebCore::WebSocketChannel::didFailSocketStream):
(WebCore::WebSocketChannel::processBuffer):
(WebCore::WebSocketChannel::resumeTimerFired):
(WebCore::WebSocketChannel::startClosingHandshake):
(WebCore::WebSocketChannel::processFrame):
(WebCore::WebSocketChannel::protectedClient const):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/284893@main">https://commits.webkit.org/284893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2af07ce61b25dffa7e2c5857f544812721a69455

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56025 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14496 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76590 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63762 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63707 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5425 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10859 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/761 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->