### PR TITLE
Adopt more smart pointers in RemoteGraphicsContextGLFunctionsGenerated.h

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -28,7 +28,7 @@
     void activeTexture(uint32_t texture)
     {
         assertIsCurrent(workQueue());
-        m_context->activeTexture(texture);
+        protectedContext()->activeTexture(texture);
     }
     void attachShader(uint32_t program, uint32_t shader)
     {
@@ -37,163 +37,163 @@
             program = m_objectNames.get(program);
         if (shader)
             shader = m_objectNames.get(shader);
-        m_context->attachShader(program, shader);
+        protectedContext()->attachShader(program, shader);
     }
     void bindAttribLocation(uint32_t arg0, uint32_t index, String&& name)
     {
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->bindAttribLocation(arg0, index, name);
+        protectedContext()->bindAttribLocation(arg0, index, name);
     }
     void bindBuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
         if (arg1)
             arg1 = m_objectNames.get(arg1);
-        m_context->bindBuffer(target, arg1);
+        protectedContext()->bindBuffer(target, arg1);
     }
     void bindFramebuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
         if (arg1)
             arg1 = m_objectNames.get(arg1);
-        m_context->bindFramebuffer(target, arg1);
+        protectedContext()->bindFramebuffer(target, arg1);
     }
     void bindRenderbuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
         if (arg1)
             arg1 = m_objectNames.get(arg1);
-        m_context->bindRenderbuffer(target, arg1);
+        protectedContext()->bindRenderbuffer(target, arg1);
     }
     void bindTexture(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
         if (arg1)
             arg1 = m_objectNames.get(arg1);
-        m_context->bindTexture(target, arg1);
+        protectedContext()->bindTexture(target, arg1);
     }
     void blendColor(float red, float green, float blue, float alpha)
     {
         assertIsCurrent(workQueue());
-        m_context->blendColor(red, green, blue, alpha);
+        protectedContext()->blendColor(red, green, blue, alpha);
     }
     void blendEquation(uint32_t mode)
     {
         assertIsCurrent(workQueue());
-        m_context->blendEquation(mode);
+        protectedContext()->blendEquation(mode);
     }
     void blendEquationSeparate(uint32_t modeRGB, uint32_t modeAlpha)
     {
         assertIsCurrent(workQueue());
-        m_context->blendEquationSeparate(modeRGB, modeAlpha);
+        protectedContext()->blendEquationSeparate(modeRGB, modeAlpha);
     }
     void blendFunc(uint32_t sfactor, uint32_t dfactor)
     {
         assertIsCurrent(workQueue());
-        m_context->blendFunc(sfactor, dfactor);
+        protectedContext()->blendFunc(sfactor, dfactor);
     }
     void blendFuncSeparate(uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha)
     {
         assertIsCurrent(workQueue());
-        m_context->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+        protectedContext()->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
     }
     void checkFramebufferStatus(uint32_t target, CompletionHandler<void(uint32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLenum returnValue = { };
-        returnValue = m_context->checkFramebufferStatus(target);
+        returnValue = protectedContext()->checkFramebufferStatus(target);
         completionHandler(returnValue);
     }
     void clear(uint32_t mask)
     {
         assertIsCurrent(workQueue());
-        m_context->clear(mask);
+        protectedContext()->clear(mask);
     }
     void clearColor(float red, float green, float blue, float alpha)
     {
         assertIsCurrent(workQueue());
-        m_context->clearColor(red, green, blue, alpha);
+        protectedContext()->clearColor(red, green, blue, alpha);
     }
     void clearDepth(float depth)
     {
         assertIsCurrent(workQueue());
-        m_context->clearDepth(depth);
+        protectedContext()->clearDepth(depth);
     }
     void clearStencil(int32_t s)
     {
         assertIsCurrent(workQueue());
-        m_context->clearStencil(s);
+        protectedContext()->clearStencil(s);
     }
     void colorMask(bool red, bool green, bool blue, bool alpha)
     {
         assertIsCurrent(workQueue());
-        m_context->colorMask(static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
+        protectedContext()->colorMask(static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
     }
     void compileShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->compileShader(arg0);
+        protectedContext()->compileShader(arg0);
     }
     void copyTexImage2D(uint32_t target, int32_t level, uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height, int32_t border)
     {
         assertIsCurrent(workQueue());
-        m_context->copyTexImage2D(target, level, internalformat, x, y, width, height, border);
+        protectedContext()->copyTexImage2D(target, level, internalformat, x, y, width, height, border);
     }
     void copyTexSubImage2D(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t x, int32_t y, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+        protectedContext()->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
     }
     void createBuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createBuffer();
+        auto result = protectedContext()->createBuffer();
         if (result)
             m_objectNames.add(name, result);
     }
     void createFramebuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createFramebuffer();
+        auto result = protectedContext()->createFramebuffer();
         if (result)
             m_objectNames.add(name, result);
     }
     void createProgram(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createProgram();
+        auto result = protectedContext()->createProgram();
         if (result)
             m_objectNames.add(name, result);
     }
     void createRenderbuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createRenderbuffer();
+        auto result = protectedContext()->createRenderbuffer();
         if (result)
             m_objectNames.add(name, result);
     }
     void createShader(uint32_t name, uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createShader(arg0);
+        auto result = protectedContext()->createShader(arg0);
         if (result)
             m_objectNames.add(name, result);
     }
     void createTexture(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createTexture();
+        auto result = protectedContext()->createTexture();
         if (result)
             m_objectNames.add(name, result);
     }
     void cullFace(uint32_t mode)
     {
         assertIsCurrent(workQueue());
-        m_context->cullFace(mode);
+        protectedContext()->cullFace(mode);
     }
     void deleteBuffer(uint32_t arg0)
     {
@@ -201,7 +201,7 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteBuffer(arg0);
+        protectedContext()->deleteBuffer(arg0);
     }
     void deleteFramebuffer(uint32_t arg0)
     {
@@ -209,7 +209,7 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteFramebuffer(arg0);
+        protectedContext()->deleteFramebuffer(arg0);
     }
     void deleteProgram(uint32_t arg0)
     {
@@ -217,7 +217,7 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteProgram(arg0);
+        protectedContext()->deleteProgram(arg0);
     }
     void deleteRenderbuffer(uint32_t arg0)
     {
@@ -225,7 +225,7 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteRenderbuffer(arg0);
+        protectedContext()->deleteRenderbuffer(arg0);
     }
     void deleteShader(uint32_t arg0)
     {
@@ -233,7 +233,7 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteShader(arg0);
+        protectedContext()->deleteShader(arg0);
     }
     void deleteTexture(uint32_t arg0)
     {
@@ -241,22 +241,22 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteTexture(arg0);
+        protectedContext()->deleteTexture(arg0);
     }
     void depthFunc(uint32_t func)
     {
         assertIsCurrent(workQueue());
-        m_context->depthFunc(func);
+        protectedContext()->depthFunc(func);
     }
     void depthMask(bool flag)
     {
         assertIsCurrent(workQueue());
-        m_context->depthMask(static_cast<GCGLboolean>(flag));
+        protectedContext()->depthMask(static_cast<GCGLboolean>(flag));
     }
     void depthRange(float zNear, float zFar)
     {
         assertIsCurrent(workQueue());
-        m_context->depthRange(zNear, zFar);
+        protectedContext()->depthRange(zNear, zFar);
     }
     void detachShader(uint32_t arg0, uint32_t arg1)
     {
@@ -265,71 +265,71 @@
             arg0 = m_objectNames.get(arg0);
         if (arg1)
             arg1 = m_objectNames.get(arg1);
-        m_context->detachShader(arg0, arg1);
+        protectedContext()->detachShader(arg0, arg1);
     }
     void disable(uint32_t cap)
     {
         assertIsCurrent(workQueue());
-        m_context->disable(cap);
+        protectedContext()->disable(cap);
     }
     void disableVertexAttribArray(uint32_t index)
     {
         assertIsCurrent(workQueue());
-        m_context->disableVertexAttribArray(index);
+        protectedContext()->disableVertexAttribArray(index);
     }
     void drawArrays(uint32_t mode, int32_t first, int32_t count)
     {
         assertIsCurrent(workQueue());
-        m_context->drawArrays(mode, first, count);
+        protectedContext()->drawArrays(mode, first, count);
     }
     void drawElements(uint32_t mode, int32_t count, uint32_t type, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
+        protectedContext()->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
     }
     void enable(uint32_t cap)
     {
         assertIsCurrent(workQueue());
-        m_context->enable(cap);
+        protectedContext()->enable(cap);
     }
     void enableVertexAttribArray(uint32_t index)
     {
         assertIsCurrent(workQueue());
-        m_context->enableVertexAttribArray(index);
+        protectedContext()->enableVertexAttribArray(index);
     }
     void finish()
     {
         assertIsCurrent(workQueue());
-        m_context->finish();
+        protectedContext()->finish();
     }
     void flush()
     {
         assertIsCurrent(workQueue());
-        m_context->flush();
+        protectedContext()->flush();
     }
     void framebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
         if (arg3)
             arg3 = m_objectNames.get(arg3);
