### PR TITLE
[Gardening]: REGRESSION (284573@main): [ macOS wk1 ] imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2965,3 +2965,5 @@ imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-
 
 # webkit.org/b/279712 Clipboard API not supported on WK1
 imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html [ Skip ]
+
+webkit.org/b/281157 imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html [ Failure ]


### PR DESCRIPTION
#### bfa9e4226cba2b702d6cb230b429f3cc1021d8a6
<pre>
REGRESSION (Sequoia): [ Sequoia wk1 ] 4 WPT tests in css/css-color/*. html are a consistent image failure
webkit.org/b/283013
<a href="https://rdar.apple.com/134315225">rdar://134315225</a>

Unreviewed test gardening.

Adding test expectations.

* LayoutTests/platform/mac-wk1/TestExpectations:
</pre>