### PR TITLE
[TextureMapper] Preserve-3d layers don't get flattened correctly

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -1338,6 +1338,11 @@ void TextureMapper::setDepthRange(double zNear, double zFar)
     updateProjectionMatrix();
 }
 
+std::pair<double, double> TextureMapper::depthRange() const
+{
+    return { data().zNear, data().zFar };
+}
+
 void TextureMapper::updateProjectionMatrix()
 {
     bool flipY;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -83,6 +83,7 @@ public:
     IntRect clipBounds();
     IntSize maxTextureSize() const { return IntSize(2000, 2000); }
     void setDepthRange(double zNear, double zFar);
+    std::pair<double, double> depthRange() const;
     void setMaskMode(bool m) { m_isMaskMode = m; }
     void setWrapMode(WrapMode m) { m_wrapMode = m; }
     void setPatternTransform(const TransformationMatrix& p) { m_patternTransform = p; }
@@ -119,7 +120,7 @@ private:
     bool beginRoundedRectClip(const TransformationMatrix&, const FloatRoundedRect&);
     void bindDefaultSurface();
     ClipStack& clipStack();
-    TextureMapperGLData& data() { return *m_data; }
+    TextureMapperGLData& data() const { return *m_data; }
 
     void updateProjectionMatrix();
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -67,6 +67,82 @@ struct TextureMapperLayer::ComputeTransformData {
     }
 };
 