-        m_context->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
+        protectedContext()->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
     }
     void framebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
     {
         assertIsCurrent(workQueue());
         if (arg3)
             arg3 = m_objectNames.get(arg3);
-        m_context->framebufferTexture2D(target, attachment, textarget, arg3, level);
+        protectedContext()->framebufferTexture2D(target, attachment, textarget, arg3, level);
     }
     void frontFace(uint32_t mode)
     {
         assertIsCurrent(workQueue());
-        m_context->frontFace(mode);
+        protectedContext()->frontFace(mode);
     }
     void generateMipmap(uint32_t target)
     {
         assertIsCurrent(workQueue());
-        m_context->generateMipmap(target);
+        protectedContext()->generateMipmap(target);
     }
     void getActiveAttrib(uint32_t program, uint32_t index, CompletionHandler<void(bool, struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
@@ -338,7 +338,7 @@
         if (program)
             program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
-        returnValue = m_context->getActiveAttrib(program, index, arg2);
+        returnValue = protectedContext()->getActiveAttrib(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
     }
     void getActiveUniform(uint32_t program, uint32_t index, CompletionHandler<void(bool, struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
@@ -348,7 +348,7 @@
         if (program)
             program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
-        returnValue = m_context->getActiveUniform(program, index, arg2);
+        returnValue = protectedContext()->getActiveUniform(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
     }
     void getAttribLocation(uint32_t arg0, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -357,56 +357,56 @@
         GCGLint returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getAttribLocation(arg0, name);
+        returnValue = protectedContext()->getAttribLocation(arg0, name);
         completionHandler(returnValue);
     }
     void getBufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getBufferParameteri(target, pname);
+        returnValue = protectedContext()->getBufferParameteri(target, pname);
         completionHandler(returnValue);
     }
     void getString(uint32_t name, CompletionHandler<void(String&&)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        returnValue = m_context->getString(name);
+        returnValue = protectedContext()->getString(name);
         completionHandler(WTFMove(returnValue));
     }
     void getFloatv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         Vector<GCGLfloat, 16> value(valueSize, 0);
-        m_context->getFloatv(pname, value);
+        protectedContext()->getFloatv(pname, value);
         completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
     }
     void getIntegerv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         Vector<GCGLint, 4> value(valueSize, 0);
-        m_context->getIntegerv(pname, value);
+        protectedContext()->getIntegerv(pname, value);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
     }
     void getIntegeri_v(uint32_t pname, uint32_t index, CompletionHandler<void(std::span<const int32_t, 4>)>&& completionHandler) // NOLINT
     {
         assertIsCurrent(workQueue());
         std::array<GCGLint, 4> value { };
-        m_context->getIntegeri_v(pname, index, value);
+        protectedContext()->getIntegeri_v(pname, index, value);
         completionHandler(std::span<const int32_t, 4>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
     }
     void getInteger64(uint32_t pname, CompletionHandler<void(int64_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint64 returnValue = { };
-        returnValue = m_context->getInteger64(pname);
+        returnValue = protectedContext()->getInteger64(pname);
         completionHandler(static_cast<int64_t>(returnValue));
     }
     void getInteger64i(uint32_t pname, uint32_t index, CompletionHandler<void(int64_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint64 returnValue = { };
-        returnValue = m_context->getInteger64i(pname, index);
+        returnValue = protectedContext()->getInteger64i(pname, index);
         completionHandler(static_cast<int64_t>(returnValue));
     }
     void getProgrami(uint32_t program, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -415,21 +415,21 @@
         GCGLint returnValue = { };
         if (program)
             program = m_objectNames.get(program);
-        returnValue = m_context->getProgrami(program, pname);
+        returnValue = protectedContext()->getProgrami(program, pname);
         completionHandler(returnValue);
     }
     void getBooleanv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const bool>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         Vector<GCGLboolean, 4> value(valueSize, 0);
-        m_context->getBooleanv(pname, value);
+        protectedContext()->getBooleanv(pname, value);
         completionHandler(std::span<const bool>(reinterpret_cast<const bool*>(value.data()), value.size()));
     }
     void getFramebufferAttachmentParameteri(uint32_t target, uint32_t attachment, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getFramebufferAttachmentParameteri(target, attachment, pname);
+        returnValue = protectedContext()->getFramebufferAttachmentParameteri(target, attachment, pname);
         completionHandler(returnValue);
     }
     void getProgramInfoLog(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
@@ -438,14 +438,14 @@
         String returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getProgramInfoLog(arg0);
+        returnValue = protectedContext()->getProgramInfoLog(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void getRenderbufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getRenderbufferParameteri(target, pname);
+        returnValue = protectedContext()->getRenderbufferParameteri(target, pname);
         completionHandler(returnValue);
     }
     void getShaderi(uint32_t arg0, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -454,7 +454,7 @@
         GCGLint returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getShaderi(arg0, pname);
+        returnValue = protectedContext()->getShaderi(arg0, pname);
         completionHandler(returnValue);
     }
     void getShaderInfoLog(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
@@ -463,7 +463,7 @@
         String returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getShaderInfoLog(arg0);
+        returnValue = protectedContext()->getShaderInfoLog(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void getShaderPrecisionFormat(uint32_t shaderType, uint32_t precisionType, CompletionHandler<void(std::span<const int32_t, 2>, int32_t)>&& completionHandler)
@@ -471,7 +471,7 @@
         assertIsCurrent(workQueue());
         std::array<GCGLint, 2> range { };
         GCGLint precision = { };
-        m_context->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
+        protectedContext()->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
         completionHandler(std::span<const int32_t, 2>(reinterpret_cast<const int32_t*>(range.data()), range.size()), precision);
     }
     void getShaderSource(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
@@ -480,21 +480,21 @@
         String returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getShaderSource(arg0);
+        returnValue = protectedContext()->getShaderSource(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void getTexParameterf(uint32_t target, uint32_t pname, CompletionHandler<void(float)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLfloat returnValue = { };
-        returnValue = m_context->getTexParameterf(target, pname);
+        returnValue = protectedContext()->getTexParameterf(target, pname);
         completionHandler(returnValue);
     }
     void getTexParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getTexParameteri(target, pname);
+        returnValue = protectedContext()->getTexParameteri(target, pname);
         completionHandler(returnValue);
     }
     void getUniformfv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
@@ -503,7 +503,7 @@
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLfloat, 16> value(valueSize, 0);
-        m_context->getUniformfv(program, location, value);
+        protectedContext()->getUniformfv(program, location, value);
         completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
     }
     void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
@@ -512,7 +512,7 @@
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLint, 4> value(valueSize, 0);
-        m_context->getUniformiv(program, location, value);
+        protectedContext()->getUniformiv(program, location, value);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
     }
     void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const uint32_t>)>&& completionHandler)
@@ -521,7 +521,7 @@
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLuint, 4> value(valueSize, 0);
-        m_context->getUniformuiv(program, location, value);
+        protectedContext()->getUniformuiv(program, location, value);
         completionHandler(std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(value.data()), value.size()));
     }
     void getUniformLocation(uint32_t arg0, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -530,20 +530,20 @@
         GCGLint returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getUniformLocation(arg0, name);
+        returnValue = protectedContext()->getUniformLocation(arg0, name);
         completionHandler(returnValue);
     }
     void getVertexAttribOffset(uint32_t index, uint32_t pname, CompletionHandler<void(uint64_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLsizeiptr returnValue = { };
-        returnValue = m_context->getVertexAttribOffset(index, pname);
+        returnValue = protectedContext()->getVertexAttribOffset(index, pname);
         completionHandler(static_cast<uint64_t>(returnValue));
     }
     void hint(uint32_t target, uint32_t mode)
     {
         assertIsCurrent(workQueue());
-        m_context->hint(target, mode);
+        protectedContext()->hint(target, mode);
     }
     void isBuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
@@ -551,14 +551,14 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isBuffer(arg0);
+        returnValue = protectedContext()->isBuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isEnabled(uint32_t cap, CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        returnValue = m_context->isEnabled(cap);
+        returnValue = protectedContext()->isEnabled(cap);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isFramebuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -567,7 +567,7 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isFramebuffer(arg0);
+        returnValue = protectedContext()->isFramebuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isProgram(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -576,7 +576,7 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isProgram(arg0);
+        returnValue = protectedContext()->isProgram(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isRenderbuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -585,7 +585,7 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isRenderbuffer(arg0);
+        returnValue = protectedContext()->isRenderbuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isShader(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -594,7 +594,7 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isShader(arg0);
+        returnValue = protectedContext()->isShader(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isTexture(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -603,331 +603,331 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isTexture(arg0);
+        returnValue = protectedContext()->isTexture(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void lineWidth(float arg0)
     {
         assertIsCurrent(workQueue());
-        m_context->lineWidth(arg0);
+        protectedContext()->lineWidth(arg0);
     }
     void linkProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->linkProgram(arg0);
+        protectedContext()->linkProgram(arg0);
     }
     void pixelStorei(uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
-        m_context->pixelStorei(pname, param);
+        protectedContext()->pixelStorei(pname, param);
     }
     void polygonOffset(float factor, float units)
     {
         assertIsCurrent(workQueue());
-        m_context->polygonOffset(factor, units);
+        protectedContext()->polygonOffset(factor, units);
     }
     void renderbufferStorage(uint32_t target, uint32_t internalformat, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->renderbufferStorage(target, internalformat, width, height);
+        protectedContext()->renderbufferStorage(target, internalformat, width, height);
     }
     void sampleCoverage(float value, bool invert)
     {
         assertIsCurrent(workQueue());
-        m_context->sampleCoverage(value, static_cast<GCGLboolean>(invert));
+        protectedContext()->sampleCoverage(value, static_cast<GCGLboolean>(invert));
     }
     void scissor(int32_t x, int32_t y, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->scissor(x, y, width, height);
+        protectedContext()->scissor(x, y, width, height);
     }
     void shaderSource(uint32_t arg0, String&& arg1)
     {
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->shaderSource(arg0, arg1);
+        protectedContext()->shaderSource(arg0, arg1);
     }
     void stencilFunc(uint32_t func, int32_t ref, uint32_t mask)
     {
         assertIsCurrent(workQueue());
-        m_context->stencilFunc(func, ref, mask);
+        protectedContext()->stencilFunc(func, ref, mask);
     }
     void stencilFuncSeparate(uint32_t face, uint32_t func, int32_t ref, uint32_t mask)
     {
         assertIsCurrent(workQueue());
-        m_context->stencilFuncSeparate(face, func, ref, mask);
+        protectedContext()->stencilFuncSeparate(face, func, ref, mask);
     }
     void stencilMask(uint32_t mask)
     {
         assertIsCurrent(workQueue());
-        m_context->stencilMask(mask);
+        protectedContext()->stencilMask(mask);
     }
     void stencilMaskSeparate(uint32_t face, uint32_t mask)
     {
         assertIsCurrent(workQueue());
-        m_context->stencilMaskSeparate(face, mask);
+        protectedContext()->stencilMaskSeparate(face, mask);
     }
     void stencilOp(uint32_t fail, uint32_t zfail, uint32_t zpass)
     {
         assertIsCurrent(workQueue());
-        m_context->stencilOp(fail, zfail, zpass);
+        protectedContext()->stencilOp(fail, zfail, zpass);
     }
     void stencilOpSeparate(uint32_t face, uint32_t fail, uint32_t zfail, uint32_t zpass)
     {
         assertIsCurrent(workQueue());
-        m_context->stencilOpSeparate(face, fail, zfail, zpass);
+        protectedContext()->stencilOpSeparate(face, fail, zfail, zpass);
     }
     void texParameterf(uint32_t target, uint32_t pname, float param)
     {
         assertIsCurrent(workQueue());
-        m_context->texParameterf(target, pname, param);
+        protectedContext()->texParameterf(target, pname, param);
     }
     void texParameteri(uint32_t target, uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
-        m_context->texParameteri(target, pname, param);
+        protectedContext()->texParameteri(target, pname, param);
     }
     void uniform1f(int32_t location, float x)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1f(location, x);
+        protectedContext()->uniform1f(location, x);
     }
     void uniform1fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1fv(location, v);
+        protectedContext()->uniform1fv(location, v);
     }
     void uniform1i(int32_t location, int32_t x)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1i(location, x);
+        protectedContext()->uniform1i(location, x);
     }
     void uniform1iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1iv(location, v);
+        protectedContext()->uniform1iv(location, v);
     }
     void uniform2f(int32_t location, float x, float y)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2f(location, x, y);
+        protectedContext()->uniform2f(location, x, y);
     }
     void uniform2fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2fv(location, v);
+        protectedContext()->uniform2fv(location, v);
     }
     void uniform2i(int32_t location, int32_t x, int32_t y)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2i(location, x, y);
+        protectedContext()->uniform2i(location, x, y);
     }
     void uniform2iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2iv(location, v);
