### PR TITLE
Web Extensions: tabs.executeScript ignores frameId parameter.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -554,6 +554,11 @@ void WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
 
     parameters.tabIdentifier = tabIdentifier;
 
+    if (objectForKey<NSNumber>(targetInfo, allFramesKey).boolValue && targetInfo[frameIDsKey]) {
+        *outExceptionString = toErrorString(nil, targetKey, @"it cannot specify both 'allFrames' and 'frameIds'");
+        return;
+    }
+
     if (NSArray *frameIDs = targetInfo[frameIDsKey]) {
         Vector<WebExtensionFrameIdentifier> frames;
         for (NSNumber *frameID in frameIDs) {
@@ -566,12 +571,9 @@ void WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
             frames.append(frameIdentifier.value());
         }
 
-        parameters.frameIDs = frames;
-        return;
-    }
-
-    if (!boolForKey(targetInfo, allFramesKey, false))
-        parameters.frameIDs = Vector { WebExtensionFrameConstants::MainFrameIdentifier };
+        parameters.frameIDs = WTFMove(frames);
+    } else if (!boolForKey(targetInfo, allFramesKey, false))
+        parameters.frameIDs = { WebExtensionFrameConstants::MainFrameIdentifier };
 }
 
 void WebExtensionAPIScripting::parseScriptInjectionOptions(NSDictionary *script, WebExtensionScriptInjectionParameters& parameters, NSString **outExceptionString)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -525,9 +525,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
         }
 
         parameters.frameIDs = { frameIdentifier.value() };
-    }
-
-    if (!boolForKey(options, allFramesKey, false))
+    } else if (!boolForKey(options, allFramesKey, false))
         parameters.frameIDs = { WebExtensionFrameConstants::MainFrameIdentifier };
 
     if (NSString *origin = options[cssOriginKey]) {


### PR DESCRIPTION
#### bb35511a78052fe3bc87e2293c1b3ce12bc8e626
<pre>
Web Extensions: tabs.executeScript ignores frameId parameter.
<a href="https://webkit.org/b/281099">https://webkit.org/b/281099</a>
<a href="https://rdar.apple.com/137449521">rdar://137449521</a>

Reviewed by Brian Weinstein.

The parsing of options for `tabs.executeScript` was overriding the `frameIdentifier`
with the main frame since the check for all frames was always returning `true` if
the `allFrames` option was missing or `false`.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::parseTargetInjectionOptions): Remove early return
and add `allFrames` else case.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseScriptOptions): Make `allFrames` be the else case.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)): Replaced
with a better test that uses pathname to verify the frame is the target.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ExecuteScriptWithFrameId)): Added.

Canonical link: <a href="https://commits.webkit.org/284915@main">https://commits.webkit.org/284915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1195e08b60b2506ba2a30039392d7dd34421a2e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56020 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14485 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20305 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64205 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63694 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5413 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10870 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/745 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->