### PR TITLE
[Static Analyzer CI] Improve the content and readability of the unexpected failures/passes comment

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -7330,8 +7330,8 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
     name = 'display-safer-cpp-results'
     resultDirectory = ''
     NUM_TO_DISPLAY = 10
-    UPDATE_COMMAND = 'Tools/Scripts/update-safer-cpp-expectations -p {project} '
-    CHECKER_ARGS = '--{checker} {files} '
+    UPDATE_COMMAND = 'Tools/Scripts/update-safer-cpp-expectations -p {project}'
+    CHECKER_ARGS = '--{checker} {files}'
     commands = set()
 
     def __init___(self, **kwargs):
@@ -7344,11 +7344,12 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
         unexpected_results_data = self.loadResultsData(os.path.join(self.resultDirectory, SCAN_BUILD_OUTPUT_DIR, 'unexpected_results.json'))
         is_log = yield self.getFilesPerProject(unexpected_results_data, 'passes')
         is_log += yield self.getFilesPerProject(unexpected_results_data, 'failures')
-        if not is_log and num_issues:
-            pluralSuffix = 's' if num_issues > 1 else ''
-            yield self._addToLog('stdio', f'Ignored {num_issues} pre-existing failure{pluralSuffix}')
         if num_issues:
+            if not is_log:
+                pluralSuffix = 's' if num_issues > 1 else ''
+                yield self._addToLog('stdio', f'Ignored {num_issues} pre-existing failure{pluralSuffix}')
             self.addURL("View failures", self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/new-results.html")
+        self.createComment()
         if self.getProperty('unexpected_failing_files', 0):
             return defer.returnValue(FAILURE)
         return defer.returnValue(SUCCESS)
@@ -7370,7 +7371,7 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
                     total_file_list.update(files)
                     file_str = '\n'.join(files)
                     log_content += f'=> {checker}\n\n{file_str}\n\n'
-                    command += self.CHECKER_ARGS.format(checker=checker, files=' '.join(files))
+                    command += ' ' + self.CHECKER_ARGS.format(checker=checker, files=' '.join(files))
             if log_content:
                 yield self._addToLog(f'{project}-unexpected-{type}', log_content)
                 is_log += 1
@@ -7378,6 +7379,39 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
                     self.commands.add(command)
         self.setProperty(f'{type}', list(total_file_list))
         return defer.returnValue(is_log)
+
+    def createComment(self):
+        num_failures = self.getProperty('unexpected_failing_files', 0)
+        num_passes = self.getProperty('unexpected_passing_files', 0)
+        num_issues = self.getProperty('unexpected_new_issues', 0)
+
+        if not num_failures and not num_passes:
+            return
+
+        results_link = self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/new-results.html"
+        build_link = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'
+        formatted_build_link = f'[#{self.getProperty("buildnumber", "")}]({build_link})'
+        comment = f'### Safer C++ Build {formatted_build_link}\n'
+
+        if num_failures:
+            pluralSuffix = 's' if num_issues > 1 else ''
+            comment += f":x: Found [{num_issues} new failure{pluralSuffix}]({results_link}). "
+            comment += 'Please address these issues before landing. See [WebKit Guidelines for Safer C++ Programming](https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines).\n(cc @rniwa)\n'
+        if num_passes:
+            pluralSuffix = 's' if num_passes > 1 else ''
+            pluralCommand = 's' if len(self.commands) > 1 else ''
+            comment += f'\n:warning: Found {num_passes} fixed file{pluralSuffix}! Please update expectations in `Source/[WebKit/WebCore]/SaferCPPExpectations` by running the following command{pluralCommand} and update your {self.change_type}:\n'
+            comment += '\n'.join([f"- `{c}`" for c in self.commands])
+
+        self.setProperty('comment_text', comment)
+        # FIXME: Add merging blocked upon failure after initial deployment period
+        self.build.addStepsAfterCurrentStep([LeaveComment(), SetBuildSummary()])
+
+    @property
+    def change_type(self):
+        if self.getProperty('github.number', False):
+            return 'pull request'
+        return 'patch'
 
     def doStepIf(self, step):
         return self.getProperty('unexpected_failing_files', 0) or self.getProperty('unexpected_passing_files', 0) or self.getProperty('unexpected_new_issues', 0)
@@ -7396,17 +7430,8 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
         passing_files = (", ").join(self.getProperty('passes', [])[:self.NUM_TO_DISPLAY])
         results_summary = ''
 
-        results_link = self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/new-results.html"
-        build_link = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'
-        formatted_build_link = f'[#{self.getProperty("buildnumber", "")}]({build_link})'
-
         if num_failures:
             pluralSuffix = 's' if num_issues > 1 else ''
-            comment = f"Safer C++ Build {formatted_build_link}: Found [{num_issues} new failure{pluralSuffix}]({results_link}).\n"
-            comment += 'Please address these issues before landing. See [WebKit Guidelines for Safer C++ Programming](https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines).\n(cc @rniwa)'
-            self.setProperty('comment_text', comment)
-            # FIXME: Add merging blocked after initial deployment period
-            self.build.addStepsAfterCurrentStep([LeaveComment()])
             results_summary = f'Found {num_issues} new failure{pluralSuffix} in {failing_files}'
             if num_failures > self.NUM_TO_DISPLAY:
                 results_summary += ' ...'
@@ -7417,18 +7442,11 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
             results_summary = f'Ignored {num_issues} pre-existing failure{pluralSuffix}'
             self.setProperty('build_summary', results_summary)
         elif num_passes:
-            # FIXME: Add link to unexpected passes file
             pluralSuffix = 's' if num_passes > 1 else ''
-            comment = f'Safer C++ Build {formatted_build_link}: Found {num_passes} fixed file{pluralSuffix}!\n'
-            pluralCommand = 's' if len(self.commands) > 1 else ''
-            comment += f'Please update expectations in Source/[WebKit/WebCore]/SaferCPPExpectations manually or by running the following command{pluralCommand}:\n'
-            comment += '\n'.join(self.commands)
-            self.setProperty('comment_text', comment)
             results_summary = f'Found {num_passes} fixed file{pluralSuffix}: {passing_files}'
             if num_passes > self.NUM_TO_DISPLAY:
                 results_summary += ' ...'
             self.setProperty('build_summary', results_summary)
-            self.build.addStepsAfterCurrentStep([LeaveComment(), SetBuildSummary()])
 
         if num_passes and num_failures:
             pluralSuffix = 's' if num_passes > 1 else ''


### PR DESCRIPTION
#### 96d957f16d1d0481aee6156b2840eb282b65bdd1
<pre>
[Static Analyzer CI] Improve the content and readability of the unexpected failures/passes comment
<a href="https://bugs.webkit.org/show_bug.cgi?id=281093">https://bugs.webkit.org/show_bug.cgi?id=281093</a>
<a href="https://rdar.apple.com/137541288">rdar://137541288</a>

Reviewed by Ryan Haddad.

Includes information for fixes and failures in one comment when both occur.
Adds code and header formatting to improve readability.
Also fixes a bug where LeaveComment is run twice upon failure.

* Tools/CISupport/ews-build/steps.py:
(DisplaySaferCPPResults):
(DisplaySaferCPPResults.run):
    Improve code clarity and call createComment.
(DisplaySaferCPPResults.getFilesPerProject):
    Remove extra space.
(DisplaySaferCPPResults.createComment): Created.
    Now comments will contain both fixes/failure info when relevant.
    Separate out comment creation for clarity.
    Add LeaveComment and SetBuildSummary to prevent duplication bug.
(DisplaySaferCPPResults.change_type): Created.
    Support both PRs and patches.
(DisplaySaferCPPResults.getResultSummary): Remove comment logic.
* Tools/CISupport/ews-build/steps_unittest.py: Update unit test coverage.

Canonical link: <a href="https://commits.webkit.org/284900@main">https://commits.webkit.org/284900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37f949071e53565e183aadeceac7722af5e0f92c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70865 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/50277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72981 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/58076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/21888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73931 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/58076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/58076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/58076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76684 "Build is in progress. Recent messages:") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/15097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/21888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/76684 "Build is in progress. Recent messages:") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/70542 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/15141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/76684 "Build is in progress. Recent messages:") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10861 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/46078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->