+        protectedContext()->uniform2iv(location, v);
     }
     void uniform3f(int32_t location, float x, float y, float z)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3f(location, x, y, z);
+        protectedContext()->uniform3f(location, x, y, z);
     }
     void uniform3fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3fv(location, v);
+        protectedContext()->uniform3fv(location, v);
     }
     void uniform3i(int32_t location, int32_t x, int32_t y, int32_t z)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3i(location, x, y, z);
+        protectedContext()->uniform3i(location, x, y, z);
     }
     void uniform3iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3iv(location, v);
+        protectedContext()->uniform3iv(location, v);
     }
     void uniform4f(int32_t location, float x, float y, float z, float w)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4f(location, x, y, z, w);
+        protectedContext()->uniform4f(location, x, y, z, w);
     }
     void uniform4fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4fv(location, v);
+        protectedContext()->uniform4fv(location, v);
     }
     void uniform4i(int32_t location, int32_t x, int32_t y, int32_t z, int32_t w)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4i(location, x, y, z, w);
+        protectedContext()->uniform4i(location, x, y, z, w);
     }
     void uniform4iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4iv(location, v);
+        protectedContext()->uniform4iv(location, v);
     }
     void uniformMatrix2fv(int32_t location, bool transpose, std::span<const float>&& value)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix2fv(location, static_cast<GCGLboolean>(transpose), value);
+        protectedContext()->uniformMatrix2fv(location, static_cast<GCGLboolean>(transpose), value);
     }
     void uniformMatrix3fv(int32_t location, bool transpose, std::span<const float>&& value)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix3fv(location, static_cast<GCGLboolean>(transpose), value);
+        protectedContext()->uniformMatrix3fv(location, static_cast<GCGLboolean>(transpose), value);
     }
     void uniformMatrix4fv(int32_t location, bool transpose, std::span<const float>&& value)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix4fv(location, static_cast<GCGLboolean>(transpose), value);
+        protectedContext()->uniformMatrix4fv(location, static_cast<GCGLboolean>(transpose), value);
     }
     void useProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->useProgram(arg0);
+        protectedContext()->useProgram(arg0);
     }
     void validateProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->validateProgram(arg0);
+        protectedContext()->validateProgram(arg0);
     }
     void vertexAttrib1f(uint32_t index, float x)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib1f(index, x);
+        protectedContext()->vertexAttrib1f(index, x);
     }
     void vertexAttrib1fv(uint32_t index, std::span<const float, 1>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib1fv(index, values);
+        protectedContext()->vertexAttrib1fv(index, values);
     }
     void vertexAttrib2f(uint32_t index, float x, float y)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib2f(index, x, y);
+        protectedContext()->vertexAttrib2f(index, x, y);
     }
     void vertexAttrib2fv(uint32_t index, std::span<const float, 2>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib2fv(index, values);
+        protectedContext()->vertexAttrib2fv(index, values);
     }
     void vertexAttrib3f(uint32_t index, float x, float y, float z)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib3f(index, x, y, z);
+        protectedContext()->vertexAttrib3f(index, x, y, z);
     }
     void vertexAttrib3fv(uint32_t index, std::span<const float, 3>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib3fv(index, values);
+        protectedContext()->vertexAttrib3fv(index, values);
     }
     void vertexAttrib4f(uint32_t index, float x, float y, float z, float w)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib4f(index, x, y, z, w);
