### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Remove exception from WebRTCMonitor and LibWebRTCSocket

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -45,7 +45,7 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCNetworkManager);
 
-LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExecutionContextIdentifier identifier)
+RefPtr<LibWebRTCNetworkManager> LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExecutionContextIdentifier identifier)
 {
     RefPtr document = Document::allDocumentsMap().get(identifier);
     if (!document)
@@ -65,7 +65,7 @@ LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExe
 void LibWebRTCNetworkManager::signalUsedInterface(WebCore::ScriptExecutionContextIdentifier contextIdentifier, String&& name)
 {
     callOnMainRunLoop([contextIdentifier, name = WTFMove(name).isolatedCopy()]() mutable {
-        if (auto* manager = LibWebRTCNetworkManager::getOrCreate(contextIdentifier))
+        if (RefPtr manager = LibWebRTCNetworkManager::getOrCreate(contextIdentifier))
             manager->signalUsedInterface(WTFMove(name));
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -39,8 +39,11 @@ namespace WebKit {
 class LibWebRTCNetworkManager final : public WebCore::RTCNetworkManager, public rtc::NetworkManagerBase, public webrtc::MdnsResponderInterface, public WebRTCMonitorObserver {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCNetworkManager);
 public:
-    static LibWebRTCNetworkManager* getOrCreate(WebCore::ScriptExecutionContextIdentifier);
+    static RefPtr<LibWebRTCNetworkManager> getOrCreate(WebCore::ScriptExecutionContextIdentifier);
     ~LibWebRTCNetworkManager();
+
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     void setEnumeratingAllNetworkInterfacesEnabled(bool);
     void setEnumeratingVisibleNetworkInterfacesEnabled(bool);

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -76,7 +76,7 @@ rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPee
     LibWebRTCCodecs::initializeIfNeeded();
 #endif
 
-    auto* networkManager = LibWebRTCNetworkManager::getOrCreate(identifier);
+    RefPtr networkManager = LibWebRTCNetworkManager::getOrCreate(identifier);
     if (!networkManager)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -29,25 +29,16 @@
 
 #include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 ALLOW_COMMA_BEGIN
 
 #include <webrtc/rtc_base/async_packet_socket.h>
 
 ALLOW_COMMA_END
-
-namespace WebKit {
-class LibWebRTCSocket;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::LibWebRTCSocket> : std::true_type { };
-}
 
 namespace IPC {
 class Connection;
@@ -58,8 +49,9 @@ namespace WebKit {
 
 class LibWebRTCSocketFactory;
 
-class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeWeakPtr<LibWebRTCSocket>, public Identified<WebCore::LibWebRTCSocketIdentifier> {
+class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeCheckedPtr<LibWebRTCSocket>, public Identified<WebCore::LibWebRTCSocketIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCSocket);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LibWebRTCSocket);
 public:
     enum class Type { UDP, ClientTCP, ServerConnectionTCP };
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -122,7 +122,7 @@ void LibWebRTCSocketFactory::removeSocket(LibWebRTCSocket& socket)
 void LibWebRTCSocketFactory::forSocketInGroup(ScriptExecutionContextIdentifier contextIdentifier, const Function<void(LibWebRTCSocket&)>& callback)
 {
     ASSERT(!WTF::isMainRunLoop());
-    for (auto& socket : m_sockets.values()) {
+    for (CheckedRef socket : m_sockets.values()) {
         if (socket->contextIdentifier() == contextIdentifier)
             callback(socket);
     }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -76,7 +76,7 @@ public:
 
 private:
     // We cannot own sockets, clients of the factory are responsible to free them.
-    HashMap<WebCore::LibWebRTCSocketIdentifier, WeakRef<LibWebRTCSocket>> m_sockets;
+    HashMap<WebCore::LibWebRTCSocketIdentifier, CheckedRef<LibWebRTCSocket>> m_sockets;
 
     HashMap<LibWebRTCResolverIdentifier, WeakRef<LibWebRTCResolver>> m_resolvers;
     bool m_disableNonLocalhostConnections { false };

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp
@@ -69,14 +69,14 @@ void WebRTCMonitor::networksChanged(Vector<RTCNetwork>&& networkList, RTCNetwork
     m_ipv4 = WTFMove(ipv4);
     m_ipv6 = WTFMove(ipv6);
 
-    for (auto& observer : m_observers)
-        observer.networksChanged(m_networkList, m_ipv4, m_ipv6);
+    for (Ref observer : m_observers)
+        observer->networksChanged(m_networkList, m_ipv4, m_ipv6);
 }
 
 void WebRTCMonitor::networkProcessCrashed()
 {
-    for (auto& observer : m_observers)
-        observer.networkProcessCrashed();
+    for (Ref observer : m_observers)
+        observer->networkProcessCrashed();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
@@ -32,15 +32,6 @@
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 
-namespace WebKit {
-class WebRTCMonitorObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebRTCMonitorObserver> : std::true_type { };
-}
-
 namespace IPC {
 class Connection;
 class Decoder;
@@ -53,6 +44,10 @@ struct NetworksChangedData;
 class WebRTCMonitorObserver : public CanMakeWeakPtr<WebRTCMonitorObserver> {
 public:
     virtual ~WebRTCMonitorObserver() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
     virtual void networksChanged(const Vector<RTCNetwork>&, const RTCNetwork::IPAddress&, const RTCNetwork::IPAddress&) = 0;
     virtual void networkProcessCrashed() = 0;
 };


### PR DESCRIPTION
#### 9e6935faed8654391f8d9d3d4ff78cef98a91bac
<pre>
[IsDeprecatedWeakRefSmartPointerException] Remove exception from WebRTCMonitor and LibWebRTCSocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=281115">https://bugs.webkit.org/show_bug.cgi?id=281115</a>
<a href="https://rdar.apple.com/137565108">rdar://137565108</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

We remove IsDeprecatedWeakRefSmartPointerException by making WebRTCMonitor ref-counted.

In the case of LibWebRTCSocket, we cannot make it ref-counted because
LibWebRTCSocketFactory::createUdpSocket and LibWebRTCSocketFactory::createClientTcpSocket
return a raw pointer of LibWebRTCSocket&apos;s base class type rtc::AsyncPacketSocket, which
could be destroyed--completely ignoring the ref-counting of LibWebRTCSocket. So we remove
the exception by making LibWebRTCSocket able to be a CheckedPtr.

* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::getOrCreate):
(WebKit::LibWebRTCNetworkManager::signalUsedInterface):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::createPeerConnection):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::forSocketInGroup):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.cpp:
(WebKit::WebRTCMonitor::networksChanged):
(WebKit::WebRTCMonitor::networkProcessCrashed):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h:

Canonical link: <a href="https://commits.webkit.org/285004@main">https://commits.webkit.org/285004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37ed0ed43bc29f02f55a870ec6195e82aed232bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71139 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22344 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42620 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63972 "Passed tests") | 
| | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63939 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/15880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5711 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92169 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10914 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1132 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/92169 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->