### PR TITLE
[scroll-animations] implement `ScrollTimeline.currentTime`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currentTime calculates the correct time for a document.scrollingElement source promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+PASS currentTime calculates the correct time for a document.scrollingElement source
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ScrollTimeline current time is updated after programmatic animated scroll. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+PASS ScrollTimeline current time is updated after programmatic animated scroll.
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -62,18 +62,19 @@ public:
     AnimationTimelinesController* controller() const override;
     static ScrollableArea* scrollableAreaForSourceRenderer(RenderElement*, Ref<Document>);
 
+    std::optional<CSSNumberishTime> currentTime() override;
+
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
 
-private:
     struct Data {
         float scrollOffset { 0 };
         float rangeStart { 0 };
         float rangeEnd { 0 };
     };
+    virtual Data computeTimelineData(const TimelineRange& = { }) const;
 
-    Data computeScrollTimelineData(const TimelineRange& = { }) const;
-
+private:
     enum class Scroller : uint8_t { Nearest, Root, Self };
 
     explicit ScrollTimeline(ScrollTimelineOptions&& = { });

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -217,7 +217,7 @@ RenderBox* ViewTimeline::sourceRenderer() const
     return subjectRenderer->enclosingScrollableContainer();
 }
 
-ViewTimeline::Data ViewTimeline::computeViewTimelineData(const TimelineRange& range) const
+ScrollTimeline::Data ViewTimeline::computeTimelineData(const TimelineRange& range) const
 {
     if (!m_subject)
         return { };
@@ -296,13 +296,13 @@ ViewTimeline::Data ViewTimeline::computeViewTimelineData(const TimelineRange& ra
 
 const CSSNumericValue& ViewTimeline::startOffset() const
 {
-    auto data = computeViewTimelineData();
+    auto data = computeTimelineData();
     return CSSNumericFactory::px(data.rangeStart);
 }
 
 const CSSNumericValue& ViewTimeline::endOffset() const
 {
-    auto data = computeViewTimelineData();
+    auto data = computeTimelineData();
     return CSSNumericFactory::px(data.rangeEnd);
 }
 

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -64,12 +64,7 @@ public:
     Element* source() const override;
 
 private:
-    struct Data {
-        float scrollOffset { 0 };
-        float rangeStart { 0 };
-        float rangeEnd { 0 };
-    };
-    Data computeViewTimelineData(const TimelineRange& = { }) const;
+    ScrollTimeline::Data computeTimelineData(const TimelineRange& = { }) const override;
 
     explicit ViewTimeline(ViewTimelineOptions&& = { });
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);


### PR DESCRIPTION
#### b1ed27f4948073a31795dc90b845554fda214420
<pre>
[scroll-animations] implement `ScrollTimeline.currentTime`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281126">https://bugs.webkit.org/show_bug.cgi?id=281126</a>
<a href="https://rdar.apple.com/137575125">rdar://137575125</a>

Reviewed by Anne van Kesteren.

The timeline data computation in `ScrollTimeline` and `ViewTimeline` yields identical data structures,
so we remove the `ViewTimeline::Data` structure in favor of just `ScrollTimeline::Data`. Then we compute
this data in the virtual method `ScrollTimeline::computeTimelineData()`.

The computed data is then used to compute the resulting `currentTime`.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting-expected.txt:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::computeTimelineData const):
(WebCore::ScrollTimeline::currentTime):
(WebCore::ScrollTimeline::computeScrollTimelineData const): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::computeTimelineData):
(WebCore::ScrollTimeline::computeScrollTimelineData): Deleted.
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::computeTimelineData const):
(WebCore::ViewTimeline::startOffset const):
(WebCore::ViewTimeline::endOffset const):
(WebCore::ViewTimeline::computeViewTimelineData const): Deleted.
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/284928@main">https://commits.webkit.org/284928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/396f3a192ecdd7ec04778b324724b68ee34a68af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50302 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23663 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21913 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36546 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18556 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18120 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63790 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5519 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10879 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/878 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47175 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->