+        protectedContext()->vertexAttrib4f(index, x, y, z, w);
     }
     void vertexAttrib4fv(uint32_t index, std::span<const float, 4>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib4fv(index, values);
+        protectedContext()->vertexAttrib4fv(index, values);
     }
     void vertexAttribPointer(uint32_t index, int32_t size, uint32_t type, bool normalized, int32_t stride, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribPointer(index, size, type, static_cast<GCGLboolean>(normalized), stride, static_cast<GCGLintptr>(offset));
+        protectedContext()->vertexAttribPointer(index, size, type, static_cast<GCGLboolean>(normalized), stride, static_cast<GCGLintptr>(offset));
     }
     void viewport(int32_t x, int32_t y, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->viewport(x, y, width, height);
+        protectedContext()->viewport(x, y, width, height);
     }
     void bufferData0(uint32_t target, uint64_t arg1, uint32_t usage)
     {
         assertIsCurrent(workQueue());
-        m_context->bufferData(target, static_cast<GCGLsizeiptr>(arg1), usage);
+        protectedContext()->bufferData(target, static_cast<GCGLsizeiptr>(arg1), usage);
     }
     void bufferData1(uint32_t target, std::span<const uint8_t>&& data, uint32_t usage)
     {
         assertIsCurrent(workQueue());
-        m_context->bufferData(target, data, usage);
+        protectedContext()->bufferData(target, data, usage);
     }
     void bufferSubData(uint32_t target, uint64_t offset, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), data);
+        protectedContext()->bufferSubData(target, static_cast<GCGLintptr>(offset), data);
     }
     void readPixelsBufferObject(WebCore::IntRect&& arg0, uint32_t format, uint32_t type, uint64_t offset, int32_t alignment, int32_t rowLength)
     {
         assertIsCurrent(workQueue());
-        m_context->readPixelsBufferObject(arg0, format, type, static_cast<GCGLintptr>(offset), alignment, rowLength);
+        protectedContext()->readPixelsBufferObject(arg0, format, type, static_cast<GCGLintptr>(offset), alignment, rowLength);
     }
     void texImage2D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+        protectedContext()->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
     }
     void texImage2D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, uint32_t format, uint32_t type, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->texImage2D(target, level, internalformat, width, height, border, format, type, static_cast<GCGLintptr>(offset));
+        protectedContext()->texImage2D(target, level, internalformat, width, height, border, format, type, static_cast<GCGLintptr>(offset));
     }
     void texSubImage2D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+        protectedContext()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
     }
     void texSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, static_cast<GCGLintptr>(offset));
+        protectedContext()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, static_cast<GCGLintptr>(offset));
     }
     void compressedTexImage2D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data);
+        protectedContext()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data);
     }
     void compressedTexImage2D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, int32_t imageSize, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, static_cast<GCGLintptr>(offset));
+        protectedContext()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, static_cast<GCGLintptr>(offset));
     }
     void compressedTexSubImage2D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data);
+        protectedContext()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data);
     }
     void compressedTexSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<GCGLintptr>(offset));
+        protectedContext()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<GCGLintptr>(offset));
     }
     void drawArraysInstanced(uint32_t mode, int32_t first, int32_t count, int32_t primcount)
     {
         assertIsCurrent(workQueue());
-        m_context->drawArraysInstanced(mode, first, count, primcount);
+        protectedContext()->drawArraysInstanced(mode, first, count, primcount);
     }
     void drawElementsInstanced(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t primcount)
     {
         assertIsCurrent(workQueue());
-        m_context->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
+        protectedContext()->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
     }
     void vertexAttribDivisor(uint32_t index, uint32_t divisor)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribDivisor(index, divisor);
+        protectedContext()->vertexAttribDivisor(index, divisor);
     }
     void createVertexArray(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createVertexArray();
+        auto result = protectedContext()->createVertexArray();
         if (result)
             m_objectNames.add(name, result);
     }
@@ -937,7 +937,7 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteVertexArray(arg0);
+        protectedContext()->deleteVertexArray(arg0);
     }
     void isVertexArray(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
@@ -945,7 +945,7 @@
         GCGLboolean returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->isVertexArray(arg0);
+        returnValue = protectedContext()->isVertexArray(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindVertexArray(uint32_t arg0)
@@ -953,99 +953,99 @@
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->bindVertexArray(arg0);
+        protectedContext()->bindVertexArray(arg0);
     }
     void copyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
     {
         assertIsCurrent(workQueue());
-        m_context->copyBufferSubData(readTarget, writeTarget, static_cast<GCGLintptr>(readOffset), static_cast<GCGLintptr>(writeOffset), static_cast<GCGLsizeiptr>(arg4));
+        protectedContext()->copyBufferSubData(readTarget, writeTarget, static_cast<GCGLintptr>(readOffset), static_cast<GCGLintptr>(writeOffset), static_cast<GCGLsizeiptr>(arg4));
     }
     void blitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     {
         assertIsCurrent(workQueue());
-        m_context->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+        protectedContext()->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     }
     void framebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     {
         assertIsCurrent(workQueue());
         if (texture)
             texture = m_objectNames.get(texture);
-        m_context->framebufferTextureLayer(target, attachment, texture, level, layer);
+        protectedContext()->framebufferTextureLayer(target, attachment, texture, level, layer);
     }
     void invalidateFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments)
     {
         assertIsCurrent(workQueue());
-        m_context->invalidateFramebuffer(target, attachments);
+        protectedContext()->invalidateFramebuffer(target, attachments);
     }
     void invalidateSubFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments, int32_t x, int32_t y, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->invalidateSubFramebuffer(target, attachments, x, y, width, height);
+        protectedContext()->invalidateSubFramebuffer(target, attachments, x, y, width, height);
     }
     void readBuffer(uint32_t src)
     {
         assertIsCurrent(workQueue());
-        m_context->readBuffer(src);
+        protectedContext()->readBuffer(src);
     }
     void renderbufferStorageMultisample(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->renderbufferStorageMultisample(target, samples, internalformat, width, height);
+        protectedContext()->renderbufferStorageMultisample(target, samples, internalformat, width, height);
     }
     void texStorage2D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->texStorage2D(target, levels, internalformat, width, height);
+        protectedContext()->texStorage2D(target, levels, internalformat, width, height);
     }
     void texStorage3D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height, int32_t depth)
     {
         assertIsCurrent(workQueue());
-        m_context->texStorage3D(target, levels, internalformat, width, height, depth);
+        protectedContext()->texStorage3D(target, levels, internalformat, width, height, depth);
     }
     void texImage3D0(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
+        protectedContext()->texImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
     }
     void texImage3D1(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->texImage3D(target, level, internalformat, width, height, depth, border, format, type, static_cast<GCGLintptr>(offset));
+        protectedContext()->texImage3D(target, level, internalformat, width, height, depth, border, format, type, static_cast<GCGLintptr>(offset));
     }
     void texSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+        protectedContext()->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
     }
     void texSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, uint32_t type, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<GCGLintptr>(offset));
+        protectedContext()->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<GCGLintptr>(offset));
     }
     void copyTexSubImage3D(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t x, int32_t y, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+        protectedContext()->copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
     }
     void compressedTexImage3D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
+        protectedContext()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
     }
     void compressedTexImage3D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, static_cast<GCGLintptr>(offset));
+        protectedContext()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, static_cast<GCGLintptr>(offset));
     }
     void compressedTexSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+        protectedContext()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
     }
     void compressedTexSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<GCGLintptr>(offset));
+        protectedContext()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<GCGLintptr>(offset));
     }
     void getFragDataLocation(uint32_t program, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
     {
@@ -1053,138 +1053,138 @@
         GCGLint returnValue = { };
         if (program)
             program = m_objectNames.get(program);
-        returnValue = m_context->getFragDataLocation(program, name);
+        returnValue = protectedContext()->getFragDataLocation(program, name);
         completionHandler(returnValue);
     }
     void uniform1ui(int32_t location, uint32_t v0)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1ui(location, v0);
+        protectedContext()->uniform1ui(location, v0);
     }
     void uniform2ui(int32_t location, uint32_t v0, uint32_t v1)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2ui(location, v0, v1);
+        protectedContext()->uniform2ui(location, v0, v1);
     }
     void uniform3ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3ui(location, v0, v1, v2);
+        protectedContext()->uniform3ui(location, v0, v1, v2);
     }
     void uniform4ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4ui(location, v0, v1, v2, v3);