+class TextureMapperFlattenedLayer final {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit TextureMapperFlattenedLayer(const IntRect& rect, double zNear, double zFar)
+        : m_rect(rect)
+        , m_zNear(zNear)
+        , m_zFar(zFar)
+    { }
+
+    IntRect layerRect() const { return m_rect; }
+
+    bool needsUpdate() const { return m_textures.isEmpty(); }
+
+    void update(TextureMapperPaintOptions& options, const std::function<void(TextureMapperPaintOptions&)>& paintFunction)
+    {
+        auto [prevZNear, prevZFar] =  options.textureMapper.depthRange();
+        options.textureMapper.setDepthRange(m_zNear, m_zFar);
+
+        m_textures.clear();
+
+        auto maxTextureSize = options.textureMapper.maxTextureSize();
+        forEachTile(maxTextureSize, [&](const IntRect& tileRect) {
+            RefPtr<BitmapTexture> surface = options.textureMapper.acquireTextureFromPool(tileRect.size(), { BitmapTexture::Flags::SupportsAlpha });
+            {
+                SetForScope scopedSurface(options.surface, surface);
+                SetForScope scopedOffset(options.offset, -toIntSize(tileRect.location()));
+                SetForScope scopedOpacity(options.opacity, 1);
+
+                options.textureMapper.bindSurface(options.surface.get());
+                paintFunction(options);
+
+                // If paintFunction applies filters to flattened surface then surface object might have
+                // changed to new intermediate filter surface and it needs to be stored for painting.
+                ASSERT(options.surface);
+                surface = options.surface;
+            }
+            m_textures.append(WTFMove(surface));
+        });
+
+        options.textureMapper.bindSurface(options.surface.get());
+        options.textureMapper.setDepthRange(prevZNear, prevZFar);
+    }
+
+    void paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, TransformationMatrix& modelViewMatrix, float opacity)
+    {
+        auto maxTextureSize = textureMapper.maxTextureSize();
+        auto allEdgesExposed = m_rect.width() <= maxTextureSize.width() && m_rect.height() <= maxTextureSize.height()
+            ? TextureMapper::AllEdgesExposed::Yes
+            : TextureMapper::AllEdgesExposed::No;
+        TransformationMatrix adjustedTransform = modelViewMatrix * TransformationMatrix::rectToRect(m_rect, targetRect);
+
+        size_t textureIndex = 0;
+        forEachTile(maxTextureSize, [&](const IntRect& tileRect) {
+            ASSERT(textureIndex < m_textures.size());
+            textureMapper.drawTexture(*m_textures[textureIndex++], tileRect, adjustedTransform, opacity, allEdgesExposed);
+        });
+    }
+
+private:
+    void forEachTile(const IntSize& maxTextureSize, const std::function<void(const IntRect&)>& tileAction)
+    {
+        for (int x = m_rect.x(); x < m_rect.maxX(); x += maxTextureSize.width()) {
+            for (int y = m_rect.y(); y < m_rect.maxY(); y += maxTextureSize.height()) {
+                IntRect tileRect({ x, y }, maxTextureSize);
+                tileRect.intersect(m_rect);
+                tileAction(tileRect);
+            }
+        }
+    }
+
+    IntRect m_rect;
+    double m_zNear;
+    double m_zFar;
+    Vector<RefPtr<BitmapTexture>> m_textures;
+};
+
 TextureMapperLayer::TextureMapperLayer(Damage::ShouldPropagate propagateDamage)
     : m_propagateDamage(propagateDamage)
 {
@@ -78,6 +154,89 @@ TextureMapperLayer::~TextureMapperLayer()
         child->m_parent = nullptr;
 
     removeFromParent();
+}
+
+void TextureMapperLayer::processDescendantLayersFlatteningRequirements()
+{
+    // Traverse all children in depth first, post-order
+    for (auto* child : m_children) {
+        child->processDescendantLayersFlatteningRequirements();
+
+        if (child->flattensAsLeafOf3DSceneOr3DPerspective())
+            child->processFlatteningRequirements();
+    }
+}
+
+void TextureMapperLayer::processFlatteningRequirements()
+{
+    m_flattenedLayer = nullptr;
+
+    // Reset transformations as this layer is root 2D
+    SetForScope scopedLocalTransform(m_layerTransforms.localTransform, TransformationMatrix::identity);
+    m_layerTransforms.combined = { };
+    m_layerTransforms.combinedForChildren = { };
+#if USE(COORDINATED_GRAPHICS)
+    SetForScope scopedFutureLocalTransform(m_layerTransforms.futureLocalTransform, TransformationMatrix::identity);
+    m_layerTransforms.futureLocalTransform = { };
+    m_layerTransforms.futureCombined = { };
+    m_layerTransforms.futureCombinedForChildren = { };
+#endif
+    ComputeTransformData data;
+    if (m_state.maskLayer)
+        m_state.maskLayer->computeTransformsRecursive(data);
+    if (m_state.replicaLayer)
+        m_state.replicaLayer->computeTransformsRecursive(data);
+    if (m_state.backdropLayer)
+        m_state.backdropLayer->computeTransformsRecursive(data);
+    for (auto* child : m_children)
+        child->computeTransformsRecursive(data);
+
+    Region layerRegion;
+    computeFlattenedRegion(layerRegion, true);
+
+    if (layerRegion.isEmpty())
+        return;
+
+    m_flattenedLayer = makeUnique<TextureMapperFlattenedLayer>(layerRegion.bounds(), data.zNear, data.zFar);
+}
+
+void TextureMapperLayer::computeFlattenedRegion(Region& region, bool layerIsFlatteningRoot)
+{
+    auto rect = isFlattened() ? m_flattenedLayer->layerRect() : layerRect();
+
+    bool shouldExpand = m_currentFilters.hasOutsets() && !m_state.masksToBounds && !m_state.maskLayer;
+    if (shouldExpand && !layerIsFlatteningRoot) {
+        auto outsets = m_currentFilters.outsets();
+        rect.move(-outsets.left(), -outsets.top());
+        rect.expand(outsets.left() + outsets.right(), outsets.top() + outsets.bottom());
+    }
+
+    region.unite(enclosingIntRect(m_layerTransforms.combined.mapRect(rect)));
+
+    if (!m_state.masksToBounds && !m_state.maskLayer) {
+        if (m_state.replicaLayer)
+            region.unite(enclosingIntRect(m_state.replicaLayer->m_layerTransforms.combined.mapRect(m_state.replicaLayer->layerRect())));
+
+        for (auto* child : m_children)
+            child->computeFlattenedRegion(region, false);
+    }
+
+    if (shouldExpand && layerIsFlatteningRoot) {
+        auto bounds = region.bounds();
+        auto outsets = m_currentFilters.outsets();
+        bounds.move(-outsets.left(), -outsets.top());
+        bounds.expand(outsets.left() + outsets.right(), outsets.top() + outsets.bottom());
+        region = bounds;
+    }
+}
+
+void TextureMapperLayer::destroyFlattenedDescendantLayers()
+{
+    if (m_flattenedLayer)
+        m_flattenedLayer = nullptr;
+
+    for (auto* child : m_children)
+        child->destroyFlattenedDescendantLayers();
 }
 
 void TextureMapperLayer::computeTransformsRecursive(ComputeTransformData& data)
