### PR TITLE
Implement caretPositionFromPoint()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6637,7 +6637,6 @@ imported/w3c/web-platform-tests/css/css-scroll-anchoring/reading-scroll-forces-a
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-variables/variable-reference-refresh.html [ Skip ]
-imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/api/abort/serviceworker-intercepted.https.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/preload-image-png-mislabeled-as-html-nosniff.tentative.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/script-html-correctly-labeled.tentative.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
@@ -107,20 +107,20 @@ PASS Screen interface: screen must inherit property "width" with the proper type
 PASS Screen interface: screen must inherit property "height" with the proper type
 PASS Screen interface: screen must inherit property "colorDepth" with the proper type
 PASS Screen interface: screen must inherit property "pixelDepth" with the proper type
-FAIL CaretPosition interface: existence and properties of interface object assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface object length assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface object name assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface: existence and properties of interface prototype object assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface: attribute offsetNode assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface: attribute offset assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition interface: operation getClientRect() assert_own_property: self does not have own property "CaretPosition" expected property "CaretPosition" missing
-FAIL CaretPosition must be primary interface of document.caretPositionFromPoint(5, 5) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(5, 5)', 'document.caretPositionFromPoint' is undefined)"
-FAIL Stringification of document.caretPositionFromPoint(5, 5) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(5, 5)', 'document.caretPositionFromPoint' is undefined)"
-FAIL CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "offsetNode" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(5, 5)', 'document.caretPositionFromPoint' is undefined)"
-FAIL CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "offset" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(5, 5)', 'document.caretPositionFromPoint' is undefined)"
-FAIL CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "getClientRect()" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(5, 5)', 'document.caretPositionFromPoint' is undefined)"
+PASS CaretPosition interface: existence and properties of interface object
+PASS CaretPosition interface object length
+PASS CaretPosition interface object name
+PASS CaretPosition interface: existence and properties of interface prototype object
+PASS CaretPosition interface: existence and properties of interface prototype object's "constructor" property
+PASS CaretPosition interface: existence and properties of interface prototype object's @@unscopables property
+PASS CaretPosition interface: attribute offsetNode
+PASS CaretPosition interface: attribute offset
+PASS CaretPosition interface: operation getClientRect()
+PASS CaretPosition must be primary interface of document.caretPositionFromPoint(5, 5)
+PASS Stringification of document.caretPositionFromPoint(5, 5)
+PASS CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "offsetNode" with the proper type
+PASS CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "offset" with the proper type
+PASS CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "getClientRect()" with the proper type
 FAIL CSSPseudoElement interface: operation getBoxQuads(optional BoxQuadOptions) assert_own_property: self does not have own property "CSSPseudoElement" expected property "CSSPseudoElement" missing
 FAIL CSSPseudoElement interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: self does not have own property "CSSPseudoElement" expected property "CSSPseudoElement" missing
 FAIL CSSPseudoElement interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: self does not have own property "CSSPseudoElement" expected property "CSSPseudoElement" missing
@@ -283,7 +283,7 @@ PASS Window interface: window must inherit property "outerHeight" with the prope
 PASS Window interface: window must inherit property "devicePixelRatio" with the proper type
 PASS Document interface: operation elementFromPoint(double, double)
 PASS Document interface: operation elementsFromPoint(double, double)
-FAIL Document interface: operation caretPositionFromPoint(double, double) assert_own_property: interface prototype object missing non-static operation expected property "caretPositionFromPoint" missing
+PASS Document interface: operation caretPositionFromPoint(double, double)
 PASS Document interface: attribute scrollingElement
 FAIL Document interface: operation getBoxQuads(optional BoxQuadOptions) assert_own_property: interface prototype object missing non-static operation expected property "getBoxQuads" missing
 FAIL Document interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertQuadFromNode" missing