+        protectedContext()->uniform4ui(location, v0, v1, v2, v3);
     }
     void uniform1uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1uiv(location, data);
+        protectedContext()->uniform1uiv(location, data);
     }
     void uniform2uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2uiv(location, data);
+        protectedContext()->uniform2uiv(location, data);
     }
     void uniform3uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3uiv(location, data);
+        protectedContext()->uniform3uiv(location, data);
     }
     void uniform4uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4uiv(location, data);
+        protectedContext()->uniform4uiv(location, data);
     }
     void uniformMatrix2x3fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix2x3fv(location, static_cast<GCGLboolean>(transpose), data);
+        protectedContext()->uniformMatrix2x3fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix3x2fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix3x2fv(location, static_cast<GCGLboolean>(transpose), data);
+        protectedContext()->uniformMatrix3x2fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix2x4fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix2x4fv(location, static_cast<GCGLboolean>(transpose), data);
+        protectedContext()->uniformMatrix2x4fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix4x2fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix4x2fv(location, static_cast<GCGLboolean>(transpose), data);
+        protectedContext()->uniformMatrix4x2fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix3x4fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix3x4fv(location, static_cast<GCGLboolean>(transpose), data);
+        protectedContext()->uniformMatrix3x4fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix4x3fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix4x3fv(location, static_cast<GCGLboolean>(transpose), data);
+        protectedContext()->uniformMatrix4x3fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void vertexAttribI4i(uint32_t index, int32_t x, int32_t y, int32_t z, int32_t w)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribI4i(index, x, y, z, w);
+        protectedContext()->vertexAttribI4i(index, x, y, z, w);
     }
     void vertexAttribI4iv(uint32_t index, std::span<const int32_t, 4>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribI4iv(index, values);
+        protectedContext()->vertexAttribI4iv(index, values);
     }
     void vertexAttribI4ui(uint32_t index, uint32_t x, uint32_t y, uint32_t z, uint32_t w)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribI4ui(index, x, y, z, w);
+        protectedContext()->vertexAttribI4ui(index, x, y, z, w);
     }
     void vertexAttribI4uiv(uint32_t index, std::span<const uint32_t, 4>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribI4uiv(index, values);
+        protectedContext()->vertexAttribI4uiv(index, values);
     }
     void vertexAttribIPointer(uint32_t index, int32_t size, uint32_t type, int32_t stride, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribIPointer(index, size, type, stride, static_cast<GCGLintptr>(offset));
+        protectedContext()->vertexAttribIPointer(index, size, type, stride, static_cast<GCGLintptr>(offset));
     }
     void drawRangeElements(uint32_t mode, uint32_t start, uint32_t end, int32_t count, uint32_t type, uint64_t offset)
     {
         assertIsCurrent(workQueue());
-        m_context->drawRangeElements(mode, start, end, count, type, static_cast<GCGLintptr>(offset));
+        protectedContext()->drawRangeElements(mode, start, end, count, type, static_cast<GCGLintptr>(offset));
     }
     void drawBuffers(std::span<const uint32_t>&& bufs)
     {
         assertIsCurrent(workQueue());
-        m_context->drawBuffers(bufs);
+        protectedContext()->drawBuffers(bufs);
     }
     void clearBufferiv(uint32_t buffer, int32_t drawbuffer, std::span<const int32_t>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferiv(buffer, drawbuffer, values);
+        protectedContext()->clearBufferiv(buffer, drawbuffer, values);
     }
     void clearBufferuiv(uint32_t buffer, int32_t drawbuffer, std::span<const uint32_t>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferuiv(buffer, drawbuffer, values);
+        protectedContext()->clearBufferuiv(buffer, drawbuffer, values);
     }
     void clearBufferfv(uint32_t buffer, int32_t drawbuffer, std::span<const float>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferfv(buffer, drawbuffer, values);
+        protectedContext()->clearBufferfv(buffer, drawbuffer, values);
     }
     void clearBufferfi(uint32_t buffer, int32_t drawbuffer, float depth, int32_t stencil)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferfi(buffer, drawbuffer, depth, stencil);
+        protectedContext()->clearBufferfi(buffer, drawbuffer, depth, stencil);
     }
     void createQuery(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createQuery();
+        auto result = protectedContext()->createQuery();
         if (result)
             m_objectNames.add(name, result);
     }
@@ -1194,7 +1194,7 @@
         if (UNLIKELY(!query))
             return;
         query = m_objectNames.take(query);
-        m_context->deleteQuery(query);
+        protectedContext()->deleteQuery(query);
     }
     void isQuery(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
     {
@@ -1202,7 +1202,7 @@
         GCGLboolean returnValue = { };
         if (query)
             query = m_objectNames.get(query);
-        returnValue = m_context->isQuery(query);
+        returnValue = protectedContext()->isQuery(query);
         completionHandler(static_cast<bool>(returnValue));
     }
     void beginQuery(uint32_t target, uint32_t query)
@@ -1210,18 +1210,18 @@
         assertIsCurrent(workQueue());
         if (query)
             query = m_objectNames.get(query);
-        m_context->beginQuery(target, query);
+        protectedContext()->beginQuery(target, query);
     }
     void endQuery(uint32_t target)
     {
         assertIsCurrent(workQueue());
-        m_context->endQuery(target);
+        protectedContext()->endQuery(target);
     }
     void getQuery(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getQuery(target, pname);
+        returnValue = protectedContext()->getQuery(target, pname);
         completionHandler(returnValue);
     }
     void getQueryObjectui(uint32_t query, uint32_t pname, CompletionHandler<void(uint32_t)>&& completionHandler)
@@ -1230,13 +1230,13 @@
         GCGLuint returnValue = { };
         if (query)
             query = m_objectNames.get(query);
-        returnValue = m_context->getQueryObjectui(query, pname);
+        returnValue = protectedContext()->getQueryObjectui(query, pname);
         completionHandler(returnValue);
     }
     void createSampler(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createSampler();
+        auto result = protectedContext()->createSampler();
         if (result)
             m_objectNames.add(name, result);
     }
@@ -1246,7 +1246,7 @@
         if (UNLIKELY(!sampler))
             return;
         sampler = m_objectNames.take(sampler);
-        m_context->deleteSampler(sampler);
+        protectedContext()->deleteSampler(sampler);
     }
     void isSampler(uint32_t sampler, CompletionHandler<void(bool)>&& completionHandler)
     {
@@ -1254,7 +1254,7 @@
         GCGLboolean returnValue = { };
         if (sampler)
             sampler = m_objectNames.get(sampler);
-        returnValue = m_context->isSampler(sampler);
+        returnValue = protectedContext()->isSampler(sampler);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindSampler(uint32_t unit, uint32_t sampler)
@@ -1262,21 +1262,21 @@
         assertIsCurrent(workQueue());
         if (sampler)
             sampler = m_objectNames.get(sampler);
-        m_context->bindSampler(unit, sampler);
+        protectedContext()->bindSampler(unit, sampler);
     }
     void samplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
         if (sampler)
             sampler = m_objectNames.get(sampler);
-        m_context->samplerParameteri(sampler, pname, param);
+        protectedContext()->samplerParameteri(sampler, pname, param);
     }
     void samplerParameterf(uint32_t sampler, uint32_t pname, float param)
     {
         assertIsCurrent(workQueue());
         if (sampler)
             sampler = m_objectNames.get(sampler);
-        m_context->samplerParameterf(sampler, pname, param);
+        protectedContext()->samplerParameterf(sampler, pname, param);
     }
     void getSamplerParameterf(uint32_t sampler, uint32_t pname, CompletionHandler<void(float)>&& completionHandler)
     {
@@ -1284,7 +1284,7 @@
         GCGLfloat returnValue = { };
         if (sampler)
             sampler = m_objectNames.get(sampler);
-        returnValue = m_context->getSamplerParameterf(sampler, pname);
+        returnValue = protectedContext()->getSamplerParameterf(sampler, pname);
         completionHandler(returnValue);
     }
     void getSamplerParameteri(uint32_t sampler, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -1293,51 +1293,51 @@
         GCGLint returnValue = { };
         if (sampler)
             sampler = m_objectNames.get(sampler);
-        returnValue = m_context->getSamplerParameteri(sampler, pname);
+        returnValue = protectedContext()->getSamplerParameteri(sampler, pname);
         completionHandler(returnValue);
     }
     void fenceSync(uint32_t condition, uint32_t flags, CompletionHandler<void(uint64_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLsync returnValue = { };
-        returnValue = m_context->fenceSync(condition, flags);
+        returnValue = protectedContext()->fenceSync(condition, flags);
         completionHandler(static_cast<uint64_t>(reinterpret_cast<intptr_t>(returnValue)));
     }
     void isSync(uint64_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        returnValue = m_context->isSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
+        returnValue = protectedContext()->isSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
         completionHandler(static_cast<bool>(returnValue));
     }
     void deleteSync(uint64_t arg0)
     {
         assertIsCurrent(workQueue());
-        m_context->deleteSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
+        protectedContext()->deleteSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
     }
     void clientWaitSync(uint64_t arg0, uint32_t flags, uint64_t timeout, CompletionHandler<void(uint32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLenum returnValue = { };
-        returnValue = m_context->clientWaitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLuint64>(timeout));
+        returnValue = protectedContext()->clientWaitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLuint64>(timeout));
         completionHandler(returnValue);
     }
     void waitSync(uint64_t arg0, uint32_t flags, int64_t timeout)
     {
         assertIsCurrent(workQueue());
-        m_context->waitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLint64>(timeout));
+        protectedContext()->waitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLint64>(timeout));
     }
     void getSynci(uint64_t arg0, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getSynci(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), pname);