@@ -108,7 +267,7 @@ void TextureMapperLayer::computeTransformsRecursive(ComputeTransformData& data)
             m_layerTransforms.combined.translate(-m_state.pos.x(), -m_state.pos.y());
 
         if (!m_state.preserves3D)
-            m_layerTransforms.combinedForChildren = m_layerTransforms.combinedForChildren.to2dTransform();
+            m_layerTransforms.combinedForChildren.flatten();
         m_layerTransforms.combinedForChildren.multiply(m_state.childrenTransform);
         m_layerTransforms.combinedForChildren.translate3d(-originX, -originY, -m_state.anchorPoint.z());
 
@@ -129,7 +288,7 @@ void TextureMapperLayer::computeTransformsRecursive(ComputeTransformData& data)
         m_layerTransforms.futureCombined.translate3d(-originX, -originY, -m_state.anchorPoint.z());
 
         if (!m_state.preserves3D)
-            m_layerTransforms.futureCombinedForChildren = m_layerTransforms.futureCombinedForChildren.to2dTransform();
+            m_layerTransforms.futureCombinedForChildren.flatten();
         m_layerTransforms.futureCombinedForChildren.multiply(m_state.childrenTransform);
         m_layerTransforms.futureCombinedForChildren.translate3d(-originX, -originY, -m_state.anchorPoint.z());
 #endif
@@ -151,23 +310,28 @@ void TextureMapperLayer::computeTransformsRecursive(ComputeTransformData& data)
         return z / w;
     };
 
-    data.updateDepthRange(calculateZ(0, 0));
-    data.updateDepthRange(calculateZ(m_state.size.width(), 0));
-    data.updateDepthRange(calculateZ(0, m_state.size.height()));
-    data.updateDepthRange(calculateZ(m_state.size.width(), m_state.size.height()));
+    auto rect = isFlattened() ? m_flattenedLayer->layerRect() : layerRect();
+
+    data.updateDepthRange(calculateZ(rect.x(), rect.y()));
+    data.updateDepthRange(calculateZ(rect.x() + rect.width(), rect.y()));
+    data.updateDepthRange(calculateZ(rect.x(), rect.y() + rect.height()));
+    data.updateDepthRange(calculateZ(rect.x() + rect.width(), rect.y() + rect.height()));
 
     if (m_parent && m_parent->m_state.preserves3D)
-        m_centerZ = calculateZ(m_state.size.width() / 2, m_state.size.height() / 2);
+        m_centerZ = calculateZ(rect.x() + rect.width() / 2, rect.y() + rect.height() / 2);
 
-    if (m_state.maskLayer)
-        m_state.maskLayer->computeTransformsRecursive(data);
-    if (m_state.replicaLayer)
-        m_state.replicaLayer->computeTransformsRecursive(data);
     if (m_state.backdropLayer)
         m_state.backdropLayer->computeTransformsRecursive(data);
