### PR TITLE
[ANGLE] Allow envvar to gate ASSERT at runtime

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/log_utils.h
+++ b/Source/ThirdParty/ANGLE/src/common/log_utils.h
@@ -13,6 +13,7 @@
 #include <assert.h>
 #include <stdio.h>
 
+#include <cstdlib>
 #include <iomanip>
 #include <ios>
 #include <mutex>
@@ -248,6 +249,13 @@ std::ostream &FmtHex(std::ostream &os, T value)
 #    define EVENT(message, ...) (void(0))
 #endif
 
+#if defined(ANGLE_ENABLE_ASSERTS)
+bool AreAssertionsEnabled() {
+    static bool enabled = [] { return GetEnvironmentVar("ANGLE_DISABLE_ASSERTS") != "1"; }();
+    return enabled;
+}
+#endif  // defined(ANGLE_ENABLE_ASSERTS)
+
 // Note that gSwallowStream is used instead of an arbitrary LOG() stream to avoid the creation of an
 // object with a non-trivial destructor (LogMessage). On MSVC x86 (checked on 2015 Update 3), this
 // causes a few additional pointless instructions to be emitted even at full optimization level,
@@ -263,9 +271,10 @@ std::ostream &FmtHex(std::ostream &os, T value)
 // A macro asserting a condition and outputting failures to the debug log
 #if defined(ANGLE_ENABLE_ASSERTS)
 #    define ASSERT(expression)                                                                \
-        (expression ? static_cast<void>(0)                                                    \
-                    : (FATAL() << "\t! Assert failed in " << __FUNCTION__ << " (" << __FILE__ \
-                               << ":" << __LINE__ << "): " << #expression))
+        ((!(expression) && AreAssertionsEnabled())                                             \
+                    ? (FATAL() << "\t! Assert failed in " << __FUNCTION__ << " (" << __FILE__ \
+                               << ":" << __LINE__ << "): " << #expression)                    \
+                    : static_cast<void>(0))
 #else
 #    define ASSERT(condition) ANGLE_EAT_STREAM_PARAMETERS << !(condition)
 #endif  // defined(ANGLE_ENABLE_ASSERTS)


### PR DESCRIPTION
#### 0e0d62f0b2e8a3004f8439f3d4791a27e9c1bb30
<pre>
[ANGLE] Allow envvar to gate ASSERT at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=281156">https://bugs.webkit.org/show_bug.cgi?id=281156</a>
<a href="https://rdar.apple.com/137613945">rdar://137613945</a>

Reviewed by Mike Wyrzykowski.

Add a `AreAssertionsEnabled()` function to `log_utils.h` to check a
runtime envvar once, and cache said value. This will allow us to
modulate the ASSERTs crashing the process regardless of how the ANGLE
build was done.

The env var gating this is `ANGLE_DISABLE_ASSERTS`.

Additionally, the function is gated behind the `ANGLE_ENABLE_ASSERTS`
guard, so this will have no impact on production builds.

* Source/ThirdParty/ANGLE/src/common/log_utils.h:
(AreAssertionsEnabled):

Canonical link: <a href="https://commits.webkit.org/286306@main">https://commits.webkit.org/286306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64b2e1fa2b23cf8e3b894b1d354265d9a2a735d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60182 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15838 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37766 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20256 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78824 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65801 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65070 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16641 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7051 "Passed tests") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->