+        returnValue = protectedContext()->getSynci(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), pname);
         completionHandler(returnValue);
     }
     void createTransformFeedback(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createTransformFeedback();
+        auto result = protectedContext()->createTransformFeedback();
         if (result)
             m_objectNames.add(name, result);
     }
@@ -1347,7 +1347,7 @@
         if (UNLIKELY(!id))
             return;
         id = m_objectNames.take(id);
-        m_context->deleteTransformFeedback(id);
+        protectedContext()->deleteTransformFeedback(id);
     }
     void isTransformFeedback(uint32_t id, CompletionHandler<void(bool)>&& completionHandler)
     {
@@ -1355,7 +1355,7 @@
         GCGLboolean returnValue = { };
         if (id)
             id = m_objectNames.get(id);
-        returnValue = m_context->isTransformFeedback(id);
+        returnValue = protectedContext()->isTransformFeedback(id);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindTransformFeedback(uint32_t target, uint32_t id)
@@ -1363,24 +1363,24 @@
         assertIsCurrent(workQueue());
         if (id)
             id = m_objectNames.get(id);
-        m_context->bindTransformFeedback(target, id);
+        protectedContext()->bindTransformFeedback(target, id);
     }
     void beginTransformFeedback(uint32_t primitiveMode)
     {
         assertIsCurrent(workQueue());
-        m_context->beginTransformFeedback(primitiveMode);
+        protectedContext()->beginTransformFeedback(primitiveMode);
     }
     void endTransformFeedback()
     {
         assertIsCurrent(workQueue());
-        m_context->endTransformFeedback();
+        protectedContext()->endTransformFeedback();
     }
     void transformFeedbackVaryings(uint32_t program, Vector<String>&& varyings, uint32_t bufferMode)
     {
         assertIsCurrent(workQueue());
         if (program)
             program = m_objectNames.get(program);
-        m_context->transformFeedbackVaryings(program, varyings, bufferMode);
+        protectedContext()->transformFeedbackVaryings(program, varyings, bufferMode);
     }
     void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
@@ -1388,32 +1388,32 @@
         if (program)
             program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
-        m_context->getTransformFeedbackVarying(program, index, arg2);
+        protectedContext()->getTransformFeedbackVarying(program, index, arg2);
         completionHandler(WTFMove(arg2));
     }
     void pauseTransformFeedback()
     {
         assertIsCurrent(workQueue());
-        m_context->pauseTransformFeedback();
+        protectedContext()->pauseTransformFeedback();
     }
     void resumeTransformFeedback()
     {
         assertIsCurrent(workQueue());
-        m_context->resumeTransformFeedback();
+        protectedContext()->resumeTransformFeedback();
     }
     void bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
     {
         assertIsCurrent(workQueue());
         if (buffer)
             buffer = m_objectNames.get(buffer);
-        m_context->bindBufferBase(target, index, buffer);
+        protectedContext()->bindBufferBase(target, index, buffer);
     }
     void bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
     {
         assertIsCurrent(workQueue());
         if (buffer)
             buffer = m_objectNames.get(buffer);
-        m_context->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
+        protectedContext()->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
     }
     void getUniformIndices(uint32_t program, Vector<String>&& uniformNames, CompletionHandler<void(Vector<uint32_t>&&)>&& completionHandler)
     {
@@ -1421,7 +1421,7 @@
         Vector<GCGLuint> returnValue = { };
         if (program)
             program = m_objectNames.get(program);
-        returnValue = m_context->getUniformIndices(program, uniformNames);
+        returnValue = protectedContext()->getUniformIndices(program, uniformNames);
         completionHandler(WTFMove(returnValue));
     }
     void getActiveUniforms(uint32_t program, Vector<uint32_t>&& uniformIndices, uint32_t pname, CompletionHandler<void(Vector<int32_t>&&)>&& completionHandler)
@@ -1430,7 +1430,7 @@
         Vector<GCGLint> returnValue = { };
         if (program)
             program = m_objectNames.get(program);
-        returnValue = m_context->getActiveUniforms(program, uniformIndices, pname);
+        returnValue = protectedContext()->getActiveUniforms(program, uniformIndices, pname);
         completionHandler(WTFMove(returnValue));
     }
     void getUniformBlockIndex(uint32_t program, String&& uniformBlockName, CompletionHandler<void(uint32_t)>&& completionHandler)
@@ -1439,7 +1439,7 @@
         GCGLuint returnValue = { };
         if (program)
             program = m_objectNames.get(program);
-        returnValue = m_context->getUniformBlockIndex(program, uniformBlockName);
+        returnValue = protectedContext()->getUniformBlockIndex(program, uniformBlockName);
         completionHandler(returnValue);
     }
     void getActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex, CompletionHandler<void(String&&)>&& completionHandler)
@@ -1448,7 +1448,7 @@
         String returnValue = { };
         if (program)
             program = m_objectNames.get(program);
-        returnValue = m_context->getActiveUniformBlockName(program, uniformBlockIndex);
+        returnValue = protectedContext()->getActiveUniformBlockName(program, uniformBlockIndex);
         completionHandler(WTFMove(returnValue));
     }
     void uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
@@ -1456,7 +1456,7 @@
         assertIsCurrent(workQueue());
         if (program)
             program = m_objectNames.get(program);
-        m_context->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+        protectedContext()->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
     void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
@@ -1464,7 +1464,7 @@
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLint, 4> params(paramsSize, 0);
-        m_context->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
+        protectedContext()->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
     }
     void getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
@@ -1473,18 +1473,18 @@
         String returnValue = { };
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->getTranslatedShaderSourceANGLE(arg0);
+        returnValue = protectedContext()->getTranslatedShaderSourceANGLE(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void drawBuffersEXT(std::span<const uint32_t>&& bufs)
     {
         assertIsCurrent(workQueue());
-        m_context->drawBuffersEXT(bufs);
+        protectedContext()->drawBuffersEXT(bufs);
     }
     void createQueryEXT(uint32_t name)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createQueryEXT();
+        auto result = protectedContext()->createQueryEXT();
         if (result)
             m_objectNames.add(name, result);
     }
@@ -1494,7 +1494,7 @@
         if (UNLIKELY(!query))
             return;
         query = m_objectNames.take(query);
-        m_context->deleteQueryEXT(query);
+        protectedContext()->deleteQueryEXT(query);
     }
     void isQueryEXT(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
     {
@@ -1502,7 +1502,7 @@
         GCGLboolean returnValue = { };
         if (query)
             query = m_objectNames.get(query);
-        returnValue = m_context->isQueryEXT(query);
+        returnValue = protectedContext()->isQueryEXT(query);
         completionHandler(static_cast<bool>(returnValue));
     }
     void beginQueryEXT(uint32_t target, uint32_t query)
@@ -1510,25 +1510,25 @@
         assertIsCurrent(workQueue());
         if (query)
             query = m_objectNames.get(query);
-        m_context->beginQueryEXT(target, query);
+        protectedContext()->beginQueryEXT(target, query);
     }
     void endQueryEXT(uint32_t target)
     {
         assertIsCurrent(workQueue());
-        m_context->endQueryEXT(target);
+        protectedContext()->endQueryEXT(target);
     }
     void queryCounterEXT(uint32_t query, uint32_t target)
     {
         assertIsCurrent(workQueue());
         if (query)
             query = m_objectNames.get(query);
-        m_context->queryCounterEXT(query, target);
+        protectedContext()->queryCounterEXT(query, target);
     }
     void getQueryiEXT(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        returnValue = m_context->getQueryiEXT(target, pname);
+        returnValue = protectedContext()->getQueryiEXT(target, pname);
         completionHandler(returnValue);
     }
     void getQueryObjectiEXT(uint32_t query, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -1537,7 +1537,7 @@
         GCGLint returnValue = { };
         if (query)
             query = m_objectNames.get(query);
-        returnValue = m_context->getQueryObjectiEXT(query, pname);
+        returnValue = protectedContext()->getQueryObjectiEXT(query, pname);
         completionHandler(returnValue);
     }
     void getQueryObjectui64EXT(uint32_t query, uint32_t pname, CompletionHandler<void(uint64_t)>&& completionHandler)