-    for (auto* child : m_children) {
-        ASSERT(child->m_parent == this);
-        child->computeTransformsRecursive(data);
+
+    if (!isFlattened()) {
+        if (m_state.maskLayer)
+            m_state.maskLayer->computeTransformsRecursive(data);
+        if (m_state.replicaLayer)
+            m_state.replicaLayer->computeTransformsRecursive(data);
+        for (auto* child : m_children) {
+            ASSERT(child->m_parent == this);
+            child->computeTransformsRecursive(data);
+        }
     }
 
     // Reorder children if needed on the way back up.
@@ -182,6 +346,8 @@ void TextureMapperLayer::computeTransformsRecursive(ComputeTransformData& data)
 
 void TextureMapperLayer::paint(TextureMapper& textureMapper)
 {
+    processDescendantLayersFlatteningRequirements();
+
     ComputeTransformData data;
     computeTransformsRecursive(data);
     textureMapper.setDepthRange(data.zNear, data.zFar);
@@ -189,6 +355,8 @@ void TextureMapperLayer::paint(TextureMapper& textureMapper)
     TextureMapperPaintOptions options(textureMapper);
     options.surface = textureMapper.currentSurface();
     paintRecursive(options);
+
+    destroyFlattenedDescendantLayers();
 }
 
 void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
@@ -204,6 +372,11 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
     transform.translate(options.offset.width(), options.offset.height());
     transform.multiply(options.transform);
     transform.multiply(m_layerTransforms.combined);
+
+    if (isFlattened() && !m_flattenedLayer->needsUpdate()) {
+        m_flattenedLayer->paintToTextureMapper(options.textureMapper, m_flattenedLayer->layerRect(), transform, options.opacity);
+        return;
+    }
 
     TextureMapperSolidColorLayer solidColorLayer;
     TextureMapperBackingStore* backingStore = m_backingStore;
@@ -305,20 +478,24 @@ void TextureMapperLayer::sortByZOrder(Vector<TextureMapperLayer* >& array)
         });
 }
 
+void TextureMapperLayer::paintBackdrop(TextureMapperPaintOptions& options)
+{
+    TransformationMatrix clipTransform;
+    clipTransform.translate(options.offset.width(), options.offset.height());
+    clipTransform.multiply(options.transform);
+    clipTransform.multiply(m_layerTransforms.combined);
+    options.textureMapper.beginClip(clipTransform, m_state.backdropFiltersRect);
+    m_state.backdropLayer->paintRecursive(options);
+    options.textureMapper.endClip();
+}
+
 void TextureMapperLayer::paintSelfAndChildren(TextureMapperPaintOptions& options)
 {
     if (m_state.backdropLayer && m_state.backdropLayer == options.backdropLayer)
         return;
 
-    if (m_state.backdropLayer && !options.backdropLayer) {
-        TransformationMatrix clipTransform;
-        clipTransform.translate(options.offset.width(), options.offset.height());
-        clipTransform.multiply(options.transform);
-        clipTransform.multiply(m_layerTransforms.combined);
-        options.textureMapper.beginClip(clipTransform, m_state.backdropFiltersRect);
-        m_state.backdropLayer->paintRecursive(options);
-        options.textureMapper.endClip();
-    }
+    if (m_state.backdropLayer && !options.backdropLayer)
+        paintBackdrop(options);
 
     paintSelf(options);
 
@@ -347,8 +524,10 @@ void TextureMapperLayer::paintSelfAndChildren(TextureMapperPaintOptions& options
         }
     }
 
-    for (auto* child : m_children)
-        child->paintRecursive(options);
+    if (!isFlattened() || m_flattenedLayer->needsUpdate()) {
+        for (auto* child : m_children)
+            child->paintRecursive(options);
+    }
 
     if (shouldClip)
         options.textureMapper.endClip();
@@ -360,6 +539,16 @@ bool TextureMapperLayer::shouldBlend() const
         return false;
 
     return m_currentOpacity < 1;
+}
+
+bool TextureMapperLayer::flattensAsLeafOf3DSceneOr3DPerspective() const
+{
+    bool isLeafOf3DScene = !m_state.preserves3D && (m_parent && m_parent->preserves3D());
+    bool hasPerspective = m_layerTransforms.localTransform.hasPerspective() && m_layerTransforms.localTransform.m34() != -1.f;
+    if ((isLeafOf3DScene || hasPerspective) && !m_children.isEmpty() && !m_layerTransforms.localTransform.isAffine())
+        return true;
+
+    return false;
 }
 
 bool TextureMapperLayer::isVisible() const