@@ -293,8 +293,8 @@ PASS Document interface: document must inherit property "elementFromPoint(double
 PASS Document interface: calling elementFromPoint(double, double) on document with too few arguments must throw TypeError
 PASS Document interface: document must inherit property "elementsFromPoint(double, double)" with the proper type
 PASS Document interface: calling elementsFromPoint(double, double) on document with too few arguments must throw TypeError
-FAIL Document interface: document must inherit property "caretPositionFromPoint(double, double)" with the proper type assert_inherits: property "caretPositionFromPoint" not found in prototype chain
-FAIL Document interface: calling caretPositionFromPoint(double, double) on document with too few arguments must throw TypeError assert_inherits: property "caretPositionFromPoint" not found in prototype chain
+PASS Document interface: document must inherit property "caretPositionFromPoint(double, double)" with the proper type
+PASS Document interface: calling caretPositionFromPoint(double, double) on document with too few arguments must throw TypeError
 PASS Document interface: document must inherit property "scrollingElement" with the proper type
 FAIL Document interface: document must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type assert_inherits: property "getBoxQuads" not found in prototype chain
 FAIL Document interface: calling getBoxQuads(optional BoxQuadOptions) on document with too few arguments must throw TypeError assert_inherits: property "getBoxQuads" not found in prototype chain

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt
@@ -1,8 +1,8 @@
 aaa
 
 PASS document.caretPositionFromPoint() throws when called without the correct parameters
-FAIL document.caretPositionFromPoint() should return null for a document with no viewport doc.caretPositionFromPoint is not a function. (In 'doc.caretPositionFromPoint(0, 0)', 'doc.caretPositionFromPoint' is undefined)
-FAIL document.caretPositionFromPoint() should return null if given coordinates outside of the viewport document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(-5, 5)', 'document.caretPositionFromPoint' is undefined)
-FAIL document.caretPositionFromPoint() should return a CaretPosition at the specified location document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(x, y)', 'document.caretPositionFromPoint' is undefined)
-FAIL CaretRange.getClientRect() should return a DOMRect that matches one obtained from a manually constructed Range document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(x, y)', 'document.caretPositionFromPoint' is undefined)
+PASS document.caretPositionFromPoint() should return null for a document with no viewport
+PASS document.caretPositionFromPoint() should return null if given coordinates outside of the viewport
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location
+PASS CaretRange.getClientRect() should return a DOMRect that matches one obtained from a manually constructed Range
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation-expected.txt
@@ -1,21 +1,5 @@
-CONSOLE MESSAGE: TypeError: frameDoc.caretPositionFromPoint is not a function. (In 'frameDoc.caretPositionFromPoint(
-          ...elementCenter(frameDoc.querySelector("h1"))
-        )', 'frameDoc.caretPositionFromPoint' is undefined)
-CONSOLE MESSAGE: TypeError: frameDoc.caretPositionFromPoint is not a function. (In 'frameDoc.caretPositionFromPoint(
-          ...elementCenter(frameDoc.querySelector("h1"))
-        )', 'frameDoc.caretPositionFromPoint' is undefined)
 
 
 
