### PR TITLE
Remove IsDeprecatedWeakRefSmartPointerException from PrivateClickMeasurementDatabase

### DIFF
--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -85,6 +85,11 @@ static WeakHashSet<Database>& allDatabases()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Database);
 
+Ref<Database> Database::create(const String& storageDirectory)
+{
+    return adoptRef(*new Database(storageDirectory));
+}
+
 Database::Database(const String& storageDirectory)
     : DatabaseUtilities(FileSystem::pathByAppendingComponent(storageDirectory, "pcm.db"_s))
 {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
@@ -27,6 +27,7 @@
 
 #include "DatabaseUtilities.h"
 #include <WebCore/PrivateClickMeasurement.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -37,22 +38,18 @@ class Database;
 }
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PCM::Database> : std::true_type { };
-}
-
 namespace WebKit::PCM {
 
 struct DebugInfo;
 
 // This is created, used, and destroyed on the Store's queue.
-class Database : public DatabaseUtilities, public CanMakeWeakPtr<Database> {
+class Database : public DatabaseUtilities, public RefCountedAndCanMakeWeakPtr<Database> {
     WTF_MAKE_TZONE_ALLOCATED(Database);
 public:
-    Database(const String& storageDirectory);
+    static Ref<Database> create(const String& storageDirectory);
+
     virtual ~Database();
-    
+
     using ApplicationBundleIdentifier = String;
 
     static void interruptAllDatabases();
@@ -77,6 +74,7 @@ private:
     using SourceEarliestTimeToSend = double;
     using DestinationEarliestTimeToSend = double;
 
+    Database(const String& storageDirectory);
     bool createSchema() final;
     void destroyStatements() final;
     std::pair<std::optional<UnattributedPrivateClickMeasurement>, std::optional<AttributedPrivateClickMeasurement>> findPrivateClickMeasurement(const WebCore::PCM::SourceSite&, const WebCore::PCM::AttributionDestinationSite&, const ApplicationBundleIdentifier&);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
@@ -58,7 +58,7 @@ PersistentStore::PersistentStore(const String& databaseDirectory)
 {
     if (!databaseDirectory.isEmpty()) {
         postTask([this, protectedThis = Ref { *this }, databaseDirectory = databaseDirectory.isolatedCopy()] () mutable {
-            m_database = makeUnique<Database>(WTFMove(databaseDirectory));
+            m_database = Database::create(WTFMove(databaseDirectory));
         });
     }
 }
@@ -80,8 +80,8 @@ void PersistentStore::postTaskReply(WTF::Function<void()>&& reply) const
 void PersistentStore::insertPrivateClickMeasurement(WebCore::PrivateClickMeasurement&& attribution, PrivateClickMeasurementAttributionType attributionType, CompletionHandler<void()>&& completionHandler)
 {
     postTask([this, protectedThis = Ref { *this }, attribution = WTFMove(attribution), attributionType, completionHandler = WTFMove(completionHandler)] () mutable {
-        if (m_database)
-            m_database->insertPrivateClickMeasurement(WTFMove(attribution), attributionType);
+        if (RefPtr database = m_database)
+            database->insertPrivateClickMeasurement(WTFMove(attribution), attributionType);
         postTaskReply(WTFMove(completionHandler));
     });
 }
@@ -89,8 +89,8 @@ void PersistentStore::insertPrivateClickMeasurement(WebCore::PrivateClickMeasure
 void PersistentStore::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting()
 {
     postTask([this, protectedThis = Ref { *this }] {
-        if (m_database)
-            m_database->markAllUnattributedPrivateClickMeasurementAsExpiredForTesting();
+        if (RefPtr database = m_database)
+            database->markAllUnattributedPrivateClickMeasurementAsExpiredForTesting();
     });
 }
 
@@ -115,8 +115,8 @@ void PersistentStore::privateClickMeasurementToStringForTesting(CompletionHandle
 {
     postTask([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         String result;
-        if (m_database)
-            result = m_database->privateClickMeasurementToStringForTesting();
+        if (RefPtr database = m_database)
+            result = database->privateClickMeasurementToStringForTesting();
         postTaskReply([result = WTFMove(result).isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler(result);
         });
@@ -127,8 +127,8 @@ void PersistentStore::allAttributedPrivateClickMeasurement(CompletionHandler<voi
 {
     postTask([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         Vector<WebCore::PrivateClickMeasurement> convertedAttributions;
-        if (m_database)
-            convertedAttributions = m_database->allAttributedPrivateClickMeasurement();
+        if (RefPtr database = m_database)
+            convertedAttributions = database->allAttributedPrivateClickMeasurement();
         postTaskReply([convertedAttributions = crossThreadCopy(WTFMove(convertedAttributions)), completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler(WTFMove(convertedAttributions));
         });
@@ -138,8 +138,8 @@ void PersistentStore::allAttributedPrivateClickMeasurement(CompletionHandler<voi
 void PersistentStore::markAttributedPrivateClickMeasurementsAsExpiredForTesting(CompletionHandler<void()>&& completionHandler)
 {
     postTask([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
-        if (m_database)
-            m_database->markAttributedPrivateClickMeasurementsAsExpiredForTesting();
+        if (RefPtr database = m_database)
+            database->markAttributedPrivateClickMeasurementsAsExpiredForTesting();
         postTaskReply(WTFMove(completionHandler));
     });
 }
@@ -147,8 +147,8 @@ void PersistentStore::markAttributedPrivateClickMeasurementsAsExpiredForTesting(
 void PersistentStore::clearPrivateClickMeasurement(CompletionHandler<void()>&& completionHandler)
 {
     postTask([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] () mutable {
-        if (m_database)
-            m_database->clearPrivateClickMeasurement(std::nullopt);
+        if (RefPtr database = m_database)
+            database->clearPrivateClickMeasurement(std::nullopt);
         postTaskReply(WTFMove(completionHandler));
     });
 }
@@ -156,8 +156,8 @@ void PersistentStore::clearPrivateClickMeasurement(CompletionHandler<void()>&& c
 void PersistentStore::clearPrivateClickMeasurementForRegistrableDomain(WebCore::RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
     postTask([this, protectedThis = Ref { *this }, domain = WTFMove(domain).isolatedCopy(), completionHandler = WTFMove(completionHandler)] () mutable {
-        if (m_database)
-            m_database->clearPrivateClickMeasurement(domain);
+        if (RefPtr database = m_database)
+            database->clearPrivateClickMeasurement(domain);
         postTaskReply(WTFMove(completionHandler));
     });
 }
@@ -165,16 +165,16 @@ void PersistentStore::clearPrivateClickMeasurementForRegistrableDomain(WebCore::
 void PersistentStore::clearExpiredPrivateClickMeasurement()
 {
     postTask([this, protectedThis = Ref { *this }]() {
-        if (m_database)
-            m_database->clearExpiredPrivateClickMeasurement();
+        if (RefPtr database = m_database)
+            database->clearExpiredPrivateClickMeasurement();
     });
 }
 
 void PersistentStore::clearSentAttribution(WebCore::PrivateClickMeasurement&& attributionToClear, WebCore::PCM::AttributionReportEndpoint attributionReportEndpoint)
 {
     postTask([this, protectedThis = Ref { *this }, attributionToClear = WTFMove(attributionToClear).isolatedCopy(), attributionReportEndpoint]() mutable {
-        if (m_database)
-            m_database->clearSentAttribution(WTFMove(attributionToClear), attributionReportEndpoint);
+        if (RefPtr database = m_database)
+            database->clearSentAttribution(WTFMove(attributionToClear), attributionReportEndpoint);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h
@@ -71,7 +71,7 @@ private:
     void postTask(Function<void()>&&) const;
     void postTaskReply(Function<void()>&&) const;
 
-    std::unique_ptr<Database> m_database;
+    RefPtr<Database> m_database;
     Ref<SuspendableWorkQueue> m_queue;
 };
 


### PR DESCRIPTION
#### 4bc97626a57c131706340100e784b3cce224aa16
<pre>
Remove IsDeprecatedWeakRefSmartPointerException from PrivateClickMeasurementDatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=281125">https://bugs.webkit.org/show_bug.cgi?id=281125</a>

Reviewed by Geoffrey Garen.

Made PrivateClickMeasurementDatabase refcounted.

* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::create):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp:
(WebKit::PCM::PersistentStore::PersistentStore):
(WebKit::PCM::PersistentStore::insertPrivateClickMeasurement):
(WebKit::PCM::PersistentStore::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting):
(WebKit::PCM::PersistentStore::privateClickMeasurementToStringForTesting const):
(WebKit::PCM::PersistentStore::allAttributedPrivateClickMeasurement):
(WebKit::PCM::PersistentStore::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PCM::PersistentStore::clearPrivateClickMeasurement):
(WebKit::PCM::PersistentStore::clearPrivateClickMeasurementForRegistrableDomain):
(WebKit::PCM::PersistentStore::clearExpiredPrivateClickMeasurement):
(WebKit::PCM::PersistentStore::clearSentAttribution):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h:

Canonical link: <a href="https://commits.webkit.org/284918@main">https://commits.webkit.org/284918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adaa9b588f8ab5fb432ad8a5340f1f9951fa3e8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22088 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14571 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42372 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76702 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18114 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63786 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5512 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10874 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/871 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->