### PR TITLE
[CoordinatedGraphics] Rename Nicosia::Buffer as CoordinatedTileBuffer

### DIFF
--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -45,8 +45,8 @@
 #include <wtf/linux/CurrentProcessMemoryStatus.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
-#if USE(NICOSIA)
-#include "NicosiaBuffer.h"
+#if USE(COORDINATED_GRAPHICS)
+#include "CoordinatedTileBuffer.h"
 #endif
 
 namespace WebCore {
@@ -109,8 +109,8 @@ void ResourceUsageThread::platformSaveStateBeforeStarting()
             m_samplingProfilerThreadID = thread->id();
     }
 #endif
-#if USE(NICOSIA)
-    Nicosia::Buffer::resetMemoryUsage();
+#if USE(COORDINATED_GRAPHICS)
+    CoordinatedTileBuffer::resetMemoryUsage();
 #endif
 }
 
@@ -326,8 +326,8 @@ void ResourceUsageThread::platformCollectMemoryData(JSC::VM* vm, ResourceUsageDa
     });
     data.categories[MemoryCategory::Images].dirtySize = imagesDecodedSize;
 
-#if USE(NICOSIA)
-    data.categories[MemoryCategory::Layers].dirtySize = Nicosia::Buffer::getMemoryUsage();
+#if USE(COORDINATED_GRAPHICS)
+    data.categories[MemoryCategory::Layers].dirtySize = CoordinatedTileBuffer::getMemoryUsage();
 #endif
 
     size_t categoriesTotalSize = 0;

--- a/Source/WebCore/platform/SourcesNicosia.txt
+++ b/Source/WebCore/platform/SourcesNicosia.txt
@@ -34,7 +34,6 @@ page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
 
 platform/graphics/nicosia/NicosiaAnimation.cpp
 platform/graphics/nicosia/NicosiaBackingStore.cpp
-platform/graphics/nicosia/NicosiaBuffer.cpp
 platform/graphics/nicosia/NicosiaScene.cpp
 platform/graphics/nicosia/NicosiaSceneIntegration.cpp
 

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -55,6 +55,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+        platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -64,6 +65,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
         platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+        platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
     )
 
     if (USE_GSTREAMER)
@@ -124,7 +126,6 @@ if (USE_NICOSIA)
         platform/graphics/nicosia/NicosiaAnimatedBackingStoreClient.h
         platform/graphics/nicosia/NicosiaAnimation.h
         platform/graphics/nicosia/NicosiaBackingStore.h
-        platform/graphics/nicosia/NicosiaBuffer.h
         platform/graphics/nicosia/NicosiaCompositionLayer.h
         platform/graphics/nicosia/NicosiaPlatformLayer.h
         platform/graphics/nicosia/NicosiaScene.h

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
@@ -52,7 +52,7 @@ void BackingStore::createTile(uint32_t tileID, float scale)
     update.tilesToCreate.append({ tileID, scale });
 }
 
-void BackingStore::updateTile(uint32_t tileID, const WebCore::IntRect& updateRect, const WebCore::IntRect& tileRect, Ref<Buffer>&& buffer)
+void BackingStore::updateTile(uint32_t tileID, const WebCore::IntRect& updateRect, const WebCore::IntRect& tileRect, Ref<WebCore::CoordinatedTileBuffer>&& buffer)
 {
     ASSERT(m_layerState.isFlushing);
     auto& update = m_layerState.update;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
@@ -31,6 +31,7 @@
 #include "CoordinatedBackingStore.h"
 #include "CoordinatedBackingStoreProxy.h"
 #include "CoordinatedBackingStoreProxyClient.h"
+#include "CoordinatedTileBuffer.h"
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -61,7 +62,7 @@ public:
             uint32_t tileID;
             WebCore::IntRect updateRect;
             WebCore::IntRect tileRect;
-            Ref<Buffer> buffer;
+            Ref<WebCore::CoordinatedTileBuffer> buffer;
         };
         Vector<UpdateData> tilesToUpdate;
 
