### PR TITLE
[Cocoa] voice activity detection does not work when changing of capturing device

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -168,6 +168,9 @@ void BaseAudioSharedUnit::prepareForNewCapture()
 void BaseAudioSharedUnit::setCaptureDevice(String&& persistentID, uint32_t captureDeviceID)
 {
     bool hasChanged = this->persistentID() != persistentID || this->captureDeviceID() != captureDeviceID;
+    if (hasChanged)
+        willChangeCaptureDevice();
+
     m_capturingDevice = { WTFMove(persistentID), captureDeviceID };
 
     auto devices = RealtimeMediaSourceCenter::singleton().audioCaptureFactory().audioCaptureDeviceManager().captureDevices();
@@ -352,6 +355,8 @@ void BaseAudioSharedUnit::voiceActivityDetected()
 {
     if (m_voiceActivityThrottleTimer.isActive() || !m_voiceActivityCallback)
         return;
+
+    RELEASE_LOG_INFO(WebRTC, "BaseAudioSharedUnit::voiceActivityDetected");
 
     m_voiceActivityCallback();
     m_voiceActivityThrottleTimer.startOneShot(voiceActivityThrottlingDuration);

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -138,6 +138,8 @@ private:
     OSStatus startUnit();
     bool shouldContinueRunning() const { return m_producingCount || m_isRenderingAudio || hasClients(); }
 
+    virtual void willChangeCaptureDevice() { };
+
     // RealtimeMediaSourceCenterObserver
     void devicesChanged() final;
     void deviceWillBeRemoved(const String&) final { }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -230,7 +230,7 @@ CoreAudioSharedUnit::CoreAudioSharedUnit()
 
 CoreAudioSharedUnit::~CoreAudioSharedUnit()
 {
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
     setMuteStatusChangedCallback({ });
 }
 
@@ -265,6 +265,7 @@ void CoreAudioSharedUnit::captureDeviceChanged()
 #else
     AVAudioSessionCaptureDeviceManager::singleton().setPreferredAudioSessionDeviceUID(persistentID());
 #endif
+    updateVoiceActivityDetection();
 }
 
 size_t CoreAudioSharedUnit::preferredIOBufferSize()
@@ -565,7 +566,7 @@ void CoreAudioSharedUnit::cleanupAudioUnit()
         m_ioUnitInitialized = false;
     }
 
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
     m_ioUnit = nullptr;
 
     m_microphoneSampleBuffer = nullptr;
@@ -651,7 +652,7 @@ OSStatus CoreAudioSharedUnit::startInternal()
     m_microphoneProcsCalled = 0;
     m_microphoneProcsCalledLastTime = 0;
 
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
     updateMutedState();
 
     return noErr;
@@ -660,7 +661,7 @@ OSStatus CoreAudioSharedUnit::startInternal()
 void CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged()
 {
     updateMutedState();
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
 
     if (!isProducingData())
         return;
@@ -778,7 +779,7 @@ void CoreAudioSharedUnit::stopInternal()
 #if PLATFORM(IOS_FAMILY)
     setIsInBackground(false);
 #endif
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
 }
 
 void CoreAudioSharedUnit::registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
@@ -823,13 +824,13 @@ bool CoreAudioSharedUnit::shouldEnableVoiceActivityDetection() const
         && m_ioUnitStarted;
 }
 
