### PR TITLE
[JSC] add support for `Iterator.concat`

### DIFF
--- a/JSTests/stress/iterator-concat.js
+++ b/JSTests/stress/iterator-concat.js
@@ -1,0 +1,42 @@
+//@ requireOptions("--useIteratorHelpers=1", "--useIteratorSequencing=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
+shouldBeArray(Array.from(Iterator.concat([1, 2, 3, 4, 5, 6])), [1, 2, 3, 4, 5, 6]);
+shouldBeArray(Array.from(Iterator.concat([1, 2], [3, 4], [5, 6])), [1, 2, 3, 4, 5, 6]);
+shouldBeArray(Array.from(Iterator.concat([], [1], [], [2], [], [3], [], [4], [], [5], [], [6], [])), [1, 2, 3, 4, 5, 6]);
+
+const customIterable = {
+    [Symbol.iterator]() {
+        return [1, 2, 3][Symbol.iterator]();
+    },
+};
+shouldBeArray(Array.from(Iterator.concat(customIterable, ["abc"], customIterable)), [1, 2, 3, "abc", 1, 2, 3]);
+
+const nonIterableArray = [];
+nonIterableArray[Symbol.iterator] = undefined;
+
+for (let invalid of [undefined, null, false, true, 42, "abc", {}, nonIterableArray]) {
+    shouldThrow(() => {
+        Iterator.concat(invalid);
+    }, TypeError);
+}

--- a/Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js
@@ -51,7 +51,10 @@ function return()
     var state = @getGeneratorInternalField(generator, @generatorFieldState);
     if (state === @GeneratorStateInit) {
         @putGeneratorInternalField(generator, @generatorFieldState, @GeneratorStateCompleted);
-        @iteratorGenericClose(@getIteratorHelperInternalField(this, @iteratorHelperFieldUnderlyingIterator));
+
+        var underlyingIterator = @getIteratorHelperInternalField(this, @iteratorHelperFieldUnderlyingIterator);
+        if (underlyingIterator !== null)
+            @iteratorGenericClose(underlyingIterator);
 
         return { value: @undefined, done: true };
     }

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -56,6 +56,9 @@ void JSIteratorConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject,
     Base::finishCreation(vm, 0, vm.propertyNames->Iterator.string(), PropertyAdditionMode::WithoutStructureTransition);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, iteratorPrototype, static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->from, jsIteratorConstructorFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::useIteratorHelpers() && Options::useIteratorSequencing())
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), jsIteratorConstructorConcatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -587,6 +587,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorHelpers, false, Normal, "Expose the Iterator Helpers."_s) \
+    v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \


### PR DESCRIPTION
#### e2cc521c373c50c6048391237658c08a00973f35
<pre>
[JSC] add support for `Iterator.concat`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281109">https://bugs.webkit.org/show_bug.cgi?id=281109</a>

Reviewed by Alexey Shvayka.

This will allow for easier composition of iterators instead of having to manually create a generator or spread into an array.

Proposal: &lt;<a href="https://github.com/tc39/proposal-iterator-sequencing">https://github.com/tc39/proposal-iterator-sequencing</a>&gt;
Spec: &lt;<a href="https://tc39.es/proposal-iterator-sequencing/">https://tc39.es/proposal-iterator-sequencing/</a>&gt;

* Source/JavaScriptCore/builtins/JSIteratorConstructor.js:
(concat): Added.
* Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp:
(JSC::JSIteratorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:

* Source/JavaScriptCore/builtins/JSIteratorHelperPrototype.js:
(return):
Check if the `UnderlyingIterator` is null (in the case of `Iterator.concat`) before attempting to close it.

* JSTests/stress/iterator-concat.js: Added.

Canonical link: <a href="https://commits.webkit.org/285587@main">https://commits.webkit.org/285587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bffc693be31e682adf6fea8689853e6883514807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24392 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57490 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15963 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22721 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66289 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79036 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72411 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/53 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65918 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65200 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16116 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7199 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94190 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/433 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20713 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->