@@ -1546,103 +1546,103 @@
         GCGLuint64 returnValue = { };
         if (query)
             query = m_objectNames.get(query);
-        returnValue = m_context->getQueryObjectui64EXT(query, pname);
+        returnValue = protectedContext()->getQueryObjectui64EXT(query, pname);
         completionHandler(static_cast<uint64_t>(returnValue));
     }
     void getInteger64EXT(uint32_t pname, CompletionHandler<void(int64_t)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLint64 returnValue = { };
-        returnValue = m_context->getInteger64EXT(pname);
+        returnValue = protectedContext()->getInteger64EXT(pname);
         completionHandler(static_cast<int64_t>(returnValue));
     }
     void enableiOES(uint32_t target, uint32_t index)
     {
         assertIsCurrent(workQueue());
-        m_context->enableiOES(target, index);
+        protectedContext()->enableiOES(target, index);
     }
     void disableiOES(uint32_t target, uint32_t index)
     {
         assertIsCurrent(workQueue());
-        m_context->disableiOES(target, index);
+        protectedContext()->disableiOES(target, index);
     }
     void blendEquationiOES(uint32_t buf, uint32_t mode)
     {
         assertIsCurrent(workQueue());
-        m_context->blendEquationiOES(buf, mode);
+        protectedContext()->blendEquationiOES(buf, mode);
     }
     void blendEquationSeparateiOES(uint32_t buf, uint32_t modeRGB, uint32_t modeAlpha)
     {
         assertIsCurrent(workQueue());
-        m_context->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
+        protectedContext()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
     }
     void blendFunciOES(uint32_t buf, uint32_t src, uint32_t dst)
     {
         assertIsCurrent(workQueue());
-        m_context->blendFunciOES(buf, src, dst);
+        protectedContext()->blendFunciOES(buf, src, dst);
     }
     void blendFuncSeparateiOES(uint32_t buf, uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha)
     {
         assertIsCurrent(workQueue());
-        m_context->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
+        protectedContext()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
     }
     void colorMaskiOES(uint32_t buf, bool red, bool green, bool blue, bool alpha)
     {
         assertIsCurrent(workQueue());
-        m_context->colorMaskiOES(buf, static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
+        protectedContext()->colorMaskiOES(buf, static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
     }
     void drawArraysInstancedBaseInstanceANGLE(uint32_t mode, int32_t first, int32_t count, int32_t instanceCount, uint32_t baseInstance)
     {
         assertIsCurrent(workQueue());
-        m_context->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
+        protectedContext()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
     }
     void drawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t instanceCount, int32_t baseVertex, uint32_t baseInstance)
     {
         assertIsCurrent(workQueue());
-        m_context->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<GCGLintptr>(offset), instanceCount, baseVertex, baseInstance);
+        protectedContext()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<GCGLintptr>(offset), instanceCount, baseVertex, baseInstance);
     }
     void clipControlEXT(uint32_t origin, uint32_t depth)
     {
         assertIsCurrent(workQueue());
-        m_context->clipControlEXT(origin, depth);
+        protectedContext()->clipControlEXT(origin, depth);
     }
     void provokingVertexANGLE(uint32_t provokeMode)
     {
         assertIsCurrent(workQueue());
-        m_context->provokingVertexANGLE(provokeMode);
+        protectedContext()->provokingVertexANGLE(provokeMode);
     }
     void polygonModeANGLE(uint32_t face, uint32_t mode)
     {
         assertIsCurrent(workQueue());
-        m_context->polygonModeANGLE(face, mode);
+        protectedContext()->polygonModeANGLE(face, mode);
     }
     void polygonOffsetClampEXT(float factor, float units, float clamp)
     {
         assertIsCurrent(workQueue());
-        m_context->polygonOffsetClampEXT(factor, units, clamp);
+        protectedContext()->polygonOffsetClampEXT(factor, units, clamp);
     }
     void renderbufferStorageMultisampleANGLE(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->renderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height);
+        protectedContext()->renderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height);
     }
     void getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         Vector<GCGLint, 4> params(paramsSize, 0);
-        m_context->getInternalformativ(target, internalformat, pname, params);
+        protectedContext()->getInternalformativ(target, internalformat, pname, params);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
     }
     void setDrawingBufferColorSpace(WebCore::DestinationColorSpace&& arg0)
     {
         assertIsCurrent(workQueue());
-        m_context->setDrawingBufferColorSpace(arg0);
+        protectedContext()->setDrawingBufferColorSpace(arg0);
     }
 #if ENABLE(WEBXR)
     void createExternalImage(uint32_t name, WebCore::GraphicsContextGL::ExternalImageSource&& arg0, uint32_t internalFormat, int32_t layer)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createExternalImage(WTFMove(arg0), internalFormat, layer);
+        auto result = protectedContext()->createExternalImage(WTFMove(arg0), internalFormat, layer);
         if (result)
             m_objectNames.add(name, result);
     }
@@ -1652,19 +1652,19 @@
         if (UNLIKELY(!handle))
             return;
         handle = m_objectNames.take(handle);
-        m_context->deleteExternalImage(handle);
+        protectedContext()->deleteExternalImage(handle);
     }
     void bindExternalImage(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
         if (arg1)
             arg1 = m_objectNames.get(arg1);
-        m_context->bindExternalImage(target, arg1);
+        protectedContext()->bindExternalImage(target, arg1);
     }
     void createExternalSync(uint32_t name, WebCore::GraphicsContextGL::ExternalSyncSource&& arg0)
     {
         assertIsCurrent(workQueue());
-        auto result = m_context->createExternalSync(WTFMove(arg0));
+        auto result = protectedContext()->createExternalSync(WTFMove(arg0));
         if (result)
             m_objectNames.add(name, result);
     }
@@ -1675,21 +1675,21 @@
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
-        m_context->deleteExternalSync(arg0);
+        protectedContext()->deleteExternalSync(arg0);
     }
 #if ENABLE(WEBXR)
     void enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        returnValue = m_context->enableRequiredWebXRExtensions();
+        returnValue = protectedContext()->enableRequiredWebXRExtensions();
         completionHandler(returnValue);
     }
     void addFoveation(WebCore::IntSize&& physicalSizeLeft, WebCore::IntSize&& physicalSizeRight, WebCore::IntSize&& screenSize, std::span<const float>&& horizontalSamplesLeft, std::span<const float>&& verticalSamples, std::span<const float>&& horizontalSamplesRight, CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        returnValue = m_context->addFoveation(physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamples, horizontalSamplesRight);
+        returnValue = protectedContext()->addFoveation(physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamples, horizontalSamplesRight);
         completionHandler(returnValue);
     }
     void enableFoveation(uint32_t arg0)
@@ -1697,24 +1697,24 @@
         assertIsCurrent(workQueue());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
-        m_context->enableFoveation(arg0);
+        protectedContext()->enableFoveation(arg0);
     }
     void disableFoveation()
     {
         assertIsCurrent(workQueue());
-        m_context->disableFoveation();
+        protectedContext()->disableFoveation();
     }
     void framebufferDiscard(uint32_t target, std::span<const uint32_t>&& attachments)
     {
         assertIsCurrent(workQueue());
-        m_context->framebufferDiscard(target, attachments);
+        protectedContext()->framebufferDiscard(target, attachments);
     }
     void framebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
         if (arg3)
             arg3 = m_objectNames.get(arg3);
