### PR TITLE
[WPE] Improve buffer handling in HeadlessViewBackendFdo

### DIFF
--- a/Tools/wpe/backends/HeadlessViewBackend.h
+++ b/Tools/wpe/backends/HeadlessViewBackend.h
@@ -71,7 +71,6 @@ public:
 
 private:
     void updateSnapshot(PlatformBuffer);
-    void vsync();
 
 #if WPE_CHECK_VERSION(1, 11, 1)
     static bool onDOMFullScreenRequest(void* data, bool fullscreen);
@@ -88,7 +87,7 @@ private:
 #if defined(USE_GLIB) && USE_GLIB
     struct {
         GSource* source { nullptr };
-        bool pending { false };
+        gint64 lastFrameTime { 0 };
     } m_update;
 #endif
 


### PR DESCRIPTION
#### eceb208b3be3c86ff3becba4da4e08ca2a180ef6
<pre>
[WPE] Improve buffer handling in HeadlessViewBackendFdo
<a href="https://bugs.webkit.org/show_bug.cgi?id=281130">https://bugs.webkit.org/show_bug.cgi?id=281130</a>

Reviewed by Miguel Gomez.

It currently has a timer running every 16ms to check if there&apos;s any
pending buffer to process. Instead of having the timer running even when
there aren&apos;t pending buffers, we could start the timer only when a new
buffer is pending and process it after 16ms since the previous one.

* Tools/wpe/backends/HeadlessViewBackend.h:
* Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp:
(WPEToolingBackends::HeadlessViewBackend::HeadlessViewBackend):
(WPEToolingBackends::HeadlessViewBackend::vsync): Deleted.

Canonical link: <a href="https://commits.webkit.org/284961@main">https://commits.webkit.org/284961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25658c4f268a5e4fd4511c8d97bf99d481d382a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56161 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14637 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18664 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18212 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63857 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5606 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10896 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46244 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->