### PR TITLE
ApplePayEnabled set in WKPreferences is ignored

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -376,4 +376,21 @@ void PageConfiguration::setApplicationManifest(RefPtr<ApplicationManifest>&& app
 }
 #endif
 
+#if ENABLE(APPLE_PAY)
+
+bool PageConfiguration::applePayEnabled() const
+{
+    if (auto applePayEnabledOverride = m_data.applePayEnabledOverride)
+        return *applePayEnabledOverride;
+
+    return preferences().applePayEnabled();
+}
+
+void PageConfiguration::setApplePayEnabled(bool enabled)
+{
+    m_data.applePayEnabledOverride = enabled;
+}
+
+#endif
+
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -321,8 +321,8 @@ public:
 #endif
 
 #if ENABLE(APPLE_PAY)
-    bool applePayEnabled() const { return m_data.applePayEnabled; }
-    void setApplePayEnabled(bool enabled) { m_data.applePayEnabled = enabled; }
+    bool applePayEnabled() const;
+    void setApplePayEnabled(bool);
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)
@@ -599,7 +599,7 @@ private:
         WebCore::UserInterfaceDirectionPolicy userInterfaceDirectionPolicy { WebCore::UserInterfaceDirectionPolicy::Content };
 #endif
 #if ENABLE(APPLE_PAY)
-        bool applePayEnabled { DEFAULT_VALUE_FOR_ApplePayEnabled };
+        std::optional<bool> applePayEnabledOverride;
 #endif
 #if ENABLE(APP_HIGHLIGHTS)
         bool appHighlightsEnabled { DEFAULT_VALUE_FOR_AppHighlightsEnabled };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm
@@ -86,7 +86,6 @@ TEST(WKPreferencesPrivate, DisableRichJavaScriptFeatures)
     result = (NSString *)[getNextMessage() body];
     EXPECT_WK_STREQ(@"Web Audio Disabled", result.get());
 
-
     [webView evaluateJavaScript:@"log(window.RTCPeerConnection ? 'Web RTC Enabled' : 'Web RTC Disabled');" completionHandler:^(id, NSError *error) {
         EXPECT_NULL(error);
     }];
@@ -116,4 +115,10 @@ TEST(WKPreferencesPrivate, DisableRichJavaScriptFeatures)
     }];
     result = (NSString *)[getNextMessage() body];
     EXPECT_WK_STREQ(@"Geolocation Disabled", result.get());
+
+    [webView evaluateJavaScript:@"log(window.ApplePaySession ? 'ApplePay Enabled' : 'ApplePay Disabled');" completionHandler:^(id, NSError *error) {
+        EXPECT_NULL(error);
+    }];
+    result = (NSString *)[getNextMessage() body];
+    EXPECT_WK_STREQ(@"ApplePay Disabled", result.get());
 }


### PR DESCRIPTION
#### dc66f2d091a96e52e1c8984c87ffedbd3f3bd4a0
<pre>
ApplePayEnabled set in WKPreferences is ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=281117">https://bugs.webkit.org/show_bug.cgi?id=281117</a>
<a href="https://rdar.apple.com/problem/137565662">rdar://problem/137565662</a>

Reviewed by Ryosuke Niwa.

Both PageConfiguration and WebPreferences have data member ApplePayEnabled. In existing implementation, we always
override the WebPreferences value with PageConfiguration value (see [WKWebVeiw _setupPageConfiguration:withPool:]), i.e.
the actual ApplePayEnabled value being used is always the value in the PageConfiguration. However, it&apos;s possible that
client uses WKWebPreferences SPI to set ApplePayEnabled, where we should actually respect that value instead of the
default value in PageConfiguration.

To fix this, we change the ApplePayEnabled in PageConfiguration to be optional. If client sets the value using
WKWebViewConfiguration SPI, then we would respect this value; otherwise we would just use the value in WebPreferences
without overriding it.

Update API test WKPreferencesPrivate.DisableRichJavaScriptFeatures to cover Apple Pay JS API; the test would fail if we
don&apos;t make the change (as the flag value cannot be changed via WKWebPreferences SPI).

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::applePayEnabled const):
(API::PageConfiguration::setApplePayEnabled):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::applePayEnabled const): Deleted.
(API::PageConfiguration::setApplePayEnabled): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm:
(DisableRichJavaScriptFeatures)):

Canonical link: <a href="https://commits.webkit.org/284921@main">https://commits.webkit.org/284921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d57501bb681f61efddf03bb9cba7242a3af1f4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56041 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14508 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63776 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11798 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5444 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/791 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->