-Harness Error (FAIL), message = TypeError: frameDoc.caretPositionFromPoint is not a function. (In 'frameDoc.caretPositionFromPoint(
-          ...elementCenter(frameDoc.querySelector("h1"))
-        )', 'frameDoc.caretPositionFromPoint' is undefined)
-
-TIMEOUT iframe's with equal content should report the same caret offset Test timed out
-
-Harness Error (FAIL), message = TypeError: frameDoc.caretPositionFromPoint is not a function. (In 'frameDoc.caretPositionFromPoint(
-          ...elementCenter(frameDoc.querySelector("h1"))
-        )', 'frameDoc.caretPositionFromPoint' is undefined)
-
-TIMEOUT iframe's with equal content should report the same caret offset Test timed out
+PASS iframe's with equal content should report the same caret offset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/Document-caretPositionFromPoint.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/Document-caretPositionFromPoint.tentative-expected.txt
@@ -1,0 +1,17 @@
+a
+b
+
+PASS document.caretPositionFromPoint() throws when called without the correct parameters
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to an input element which is the offsetNode.
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to a textarea element which is the offsetNode.
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to a closed shadaw tree when the shadow tree is specified as an argument
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location when the non-intersecting shadow tree is specified as an argument
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to an input element when the shadow tree is specified as an argument.
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the input element's shadow host's parent when the shadow tree is not specified as an argument.
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the shadow host's parent when the shadow tree is not specified as an argument
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the outer shadow host's parent when the point is in an inner shadow tree and no shadow tree is specified as an argument
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the inner shadow tree when the point is in an inner shadow tree and the inner shadow tree is specified as an argument
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the outer shadow tree when the point is in an inner shadow tree and the outer shadow tree is specified as an argument
+PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the inner shadow tree when the point is in an inner shadow tree and the inner shadow tree and the outer shadow tree are specified as an argument
+

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/Document-caretPositionFromPoint.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/Document-caretPositionFromPoint.tentative.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html>
+<body>
+<meta name="author" title="Siye Liu" href="mailto:siliu@microsoft.com">
+<meta name="assert" content="Document's caretPositionFromPoint should return a CaretPosition inside Shadow Root which is provided as argument.">
+<link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-document-caretpositionfrompoint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="container"></div>
+<script>
+
+test(() => {
+    assert_throws_js(TypeError, () => { document.caretPositionFromPoint(5, 5, "foo"); });
+    assert_throws_js(TypeError, () => { document.caretPositionFromPoint(5, 5, 6); });
+  }, "document.caretPositionFromPoint() throws when called without the correct parameters");
+
+test(() => {
+    container.setHTMLUnsafe(`<span>hello, world</span>`);
+    const rect = container.firstChild.getBoundingClientRect();
+    const characterWidth = rect.width / container.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `he|llo, world`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Text);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, container.firstChild.firstChild);
+    assert_equals(caretPosition.offset, characterIndex);
+}, "document.caretPositionFromPoint() should return a CaretPosition at the specified location");
+
+test(() => {
+    container.setHTMLUnsafe(`<input value='text inside input' />`);
+    const rect = container.firstChild.getBoundingClientRect();
+    // Get x and y coordinate at left-most location inside input element.
+    const x = rect.left + 1;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y);
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, container.firstChild);
+    assert_equals(caretPosition.offset, 0);
+}, "document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to an input element which is the offsetNode.");
+
+test(() => {
+    container.setHTMLUnsafe(`<textarea rows="2" cols="4">12345678901234567890</textarea>`);
+    const rect = container.firstChild.getBoundingClientRect();
+    // Get x and y coordinate at "1234|5678..."
+    const x = rect.left + 1;
+    const y = rect.top + rect.height * 0.75;
+    const caretPosition = document.caretPositionFromPoint(x, y);
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, container.firstChild);
+    assert_equals(caretPosition.offset, 4);
+}, "document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to a textarea element which is the offsetNode.");
+
+test(() => {
+    container.setHTMLUnsafe(`a<div id="host"></div>b`);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.setHTMLUnsafe(`<span>hello, world</span>`);
+    const rect = shadowRoot.firstChild.getBoundingClientRect();
+    const characterWidth = rect.width / shadowRoot.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `he|llo, world`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: [shadowRoot]});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Text);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, shadowRoot.firstChild.firstChild);
+    assert_equals(caretPosition.offset, characterIndex);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to a closed shadaw tree when the shadow tree is specified as an argument');
+
+test(() => {
+    container.setHTMLUnsafe(`
+        <span>abcd</span>
+        <div id="host">
+            <template shadowrootmode=open>
+                <span>hello, world</span>
+            </template>
+        </div>efg`);
+    const shadowRoot = host.shadowRoot;
+    const spanElement = document.querySelector("span");
+    const rect = spanElement.getBoundingClientRect();
+    const characterWidth = rect.width / spanElement.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `ab|cd`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: [shadowRoot]});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Text);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, spanElement.firstChild);
+    assert_equals(caretPosition.offset, characterIndex);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location when the non-intersecting shadow tree is specified as an argument');
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="host">
+            <template shadowrootmode=open>
+                <input value='text inside input' />
+            </template>
+        </div>efg`);
+    const shadowRoot = host.shadowRoot;
+    const shadowRootInputElement = shadowRoot.querySelector("input");
+    const rect = shadowRootInputElement.getBoundingClientRect();
+    // Get x and y coordinate at left-most location inside input element.
+    const x = rect.left + 1;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: [shadowRoot]});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, shadowRootInputElement);
+    assert_equals(caretPosition.offset, 0);
+}, "document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to an input element when the shadow tree is specified as an argument.");
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="host">
+            <template shadowrootmode=open>
+                <input value='text inside input' />
+            </template>
+        </div>efg`);
+    const shadowRoot = host.shadowRoot;
+    const shadowRootInputElement = shadowRoot.querySelector("input");
+    const rect = shadowRootInputElement.getBoundingClientRect();
+    // Get x and y coordinate at left-most location inside input element.
+    const x = rect.left + 1;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: []});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 1);
+}, "document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the input element's shadow host\'s parent when the shadow tree is not specified as an argument.");
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="host">
+            <template shadowrootmode=open>
+                <span>hello, world</span>
+            </template>
+        </div>b`);
+    const shadowRoot = host.shadowRoot;
+    const shadowRootSpanElement = shadowRoot.querySelector("span");
+    const rect = shadowRootSpanElement.getBoundingClientRect();
+    const characterWidth = rect.width / shadowRootSpanElement.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `he|llo, world`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y);
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 1);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the shadow host\'s parent when the shadow tree is not specified as an argument');
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="outerHost">
+            <template shadowrootmode=open>
+                <div id="innerHost">
+                    <template shadowrootmode=open>
+                        <span>some text</span>
+                    </template>
+                </div>
+                <div>world</div>
+            </template>
+        </div>b`);
+    const outerShadowRoot = outerHost.shadowRoot;
+    const innerShadowRoot = outerShadowRoot.getElementById('innerHost').shadowRoot;
+    const innerShadowRootSpanElement = innerShadowRoot.querySelector("span");
+    const rect = innerShadowRootSpanElement.getBoundingClientRect();
+    const characterWidth = rect.width / innerShadowRootSpanElement.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `so|me text`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y);
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 1);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the outer shadow host\'s parent when the point is in an inner shadow tree and no shadow tree is specified as an argument');
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="outerHost">
+            <template shadowrootmode=open>
+                <div id="innerHost">
+                    <template shadowrootmode=open>
+                        <span>some text</span>
+                    </template>
+                </div>
+                <div>world</div>
+            </template>
+        </div>b`);
+    const outerShadowRoot = outerHost.shadowRoot;
+    const innerShadowRoot = outerShadowRoot.getElementById('innerHost').shadowRoot;
+    const innerShadowRootSpanElement = innerShadowRoot.querySelector("span");
+    const rect = innerShadowRootSpanElement.getBoundingClientRect();
+    const characterWidth = rect.width / innerShadowRootSpanElement.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `so|me text`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: [innerShadowRoot]});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Text);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, innerShadowRootSpanElement.firstChild);
+    assert_equals(caretPosition.offset, characterIndex);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the inner shadow tree when the point is in an inner shadow tree and the inner shadow tree is specified as an argument');
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="outerHost">
+            <template shadowrootmode=open>
+                <div id="innerHost">
+                    <template shadowrootmode=open>
+                        <span>some text</span>
+                    </template>
+                </div>
+                <div>world</div>
+            </template>
+        </div>b`);
+    const outerShadowRoot = outerHost.shadowRoot;
+    const innerShadowRoot = outerShadowRoot.getElementById('innerHost').shadowRoot;
+    const innerShadowRootSpanElement = innerShadowRoot.querySelector("span");
+    const rect = innerShadowRootSpanElement.getBoundingClientRect();
+    const characterWidth = rect.width / innerShadowRootSpanElement.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `so|me text`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: [outerShadowRoot]});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Node);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, outerShadowRoot);
+    assert_equals(caretPosition.offset, 1);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the outer shadow tree when the point is in an inner shadow tree and the outer shadow tree is specified as an argument');
+
+test(() => {
+    container.setHTMLUnsafe(`
+        a<div id="outerHost">
+            <template shadowrootmode=open>
+                <div id="innerHost">
+                    <template shadowrootmode=open>
+                        <span>some text</span>
+                    </template>
+                </div>
+                <div>world</div>
+            </template>
+        </div>b`);
+
+    const outerShadowRoot = outerHost.shadowRoot;
+    const innerShadowRoot = outerShadowRoot.getElementById('innerHost').shadowRoot;
+    const innerShadowRootSpanElement = innerShadowRoot.querySelector("span");
+    const rect = innerShadowRootSpanElement.getBoundingClientRect();
+    const characterWidth = rect.width / innerShadowRootSpanElement.textContent.length;
+    const characterIndex = 2
+    // Get x and y coordinate at `so|me text`.
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y, {shadowRoots: [innerShadowRoot, outerShadowRoot]});
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Text);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, innerShadowRootSpanElement.firstChild);
+    assert_equals(caretPosition.offset, characterIndex);
+}, 'document.caretPositionFromPoint() should return a CaretPosition at the specified location pointing to the inner shadow tree when the point is in an inner shadow tree and the inner shadow tree and the outer shadow tree are specified as an argument');
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1886,6 +1886,20 @@ CaretBrowsingEnabled:
     WebCore:
       default: false
 
+CaretPositionFromPointEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "document.caretPositionFromPoint() API"
+  humanReadableDescription: "Enable document.caretPositionFromPoint() API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ChildProcessDebuggabilityEnabled:
   comment: Disables GPU process IPC timeouts
   type: bool

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1063,6 +1063,8 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/BeforeUnloadEvent.idl
     dom/BroadcastChannel.idl
     dom/CDATASection.idl
+    dom/CaretPosition.idl
+    dom/CaretPositionFromPointOptions.idl
     dom/CharacterData.idl
     dom/CheckVisibilityOptions.idl
     dom/ChildNode.idl
@@ -1097,6 +1099,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/DeviceOrientationEvent.idl
     dom/DeviceOrientationOrMotionPermissionState.idl
     dom/Document+CSSOMView.idl
+    dom/Document+CaretPositionFromPoint.idl
     dom/Document+Fullscreen.idl
     dom/Document+HTML.idl
     dom/Document+HTMLObsolete.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1384,6 +1384,8 @@ $(PROJECT_DIR)/dom/Attr.idl
 $(PROJECT_DIR)/dom/BeforeUnloadEvent.idl
 $(PROJECT_DIR)/dom/BroadcastChannel.idl
 $(PROJECT_DIR)/dom/CDATASection.idl