@@ -583,7 +772,9 @@ void TextureMapperLayer::computeOverlapRegions(ComputeOverlapRegionData& data, c
         return;
 
     FloatRect localBoundingRect;
-    if (m_backingStore || m_state.masksToBounds || m_state.maskLayer || hasFilters())
+    if (isFlattened() && !m_isBackdrop)
+        localBoundingRect = m_flattenedLayer->layerRect();
+    else if (m_backingStore || m_state.masksToBounds || m_state.maskLayer || hasFilters())
         localBoundingRect = layerRect();
     else if (m_contentsLayer || m_state.solidColor.isVisible())
         localBoundingRect = m_state.contentsRect;
@@ -615,7 +806,7 @@ void TextureMapperLayer::computeOverlapRegions(ComputeOverlapRegionData& data, c
         computeOverlapRegions(data, newReplicaTransform, false);
     }
 
-    if (!m_state.masksToBounds && data.mode != ComputeOverlapRegionMode::Mask) {
+    if (!m_state.masksToBounds && data.mode != ComputeOverlapRegionMode::Mask && !isFlattened()) {
         for (auto* child : m_children)
             child->computeOverlapRegions(data, accumulatedReplicaTransform);
     }
@@ -726,6 +917,7 @@ void TextureMapperLayer::paintIntoSurface(TextureMapperPaintOptions& options)
         SetForScope scopedTransform(options.transform, TransformationMatrix());
         SetForScope scopedReplicaLayer(options.replicaLayer, nullptr);
         SetForScope scopedBackdropLayer(options.backdropLayer, this);
+
         rootLayer().paintSelfAndChildren(options);
     } else
         paintSelfAndChildren(options);
@@ -809,12 +1001,38 @@ void TextureMapperLayer::paintRecursive(TextureMapperPaintOptions& options)
 
     SetForScope scopedOpacity(options.opacity, options.opacity * m_currentOpacity);
 
-    if (m_state.preserves3D)
+    if (preserves3D())
         paintWith3DRenderingContext(options);
+    else if (isFlattened())
+        paintFlattened(options);
     else if (shouldBlend())
         paintUsingOverlapRegions(options);
     else
         paintSelfChildrenReplicaFilterAndMask(options);
+}
+
+void TextureMapperLayer::paintFlattened(TextureMapperPaintOptions& options)
+{
+    // If painting a backdrop for a flattened layer, processing should stop here.
+    // Only the elements up to the flattened layer need to be painted into the backdrop buffer.
+    if (m_state.backdropLayer && m_state.backdropLayer == options.backdropLayer)
+        return;
+
+    if (m_state.backdropLayer && !options.backdropLayer)
+        paintBackdrop(options);
+
+    if (m_flattenedLayer->needsUpdate()) {
+        SetForScope scopedOffset(options.offset, IntSize());
+        SetForScope scopedTransform(options.transform, TransformationMatrix());
+        SetForScope scopedCombinedTransform(m_layerTransforms.combined, TransformationMatrix());
+        SetForScope scopedBackdropLayer(m_state.backdropLayer, nullptr);
+
+        m_flattenedLayer->update(options, [&](TextureMapperPaintOptions& options) {
+            paintIntoSurface(options);
+        });
+    }
+
+    paintSelf(options);
 }
 
 void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& options)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -39,6 +39,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TextureMappe
 namespace WebCore {
 
 class TextureMapper;
+class TextureMapperFlattenedLayer;
 class TextureMapperPaintOptions;
 class TextureMapperPlatformLayer;
 
@@ -133,10 +134,18 @@ private:
     {
         if (m_effectTarget)
             return m_effectTarget->rootLayer();
-        if (m_parent)
+        if (m_parent) {
+            if (m_parent->flattensAsLeafOf3DSceneOr3DPerspective())
+                return *m_parent;
             return m_parent->rootLayer();
+        }
         return const_cast<TextureMapperLayer&>(*this);
     }
+
+    void processDescendantLayersFlatteningRequirements();
+    void processFlatteningRequirements();
+    void computeFlattenedRegion(Region&, bool);
+    void destroyFlattenedDescendantLayers();
 
     struct ComputeTransformData;
     void computeTransformsRecursive(ComputeTransformData&);
@@ -161,6 +170,7 @@ private:
     void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix&, bool includesReplica = true);
 
     void paintRecursive(TextureMapperPaintOptions&);
