### PR TITLE
Add support for documentId to message sender object.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
@@ -41,6 +41,7 @@ struct WebExtensionMessageSenderParameters {
     WebPageProxyIdentifier pageProxyIdentifier;
     WebExtensionContentWorldType contentWorldType { WebExtensionContentWorldType::ContentScript };
     URL url;
+    WTF::UUID documentIdentifier { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::WebExtensionMessageSenderParameters {
     WebKit::WebPageProxyIdentifier pageProxyIdentifier;
     WebKit::WebExtensionContentWorldType contentWorldType;
     URL url;
+    WTF::UUID documentIdentifier;
 };
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -31,6 +31,8 @@
 #include <JavaScriptCore/JSBase.h>
 #include <wtf/Function.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Markable.h>
+#include <wtf/UUID.h>
 #include <wtf/Vector.h>
 
 #ifdef __OBJC__
@@ -39,6 +41,8 @@
 #endif
 
 namespace WebKit {
+
+class WebFrame;
 
 Ref<JSON::Array> filterObjects(const JSON::Array&, WTF::Function<bool(const JSON::Value&)>&& lambda);
 
@@ -117,6 +121,8 @@ Unexpected<WebExtensionError> toWebExtensionError(NSString *callingAPIName, NSSt
 }
 
 #endif // __OBJC__
+
+Markable<WTF::UUID> toDocumentIdentifier(WebFrame&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -416,6 +416,15 @@ bool anyItemsExceedQuota(NSDictionary *items, size_t quota, NSString **outKeyWit
     return itemExceededQuota;
 }
 
+Markable<WTF::UUID> toDocumentIdentifier(WebFrame& frame)
+{
+    RefPtr coreFrame = frame.coreLocalFrame();
+    RefPtr document = coreFrame ? coreFrame->document() : nullptr;
+    if (!document)
+        return { };
+    return document->identifier().object();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -418,12 +418,15 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
         @"  browser.test.assertEq(typeof sender, 'object', 'sender should be an object')",
 
         @"  browser.test.assertEq(typeof sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(sender.tab.url, expectedURL, 'sender.tab.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.tab?.url, expectedURL, 'sender.tab.url should be the expected URL')",
 
-        @"  browser.test.assertEq(sender.url, expectedURL, 'sender.url should be the expected URL')",
-        @"  browser.test.assertEq(sender.origin, expectedOrigin, 'sender.origin should be the expected origin')",
+        @"  browser.test.assertEq(sender?.url, expectedURL, 'sender.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.origin, expectedOrigin, 'sender.origin should be the expected origin')",
 
-        @"  browser.test.assertEq(sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(sender?.frameId, 0, 'sender.frameId should be 0')",
+
+        @"  browser.test.assertEq(typeof sender?.documentId, 'string', 'sender.documentId should be')",
+        @"  browser.test.assertEq(sender?.documentId?.length, 36, 'sender.documentId.length should be')",
 
         @"  sendResponse({ content: 'Received' })",
         @"})",
@@ -474,12 +477,15 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)
         @"  browser.test.assertEq(typeof sender, 'object', 'sender should be an object')",
 
         @"  browser.test.assertEq(typeof sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(sender.tab.url, expectedURL, 'sender.tab.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.tab?.url, expectedURL, 'sender.tab.url should be the expected URL')",
 
-        @"  browser.test.assertEq(sender.url, expectedURL, 'sender.url should be the expected URL')",
-        @"  browser.test.assertEq(sender.origin, expectedOrigin, 'sender.origin should be the expected origin')",
+        @"  browser.test.assertEq(sender?.url, expectedURL, 'sender.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.origin, expectedOrigin, 'sender.origin should be the expected origin')",
 
-        @"  browser.test.assertEq(sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(sender?.frameId, 0, 'sender.frameId should be 0')",
+
+        @"  browser.test.assertEq(typeof sender?.documentId, 'string', 'sender.documentId should be')",
+        @"  browser.test.assertEq(sender?.documentId?.length, 36, 'sender.documentId.length should be')",
 
         @"  setTimeout(() => sendResponse({ content: 'Received' }), 1000)",
 
@@ -532,12 +538,15 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)
         @"  browser.test.assertEq(typeof sender, 'object', 'sender should be an object')",
 
         @"  browser.test.assertEq(typeof sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(sender.tab.url, expectedURL, 'sender.tab.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.tab?.url, expectedURL, 'sender.tab.url should be the expected URL')",
 
-        @"  browser.test.assertEq(sender.url, expectedURL, 'sender.url should be the expected URL')",
-        @"  browser.test.assertEq(sender.origin, expectedOrigin, 'sender.origin should be the expected origin')",
+        @"  browser.test.assertEq(sender?.url, expectedURL, 'sender.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.origin, expectedOrigin, 'sender.origin should be the expected origin')",
 
-        @"  browser.test.assertEq(sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(sender?.frameId, 0, 'sender.frameId should be 0')",
+
+        @"  browser.test.assertEq(typeof sender?.documentId, 'string', 'sender.documentId should be')",
+        @"  browser.test.assertEq(sender?.documentId?.length, 36, 'sender.documentId.length should be')",
 
         @"  return Promise.resolve({ content: 'Received' })",
         @"})",
@@ -588,12 +597,15 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply
         @"  browser.test.assertEq(typeof sender, 'object', 'sender should be an object')",
 
         @"  browser.test.assertEq(typeof sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(sender.tab.url, expectedURL, 'sender.tab.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.tab?.url, expectedURL, 'sender.tab.url should be the expected URL')",
 
-        @"  browser.test.assertEq(sender.url, expectedURL, 'sender.url should be the expected URL')",
-        @"  browser.test.assertEq(sender.origin, expectedOrigin, 'sender.origin should be the expected origin')",
+        @"  browser.test.assertEq(sender?.url, expectedURL, 'sender.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.origin, expectedOrigin, 'sender.origin should be the expected origin')",
 
-        @"  browser.test.assertEq(sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(sender?.frameId, 0, 'sender.frameId should be 0')",
+
+        @"  browser.test.assertEq(typeof sender?.documentId, 'string', 'sender.documentId should be')",
+        @"  browser.test.assertEq(sender?.documentId?.length, 36, 'sender.documentId.length should be')",
 
         @"  return new Promise((resolve) => {",
         @"    setTimeout(() => resolve({ content: 'Received' }), 1000)",
@@ -646,12 +658,15 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)
         @"  browser.test.assertEq(typeof sender, 'object', 'sender should be an object')",
 
         @"  browser.test.assertEq(typeof sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(sender.tab.url, expectedURL, 'sender.tab.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.tab?.url, expectedURL, 'sender.tab.url should be the expected URL')",
 
-        @"  browser.test.assertEq(sender.url, expectedURL, 'sender.url should be the expected URL')",
-        @"  browser.test.assertEq(sender.origin, expectedOrigin, 'sender.origin should be the expected origin')",
+        @"  browser.test.assertEq(sender?.url, expectedURL, 'sender.url should be the expected URL')",
+        @"  browser.test.assertEq(sender?.origin, expectedOrigin, 'sender.origin should be the expected origin')",
 
-        @"  browser.test.assertEq(sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(sender?.frameId, 0, 'sender.frameId should be 0')",
+
+        @"  browser.test.assertEq(typeof sender?.documentId, 'string', 'sender.documentId should be')",
+        @"  browser.test.assertEq(sender?.documentId?.length, 36, 'sender.documentId.length should be')",
 
         @"  return false",
         @"})",
@@ -1779,10 +1794,16 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
         @"  browser.test.assertEq(typeof sender, 'object', 'sender should be an object')",
         @"  browser.test.assertEq(typeof sender?.url, 'string', 'sender.url should be a string')",
         @"  browser.test.assertEq(typeof sender?.origin, 'string', 'sender.origin should be a string')",
+
         @"  browser.test.assertTrue(sender?.url?.startsWith('http'), 'sender.url should start with http')",
         @"  browser.test.assertTrue(sender?.origin?.startsWith('http'), 'sender.origin should start with http')",
+
         @"  browser.test.assertEq(typeof sender?.tab, 'object', 'sender.tab should be an object')",
+
         @"  browser.test.assertEq(sender?.frameId, 0, 'sender.frameId should be 0')",
+
+        @"  browser.test.assertEq(typeof sender?.documentId, 'string', 'sender.documentId should be')",
+        @"  browser.test.assertEq(sender?.documentId?.length, 36, 'sender.documentId.length should be')",
 
         @"  sendResponse('Received')",
         @"})",


### PR DESCRIPTION
#### 0217575ddd41b0302e6c68c09da31d0f38a7923f
<pre>
Add support for documentId to message sender object.
<a href="https://webkit.org/b/281083">https://webkit.org/b/281083</a>
<a href="https://rdar.apple.com/problem/137532821">rdar://problem/137532821</a>

Reviewed by Brian Weinstein.

Adds support for `documentId` to the `sender` object for `onMessage`, `onConnect`, `onMessageExternal`
and `onConnectExternal` event listeners. `WebCore::Document` already had a `UUID` identifier we can use.

* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::toDocumentIdentifier): Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::sendMessage): Get document identifier or throw error.
(WebKit::WebExtensionAPIRuntime::connect): Ditto.
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage): Ditto.
(WebKit::WebExtensionAPIWebPageRuntime::connect): Ditto.
(WebKit::toWebAPI): Added `documentId` to the result.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::sendMessage): Get document identifier or throw error.
(WebKit::WebExtensionAPITabs::connect): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)): Test `documentId` and use optional chaining.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)): Ditto.

Canonical link: <a href="https://commits.webkit.org/284855@main">https://commits.webkit.org/284855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98dfe59a77863ae129bdfa694b581f5332832708

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74816 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21744 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60970 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76534 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14953 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63669 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11731 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10842 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45934 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->