+$(PROJECT_DIR)/dom/CaretPosition.idl
+$(PROJECT_DIR)/dom/CaretPositionFromPointOptions.idl
 $(PROJECT_DIR)/dom/CharacterData.idl
 $(PROJECT_DIR)/dom/CheckVisibilityOptions.idl
 $(PROJECT_DIR)/dom/ChildNode.idl
@@ -1418,6 +1420,7 @@ $(PROJECT_DIR)/dom/DeviceMotionEvent.idl
 $(PROJECT_DIR)/dom/DeviceOrientationEvent.idl
 $(PROJECT_DIR)/dom/DeviceOrientationOrMotionEvent.idl
 $(PROJECT_DIR)/dom/DeviceOrientationOrMotionPermissionState.idl
+$(PROJECT_DIR)/dom/Document+CaretPositionFromPoint.idl
 $(PROJECT_DIR)/dom/Document+CSSOMView.idl
 $(PROJECT_DIR)/dom/Document+Fullscreen.idl
 $(PROJECT_DIR)/dom/Document+HTML.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -577,6 +577,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasTransform.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasTransform.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasUserInterface.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasUserInterface.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPosition.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPosition.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPositionFromPointOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCaretPositionFromPointOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChannelCountMode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChannelCountMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChannelInterpretation.cpp