@@ -110,7 +111,7 @@ public:
     // FIXME: Move these to private once updateTile() is not called from CoordinatedGrahpicsLayer.
     void tiledBackingStoreHasPendingTileCreation() override;
     void createTile(uint32_t, float) override;
-    void updateTile(uint32_t, const WebCore::IntRect&, const WebCore::IntRect&, Ref<Buffer>&&) override;
+    void updateTile(uint32_t, const WebCore::IntRect&, const WebCore::IntRect&, Ref<WebCore::CoordinatedTileBuffer>&&) override;
     void removeTile(uint32_t) override;
 
 private:

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.cpp
@@ -46,7 +46,7 @@ using ForRecordingClass = PaintingContextCairo::ForRecording;
 #endif
 
 
-std::unique_ptr<PaintingContext> PaintingContext::createForPainting(Buffer& buffer)
+std::unique_ptr<PaintingContext> PaintingContext::createForPainting(WebCore::CoordinatedTileBuffer& buffer)
 {
     return std::unique_ptr<PaintingContext>(new ForPaintingClass(buffer));
 }

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.h
@@ -33,18 +33,17 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class CoordinatedTileBuffer;
 class GraphicsContext;
 }
 
 namespace Nicosia {
 
-class Buffer;
-
 class PaintingContext {
     WTF_MAKE_TZONE_ALLOCATED(PaintingContext);
 public:
     template<typename T>
-    static void paint(Buffer& buffer, const T& paintFunctor)
+    static void paint(WebCore::CoordinatedTileBuffer& buffer, const T& paintFunctor)
     {
         auto paintingContext = PaintingContext::createForPainting(buffer);
         paintFunctor(paintingContext->graphicsContext());
@@ -57,7 +56,7 @@ public:
         recordFunctor(recordingContext->graphicsContext());
     }
 
-    static void replay(Buffer& buffer, const PaintingOperations& paintingOperations)
+    static void replay(WebCore::CoordinatedTileBuffer& buffer, const PaintingOperations& paintingOperations)
     {
         auto paintingContext = PaintingContext::createForPainting(buffer);
         paintingContext->replay(paintingOperations);
@@ -70,7 +69,7 @@ protected:
     virtual void replay(const PaintingOperations&) = 0;
 
 private:
-    static std::unique_ptr<PaintingContext> createForPainting(Buffer&);
+    static std::unique_ptr<PaintingContext> createForPainting(WebCore::CoordinatedTileBuffer&);
     static std::unique_ptr<PaintingContext> createForRecording(PaintingOperations&);
 };
 

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.h
@@ -33,13 +33,12 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class CoordinatedTileBuffer;
 class GraphicsLayer;
 class IntRect;
 }
 
 namespace Nicosia {
-
-class Buffer;
 
 class PaintingEngine {
     WTF_MAKE_TZONE_ALLOCATED(PaintingEngine);
@@ -48,7 +47,7 @@ public:
 
     virtual ~PaintingEngine() = default;
 
-    virtual void paint(WebCore::GraphicsLayer&, Buffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) = 0;
+    virtual void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) = 0;
 };
 
 } /// namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.cpp
@@ -29,9 +29,9 @@
 #include "config.h"
 #include "NicosiaPaintingEngineBasic.h"
 