-void CoreAudioSharedUnit::updateVoiceActiveDetection()
+void CoreAudioSharedUnit::updateVoiceActivityDetection(bool shouldDisableVoiceActivityDetection)
 {
     if (!m_ioUnit)
         return;
 
     if (m_voiceActivityDetectionEnabled) {
-        if (shouldEnableVoiceActivityDetection())
+        if (shouldEnableVoiceActivityDetection() && !shouldDisableVoiceActivityDetection)
             return;
         if (m_ioUnit->setVoiceActivityDetection(false))
             m_voiceActivityDetectionEnabled = false;
@@ -845,19 +846,28 @@ void CoreAudioSharedUnit::updateVoiceActiveDetection()
 void CoreAudioSharedUnit::enableMutedSpeechActivityEventListener(Function<void()>&& callback)
 {
     setVoiceActivityListenerCallback(WTFMove(callback));
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
 }
 
 void CoreAudioSharedUnit::disableMutedSpeechActivityEventListener()
 {
     setVoiceActivityListenerCallback({ });
-    updateVoiceActiveDetection();
+    updateVoiceActivityDetection();
 }
 
 void CoreAudioSharedUnit::handleMuteStatusChangedNotification(bool isMuting)
 {
     if (m_muteStatusChangedCallback && isMuting == isProducingMicrophoneSamples())
         m_muteStatusChangedCallback(isMuting);
+}
+
+void CoreAudioSharedUnit::willChangeCaptureDevice()
+{
+    if (!m_voiceActivityDetectionEnabled)
+        return;
+
+    bool shouldDisableVoiceActivityDetection = true;
+    updateVoiceActivityDetection(shouldDisableVoiceActivityDetection);
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -159,6 +159,8 @@ private:
     int actualSampleRate() const final;
     void resetSampleRate();
 
+    void willChangeCaptureDevice() final;
+
     OSStatus configureSpeakerProc(int sampleRate);
     OSStatus configureMicrophoneProc(int sampleRate);
 
@@ -172,7 +174,7 @@ private:
 
     void verifyIsCapturing();
 
-    void updateVoiceActiveDetection();
+    void updateVoiceActivityDetection(bool shouldDisableVoiceActivityDetection = false);
     bool shouldEnableVoiceActivityDetection() const;
     RetainPtr<WebCoreAudioInputMuteChangeListener> createAudioInputMuteChangeListener();
     void setMutedState(bool isMuted);


### PR DESCRIPTION
#### 5dd3f262832b2ca143236ab8b15a3c9a38bc806a
<pre>
[Cocoa] voice activity detection does not work when changing of capturing device
<a href="https://rdar.apple.com/136356108">rdar://136356108</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280055">https://bugs.webkit.org/show_bug.cgi?id=280055</a>

Reviewed by Andy Estes.

When moving capture from say AirPods to default microphone, we would not unregister the voice detection listener for the AirPods,
and we would not register the voice detection listeners for the default microphone.
This would prevent voice detection to work properly.

In case of capture device change, we are now unregistering the voice detection listener before changing of capture device.
This is done by adding an optional boolean parameter to CoreAudioSharedUnit::updateVoiceActiveDetection which is renamed to CoreAudioSharedUnit::updateVoiceActivityDetection.

We then call CoreAudioSharedUnit::updateVoiceActivityDetection after having changed of capture device to readd the listener if needed.

Manually tested.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::setCaptureDevice):
(WebCore::BaseAudioSharedUnit::voiceActivityDetected):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::willChangeCaptureDevice):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::~CoreAudioSharedUnit):
(WebCore::CoreAudioSharedUnit::captureDeviceChanged):
(WebCore::CoreAudioSharedUnit::cleanupAudioUnit):
(WebCore::CoreAudioSharedUnit::startInternal):
(WebCore::CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged):
(WebCore::CoreAudioSharedUnit::stopInternal):
(WebCore::CoreAudioSharedUnit::updateVoiceActivityDetection):
(WebCore::CoreAudioSharedUnit::enableMutedSpeechActivityEventListener):
(WebCore::CoreAudioSharedUnit::disableMutedSpeechActivityEventListener):
(WebCore::CoreAudioSharedUnit::willChangeCaptureDevice):
(WebCore::CoreAudioSharedUnit::updateVoiceActiveDetection): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/284979@main">https://commits.webkit.org/284979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559ad46e46d3605d4f67bcca72613618aa02d980

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56187 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18707 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15338 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63893 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5642 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1051 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->