### PR TITLE
AudioSampleBufferCompressor and VideoSampleBufferCompressor are using sync dispatch

### DIFF
--- a/Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.h
@@ -26,19 +26,18 @@
 
 #if ENABLE(MEDIA_RECORDER) && USE(AVFOUNDATION)
 
-#import <CoreMedia/CoreMedia.h>
-#import <wtf/TZoneMalloc.h>
-#import <wtf/WorkQueue.h>
+#include <CoreMedia/CoreMedia.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WorkQueue.h>
 
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 typedef struct OpaqueAudioConverter* AudioConverterRef;
 
 namespace WebCore {
 
-class AudioSampleBufferCompressor {
-    WTF_MAKE_TZONE_ALLOCATED(AudioSampleBufferCompressor);
+class AudioSampleBufferCompressor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioSampleBufferCompressor, WTF::DestructionThread::Main> {
 public:
-    static std::unique_ptr<AudioSampleBufferCompressor> create(CMBufferQueueTriggerCallback, void* callbackObject);
+    static RefPtr<AudioSampleBufferCompressor> create(CMBufferQueueTriggerCallback, void* callbackObject);
     ~AudioSampleBufferCompressor();
 
     void setBitsPerSecond(unsigned);

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
@@ -122,11 +122,11 @@ private:
     CompletionHandler<void(RefPtr<FragmentedSharedBuffer>&&, double)> m_fetchDataCompletionHandler;
 
     RetainPtr<CMFormatDescriptionRef> m_audioFormatDescription;
-    std::unique_ptr<AudioSampleBufferCompressor> m_audioCompressor;
+    RefPtr<AudioSampleBufferCompressor> m_audioCompressor;
     RetainPtr<AVAssetWriterInput> m_audioAssetWriterInput;
 
     RetainPtr<CMFormatDescriptionRef> m_videoFormatDescription;
-    std::unique_ptr<VideoSampleBufferCompressor> m_videoCompressor;
+    RefPtr<VideoSampleBufferCompressor> m_videoCompressor;
     RetainPtr<AVAssetWriterInput> m_videoAssetWriterInput;
     CMTime m_lastVideoPresentationTime;
     CMTime m_lastVideoDecodingTime;

--- a/Source/WebCore/platform/mediarecorder/cocoa/VideoSampleBufferCompressor.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/VideoSampleBufferCompressor.h
@@ -28,7 +28,7 @@
 
 #include <CoreMedia/CoreMedia.h>
 #include <VideoToolbox/VTErrors.h>
-#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WorkQueue.h>
 
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
@@ -36,10 +36,9 @@ typedef struct OpaqueVTCompressionSession *VTCompressionSessionRef;
 
 namespace WebCore {
 
-class VideoSampleBufferCompressor {
-    WTF_MAKE_TZONE_ALLOCATED(VideoSampleBufferCompressor);
+class VideoSampleBufferCompressor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoSampleBufferCompressor, WTF::DestructionThread::Main> {
 public:
-    static std::unique_ptr<VideoSampleBufferCompressor> create(String mimeType, CMBufferQueueTriggerCallback, void* callbackObject);
+    static RefPtr<VideoSampleBufferCompressor> create(String mimeType, CMBufferQueueTriggerCallback, void* callbackObject);
     ~VideoSampleBufferCompressor();
 
     void setBitsPerSecond(unsigned);


### PR DESCRIPTION
#### f40822a656dc370b02a88bac25f1beb96ad9ad3f
<pre>
AudioSampleBufferCompressor and VideoSampleBufferCompressor are using sync dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=281107">https://bugs.webkit.org/show_bug.cgi?id=281107</a>
<a href="https://rdar.apple.com/137560529">rdar://137560529</a>

Reviewed by Youenn Fablet.

Dispatch frame to be compressed to the encoding WorkQueue asynchronously.
To safely do so, make both AudioSampleBufferCompressor and VideoSampleBufferCompressor
inheriting ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr

No change in observable behaviour, covered by existing tests.

* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.h:
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm:
(WebCore::AudioSampleBufferCompressor::create):
(WebCore::AudioSampleBufferCompressor::addSampleBuffer):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h:
* Source/WebCore/platform/mediarecorder/cocoa/VideoSampleBufferCompressor.h:
* Source/WebCore/platform/mediarecorder/cocoa/VideoSampleBufferCompressor.mm:
(WebCore::VideoSampleBufferCompressor::create):
(WebCore::VideoSampleBufferCompressor::addSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/284926@main">https://commits.webkit.org/284926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/974ff197b6ea8526725eb7793afb6e9f270059d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22047 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56062 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14537 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20389 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76661 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63808 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5480 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/829 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47130 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->