+#include "CoordinatedTileBuffer.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
-#include "NicosiaBuffer.h"
 #include "NicosiaPaintingContext.h"
 
 namespace Nicosia {
@@ -41,7 +41,7 @@ using namespace WebCore;
 PaintingEngineBasic::PaintingEngineBasic() = default;
 PaintingEngineBasic::~PaintingEngineBasic() = default;
 
-void PaintingEngineBasic::paint(GraphicsLayer& layer, Buffer& buffer, const IntRect& sourceRect, const IntRect& mappedSourceRect, const IntRect& targetRect, float contentsScale)
+void PaintingEngineBasic::paint(GraphicsLayer& layer, CoordinatedTileBuffer& buffer, const IntRect& sourceRect, const IntRect& mappedSourceRect, const IntRect& targetRect, float contentsScale)
 {
     buffer.beginPainting();
 

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.h
@@ -38,7 +38,7 @@ public:
     virtual ~PaintingEngineBasic();
 
 private:
-    void paint(WebCore::GraphicsLayer&, Buffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
+    void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
 };
 
 } // namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.cpp
@@ -31,9 +31,9 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
+#include "CoordinatedTileBuffer.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
-#include "NicosiaBuffer.h"
 #include "NicosiaPaintingContext.h"
 
 namespace Nicosia {
@@ -68,7 +68,7 @@ PaintingEngineThreaded::~PaintingEngineThreaded()
 {
 }
 
-void PaintingEngineThreaded::paint(GraphicsLayer& layer, Buffer& buffer, const IntRect& sourceRect, const IntRect& mappedSourceRect, const IntRect& targetRect, float contentsScale)
+void PaintingEngineThreaded::paint(GraphicsLayer& layer, CoordinatedTileBuffer& buffer, const IntRect& sourceRect, const IntRect& mappedSourceRect, const IntRect& targetRect, float contentsScale)
 {
     buffer.beginPainting();
 

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.h
@@ -41,7 +41,7 @@ public:
     virtual ~PaintingEngineThreaded();
 
 private:
-    void paint(WebCore::GraphicsLayer&, Buffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
+    void paint(WebCore::GraphicsLayer&, WebCore::CoordinatedTileBuffer&, const WebCore::IntRect&, const WebCore::IntRect&, const WebCore::IntRect&, float) override;
 
     Ref<WorkerPool> m_workerPool;
 };

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.cpp
@@ -31,9 +31,9 @@
 
 #if USE(CAIRO)
 
+#include "CoordinatedTileBuffer.h"
 #include "GraphicsContext.h"
 #include "GraphicsContextCairo.h"
-#include "NicosiaBuffer.h"
 #include "NicosiaCairoOperationRecorder.h"
 #include "NicosiaPaintingOperationReplayCairo.h"
 #include "RefPtrCairo.h"
@@ -42,10 +42,10 @@
 
 namespace Nicosia {
 
-PaintingContextCairo::ForPainting::ForPainting(Buffer& baseBuffer)
+PaintingContextCairo::ForPainting::ForPainting(WebCore::CoordinatedTileBuffer& baseBuffer)
 {
     // All buffers used for painting with Cairo are unaccelerated.
-    auto& buffer = static_cast<UnacceleratedBuffer&>(baseBuffer);
+    auto& buffer = static_cast<WebCore::CoordinatedUnacceleratedTileBuffer&>(baseBuffer);
 
     // Balanced by the deref in the s_bufferKey user data destroy callback.
     buffer.ref();
@@ -55,12 +55,12 @@ PaintingContextCairo::ForPainting::ForPainting(Buffer& baseBuffer)
 
     static cairo_user_data_key_t s_bufferKey;
     cairo_surface_set_user_data(m_surface.get(), &s_bufferKey,
-        new std::pair<Buffer*, ForPainting*> { &buffer, this },
+        new std::pair<WebCore::CoordinatedTileBuffer*, ForPainting*> { &buffer, this },
         [](void* data)
         {
-            auto* userData = static_cast<std::pair<Buffer*, ForPainting*>*>(data);
+            auto* userData = static_cast<std::pair<WebCore::CoordinatedTileBuffer*, ForPainting*>*>(data);
 
-            // Deref the Buffer object.
+            // Deref the CoordinatedTileBuffer object.
             userData->first->deref();
 #if ASSERT_ENABLED
             // Mark the deletion of the cairo_surface_t object associated with this

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.h
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.h
@@ -47,7 +47,7 @@ class PaintingContextCairo final {
 public:
     class ForPainting final : public PaintingContext {
     public:
-        explicit ForPainting(Buffer&);
+        explicit ForPainting(WebCore::CoordinatedTileBuffer&);
         virtual ~ForPainting();
 
     private:

--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
@@ -28,6 +28,7 @@
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include "CoordinatedGraphicsLayer.h"
+#include "CoordinatedTileBuffer.h"
 #include "DisplayListRecorderImpl.h"
 #include "GraphicsContextSkia.h"
 #include <wtf/NumberOfCores.h>
@@ -59,7 +60,7 @@ std::unique_ptr<DisplayList::DisplayList> SkiaThreadedPaintingPool::recordDispla
     return displayList;
 }
 
-void SkiaThreadedPaintingPool::postPaintingTask(Ref<Nicosia::Buffer>& buffer, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect)
+void SkiaThreadedPaintingPool::postPaintingTask(Ref<CoordinatedTileBuffer>& buffer, const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect)
 {
     WTFBeginSignpost(this, RecordTile);
     auto displayList = recordDisplayList(layer, dirtyRect);

--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h
@@ -26,14 +26,13 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
-#include "NicosiaBuffer.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WorkerPool.h>
 
 namespace WebCore {
-
 class CoordinatedGraphicsLayer;
+class CoordinatedTileBuffer;
 class IntRect;
 
 namespace DisplayList {
@@ -49,7 +48,7 @@ public:
 
     static std::unique_ptr<SkiaThreadedPaintingPool> create();
 
-    void postPaintingTask(Ref<Nicosia::Buffer>&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect);
+    void postPaintingTask(Ref<CoordinatedTileBuffer>&, const CoordinatedGraphicsLayer&, const IntRect& dirtyRect);
 
 private:
     std::unique_ptr<DisplayList::DisplayList> recordDisplayList(const CoordinatedGraphicsLayer&, const IntRect& dirtyRect) const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -21,8 +21,8 @@
 #include "CoordinatedBackingStore.h"
 
 #if USE(COORDINATED_GRAPHICS)
-
 #include "BitmapTexture.h"
+#include "CoordinatedTileBuffer.h"
 #include "GraphicsLayer.h"
 #include "TextureMapper.h"
 #include <wtf/SystemTracing.h>
@@ -74,7 +74,7 @@ void CoordinatedBackingStoreTile::swapBuffers(TextureMapper& textureMapper)
 #if USE(SKIA)
         if (update.buffer->isBackedByOpenGL()) {
             WTFBeginSignpost(this, CopyTextureGPUToGPU);
-            auto& buffer = static_cast<Nicosia::AcceleratedBuffer&>(*update.buffer);
+            auto& buffer = static_cast<CoordinatedAcceleratedTileBuffer&>(*update.buffer);
 
             // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
             if (update.sourceRect.size() == update.tileRect.size()) {
@@ -92,7 +92,7 @@ void CoordinatedBackingStoreTile::swapBuffers(TextureMapper& textureMapper)
 
         WTFBeginSignpost(this, CopyTextureCPUToGPU);
         ASSERT(!update.buffer->isBackedByOpenGL());
-        auto& buffer = static_cast<Nicosia::UnacceleratedBuffer&>(*update.buffer);
+        auto& buffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(*update.buffer);
         m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride(), buffer.pixelFormat());
         update.buffer = nullptr;
         WTFEndSignpost(this, CopyTextureCPUToGPU);
@@ -115,7 +115,7 @@ void CoordinatedBackingStore::removeTile(uint32_t id)
     m_tiles.remove(id);
 }
 
-void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect, const IntRect& tileRect, RefPtr<Nicosia::Buffer>&& buffer, const IntPoint& offset)
+void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect, const IntRect& tileRect, RefPtr<CoordinatedTileBuffer>&& buffer, const IntPoint& offset)
 {
     auto it = m_tiles.find(id);
     ASSERT(it != m_tiles.end());

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -20,9 +20,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
-
 #include "IntRect.h"
-#include "NicosiaBuffer.h"
 #include "TextureMapperBackingStore.h"
 #include "TextureMapperTile.h"
 #include <wtf/HashMap.h>
@@ -31,7 +29,7 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
-
+class CoordinatedTileBuffer;
 class TextureMapper;
 
 class CoordinatedBackingStoreTile final : public TextureMapperTile {
@@ -46,7 +44,7 @@ public:
     float scale() const { return m_scale; }
 
     struct Update {
-        RefPtr<Nicosia::Buffer> buffer;
+        RefPtr<CoordinatedTileBuffer> buffer;
         IntRect sourceRect;
         IntRect tileRect;
         IntPoint bufferOffset;
@@ -72,7 +70,7 @@ public:
 
     void createTile(uint32_t tileID, float scale);
     void removeTile(uint32_t tileID);
-    void updateTile(uint32_t tileID, const IntRect&, const IntRect&, RefPtr<Nicosia::Buffer>&&, const IntPoint&);
+    void updateTile(uint32_t tileID, const IntRect&, const IntRect&, RefPtr<CoordinatedTileBuffer>&&, const IntPoint&);
 
     void swapBuffers(TextureMapper&);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h
@@ -21,12 +21,8 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
-namespace Nicosia {
-class Buffer;
-}
-
 namespace WebCore {
-
+class CoordinatedTileBuffer;
 class GraphicsContext;
 class SurfaceUpdateInfo;
 
@@ -36,7 +32,7 @@ public:
     virtual void tiledBackingStoreHasPendingTileCreation() = 0;
 
     virtual void createTile(uint32_t tileID, float) = 0;
-    virtual void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<Nicosia::Buffer>&&) = 0;
+    virtual void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&) = 0;
     virtual void removeTile(uint32_t tileID) = 0;
 };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -28,6 +28,7 @@
 
 #include "CoordinatedBackingStoreProxy.h"
 #include "CoordinatedImageBackingStore.h"
+#include "CoordinatedTileBuffer.h"
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -29,7 +29,6 @@
 #include "IntSize.h"
 #include "NicosiaAnimatedBackingStoreClient.h"
 #include "NicosiaAnimation.h"
-#include "NicosiaBuffer.h"
 #include "NicosiaCompositionLayer.h"
 #include "NicosiaPlatformLayer.h"
 #include "TransformationMatrix.h"
@@ -55,6 +54,7 @@ class PaintingEngine;
 namespace WebCore {
 class CoordinatedGraphicsLayer;
 class CoordinatedImageBackingStore;
+class CoordinatedTileBuffer;
 class TextureMapperPlatformLayerProxy;
 
 class CoordinatedGraphicsLayerClient {
@@ -215,7 +215,7 @@ private:
     bool checkPendingStateChanges();
     bool checkContentLayerUpdated();
 
-    Ref<Nicosia::Buffer> paintTile(const IntRect& dirtyRect);
+    Ref<CoordinatedTileBuffer> paintTile(const IntRect& dirtyRect);
 
     void notifyFlushRequired();
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
@@ -21,6 +21,7 @@
 #include "CoordinatedGraphicsLayer.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(CAIRO)
+#include "CoordinatedTileBuffer.h"
 #include "FloatRect.h"
 #include "GraphicsContext.h"
 #include "NicosiaPaintingContext.h"
@@ -28,13 +29,13 @@
 
 namespace WebCore {
 
-Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& dirtyRect)
+Ref<CoordinatedTileBuffer> CoordinatedGraphicsLayer::paintTile(const IntRect& dirtyRect)
 {
     auto scale = effectiveContentsScale();
     FloatRect scaledDirtyRect(dirtyRect);
     scaledDirtyRect.scale(1 / scale);
 
-    auto buffer = Nicosia::UnacceleratedBuffer::create(dirtyRect.size(), contentsOpaque() ? Nicosia::Buffer::NoFlags : Nicosia::Buffer::SupportsAlpha);
+    auto buffer = CoordinatedUnacceleratedTileBuffer::create(dirtyRect.size(), contentsOpaque() ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
     m_coordinator->paintingEngine().paint(*this, buffer.get(), dirtyRect, enclosingIntRect(scaledDirtyRect), IntRect { { }, dirtyRect.size() }, scale);
     return buffer;
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -27,7 +27,6 @@
 #include <WebCore/CoordinatedBackingStore.h>
 #include <WebCore/CoordinatedPlatformLayerBuffer.h>
 #include <WebCore/NicosiaBackingStore.h>
-#include <WebCore/NicosiaBuffer.h>
 #include <WebCore/NicosiaCompositionLayer.h>
 #include <WebCore/NicosiaScene.h>
 #include <WebCore/TextureMapperLayer.h>

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
@@ -35,10 +35,6 @@
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/Vector.h>
 
-namespace Nicosia {
-class Buffer;
-}
-
 namespace WebCore {
 class CoordinatedBackingStore;
 }


### PR DESCRIPTION
#### 983852874ac67f4a539dbd1f3079fa0f513637ba
<pre>
[CoordinatedGraphics] Rename Nicosia::Buffer as CoordinatedTileBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=281135">https://bugs.webkit.org/show_bug.cgi?id=281135</a>

Reviewed by Alejandro G. Castro.

* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::ResourceUsageThread::platformSaveStateBeforeStarting):
(WebCore::ResourceUsageThread::platformCollectMemoryData):
* Source/WebCore/platform/SourcesNicosia.txt:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp:
(Nicosia::BackingStore::updateTile):
* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingContext.h:
(Nicosia::PaintingContext::paint):
(Nicosia::PaintingContext::replay):
* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.cpp:
(Nicosia::PaintingEngineBasic::paint):
* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineBasic.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.cpp:
(Nicosia::PaintingEngineThreaded::paint):
* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngineThreaded.h:
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.cpp:
(Nicosia::PaintingContextCairo::ForPainting::ForPainting):
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.h:
* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp:
(WebCore::SkiaThreadedPaintingPool::postPaintingTask):
* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStoreTile::swapBuffers):
(WebCore::CoordinatedBackingStore::updateTile):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxyClient.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp.
(WebCore::CoordinatedTileBuffer::resetMemoryUsage):
(WebCore::CoordinatedTileBuffer::getMemoryUsage):
(WebCore::CoordinatedTileBuffer::canvas):
(WebCore::CoordinatedUnacceleratedTileBuffer::create):
(WebCore::CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer):
(WebCore::CoordinatedUnacceleratedTileBuffer::pixelFormat const):
(WebCore::CoordinatedUnacceleratedTileBuffer::~CoordinatedUnacceleratedTileBuffer):
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface):
(WebCore::CoordinatedUnacceleratedTileBuffer::beginPainting):
(WebCore::CoordinatedUnacceleratedTileBuffer::completePainting):
(WebCore::CoordinatedUnacceleratedTileBuffer::waitUntilPaintingComplete):
(WebCore::CoordinatedAcceleratedTileBuffer::create):
(WebCore::CoordinatedAcceleratedTileBuffer::CoordinatedAcceleratedTileBuffer):
(WebCore::CoordinatedAcceleratedTileBuffer::~CoordinatedAcceleratedTileBuffer):
(WebCore::CoordinatedAcceleratedTileBuffer::size const):
(WebCore::CoordinatedAcceleratedTileBuffer::tryEnsureSurface):
(WebCore::CoordinatedAcceleratedTileBuffer::completePainting):
(WebCore::CoordinatedAcceleratedTileBuffer::waitUntilPaintingComplete):
(WebCore::CoordinatedTileBuffer::CoordinatedTileBuffer):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h: Renamed from Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h.
(WebCore::CoordinatedTileBuffer::supportsAlpha const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h:

Canonical link: <a href="https://commits.webkit.org/284965@main">https://commits.webkit.org/284965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9a048bc853efa77ba9904e18fd9f87c198fc4f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56063 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14538 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18516 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76662 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63889 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63754 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5482 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10897 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/830 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->