@@ -869,6 +873,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+CSSOMView.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+CSSOMView.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+CaretPositionFromPoint.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+CaretPositionFromPoint.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+Fullscreen.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+Fullscreen.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+HTML.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1081,6 +1081,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/BeforeUnloadEvent.idl \
     $(WebCore)/dom/BroadcastChannel.idl \
     $(WebCore)/dom/CDATASection.idl \
+    $(WebCore)/dom/CaretPositionFromPointOptions.idl \
+    $(WebCore)/dom/CaretPosition.idl \
     $(WebCore)/dom/CharacterData.idl \
     $(WebCore)/dom/CheckVisibilityOptions.idl \
     $(WebCore)/dom/ChildNode.idl \
@@ -1117,6 +1119,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/DeviceOrientationOrMotionPermissionState.idl \
     $(WebCore)/dom/Document.idl \
     $(WebCore)/dom/Document+CSSOMView.idl \
+    $(WebCore)/dom/Document+CaretPositionFromPoint.idl \
     $(WebCore)/dom/Document+Fullscreen.idl \
     $(WebCore)/dom/Document+HTML.idl \
     $(WebCore)/dom/Document+HTMLObsolete.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -992,6 +992,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/BroadcastChannelRegistry.h
     dom/CDATASection.h
     dom/CallbackResult.h
+    dom/CaretPosition.h
     dom/CharacterData.h
     dom/CheckVisibilityOptions.h
     dom/CollectionIndexCache.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1187,6 +1187,7 @@ dom/BeforeUnloadEvent.cpp
 dom/BoundaryPoint.cpp
 dom/BroadcastChannel.cpp
 dom/CDATASection.cpp
+dom/CaretPosition.cpp
 dom/CharacterData.cpp
 dom/ChildListMutationScope.cpp
 dom/ChildNodeList.cpp
@@ -3565,6 +3566,8 @@ JSCanvasTextBaseline.cpp
 JSCanvasTextDrawingStyles.cpp
 JSCanvasTransform.cpp
 JSCanvasUserInterface.cpp
+JSCaretPosition.cpp
+JSCaretPositionFromPointOptions.cpp
 JSChannelCountMode.cpp
 JSChannelInterpretation.cpp
 JSChannelMergerNode.cpp

