### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make FrameLoadState and subclasses RefCounted or equivalent

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -43,6 +43,9 @@ public:
 
     ~SubFrameSOAuthorizationSession();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
 private:
     using Supplement = std::variant<Vector<uint8_t>, String>;
 

--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -51,7 +51,7 @@ void FrameLoadState::didStartProvisionalLoad(const URL& url)
     m_state = State::Provisional;
     m_provisionalURL = url;
 
-    m_observers.forEach([&url](FrameLoadStateObserver& observer) {
+    forEachObserver([&url](FrameLoadStateObserver& observer) {
         observer.didReceiveProvisionalURL(url);
         observer.didStartProvisionalLoad(url);
     });
@@ -62,7 +62,7 @@ void FrameLoadState::didSuspend()
     m_state = State::Finished;
     m_provisionalURL = { };
 
-    m_observers.forEach([](FrameLoadStateObserver& observer) {
+    forEachObserver([](FrameLoadStateObserver& observer) {
         observer.didCancelProvisionalLoad();
     });
 }
@@ -80,7 +80,7 @@ void FrameLoadState::didReceiveServerRedirectForProvisionalLoad(const URL& url)
 
     m_provisionalURL = url;
 
-    m_observers.forEach([&url](FrameLoadStateObserver& observer) {
+    forEachObserver([&url](FrameLoadStateObserver& observer) {
         observer.didReceiveProvisionalURL(url);
     });
 }
@@ -93,7 +93,7 @@ void FrameLoadState::didFailProvisionalLoad()
     m_provisionalURL = { };
     m_unreachableURL = m_lastUnreachableURL;
 
-    m_observers.forEach([&](FrameLoadStateObserver& observer) {
+    forEachObserver([&](FrameLoadStateObserver& observer) {
         observer.didCancelProvisionalLoad();
         observer.didFailProvisionalLoad(m_unreachableURL);
     });
@@ -108,7 +108,7 @@ void FrameLoadState::didCommitLoad()
     m_url = m_provisionalURL.isNull() ? aboutBlankURL() : m_provisionalURL;
     m_provisionalURL = { };
 
-    m_observers.forEach([&](FrameLoadStateObserver& observer) {
+    forEachObserver([&](FrameLoadStateObserver& observer) {
         observer.didCommitProvisionalLoad();
         observer.didCommitProvisionalLoad(m_isMainFrame);
     });
@@ -121,7 +121,7 @@ void FrameLoadState::didFinishLoad()
 
     m_state = State::Finished;
 
-    m_observers.forEach([&](FrameLoadStateObserver& observer) {
+    forEachObserver([&](FrameLoadStateObserver& observer) {
         observer.didFinishLoad(m_isMainFrame, m_url);
     });
 }
@@ -132,7 +132,7 @@ void FrameLoadState::didFailLoad()
     ASSERT(m_provisionalURL.isEmpty());
 
     m_state = State::Finished;
-    m_observers.forEach([&](FrameLoadStateObserver& observer) {
+    forEachObserver([&](FrameLoadStateObserver& observer) {
         observer.didFailLoad(m_url);
     });
 }
@@ -146,7 +146,7 @@ void FrameLoadState::didSameDocumentNotification(const URL& url)
 void FrameLoadState::setURL(const URL& url)
 {
     m_url = url;
-    m_observers.forEach([&url](FrameLoadStateObserver& observer) {
+    forEachObserver([&url](FrameLoadStateObserver& observer) {
         observer.didCancelProvisionalLoad();
         observer.didReceiveProvisionalURL(url);
         observer.didCommitProvisionalLoad();
@@ -157,6 +157,13 @@ void FrameLoadState::setUnreachableURL(const URL& unreachableURL)
 {
     m_lastUnreachableURL = m_unreachableURL;
     m_unreachableURL = unreachableURL;
+}
+
+void FrameLoadState::forEachObserver(const Function<void(FrameLoadStateObserver&)>& callback)
+{
+    m_observers.forEach([&callback](FrameLoadStateObserver& observer) {
+        callback(Ref { observer });
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/FrameLoadState.h
+++ b/Source/WebKit/UIProcess/FrameLoadState.h
@@ -29,21 +29,15 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
-class FrameLoadStateObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::FrameLoadStateObserver> : std::true_type { };
-}
-
-namespace WebKit {
 
 enum class IsMainFrame : bool;
 
 class FrameLoadStateObserver : public CanMakeWeakPtr<FrameLoadStateObserver> {
 public:
     virtual ~FrameLoadStateObserver() = default;
+
+    DECLARE_VIRTUAL_REFCOUNTED;
+
     virtual void didReceiveProvisionalURL(const URL&) { }
     virtual void didStartProvisionalLoad(const URL&) { }
     virtual void didFailProvisionalLoad(const URL&) { }
@@ -91,7 +85,10 @@ public:
     const URL& unreachableURL() const { return m_unreachableURL; }
 
     IsMainFrame isMainFrame() const { return m_isMainFrame; }
+
 private:
+    void forEachObserver(const Function<void(FrameLoadStateObserver&)>&);
+
     const IsMainFrame m_isMainFrame;
     State m_state { State::Finished };
     URL m_url;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -104,8 +104,11 @@ class WebPageProxyFrameLoadStateObserver final : public FrameLoadStateObserver {
 public:
     static constexpr size_t maxVisitedDomainsSize = 6;
 
-    WebPageProxyFrameLoadStateObserver();
+    explicit WebPageProxyFrameLoadStateObserver(const WebPageProxy&);
     virtual ~WebPageProxyFrameLoadStateObserver();
+
+    void ref() const final;
+    void deref() const final;
 
     void didReceiveProvisionalURL(const URL& url) override
     {
@@ -140,6 +143,7 @@ private:
             m_visitedDomains.removeLast();
     }
 
+    WeakRef<WebPageProxy> m_page;
     Vector<URL> m_provisionalURLs;
     ListHashSet<WebCore::RegistrableDomain> m_visitedDomains;
 };
@@ -147,6 +151,14 @@ private:
 
 class PageLoadTimingFrameLoadStateObserver final : public FrameLoadStateObserver {
 public:
+    explicit PageLoadTimingFrameLoadStateObserver(const WebPageProxy&page)
+        : m_page(page)
+    {
+    }
+
+    void ref() const final;
+    void deref() const final;
+
     bool hasLoadingFrame() const { return !!m_loadingFrameCount; }
 
 private:
@@ -182,6 +194,7 @@ private:
         // FIXME: Assert that m_loadingFrameCount is zero if this is a main frame.
     }
 
+    WeakRef<WebPageProxy> m_page;
     size_t m_loadingFrameCount { 0 };
 };
 


### PR DESCRIPTION
#### 9af1550239785975e253bb8fc965060f7f05aa9e
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make FrameLoadState and subclasses RefCounted or equivalent
<a href="https://bugs.webkit.org/show_bug.cgi?id=281095">https://bugs.webkit.org/show_bug.cgi?id=281095</a>
<a href="https://rdar.apple.com/problem/137548780">rdar://problem/137548780</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

Removing IsDeprecatedWeakRefSmartPointerException for FrameLoadState and make those classes ref/defef.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/FrameLoadState.cpp:
(WebKit::FrameLoadState::didStartProvisionalLoad):
(WebKit::FrameLoadState::didSuspend):
(WebKit::FrameLoadState::didReceiveServerRedirectForProvisionalLoad):
(WebKit::FrameLoadState::didFailProvisionalLoad):
(WebKit::FrameLoadState::didCommitLoad):
(WebKit::FrameLoadState::didFinishLoad):
(WebKit::FrameLoadState::didFailLoad):
(WebKit::FrameLoadState::setURL):
(WebKit::FrameLoadState::forEachObserver):
* Source/WebKit/UIProcess/FrameLoadState.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxyFrameLoadStateObserver::WebPageProxyFrameLoadStateObserver):
(WebKit::WebPageProxyFrameLoadStateObserver::ref const):
(WebKit::WebPageProxyFrameLoadStateObserver::deref const):
(WebKit::PageLoadTimingFrameLoadStateObserver::ref const):
(WebKit::PageLoadTimingFrameLoadStateObserver::deref const):
(WebKit::WebPageProxy::initializeWebPage):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/284995@main">https://commits.webkit.org/284995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04fcc171b4186044cd0c33b993f89cf4028a8770

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22302 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22122 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14701 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42578 "Passed tests") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20643 "Hash 04fcc171 for PR 34871 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76925 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18292 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63953 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15374 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15752 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5684 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1090 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->