### PR TITLE
REGRESSION(284791@main): [ Debug ] 2x TestWebKitAPI.JavaScriptCore.Incremental* (api-tests) are constant asserts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm
@@ -27,6 +27,7 @@
 
 #import "Test.h"
 #import <JavaScriptCore/JavaScriptCore.h>
+#import <JavaScriptCore/Options.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/URL.h>
@@ -81,6 +82,7 @@ static void cycleRunLoop()
 
 TEST(JavaScriptCore, IncrementalSweeperMainThread)
 {
+    JSC::Options::AllowUnfinalizedAccessScope scope;
     auto context = adoptNS([JSContext new]);
     s_expectedRunLoop = &RunLoop::current();
 
@@ -92,6 +94,7 @@ TEST(JavaScriptCore, IncrementalSweeperMainThread)
 
 TEST(JavaScriptCore, IncrementalSweeperSecondaryThread)
 {
+    JSC::Options::AllowUnfinalizedAccessScope scope;
     auto context = adoptNS([JSContext new]);
     s_expectedRunLoop = &RunLoop::current();
 


### PR DESCRIPTION
#### 2a1b1155c94e3831b78c8dd2e9fc748fffe08662
<pre>
REGRESSION(284791@main): [ Debug ] 2x TestWebKitAPI.JavaScriptCore.Incremental* (api-tests) are constant asserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=281074">https://bugs.webkit.org/show_bug.cgi?id=281074</a>

Reviewed by NOBODY (OOPS!).

This test doesn&apos;t seem to call JSC::Initialize before creating a Strong&lt;&gt;,
causing debug builds to hit an assertion when checking if the debug-mode
StrongRefTracker is enabled.

* Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm:
(TestWebKitAPI::TEST(JavaScriptCore, IncrementalSweeperMainThread)):
(TestWebKitAPI::TEST(JavaScriptCore, IncrementalSweeperSecondaryThread)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a1b1155c94e3831b78c8dd2e9fc748fffe08662

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55999 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14471 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36450 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20267 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63847 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76536 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69974 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63733 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63670 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5386 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91755 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45936 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20004 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->