--- a/Source/WebCore/dom/CaretPosition.cpp
+++ b/Source/WebCore/dom/CaretPosition.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CaretPosition.h"
+
+#include "DOMRect.h"
+#include "Range.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CaretPosition);
+
+CaretPosition::CaretPosition(RefPtr<Node>&& offsetNode, unsigned offset)
+    : m_offsetNode(WTFMove(offsetNode))
+    , m_offset(offset)
+{
+}
+
+RefPtr<DOMRect> CaretPosition::getClientRect()
+{
+    if (!m_offsetNode)
+        return nullptr;
+
+    return Range::boundingClientRect(SimpleRange { BoundaryPoint { *m_offsetNode, m_offset }, BoundaryPoint { *m_offsetNode, m_offset } });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CaretPosition.h
+++ b/Source/WebCore/dom/CaretPosition.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScriptWrappable.h"
+
+namespace WebCore {
+
+class DOMRect;
+class Node;
+
+class CaretPosition : public ScriptWrappable, public RefCounted<CaretPosition> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(CaretPosition, WEBCORE_EXPORT);
+public:
+    static Ref<CaretPosition> create(RefPtr<Node>&& offsetNode, unsigned offset) { return adoptRef(*new CaretPosition(WTFMove(offsetNode), offset)); }
+
+    RefPtr<Node> offsetNode() const { return m_offsetNode; }
+    unsigned offset() const { return m_offset; }
+
+    RefPtr<DOMRect> getClientRect();
+
+private:
+    CaretPosition(RefPtr<Node>&& offsetNode, unsigned offset);
+
+    RefPtr<Node> m_offsetNode;
+    unsigned m_offset;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CaretPosition.idl
+++ b/Source/WebCore/dom/CaretPosition.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ExportMacro=WEBCORE_EXPORT,
+    Exposed=(Window),
+    TaggedWrapper,
+] interface CaretPosition {
+    readonly attribute Node offsetNode;
+    readonly attribute unsigned long offset;
+    [NewObject] DOMRect? getClientRect();
+};

--- a/Source/WebCore/dom/CaretPositionFromPointOptions.h
+++ b/Source/WebCore/dom/CaretPositionFromPointOptions.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ShadowRoot.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct CaretPositionFromPointOptions {
+    Vector<Ref<ShadowRoot>> shadowRoots;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CaretPositionFromPointOptions.idl
+++ b/Source/WebCore/dom/CaretPositionFromPointOptions.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary CaretPositionFromPointOptions {
+    sequence<ShadowRoot> shadowRoots = [];
+};

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -29,6 +29,7 @@
 #include "DeviceMotionData.h"
 #include "DeviceOrientationAndMotionAccessController.h"
 #include "JSDOMPromiseDeferred.h"
+#include "LocalDOMWindow.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/dom/Document+CaretPositionFromPoint.idl
+++ b/Source/WebCore/dom/Document+CaretPositionFromPoint.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface
+partial interface Document {
+    [EnabledBySetting=CaretPositionFromPointEnabled] CaretPosition? caretPositionFromPoint(double x, double y, optional CaretPositionFromPointOptions options = {});
+};

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -107,6 +107,7 @@ class CachedResourceLoader;
 class CachedScript;
 class CanvasRenderingContext;
 class CanvasRenderingContext2D;
+class CaretPosition;
 class CharacterData;
 class Comment;
 class ConstantPropertyMap;
@@ -273,6 +274,7 @@ class DOMTimerHoldingTank;
 struct ApplicationManifest;
 struct BoundaryPoint;
 struct CSSParserContext;
+struct CaretPositionFromPointOptions;
 struct ClientOrigin;
 struct FocusOptions;
 struct IntersectionObserverData;
@@ -527,6 +529,7 @@ public:
 
     WEBCORE_EXPORT RefPtr<Range> caretRangeFromPoint(int x, int y, HitTestSource = HitTestSource::Script);
     std::optional<BoundaryPoint> caretPositionFromPoint(const LayoutPoint& clientPoint, HitTestSource);
+    RefPtr<CaretPosition> caretPositionFromPoint(double x, double y, CaretPositionFromPointOptions);
 
     WEBCORE_EXPORT Element* scrollingElementForAPI();
     WEBCORE_EXPORT Element* scrollingElement();

--- a/Source/WebCore/dom/DocumentOrShadowRoot.idl
+++ b/Source/WebCore/dom/DocumentOrShadowRoot.idl
@@ -36,5 +36,4 @@ interface mixin DocumentOrShadowRoot {
     // We should get this resolved in the CSSOM spec and move these to the correct IDL files.
     Element? elementFromPoint(double x, double y);
     sequence<Element> elementsFromPoint(double x, double y);
-    // CaretPosition? caretPositionFromPoint(double x, double y); // FIXME: Implement this.
 };

--- a/Source/WebCore/dom/InternalObserver.cpp
+++ b/Source/WebCore/dom/InternalObserver.cpp
@@ -28,8 +28,9 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "JSDOMExceptionHandling.h"
+#include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/JSCJSValue.h>
-#include <JavaScriptCore/JSGlobalObjectInlines.h>
+#include <JavaScriptCore/JSGlobalObject.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -1108,8 +1108,13 @@ Ref<DOMRectList> Range::getClientRects() const
 
 Ref<DOMRect> Range::getBoundingClientRect() const
 {
-    startContainer().protectedDocument()->updateLayout();
-    return DOMRect::create(unionRectIgnoringZeroRects(RenderObject::clientBorderAndTextRects(makeSimpleRange(*this))));
+    return boundingClientRect(makeSimpleRange(*this));
+}
+
+Ref<DOMRect> Range::boundingClientRect(const SimpleRange& simpleRange)
+{
+    simpleRange.startContainer().protectedDocument()->updateLayout();
+    return DOMRect::create(unionRectIgnoringZeroRects(RenderObject::clientBorderAndTextRects(simpleRange)));
 }
 
 static void setBothEndpoints(Range& range, const SimpleRange& value)

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -90,6 +90,7 @@ public:
 
     Ref<DOMRectList> getClientRects() const;
     Ref<DOMRect> getBoundingClientRect() const;
+    static Ref<DOMRect> boundingClientRect(const SimpleRange&);
 
     WEBCORE_EXPORT ExceptionOr<Ref<DocumentFragment>> createContextualFragment(std::variant<RefPtr<TrustedHTML>, String>&& fragment);
 


### PR DESCRIPTION
#### 129140715fbb75dd8c82cf598f622c98deee56ba
<pre>
Implement caretPositionFromPoint()
<a href="https://bugs.webkit.org/show_bug.cgi?id=172137">https://bugs.webkit.org/show_bug.cgi?id=172137</a>

Reviewed by Darin Adler.

Implement Document.caretPositionFromPoint() based on the latest draft:
<a href="https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint">https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint</a>

The feature depends on the runtime flag CaretPositionFromPointEnabled, disabled by default.

This PR imports shadow-dom/Document-caretPositionFromPoint.tentative.html to test
the shadowRoots argument.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/Document-caretPositionFromPoint.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/Document-caretPositionFromPoint.tentative.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/CaretPosition.cpp: Copied from Source/WebCore/dom/InternalObserver.cpp.
(WebCore::CaretPosition::CaretPosition):
(WebCore::CaretPosition::getClientRect):
* Source/WebCore/dom/CaretPosition.h: Copied from Source/WebCore/dom/InternalObserver.cpp.
(WebCore::CaretPosition::create):
(WebCore::CaretPosition::offsetNode const):
(WebCore::CaretPosition::offset const):
* Source/WebCore/dom/CaretPosition.idl: Copied from Source/WebCore/dom/InternalObserver.cpp.
* Source/WebCore/dom/CaretPositionFromPointOptions.h: Copied from Source/WebCore/dom/InternalObserver.cpp.
* Source/WebCore/dom/CaretPositionFromPointOptions.idl: Copied from Source/WebCore/dom/InternalObserver.cpp.
* Source/WebCore/dom/DeviceMotionEvent.cpp:
* Source/WebCore/dom/Document+CaretPositionFromPoint.idl: Copied from Source/WebCore/dom/InternalObserver.cpp.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::caretPositionFromPoint):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentOrShadowRoot.idl:
* Source/WebCore/dom/InternalObserver.cpp:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::getBoundingClientRect const):
(WebCore::Range::getBoundingClientRect):
* Source/WebCore/dom/Range.h:

Canonical link: <a href="https://commits.webkit.org/287047@main">https://commits.webkit.org/287047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c072d0f1aad6701b4617220569f80fc994563629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82741 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61154 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27686 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71229 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84102 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77321 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5452 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3682 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69375 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68629 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10839 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99634 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8153 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21770 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->