-        m_context->framebufferResolveRenderbuffer(target, attachment, renderbuffertarget, arg3);
+        protectedContext()->framebufferResolveRenderbuffer(target, attachment, renderbuffertarget, arg3);
     }
 #endif
 

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,7 +2,6 @@ AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 GPUProcess/graphics/RemoteDisplayListRecorder.h
-GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
 GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
 GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
 GPUProcess/media/RemoteAudioTrackProxy.h

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -879,7 +879,7 @@ class webkit_ipc_cpp_impl(object):
         in_exprs = ", ".join(str(e) for e in self.in_exprs)
         is_async = len(self.out_exprs) == 0
 
-        call_expr = f"m_context->{self.name}({in_exprs})"
+        call_expr = f"protectedContext()->{self.name}({in_exprs})"
         if not self.return_value_expr:
             self.call_stmts += [f"{call_expr};"]
         else:


### PR DESCRIPTION
#### a0a16a8c8413a9b76aabc3eec67418f2c09baf8c
<pre>
Adopt more smart pointers in RemoteGraphicsContextGLFunctionsGenerated.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=281098">https://bugs.webkit.org/show_bug.cgi?id=281098</a>
<a href="https://rdar.apple.com/137549546">rdar://137549546</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.

We update the generate-gpup-webgl script to generate RemoteGraphicsContextGLFunctionsGenerated.h
so that it uses `protectedContext()` (defined in RemoteGraphicsContextGL.h) instead of `m_context`.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(activeTexture):
(attachShader):
(bindAttribLocation):
(bindBuffer):
(bindFramebuffer):
(bindRenderbuffer):
(bindTexture):
(blendColor):
(blendEquation):
(blendEquationSeparate):
(blendFunc):
(blendFuncSeparate):
(checkFramebufferStatus):
(clear):
(clearColor):
(clearDepth):
(clearStencil):
(colorMask):
(compileShader):
(copyTexImage2D):
(copyTexSubImage2D):
(createBuffer):
(createFramebuffer):
(createProgram):
(createRenderbuffer):
(createShader):
(createTexture):
(cullFace):
(deleteBuffer):
(deleteFramebuffer):
(deleteProgram):
(deleteRenderbuffer):
(deleteShader):
(deleteTexture):
(depthFunc):
(depthMask):
(depthRange):
(detachShader):
(disable):
(disableVertexAttribArray):
(drawArrays):
(drawElements):
(enable):
(enableVertexAttribArray):
(finish):
(flush):
(framebufferRenderbuffer):
(framebufferTexture2D):
(frontFace):
(generateMipmap):
(getActiveAttrib):
(getActiveUniform):
(getAttribLocation):
(getBufferParameteri):
(getString):
(getFloatv):
(getIntegerv):
(getIntegeri_v):
(getInteger64):
(getInteger64i):
(getProgrami):
(getBooleanv):
(getFramebufferAttachmentParameteri):
(getProgramInfoLog):
(getRenderbufferParameteri):
(getShaderi):
(getShaderInfoLog):
(getShaderPrecisionFormat):
(getShaderSource):
(getTexParameterf):
(getTexParameteri):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getUniformLocation):
(getVertexAttribOffset):
(hint):
(isBuffer):
(isEnabled):
(isFramebuffer):
(isProgram):
(isRenderbuffer):
(isShader):
(isTexture):
(lineWidth):
(linkProgram):
(pixelStorei):
(polygonOffset):
(renderbufferStorage):
(sampleCoverage):
(scissor):
(shaderSource):
(stencilFunc):
(stencilFuncSeparate):
(stencilMask):
(stencilMaskSeparate):
(stencilOp):
(stencilOpSeparate):
(texParameterf):
(texParameteri):
(uniform1f):
(uniform1fv):
(uniform1i):
(uniform1iv):
(uniform2f):
(uniform2fv):
(uniform2i):
(uniform2iv):
(uniform3f):
(uniform3fv):
(uniform3i):
(uniform3iv):
(uniform4f):
(uniform4fv):
(uniform4i):
(uniform4iv):
(uniformMatrix2fv):
(uniformMatrix3fv):
(uniformMatrix4fv):
(useProgram):
(validateProgram):
(vertexAttrib1f):
(vertexAttrib1fv):
(vertexAttrib2f):
(vertexAttrib2fv):
(vertexAttrib3f):
(vertexAttrib3fv):
(vertexAttrib4f):
(vertexAttrib4fv):
(vertexAttribPointer):
(viewport):
(bufferData0):
(bufferData1):
(bufferSubData):
(readPixelsBufferObject):
(texImage2D0):
(texImage2D1):
(texSubImage2D0):
(texSubImage2D1):
(compressedTexImage2D0):
(compressedTexImage2D1):
(compressedTexSubImage2D0):
(compressedTexSubImage2D1):
(drawArraysInstanced):
(drawElementsInstanced):
(vertexAttribDivisor):
(createVertexArray):
(deleteVertexArray):
(isVertexArray):
(bindVertexArray):
(copyBufferSubData):
(blitFramebuffer):
(framebufferTextureLayer):
(invalidateFramebuffer):
(invalidateSubFramebuffer):
(readBuffer):
(renderbufferStorageMultisample):
(texStorage2D):
(texStorage3D):
(texImage3D0):
(texImage3D1):
(texSubImage3D0):
(texSubImage3D1):
(copyTexSubImage3D):
(compressedTexImage3D0):
(compressedTexImage3D1):
(compressedTexSubImage3D0):
(compressedTexSubImage3D1):
(getFragDataLocation):
(uniform1ui):
(uniform2ui):
(uniform3ui):
(uniform4ui):
(uniform1uiv):
(uniform2uiv):
(uniform3uiv):
(uniform4uiv):
(uniformMatrix2x3fv):
(uniformMatrix3x2fv):
(uniformMatrix2x4fv):
(uniformMatrix4x2fv):
(uniformMatrix3x4fv):
(uniformMatrix4x3fv):
(vertexAttribI4i):
(vertexAttribI4iv):
(vertexAttribI4ui):
(vertexAttribI4uiv):
(vertexAttribIPointer):
(drawRangeElements):
(drawBuffers):
(clearBufferiv):
(clearBufferuiv):
(clearBufferfv):
(clearBufferfi):
(createQuery):
(deleteQuery):
(isQuery):
(beginQuery):
(endQuery):
(getQuery):
(getQueryObjectui):
(createSampler):
(deleteSampler):
(isSampler):
(bindSampler):
(samplerParameteri):
(samplerParameterf):
(getSamplerParameterf):
(getSamplerParameteri):
(fenceSync):
(isSync):
(deleteSync):
(clientWaitSync):
(waitSync):
(getSynci):
(createTransformFeedback):
(deleteTransformFeedback):
(isTransformFeedback):
(bindTransformFeedback):
(beginTransformFeedback):
(endTransformFeedback):
(transformFeedbackVaryings):
(getTransformFeedbackVarying):
(pauseTransformFeedback):
(resumeTransformFeedback):
(bindBufferBase):
(bindBufferRange):
(getUniformIndices):
(getActiveUniforms):
(getUniformBlockIndex):
(getActiveUniformBlockName):
(uniformBlockBinding):
(getActiveUniformBlockiv):
(getTranslatedShaderSourceANGLE):
(drawBuffersEXT):
(createQueryEXT):
(deleteQueryEXT):
(isQueryEXT):
(beginQueryEXT):
(endQueryEXT):
(queryCounterEXT):
(getQueryiEXT):
(getQueryObjectiEXT):
(getQueryObjectui64EXT):
(getInteger64EXT):
(enableiOES):
(disableiOES):
(blendEquationiOES):
(blendEquationSeparateiOES):
(blendFunciOES):
(blendFuncSeparateiOES):
(colorMaskiOES):
(drawArraysInstancedBaseInstanceANGLE):
(drawElementsInstancedBaseVertexBaseInstanceANGLE):
(clipControlEXT):
(provokingVertexANGLE):
(polygonModeANGLE):
(polygonOffsetClampEXT):
(renderbufferStorageMultisampleANGLE):
(getInternalformativ):
(setDrawingBufferColorSpace):
(createExternalImage):
(deleteExternalImage):
(bindExternalImage):
(createExternalSync):
(deleteExternalSync):
(enableRequiredWebXRExtensions):
(addFoveation):
(enableFoveation):
(disableFoveation):
(framebufferDiscard):
(framebufferResolveRenderbuffer):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_cpp_impl.process_call):

Canonical link: <a href="https://commits.webkit.org/284877@main">https://commits.webkit.org/284877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a798b04fd25c6b5da3b60c9f2b5fc8d10908b746

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56019 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14484 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63751 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11765 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5412 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/744 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47045 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->