### PR TITLE
[JSC] add support for `Iterator.prototype.chunks` and `Iterator.prototype.windows`

### DIFF
--- a/JSTests/stress/iterator-prototype-chunks.js
+++ b/JSTests/stress/iterator-prototype-chunks.js
@@ -1,0 +1,171 @@
+//@ requireOptions("--useIteratorHelpers=1", "--useIteratorChunking=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function sameArray(a, b) {
+    sameValue(JSON.stringify(a), JSON.stringify(b));
+}
+
+function shouldThrow(fn, error, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+    }
+}
+
+{
+    class Iter extends Iterator {
+        i = 1;
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        }
+    }
+    const iter = new Iter();
+    const result = Array.from(iter.chunks(1));
+    sameArray(result, [[1], [2], [3], [4], [5]]);
+}
+
+{
+    const iter = {
+        i: 1,
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        },
+    };
+    const result = Array.from(Iterator.prototype.chunks.call(iter, 2));
+    sameArray(result, [[1, 2], [3, 4], [5]]);
+}
+
+{
+    let nextGetCount = 0;
+    class Iter extends Iterator {
+        get next() {
+            nextGetCount++;
+            let i = 1;
+            return function() {
+                if (i > 5)
+                    return { value: i, done: true }
+                return { value: i++, done: false }
+            }
+        };
+    };
+    const iter = new Iter();
+    sameValue(nextGetCount, 0);
+    const result = Array.from(iter.chunks(3));
+    sameValue(nextGetCount, 1);
+    sameArray(result, [[1, 2, 3], [4, 5]]);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+        yield 4;
+        yield 5;
+    }
+    const iter = gen();
+    const result = Array.from(iter.chunks(4));
+    sameArray(result, [[1, 2, 3, 4], [5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.chunks === Iterator.prototype.chunks);
+    const result = Array.from(iter.chunks(5));
+    sameArray(result, [[1, 2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.chunks === Iterator.prototype.chunks);
+    const result = Array.from(iter.chunks(6));
+    sameArray(result, [[1, 2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.chunks === Iterator.prototype.chunks);
+    const chunks = iter.chunks(2);
+    const result1 = chunks.next().value;
+    sameArray(result1, [1, 2]);
+    result1.pop();
+    sameArray(result1, [1]);
+    const result2 = chunks.next().value;
+    sameArray(result2, [3, 4]);
+    result2.pop();
+    sameArray(result2, [3]);
+    assert(result1 !== result2);
+    const result3 = chunks.next().value;
+    sameArray(result3, [5]);
+    result3.pop();
+    sameArray(result3, []);
+    assert(result2 !== result3);
+    assert(chunks.next().done);
+}
+
+{
+    const invalidIterators = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    for (const invalidIterator of invalidIterators) {
+        shouldThrow(function () {
+            Iterator.prototype.chunks.call(invalidIterator);
+        }, TypeError, "Iterator.prototype.chunks requires that |this| be an Object.");
+    }
+}
+
+{
+    const invalidChunkSizes = [
+        undefined,
+        "test",
+        {},
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidChunkSize of invalidChunkSizes) {
+        shouldThrow(function () {
+            Iterator.prototype.chunks.call(validIter, invalidChunkSize);
+        }, RangeError, "Iterator.prototype.chunks requires that argument not be NaN.");
+    }
+}
+
+{
+    const invalidChunkSizes = [
+        -1,
+        0,
+        2 ** 32,
+        null,
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidChunkSize of invalidChunkSizes) {
+        shouldThrow(function () {
+            Iterator.prototype.chunks.call(validIter, invalidChunkSize);
+        }, RangeError, "Iterator.prototype.chunks requires that argument be between 1 and 2**32 - 1.");
+    }
+}

--- a/JSTests/stress/iterator-prototype-windows.js
+++ b/JSTests/stress/iterator-prototype-windows.js
@@ -1,0 +1,176 @@
+//@ requireOptions("--useIteratorHelpers=1", "--useIteratorChunking=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function sameArray(a, b) {
+    sameValue(JSON.stringify(a), JSON.stringify(b));
+}
+
+function shouldThrow(fn, error, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+    }
+}
+
+{
+    class Iter extends Iterator {
+        i = 1;
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        }
+    }
+    const iter = new Iter();
+    const result = Array.from(iter.windows(1));
+    sameArray(result, [[1], [2], [3], [4], [5]]);
+}
+
+{
+    const iter = {
+        i: 1,
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        },
+    };
+    const result = Array.from(Iterator.prototype.windows.call(iter, 2));
+    sameArray(result, [[1, 2], [2, 3], [3, 4], [4, 5]]);
+}
+
+{
+    let nextGetCount = 0;
+    class Iter extends Iterator {
+        get next() {
+            nextGetCount++;
+            let i = 1;
+            return function() {
+                if (i > 5)
+                    return { value: i, done: true }
+                return { value: i++, done: false }
+            }
+        };
+    };
+    const iter = new Iter();
+    sameValue(nextGetCount, 0);
+    const result = Array.from(iter.windows(3));
+    sameValue(nextGetCount, 1);
+    sameArray(result, [[1, 2, 3], [2, 3, 4], [3, 4, 5]]);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+        yield 4;
+        yield 5;
+    }
+    const iter = gen();
+    const result = Array.from(iter.windows(4));
+    sameArray(result, [[1, 2, 3, 4], [2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.windows === Iterator.prototype.windows);
+    const result = Array.from(iter.windows(5));
+    sameArray(result, [[1, 2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.windows === Iterator.prototype.windows);
+    const result = Array.from(iter.windows(6));
+    sameArray(result, []);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.windows === Iterator.prototype.windows);
+    const windows = iter.windows(2);
+    const result1 = windows.next().value;
+    sameArray(result1, [1, 2]);
+    result1.pop();
+    sameArray(result1, [1]);
+    const result2 = windows.next().value;
+    sameArray(result2, [2, 3]);
+    result2.pop();
+    sameArray(result2, [2]);
+    assert(result1 !== result2);
+    const result3 = windows.next().value;
+    sameArray(result3, [3, 4]);
+    result3.pop();
+    sameArray(result3, [3]);
+    assert(result2 !== result3);
+    const result4 = windows.next().value;
+    sameArray(result4, [4, 5]);
+    result4.pop();
+    sameArray(result4, [4]);
+    assert(result3 !== result4);
+    assert(windows.next().done);
+}
+
+{
+    const invalidIterators = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    for (const invalidIterator of invalidIterators) {
+        shouldThrow(function () {
+            Iterator.prototype.windows.call(invalidIterator);
+        }, TypeError, "Iterator.prototype.windows requires that |this| be an Object.");
+    }
+}
+
+{
+    const invalidWindowSizes = [
+        undefined,
+        "test",
+        {},
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidWindowSize of invalidWindowSizes) {
+        shouldThrow(function () {
+            Iterator.prototype.windows.call(validIter, invalidWindowSize);
+        }, RangeError, "Iterator.prototype.windows requires that argument not be NaN.");
+    }
+}
+
+{
+    const invalidWindowSizes = [
+        -1,
+        0,
+        2 ** 32,
+        null,
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidWindowSize of invalidWindowSizes) {
+        shouldThrow(function () {
+            Iterator.prototype.windows.call(validIter, invalidWindowSize);
+        }, RangeError, "Iterator.prototype.windows requires that argument be between 1 and 2**32 - 1.");
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -84,6 +84,13 @@ void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
         // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatMapPublicName(), jsIteratorPrototypeFlatMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     }
+
+    if (Options::useIteratorChunking()) {
+        // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.chunks
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("chunks"_s, jsIteratorPrototypeChunksCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.windows
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("windows"_s, jsIteratorPrototypeWindowsCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
 }
 
 JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIterator, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -585,6 +585,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useAtomicsPause, true, Normal, "Expose Atomics.pause."_s) \
     v(Bool, useErrorIsError, false, Normal, "Expose Error.isError feature."_s) \
     v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
+    v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorHelpers, false, Normal, "Expose the Iterator Helpers."_s) \
     v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \


### PR DESCRIPTION
#### 6d98a9cf99d4e000702b64ca31e9f5eefd413e0f
<pre>
[JSC] add support for `Iterator.prototype.chunks` and `Iterator.prototype.windows`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281112">https://bugs.webkit.org/show_bug.cgi?id=281112</a>

Reviewed by Alexey Shvayka.

These will allow for alternative consumptions of iterators (e.g. batched processing, something like C++ `std::adjacent_difference`, etc.) instead of having to manually create a generator wrapper.

Proposal: &lt;<a href="https://github.com/tc39/proposal-iterator-chunking">https://github.com/tc39/proposal-iterator-chunking</a>&gt;
Spec: &lt;<a href="https://tc39.es/proposal-iterator-chunking/">https://tc39.es/proposal-iterator-chunking/</a>&gt;

* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(chunks): Added.
(windows): Added.
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSIteratorPrototype::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:

* JSTests/stress/iterator-prototype-chunks.js: Added.
* JSTests/stress/iterator-prototype-windows.js: Added.

Canonical link: <a href="https://commits.webkit.org/285240@main">https://commits.webkit.org/285240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30f399c48748b13d60a9f9695e86d8ac0b6becb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22196 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14623 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18629 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20537 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64115 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76811 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70240 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63878 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63839 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5581 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92021 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46204 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20058 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->