### PR TITLE
Adopt

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -323,8 +323,9 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     // Use this flag to force synchronous messages to be treated as asynchronous messages in the WebProcess.
     // Otherwise, the WebProcess would process incoming synchronous IPC while waiting for a synchronous IPC
     // reply from the GPU process, which would be unsafe.
-    m_connection->setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(true);
-    m_connection->open(*this);
+    Ref connection = m_connection;
+    connection->setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(true);
+    connection->open(*this);
 
 #if ENABLE(VP9)
     bool hasVP9HardwareDecoder;
@@ -364,7 +365,7 @@ GPUConnectionToWebProcess::~GPUConnectionToWebProcess()
 {
     RELEASE_ASSERT(RunLoop::isMain());
 
-    m_connection->invalidate();
+    protectedConnection()->invalidate();
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     protectedSampleBufferDisplayLayerManager()->close();
@@ -414,7 +415,7 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #endif
 #if ENABLE(VIDEO)
     protectedVideoFrameObjectHeap()->close();
-    m_remoteMediaPlayerManagerProxy->clear();
+    protectedRemoteMediaPlayerManagerProxy()->clear();
 #endif
     // RemoteRenderingBackend objects ref their GPUConnectionToWebProcess so we need to make sure
     // to break the reference cycle by destroying them.
@@ -436,8 +437,8 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
     m_libWebRTCCodecsProxy = nullptr;
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    if (m_cdmFactoryProxy)
-        m_cdmFactoryProxy->clear();
+    if (RefPtr cdmFactoryProxy = m_cdmFactoryProxy)
+        cdmFactoryProxy->clear();
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
@@ -574,8 +575,8 @@ void GPUConnectionToWebProcess::terminateWebProcess()
 
 void GPUConnectionToWebProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)
 {
-    if (m_sharedResourceCache)
-        m_sharedResourceCache->lowMemoryHandler();
+    if (RefPtr sharedResourceCache = m_sharedResourceCache)
+        sharedResourceCache->lowMemoryHandler();
 #if ENABLE(VIDEO)
     protectedVideoFrameObjectHeap()->lowMemoryHandler();
 #endif
@@ -1254,7 +1255,7 @@ void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPrefe
 {
     m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess);
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
-    m_libWebRTCCodecsProxy->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+    protectedLibWebRTCCodecsProxy()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -268,8 +268,6 @@ public:
 private:
     GPUConnectionToWebProcess(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
 
-    Ref<IPC::Connection> protectedConnection() const { return m_connection.copyRef(); }
-
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
     Ref<LibWebRTCCodecsProxy> protectedLibWebRTCCodecsProxy() const;
 #endif

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
@@ -90,7 +90,7 @@ void RemoteSharedResourceCache::releaseSerializedImageBuffer(WebCore::RenderingR
 void RemoteSharedResourceCache::lowMemoryHandler()
 {
 #if HAVE(IOSURFACE)
-    m_ioSurfacePool->discardAllSurfaces();
+    Ref { m_ioSurfacePool }->discardAllSurfaces();
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
@@ -64,7 +64,7 @@ void RemoteFaceDetector::detect(WebCore::RenderingResourceIdentifier renderingRe
         return;
     }
 
-    m_backing->detect(*sourceImage, WTFMove(completionHandler));
+    Ref { m_backing }->detect(*sourceImage, WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -59,7 +59,7 @@ Vector<S> vectorCopyCast(const T& arrayReference)
 }
 
 // Currently we have one global WebGL processing instance.
-IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueue()
+IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueueSingleton()
 {
     static LazyNeverDestroyed<IPC::StreamConnectionWorkQueue> instance;
     static std::once_flag onceKey;
@@ -83,7 +83,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextGL);
 
 RemoteGraphicsContextGL::RemoteGraphicsContextGL(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
-    , m_workQueue(remoteGraphicsContextGLStreamWorkQueue())
+    , m_workQueue(remoteGraphicsContextGLStreamWorkQueueSingleton())
     , m_streamConnection(WTFMove(streamConnection))
     , m_graphicsContextGLIdentifier(graphicsContextGLIdentifier)
     , m_renderingBackend(renderingBackend)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -80,7 +80,7 @@ namespace WebKit {
 class RemoteVideoFrameObjectHeap;
 #endif
 
-IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueue();
+IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueueSingleton();
 
 
 // GPU process side implementation of that receives messages about GraphicsContextGL calls

--- a/Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
@@ -47,7 +47,7 @@ void ScopedWebGLRenderingResourcesRequest::scheduleFreeWebGLRenderingResources()
 #if !USE(GRAPHICS_LAYER_WC)
     if (didScheduleFreeWebGLRenderingResources)
         return;
-    RunLoop::main().dispatchAfter(freeWebGLRenderingResourcesTimeout, freeWebGLRenderingResources);
+    RunLoop::protectedMain()->dispatchAfter(freeWebGLRenderingResourcesTimeout, freeWebGLRenderingResources);
     didScheduleFreeWebGLRenderingResources = true;
 #endif
 }
@@ -57,7 +57,7 @@ void ScopedWebGLRenderingResourcesRequest::freeWebGLRenderingResources()
     didScheduleFreeWebGLRenderingResources = false;
     if (s_requests)
         return;
-    remoteGraphicsContextGLStreamWorkQueue().dispatch([] {
+    remoteGraphicsContextGLStreamWorkQueueSingleton().dispatch([] {
         WebCore::GraphicsContextGLANGLE::releaseThreadResources(WebCore::GraphicsContextGLANGLE::ReleaseThreadResourceBehavior::TerminateAndReleaseThreadResources);
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -84,6 +84,9 @@ private:
     RemoteBuffer& operator=(RemoteBuffer&&) = delete;
 
     WebCore::WebGPU::Buffer& backing() { return m_backing; }
+    Ref<WebCore::WebGPU::Buffer> protectedBacking();
+
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -45,24 +45,29 @@ RemoteRenderBundle::RemoteRenderBundle(WebCore::WebGPU::RenderBundle& renderBund
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteRenderBundle::~RemoteRenderBundle() = default;
 
 void RemoteRenderBundle::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteRenderBundle::stopListeningForIPC()
 {
-    m_streamConnection->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
+    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteRenderBundle::setLabel(String&& label)
 {
-    m_backing->setLabel(WTFMove(label));
+    Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+Ref<IPC::StreamServerConnection> RemoteRenderBundle::protectedStreamConnection() const
+{
+    return m_streamConnection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -76,6 +76,8 @@ private:
 
     WebCore::WebGPU::RenderBundle& backing() { return m_backing; }
 
+    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -84,7 +84,7 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
     }
     auto textureView = protectedBacking()->createView(convertedDescriptor);
     MESSAGE_CHECK(textureView);
-    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), Ref { m_gpu.get() }, identifier);
+    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), objectHeap, m_streamConnection.copyRef(), Ref { m_gpu.get() }, identifier);
     objectHeap->addObject(identifier, remoteTextureView);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
@@ -73,7 +73,7 @@ Ref<RemoteGPU> RemoteXRBinding::protectedGPU()
 
 void RemoteXRBinding::destruct()
 {
-    m_objectHeap->removeObject(m_identifier);
+    Ref { m_objectHeap.get() }->removeObject(m_identifier);
 }
 
 void RemoteXRBinding::createProjectionLayer(WebCore::WebGPU::TextureFormat colorFormat, std::optional<WebCore::WebGPU::TextureFormat> depthStencilFormat, WebCore::WebGPU::TextureUsageFlags textureUsage, double scaleFactor, WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 IPC::StreamConnectionWorkQueue& remoteGraphicsStreamWorkQueue()
 {
 #if ENABLE(WEBGL)
-    return remoteGraphicsContextGLStreamWorkQueue();
+    return remoteGraphicsContextGLStreamWorkQueueSingleton();
 #else
     static LazyNeverDestroyed<IPC::StreamConnectionWorkQueue> instance;
     static std::once_flag onceKey;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -145,13 +145,13 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
 {
     String sceneIdentifier;
     std::optional<AudioSession::SoundStageSize> maxSize;
-    for (auto& proxy : m_proxies) {
-        if (!proxy.isActive())
+    for (Ref proxy : m_proxies) {
+        if (!proxy->isActive())
             continue;
 
-        if (!maxSize || proxy.soundStageSize() > *maxSize) {
-            maxSize = proxy.soundStageSize();
-            sceneIdentifier = proxy.sceneIdentifier();
+        if (!maxSize || proxy->soundStageSize() > *maxSize) {
+            maxSize = proxy->soundStageSize();
+            sceneIdentifier = proxy->sceneIdentifier();
         }
     }
 
@@ -161,8 +161,8 @@ void RemoteAudioSessionProxyManager::updateSpatialExperience()
 
 bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude)
 {
-    for (auto& proxy : m_proxies) {
-        if (proxy.isActive() && &proxy != &proxyToExclude)
+    for (Ref proxy : m_proxies) {
+        if (proxy->isActive() && proxy.ptr() != &proxyToExclude)
             return true;
     }
     return false;
@@ -170,8 +170,8 @@ bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionP
 
 bool RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy()
 {
-    for (auto& proxy : m_proxies) {
-        if (proxy.isActive() && !proxy.isInterrupted())
+    for (Ref proxy : m_proxies) {
+        if (proxy->isActive() && !proxy->isInterrupted())
             return true;
     }
     return false;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
     auto result = ProducerSharedCARingBuffer::allocate(format, frameCount);
     RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
     auto [ringBuffer, handle] = WTFMove(*result);
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
+    protectedConnection()->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
     // Use a redundant variable to avoid move in return position and to obtain copy elision. Clang or libc++ does not allow returning covariant of Ts from std::unique_ptr<T>s in this position.
     std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTFMove(ringBuffer);  // NOLINT: see above.
     return caRingBuffer;
@@ -68,7 +68,7 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
 
 void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames)
 {
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames }, 0);
+    protectedConnection()->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -56,6 +56,8 @@ private:
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final { }
 
+    Ref<IPC::Connection> protectedConnection() const { return m_connection; }
+
     WebCore::MediaPlayerIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;
 };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -63,7 +63,7 @@ public:
     void setEnabled(bool enabled)
     {
         m_enabled = enabled;
-        m_trackPrivate->setEnabled(enabled);
+        Ref { m_trackPrivate }->setEnabled(enabled);
     }
     bool operator==(const WebCore::AudioTrackPrivate& track) const { return track == m_trackPrivate.get(); }
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -63,7 +63,7 @@ public:
     void setSelected(bool selected)
     {
         m_selected = selected;
-        m_trackPrivate->setSelected(selected);
+        Ref { m_trackPrivate }->setSelected(selected);
     }
     bool operator==(const WebCore::VideoTrackPrivate& track) const { return track == m_trackPrivate.get(); }
 

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,16 +1,9 @@
 AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
-GPUProcess/GPUConnectionToWebProcess.cpp
-GPUProcess/RemoteSharedResourceCache.cpp
-GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
 GPUProcess/graphics/RemoteDisplayListRecorder.h
 GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
 GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
-GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
-GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
-GPUProcess/graphics/WebGPU/RemoteTexture.cpp
-GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
 GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
 GPUProcess/media/RemoteAudioTrackProxy.h
 GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -398,7 +391,6 @@ WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/GPUProcessConnection.cpp
 WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
-WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
 WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -3,11 +3,7 @@ AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 GPUProcess/graphics/RemoteDisplayListRecorder.h
 GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
-GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
-GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
-GPUProcess/media/RemoteAudioTrackProxy.h
 GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
-GPUProcess/media/RemoteVideoTrackProxy.h
 JSWebExtensionAPIAction.mm
 JSWebExtensionAPIAlarms.mm
 JSWebExtensionAPICommands.mm
@@ -389,7 +385,6 @@ WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/GPU/GPUProcessConnection.cpp
 WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
 WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-GPUProcess/media/RemoteAudioSessionProxyManager.cpp
 NetworkProcess/NetworkLoadScheduler.cpp
 NetworkProcess/NetworkSession.cpp
 NetworkProcess/PingLoad.h

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -56,12 +56,17 @@ RemoteFaceDetectorProxy::RemoteFaceDetectorProxy(Ref<IPC::StreamClientConnection
 
 RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy()
 {
-    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier);
+    protectedStreamClientConnection()->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier);
 }
 
 void RemoteFaceDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
+    protectedStreamClientConnection()->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
+}
+
+Ref<IPC::StreamClientConnection> RemoteFaceDetectorProxy::protectedStreamClientConnection() const
+{
+    return m_streamClientConnection;
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -64,6 +64,8 @@ private:
 
     ShapeDetectionIdentifier backing() const { return m_backing; }
 
+    Ref<IPC::StreamClientConnection> protectedStreamClientConnection() const;
+
     void detect(Ref<WebCore::ImageBuffer>&&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&) final;
 
     ShapeDetectionIdentifier m_backing;


### PR DESCRIPTION
#### 50a32c3aa228b4778154403480ce342e2167fb54
<pre>
Adopt more smart pointers in GPUProcess related files
<a href="https://bugs.webkit.org/show_bug.cgi?id=281101">https://bugs.webkit.org/show_bug.cgi?id=281101</a>
<a href="https://rdar.apple.com/137553976">rdar://137553976</a>

Reviewed by NOBODY (OOPS!).

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::remoteGraphicsContextGLStreamWorkQueueSingleton):
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::remoteGraphicsContextGLStreamWorkQueue): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp:
(WebKit::ScopedWebGLRenderingResourcesRequest::scheduleFreeWebGLRenderingResources):
(WebKit::ScopedWebGLRenderingResourcesRequest::freeWebGLRenderingResources):
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
(WebKit::remoteGraphicsStreamWorkQueue):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::configureAudioStorage):
(WebKit::RemoteAudioSourceProviderProxy::newAudioSamples):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:
(WebKit::RemoteAudioSourceProviderProxy::protectedConnection const):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::GPUProcessConnection):
(WebKit::GPUProcessConnection::~GPUProcessConnection):
(WebKit::GPUProcessConnection::invalidate):
(WebKit::GPUProcessConnection::waitForDidInitialize):
</pre>
----------------------------------------------------------------------
#### 2ea18f1009e169f9c0c787505820e879429f2865
<pre>
Adopt smart pointers in more GPUProcess files
<a href="https://bugs.webkit.org/show_bug.cgi?id=280988">https://bugs.webkit.org/show_bug.cgi?id=280988</a>
<a href="https://rdar.apple.com/137437166">rdar://137437166</a>

Reviewed by NOBODY (OOPS!).

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::~GPUConnectionToWebProcess):
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::lowMemoryHandler):
(WebKit::GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::protectedConnection const): Deleted.
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp:
(WebKit::RemoteSharedResourceCache::lowMemoryHandler):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp:
(WebKit::RemoteFaceDetector::detect):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::RemoteBuffer):
(WebKit::RemoteBuffer::stopListeningForIPC):
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::getMappedRange):
(WebKit::RemoteBuffer::unmap):
(WebKit::RemoteBuffer::copy):
(WebKit::RemoteBuffer::destroy):
(WebKit::RemoteBuffer::destruct):
(WebKit::RemoteBuffer::setLabel):
(WebKit::RemoteBuffer::protectedBacking):
(WebKit::RemoteBuffer::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp:
(WebKit::RemoteRenderBundle::RemoteRenderBundle):
(WebKit::RemoteRenderBundle::destruct):
(WebKit::RemoteRenderBundle::stopListeningForIPC):
(WebKit::RemoteRenderBundle::setLabel):
(WebKit::RemoteRenderBundle::protectedStreamConnection const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::createView):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp:
(WebKit::RemoteXRBinding::destruct):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateSpatialExperience):
(WebKit::RemoteAudioSessionProxyManager::hasOtherActiveProxyThan):
(WebKit::RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::detect):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::protectedStreamClientConnection const):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50a32c3aa228b4778154403480ce342e2167fb54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70771 "Failed to checkout and rebase branch from PR 34875") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50181 "Failed to checkout and rebase branch from PR 34875") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23540 "Failed to checkout and rebase branch from PR 34875") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57979 "Failed to checkout and rebase branch from PR 34875") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21792 "Failed to checkout and rebase branch from PR 34875") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73837 "Failed to checkout and rebase branch from PR 34875") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/57979 "Failed to checkout and rebase branch from PR 34875") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/23540 "Failed to checkout and rebase branch from PR 34875") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/57979 "Failed to checkout and rebase branch from PR 34875") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/23540 "Failed to checkout and rebase branch from PR 34875") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/57979 "Failed to checkout and rebase branch from PR 34875") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/23540 "Failed to checkout and rebase branch from PR 34875") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15001 "Failed to checkout and rebase branch from PR 34875") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/21792 "Failed to checkout and rebase branch from PR 34875") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/76582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15045 "Failed to checkout and rebase branch from PR 34875") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/23540 "Failed to checkout and rebase branch from PR 34875") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/23540 "Failed to checkout and rebase branch from PR 34875") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45982 "Failed to checkout and rebase branch from PR 34875") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47054 "Failed to checkout and rebase branch from PR 34875") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->