### PR TITLE
Web Inspector: add error cases to match new source map spec

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1616,6 +1616,7 @@ localizedStrings["Sort Descending"] = "Sort Descending";
 localizedStrings["Source"] = "Source";
 /* Title for Source row in Media Sidebar */
 localizedStrings["Source @ Media Sidebar"] = "Source";
+localizedStrings["Source Map \u0022%s\u0022 has %s"] = "Source Map \u0022%s\u0022 has %s";
 localizedStrings["Source Map loading errors"] = "Source Map loading errors";
 localizedStrings["Source Maps:"] = "Source Maps:";
 localizedStrings["Sources"] = "Sources";
@@ -2045,8 +2046,12 @@ localizedStrings["for changes to take effect"] = "for changes to take effect";
 localizedStrings["image @ Network Tab Resource Type Column Value"] = "image";
 localizedStrings["invalid HAR"] = "invalid HAR";
 localizedStrings["invalid JSON"] = "invalid JSON";
+/* Error message template when failing to parse a JS source map. */
+localizedStrings["invalid \u0022%s\u0022 @ Source Map"] = "invalid \u0022%s\u0022";
 localizedStrings["key"] = "key";
 localizedStrings["line "] = "line ";
+/* Error when a JS source map is missing a starting newline. */
+localizedStrings["missing newline @ Source Map"] = "missing newline";
 /* Placeholder text indicating that no directory has been selected. */
 localizedStrings["no directory selected @ Local Override Popover"] = "no directory selected";
 /* Placeholder text indicating that no file has been selected. */

--- a/Source/WebInspectorUI/UserInterface/Base/URLUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/URLUtilities.js
@@ -72,7 +72,7 @@ function parseSecurityOrigin(securityOrigin)
 
 function parseDataURL(url)
 {
-    if (!url.startsWith("data:"))
+    if (!url || !url.startsWith("data:"))
         return null;
 
     // data:[<media type>][;charset=<character set>][;base64],<data>
@@ -249,7 +249,7 @@ function parseQueryString(queryString, arrayResult)
 
 WI.displayNameForURL = function(url, urlComponents, options = {})
 {
-    if (url.startsWith("data:"))
+    if (url && url.startsWith("data:"))
         return WI.truncateURL(url);
 
     if (!urlComponents)
@@ -270,7 +270,7 @@ WI.displayNameForURL = function(url, urlComponents, options = {})
 
 WI.truncateURL = function(url, multiline = false, dataURIMaxSize = 6)
 {
-    if (!url.startsWith("data:"))
+    if (!url || !url.startsWith("data:"))
         return url;
 
     const dataIndex = url.indexOf(",") + 1;


### PR DESCRIPTION
#### 329e42fff238f8f575efeef32904cbb6d49ba9c3
<pre>
Web Inspector: add error cases to match new source map spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=281034">https://bugs.webkit.org/show_bug.cgi?id=281034</a>

Reviewed by Anne van Kesteren.

Spec: &lt;<a href="https://tc39.es/source-map/">https://tc39.es/source-map/</a>&gt;
Tests: &lt;<a href="https://github.com/tc39/source-map-tests">https://github.com/tc39/source-map-tests</a>&gt;

* Source/WebInspectorUI/UserInterface/Models/SourceMap.js:
(WI.SourceMap.prototype.calculateBlackboxSourceRangesForProtocol):
(WI.SourceMap.prototype._parseMappingPayload):
(WI.SourceMap.prototype._parseMap):
(WI.SourceMap.prototype._decodeVLQ):
(WI.SourceMap.prototype._invalidPropertyError): Added.
Add checks that each property is the right type/shape, as well as if linked propoties are valid (e.g. the indexes in `ignoreList` are keys in `sources`).
Reimplement the logic for parsing `mappings` and decoding VLQ values to more closely match the spec (e.g. the spec specifically handles VLQ integer overflow).

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.isSourceMapURL):
(WI.NetworkManager.prototype._loadAndParseSourceMap):
(WI.NetworkManager.prototype._sourceMapParseFailed): Added.
(WI.NetworkManager.prototype._sourceMapLoadAndParseFailed): Deleted.
Also include successfully loaded source map URLs when checking if a URL is a source map URL.
Drive-by: Show a console warning if the source map cannot be parsed.

* Source/WebInspectorUI/UserInterface/Base/URLUtilities.js:
(parseDataURL):
(WI.displayNameForURL):
(WI.truncateURL):
Drive-by: Don&apos;t assume that the given `url` is a string.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/285541@main">https://commits.webkit.org/285541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/522d0c802dbe78059b637ab505bca94d881c0b31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21976 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56024 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14494 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18452 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76587 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63703 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5421 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45987 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->