### PR TITLE
Adopt more smart pointers in GPUProcess related files

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -59,7 +59,7 @@ Vector<S> vectorCopyCast(const T& arrayReference)
 }
 
 // Currently we have one global WebGL processing instance.
-IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueue()
+IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueueSingleton()
 {
     static LazyNeverDestroyed<IPC::StreamConnectionWorkQueue> instance;
     static std::once_flag onceKey;
@@ -83,7 +83,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextGL);
 
 RemoteGraphicsContextGL::RemoteGraphicsContextGL(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
-    , m_workQueue(remoteGraphicsContextGLStreamWorkQueue())
+    , m_workQueue(remoteGraphicsContextGLStreamWorkQueueSingleton())
     , m_streamConnection(WTFMove(streamConnection))
     , m_graphicsContextGLIdentifier(graphicsContextGLIdentifier)
     , m_renderingBackend(renderingBackend)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -80,7 +80,7 @@ namespace WebKit {
 class RemoteVideoFrameObjectHeap;
 #endif
 
-IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueue();
+IPC::StreamConnectionWorkQueue& remoteGraphicsContextGLStreamWorkQueueSingleton();
 
 
 // GPU process side implementation of that receives messages about GraphicsContextGL calls

--- a/Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
@@ -47,7 +47,7 @@ void ScopedWebGLRenderingResourcesRequest::scheduleFreeWebGLRenderingResources()
 #if !USE(GRAPHICS_LAYER_WC)
     if (didScheduleFreeWebGLRenderingResources)
         return;
-    RunLoop::main().dispatchAfter(freeWebGLRenderingResourcesTimeout, freeWebGLRenderingResources);
+    RunLoop::protectedMain()->dispatchAfter(freeWebGLRenderingResourcesTimeout, freeWebGLRenderingResources);
     didScheduleFreeWebGLRenderingResources = true;
 #endif
 }
@@ -57,7 +57,7 @@ void ScopedWebGLRenderingResourcesRequest::freeWebGLRenderingResources()
     didScheduleFreeWebGLRenderingResources = false;
     if (s_requests)
         return;
-    remoteGraphicsContextGLStreamWorkQueue().dispatch([] {
+    remoteGraphicsContextGLStreamWorkQueueSingleton().dispatch([] {
         WebCore::GraphicsContextGLANGLE::releaseThreadResources(WebCore::GraphicsContextGLANGLE::ReleaseThreadResourceBehavior::TerminateAndReleaseThreadResources);
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 IPC::StreamConnectionWorkQueue& remoteGraphicsStreamWorkQueue()
 {
 #if ENABLE(WEBGL)
-    return remoteGraphicsContextGLStreamWorkQueue();
+    return remoteGraphicsContextGLStreamWorkQueueSingleton();
 #else
     static LazyNeverDestroyed<IPC::StreamConnectionWorkQueue> instance;
     static std::once_flag onceKey;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
     auto result = ProducerSharedCARingBuffer::allocate(format, frameCount);
     RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
     auto [ringBuffer, handle] = WTFMove(*result);
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
+    protectedConnection()->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
     // Use a redundant variable to avoid move in return position and to obtain copy elision. Clang or libc++ does not allow returning covariant of Ts from std::unique_ptr<T>s in this position.
     std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTFMove(ringBuffer);  // NOLINT: see above.
     return caRingBuffer;
@@ -68,7 +68,7 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
 
 void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames)
 {
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames }, 0);
+    protectedConnection()->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -56,6 +56,8 @@ private:
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final { }
 
+    Ref<IPC::Connection> protectedConnection() const { return m_connection; }
+
     WebCore::MediaPlayerIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;
 };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -63,7 +63,7 @@ public:
     void setEnabled(bool enabled)
     {
         m_enabled = enabled;
-        m_trackPrivate->setEnabled(enabled);
+        Ref { m_trackPrivate }->setEnabled(enabled);
     }
     bool operator==(const WebCore::AudioTrackPrivate& track) const { return track == m_trackPrivate.get(); }
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -63,7 +63,7 @@ public:
     void setSelected(bool selected)
     {
         m_selected = selected;
-        m_trackPrivate->setSelected(selected);
+        Ref { m_trackPrivate }->setSelected(selected);
     }
     bool operator==(const WebCore::VideoTrackPrivate& track) const { return track == m_trackPrivate.get(); }
 

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,11 +2,7 @@ AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 GPUProcess/graphics/RemoteDisplayListRecorder.h
-GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp
-GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
-GPUProcess/media/RemoteAudioTrackProxy.h
 GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
-GPUProcess/media/RemoteVideoTrackProxy.h
 JSWebExtensionAPIAction.mm
 JSWebExtensionAPIAlarms.mm
 JSWebExtensionAPICommands.mm
@@ -388,7 +384,6 @@ WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/GPU/GPUProcessConnection.cpp
 WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
 WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp


### PR DESCRIPTION
#### 4e64b34dc5a6cc10db26b60feb2b86061927db02
<pre>
Adopt more smart pointers in GPUProcess related files
<a href="https://bugs.webkit.org/show_bug.cgi?id=281101">https://bugs.webkit.org/show_bug.cgi?id=281101</a>
<a href="https://rdar.apple.com/137553976">rdar://137553976</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::remoteGraphicsContextGLStreamWorkQueueSingleton):
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::remoteGraphicsContextGLStreamWorkQueue): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp:
(WebKit::ScopedWebGLRenderingResourcesRequest::scheduleFreeWebGLRenderingResources):
(WebKit::ScopedWebGLRenderingResourcesRequest::freeWebGLRenderingResources):
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
(WebKit::remoteGraphicsStreamWorkQueue):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::configureAudioStorage):
(WebKit::RemoteAudioSourceProviderProxy::newAudioSamples):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:
(WebKit::RemoteAudioSourceProviderProxy::protectedConnection const):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::GPUProcessConnection):
(WebKit::GPUProcessConnection::~GPUProcessConnection):
(WebKit::GPUProcessConnection::invalidate):
(WebKit::GPUProcessConnection::waitForDidInitialize):

Canonical link: <a href="https://commits.webkit.org/284909@main">https://commits.webkit.org/284909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94ee32c5cc20ff03071e171300fa8b60836cefbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23655 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21905 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73948 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61112 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42368 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76701 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18112 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61171 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15695 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5510 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46095 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->