+    void paintFlattened(TextureMapperPaintOptions&);
     void paintWith3DRenderingContext(TextureMapperPaintOptions&);
     void paintSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&);
     void paintUsingOverlapRegions(TextureMapperPaintOptions&);
@@ -171,12 +181,18 @@ private:
     void paintSelf(TextureMapperPaintOptions&);
     void paintSelfAndChildren(TextureMapperPaintOptions&);
     void paintSelfAndChildrenWithReplica(TextureMapperPaintOptions&);
+    void paintBackdrop(TextureMapperPaintOptions&);
     void applyMask(TextureMapperPaintOptions&);
     void recordDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
 
     bool isVisible() const;
 
     bool shouldBlend() const;
+
+    bool flattensAsLeafOf3DSceneOr3DPerspective() const;
+
+    bool preserves3D() const { return m_state.preserves3D; }
+    bool isFlattened() const { return !!m_flattenedLayer; }
 
     inline FloatRect layerRect() const
     {
@@ -188,6 +204,7 @@ private:
     WeakPtr<TextureMapperLayer> m_effectTarget;
     TextureMapperBackingStore* m_backingStore { nullptr };
     TextureMapperPlatformLayer* m_contentsLayer { nullptr };
+    std::unique_ptr<TextureMapperFlattenedLayer> m_flattenedLayer;
     float m_currentOpacity { 1.0 };
     FilterOperations m_currentFilters;
     float m_centerZ { 0 };


### PR DESCRIPTION
#### 7f89d2259aab7f09b486a956fbdc7d1162fb0f92
<pre>
[TextureMapper] Preserve-3d layers don&apos;t get flattened correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=281079">https://bugs.webkit.org/show_bug.cgi?id=281079</a>

Reviewed by Nikolas Zimmermann and Fujii Hironori.

The TextureMapper incorrectly flattens layers to wrong 2D plane
in the 3D rendering context. Instead of accumulating 3D transformations
for each layer, it resets transformations to the page root layer&apos;s 2D plane
for leaf layers. This fix ensures that proper 3D transforms are applied
throughout the entire 3D context and leaf layers are flattened correctly.

Expected Behavior (as per CSS spec):

&quot;The element establishing the 3D rendering context, along with other 3D transformed
elements participating in the context, should be rendered into its own plane.
This plane includes the element’s backgrounds, borders, box decorations, content,
and descendant elements—excluding descendants that have their own planes.&quot;

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperFlattenedLayer::TextureMapperFlattenedLayer):
(WebCore::TextureMapperFlattenedLayer::bind):
(WebCore::TextureMapperFlattenedLayer::layerRect const):
(WebCore::TextureMapperFlattenedLayer::surface const):
(WebCore::TextureMapperFlattenedLayer::paintToTextureMapper):
(WebCore::TextureMapperLayer::preprocess):
(WebCore::TextureMapperLayer::collectLayersToFlattenRecursive):
(WebCore::TextureMapperLayer::flatten):
(WebCore::TextureMapperLayer::computeFlattenedRegion):
(WebCore::TextureMapperLayer::postprocess):
(WebCore::TextureMapperLayer::freeFlattenedLayersRecursive):
(WebCore::TextureMapperLayer::computeTransformsRecursive):
(WebCore::TextureMapperLayer::paint):
(WebCore::TextureMapperLayer::paintSelf):
(WebCore::TextureMapperLayer::paintSelfAndChildren):
(WebCore::TextureMapperLayer::flattensAsLeafOf3DSceneOr3DPerspective const):
(WebCore::TextureMapperLayer::has3DLocalTransform const):
(WebCore::TextureMapperLayer::accumulatesTransform const):
(WebCore::TextureMapperLayer::computeOverlapRegions):
(WebCore::TextureMapperLayer::paintRecursive):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:

Canonical link: <a href="https://commits.webkit.org/285820@main">https://commits.webkit.org/285820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f629e0b8c5ca26c87883edbf42740e73dc69411e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58066 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16426 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79705 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65677 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16270 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9545 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/7808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1097 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3847 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->