### PR TITLE
[iOS] Add a (off-by-default) setting to make bidi text selections appear visually contiguous

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-expected.txt
@@ -1,0 +1,11 @@
+Arabic, مثل هذا النص, is right to left.
+
+This test verifies that the text selection appears visually contiguous when selecting across bidi text boundaries.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS isVisuallyContiguous is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+
+.start {
+    border: 1px solid tomato;
+    padding: 4px;
+}
+
+.stop {
+    border: 1px solid orange;
+    padding: 4px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that the text selection appears visually contiguous when selecting across bidi text boundaries.");
+
+    await UIHelper.longPressElement(document.querySelector(".start"));
+    await UIHelper.waitForSelectionToAppear();
+
+    const touchStart = UIHelper.midPointOfRect(await UIHelper.getSelectionStartGrabberViewRect());
+    const touchEnd = UIHelper.midPointOfRect(document.querySelector(".stop").getBoundingClientRect());
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(touchStart.x, touchStart.y)
+        .move(touchEnd.x, touchEnd.y, 0.5)
+        .takeResult());
+
+    isVisuallyContiguous = await UIHelper.isSelectionVisuallyContiguous();
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().end().takeResult());
+
+    shouldBeTrue("isVisuallyContiguous");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p>Arabic, <span class="stop">مثل</span> هذا النص, is right to <span class="start">left</span>.</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -982,6 +982,34 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async isSelectionVisuallyContiguous()
+    {
+        const rects = await this.getUISelectionViewRects();
+        if (!rects?.length)
+            return false;
+
+        rects.sort((a, b) => {
+            if (a.top < b.top)
+                return -1;
+            if (a.top > b.top)
+                return 1;
+            return a.left < b.left ? -1 : (a.left > b.left ? 1 : 0);
+        });
+
+        for (let i = 1; i < rects.length; ++i) {
+            const previousRect = rects[i - 1];
+            const rect = rects[i];
+
+            if (previousRect.top !== rect.top)
+                continue;
+
+            if (previousRect.left + previousRect.width < rect.left)
+                return false;
+        }
+
+        return true;
+    }
+
     static getSelectionStartGrabberViewRect()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7926,6 +7926,20 @@ VisualViewportEnabled:
     WebCore:
       default: true
 
+VisuallyContiguousBidiTextSelectionEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Visually Contiguous Bidi Selection"
+  humanReadableDescription: "Visually contiguous bidi selection"
+  conditional: PLATFORM(IOS_FAMILY)
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 VorbisDecoderEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/platform/ios/SelectionGeometry.cpp
+++ b/Source/WebCore/platform/ios/SelectionGeometry.cpp
@@ -62,7 +62,7 @@ SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBe
 {
 }
 
-SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBehavior behavior, TextDirection direction, int minX, int maxX, int maxY, int lineNumber, bool isLineBreak, bool isFirstOnLine, bool isLastOnLine, bool containsStart, bool containsEnd, bool isHorizontal)
+SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBehavior behavior, TextDirection direction, int minX, int maxX, int maxY, int lineNumber, bool isLineBreak, bool isFirstOnLine, bool isLastOnLine, bool containsStart, bool containsEnd, bool isHorizontal, bool mayAppearLogicallyDiscontiguous)
     : m_quad(quad)
     , m_behavior(behavior)
     , m_direction(direction)
@@ -76,6 +76,7 @@ SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBe
     , m_containsStart(containsStart)
     , m_containsEnd(containsEnd)
     , m_isHorizontal(isHorizontal)
+    , m_mayAppearLogicallyDiscontiguous(mayAppearLogicallyDiscontiguous)
 {
 }
 
@@ -172,6 +173,9 @@ TextStream& operator<<(TextStream& stream, const SelectionGeometry& rect)
 
     if (rect.behavior() == SelectionRenderingBehavior::UseIndividualQuads)
         stream.dumpProperty("using individual quads", true);
+
+    if (rect.mayAppearLogicallyDiscontiguous())
+        stream.dumpProperty("reverse bidi", true);
 
     stream.dumpProperty("page number", rect.pageNumber());
     return stream;

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -42,7 +42,7 @@ public:
 
     // FIXME: We should move some of these arguments to an auxillary struct.
     SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool, bool, int);
-    WEBCORE_EXPORT SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool);
+    WEBCORE_EXPORT SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool, bool /* mayAppearLogicallyDiscontiguous */);
     SelectionGeometry() = default;
     ~SelectionGeometry() = default;
 
@@ -71,6 +71,7 @@ public:
     bool isInFixedPosition() const { return m_isInFixedPosition; }
     int pageNumber() const { return m_pageNumber; }
     SelectionRenderingBehavior behavior() const { return m_behavior; }
+    bool mayAppearLogicallyDiscontiguous() const { return m_mayAppearLogicallyDiscontiguous; }
 
     void setLogicalLeft(int);
     void setLogicalWidth(int);
@@ -89,6 +90,7 @@ public:
     void setContainsEnd(bool containsEnd) { m_containsEnd = containsEnd; }
     void setIsHorizontal(bool isHorizontal) { m_isHorizontal = isHorizontal; }
     void setBehavior(SelectionRenderingBehavior behavior) { m_behavior = behavior; }
+    void setMayAppearLogicallyDiscontiguous(bool value) { m_mayAppearLogicallyDiscontiguous = value; }
 
 private:
     FloatQuad m_quad;
@@ -105,6 +107,7 @@ private:
     bool m_containsEnd { false };
     bool m_isHorizontal { true };
     bool m_isInFixedPosition { false };
+    bool m_mayAppearLogicallyDiscontiguous { false };
     int m_pageNumber { 0 };
 
     mutable std::optional<IntRect> m_cachedEnclosingRect;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1185,7 +1185,8 @@ private:
 #if PLATFORM(IOS_FAMILY)
     struct SelectionGeometries {
         Vector<SelectionGeometry> geometries;
-        int maxLineNumber;
+        int maxLineNumber { 0 };
+        bool hasAnyRightToLeftText { false };
     };
     WEBCORE_EXPORT static SelectionGeometries collectSelectionGeometriesInternal(const SimpleRange&);
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2525,6 +2525,7 @@ class WebCore::SelectionGeometry {
     bool containsStart();
     bool containsEnd();
     bool isHorizontal();
+    bool mayAppearLogicallyDiscontiguous();
 };
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
@@ -123,7 +123,10 @@
 
 - (NSWritingDirection)writingDirection
 {
-    return _selectionGeometry.direction() == WebCore::TextDirection::LTR ? NSWritingDirectionLeftToRight : NSWritingDirectionRightToLeft;
+    if (_selectionGeometry.direction() == WebCore::TextDirection::LTR || _selectionGeometry.mayAppearLogicallyDiscontiguous())
+        return NSWritingDirectionLeftToRight;
+
+    return NSWritingDirectionRightToLeft;
 }
 
 - (UITextRange *)range


### PR DESCRIPTION
#### fc02c970c4f7dd90289db2a822a60e38581556aa
<pre>
[iOS] Add a (off-by-default) setting to make bidi text selections appear visually contiguous
<a href="https://bugs.webkit.org/show_bug.cgi?id=281100">https://bugs.webkit.org/show_bug.cgi?id=281100</a>

Reviewed by Richard Robinson.

Adjust some iOS text selection codepaths to allow for visually-contiguous selection views (that
appear logically discontiguous); guard this new behavior behind a feature flag, which is off by
default. This is work towards implementing a more intuitive selection behaviors for bidi text, by
ensuring visual stability while the user is interacting with selection handles.

In a subsequent patch, we&apos;ll extend the selection to ensure both logical and visual contiguity after
the user is done selecting text.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection.html: Added.

Add a basic layout test to ensure that selection UI remains stable while the user is in the process
of selecting text.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add the new internal feature flag.

* Source/WebCore/platform/ios/SelectionGeometry.cpp:
(WebCore::SelectionGeometry::SelectionGeometry):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ios/SelectionGeometry.h:
(WebCore::SelectionGeometry::mayAppearLogicallyDiscontiguous const):
(WebCore::SelectionGeometry::setMayAppearLogicallyDiscontiguous):

Add a new boolean flag to indicate that the `SelectionGeometry` may have a logically discontiguous
appearance.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::areOnSameLine):
(WebCore::makeBidiSelectionVisuallyContiguousIfNeeded):

Implement the main heuristic to ensure visual contiguity here. At a high level, this post-processes
coalesced selection geometries such that:

-   Interior selection geometries (neither the start nor end) are unaltered.
-   Geometries that contain the start are all coalesced into a single selection that extends from
    the selection start caret rect, to the end of the line containing the start position.
-   Likewise, geometries that contain the end are coalesced into a selection that extends from the
    start of the line containing the end position, to the end caret rect.

If all of the selected text is left-to-right, we simply skip the steps above. For now, we also only
support horizontal bidi text (i.e. bail from this codepath if there are any vertical selections).

(WebCore::RenderObject::collectSelectionGeometriesInternal):
(WebCore::RenderObject::collectSelectionGeometries):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm:
(-[WKTextSelectionRect writingDirection]):

Canonical link: <a href="https://commits.webkit.org/284907@main">https://commits.webkit.org/284907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea7e39db714d54f5771088377e22733a52cf8487

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21878 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14554 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20406 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63987 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76682 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70106 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18094 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15693 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5490 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91887 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/839 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20027 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->