### PR TITLE
Port more identifier types to ObjectIdentifier

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClientIdentifier.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClientIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class SpeechRecognitionConnectionClientIdentifierType { };
-using SpeechRecognitionConnectionClientIdentifier = LegacyNullableObjectIdentifier<SpeechRecognitionConnectionClientIdentifierType>;
+using SpeechRecognitionConnectionClientIdentifier = ObjectIdentifier<SpeechRecognitionConnectionClientIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
+++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WebSpeechRecognizerTaskImpl : NSObject<SFSpeechRecognitionTaskDelegate, SFSpeechRecognizerDelegate> {
 @private
-    WebCore::SpeechRecognitionConnectionClientIdentifier _identifier;
+    Markable<WebCore::SpeechRecognitionConnectionClientIdentifier> _identifier;
     BlockPtr<void(const WebCore::SpeechRecognitionUpdate&)> _delegateCallback;
     bool _doMultipleRecognitions;
     uint64_t _maxAlternatives;
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (alternatives.size() == _maxAlternatives)
             break;
     }
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::createResult(_identifier, { WebCore::SpeechRecognitionResultData { WTFMove(alternatives), !!isFinal } }));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::createResult(*_identifier, { WebCore::SpeechRecognitionResultData { WTFMove(alternatives), !!isFinal } }));
 }
 
 - (void)audioSamplesAvailable:(CMSampleBufferRef)sampleBuffer
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
 
     _hasSentSpeechStart = true;
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(_identifier, WebCore::SpeechRecognitionUpdateType::SpeechStart));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(*_identifier, WebCore::SpeechRecognitionUpdateType::SpeechStart));
 }
 
 - (void)sendSpeechEndIfNeeded
@@ -179,7 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
 
     _hasSentSpeechEnd = true;
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(_identifier, WebCore::SpeechRecognitionUpdateType::SpeechEnd));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(*_identifier, WebCore::SpeechRecognitionUpdateType::SpeechEnd));
 }
 
 - (void)sendEndIfNeeded
@@ -188,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
 
     _hasSentEnd = true;
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(_identifier, WebCore::SpeechRecognitionUpdateType::End));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(*_identifier, WebCore::SpeechRecognitionUpdateType::End));
 }
 
 #pragma mark SFSpeechRecognizerDelegate
@@ -201,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
 
     auto error = WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::ServiceNotAllowed, "Speech recognition service becomes unavailable"_s };
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::createError(_identifier, WTFMove(error)));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::createError(*_identifier, WTFMove(error)));
 }
 
 #pragma mark SFSpeechRecognitionTaskDelegate
@@ -241,7 +241,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (!successfully) {
         auto error = WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::Aborted, task.error.localizedDescription };
-        _delegateCallback(WebCore::SpeechRecognitionUpdate::createError(_identifier, WTFMove(error)));
+        _delegateCallback(WebCore::SpeechRecognitionUpdate::createError(*_identifier, WTFMove(error)));
     }
     
     [self sendEndIfNeeded];

--- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.h
+++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WebSpeechRecognizerTaskMock : WebSpeechRecognizerTask {
 @private
-    WebCore::SpeechRecognitionConnectionClientIdentifier _identifier;
+    Markable<WebCore::SpeechRecognitionConnectionClientIdentifier> _identifier;
     BlockPtr<void(const WebCore::SpeechRecognitionUpdate&)> _delegateCallback;
     bool _doMultipleRecognitions;
     bool _hasSentSpeechStart;

--- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
+++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
@@ -57,12 +57,12 @@ NS_ASSUME_NONNULL_BEGIN
     
     if (!_hasSentSpeechStart) {
         _hasSentSpeechStart = true;
-        _delegateCallback(WebCore::SpeechRecognitionUpdate::create(_identifier, WebCore::SpeechRecognitionUpdateType::SpeechStart));
+        _delegateCallback(WebCore::SpeechRecognitionUpdate::create(*_identifier, WebCore::SpeechRecognitionUpdateType::SpeechStart));
     }
 
     // Fake some recognition results.
     WebCore::SpeechRecognitionAlternativeData alternative { "Test"_s, 1.0 };
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::createResult(_identifier, { WebCore::SpeechRecognitionResultData { { WTFMove(alternative) }, true } }));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::createResult(*_identifier, { WebCore::SpeechRecognitionResultData { { WTFMove(alternative) }, true } }));
 
     if (!_doMultipleRecognitions)
         [self abort];
@@ -76,10 +76,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (!_hasSentSpeechEnd && _hasSentSpeechStart) {
         _hasSentSpeechEnd = true;
-        _delegateCallback(WebCore::SpeechRecognitionUpdate::create(_identifier, WebCore::SpeechRecognitionUpdateType::SpeechEnd));
+        _delegateCallback(WebCore::SpeechRecognitionUpdate::create(*_identifier, WebCore::SpeechRecognitionUpdateType::SpeechEnd));
     }
 
-    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(_identifier, WebCore::SpeechRecognitionUpdateType::End));
+    _delegateCallback(WebCore::SpeechRecognitionUpdate::create(*_identifier, WebCore::SpeechRecognitionUpdateType::End));
 }
 
 - (void)stop

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -321,8 +321,6 @@ void AlternativeTextController::timerFired()
         if (!m_rangeWithAlternative)
             return;
         auto dictationContext = std::get<DictationContext>(m_details);
-        if (!dictationContext)
-            return;
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         m_isActive = true;
         if (!boundingBox.isEmpty()) {

--- a/Source/WebCore/editing/DictationContext.h
+++ b/Source/WebCore/editing/DictationContext.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 struct DictationContextType;
-using DictationContext = LegacyNullableObjectIdentifier<DictationContextType>;
+using DictationContext = ObjectIdentifier<DictationContextType>;
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/AlternativeTextContextController.h
+++ b/Source/WebCore/editing/cocoa/AlternativeTextContextController.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class AlternativeTextContextController {
 public:
-    DictationContext addAlternatives(PlatformTextAlternatives *);
+    std::optional<DictationContext> addAlternatives(PlatformTextAlternatives *);
     void replaceAlternatives(PlatformTextAlternatives *, DictationContext);
     void removeAlternativesForContext(DictationContext);
     void clear();

--- a/Source/WebCore/editing/cocoa/AlternativeTextContextController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextContextController.mm
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-DictationContext AlternativeTextContextController::addAlternatives(PlatformTextAlternatives *alternatives)
+std::optional<DictationContext> AlternativeTextContextController::addAlternatives(PlatformTextAlternatives *alternatives)
 {
     if (!alternatives)
         return { };
@@ -51,15 +51,11 @@ void AlternativeTextContextController::replaceAlternatives(PlatformTextAlternati
 
 PlatformTextAlternatives *AlternativeTextContextController::alternativesForContext(DictationContext context) const
 {
-    if (!context)
-        return nil;
     return m_alternatives.get(context).get();
 }
 
 void AlternativeTextContextController::removeAlternativesForContext(DictationContext context)
 {
-    if (!context)
-        return;
     if (auto alternatives = m_alternatives.take(context))
         m_contexts.remove(alternatives);
 }

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.h
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.h
@@ -35,7 +35,7 @@ class FloatRect;
 class AlternativeTextUIController {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AlternativeTextUIController, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT DictationContext addAlternatives(PlatformTextAlternatives *);
+    WEBCORE_EXPORT std::optional<DictationContext> addAlternatives(PlatformTextAlternatives *);
     WEBCORE_EXPORT void replaceAlternatives(PlatformTextAlternatives *, DictationContext);
     WEBCORE_EXPORT void removeAlternatives(DictationContext);
     WEBCORE_EXPORT void clear();

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
@@ -43,7 +43,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AlternativeTextUIController);
 
-DictationContext AlternativeTextUIController::addAlternatives(PlatformTextAlternatives *alternatives)
+std::optional<DictationContext> AlternativeTextUIController::addAlternatives(PlatformTextAlternatives *alternatives)
 {
     return m_contextController.addAlternatives(alternatives);
 }

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -78,13 +78,13 @@ namespace WebCore {
 class Font;
 
 struct AttributedStringTextTableIDType;
-using AttributedStringTextTableID = LegacyNullableObjectIdentifier<AttributedStringTextTableIDType>;
+using AttributedStringTextTableID = ObjectIdentifier<AttributedStringTextTableIDType>;
 
 struct AttributedStringTextTableBlockIDType;
-using AttributedStringTextTableBlockID = LegacyNullableObjectIdentifier<AttributedStringTextTableBlockIDType>;
+using AttributedStringTextTableBlockID = ObjectIdentifier<AttributedStringTextTableBlockIDType>;
 
 struct AttributedStringTextListIDType;
-using AttributedStringTextListID = LegacyNullableObjectIdentifier<AttributedStringTextListIDType>;
+using AttributedStringTextListID = ObjectIdentifier<AttributedStringTextListIDType>;
 
 struct WEBCORE_EXPORT AttributedString {
     struct Range {

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -65,13 +65,6 @@ template: enum class WebCore::MediaSessionGroupIdentifierType
 template: enum class WebCore::MediaUniqueIdentifierType
 template: enum class WebCore::PushSubscriptionIdentifierType
 template: enum class WebCore::RealtimeMediaSourceIdentifierType
-template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
-template: struct WebCore::AttributedStringTextListIDType
-#if PLATFORM(COCOA)
-template: struct WebCore::AttributedStringTextTableBlockIDType
-template: struct WebCore::AttributedStringTextTableIDType
-#endif
-template: struct WebCore::DictationContextType
 template: struct WebCore::MediaKeySystemRequestIdentifierType
 template: struct WebCore::MediaPlayerIdentifierType
 template: struct WebCore::MediaPlayerClientIdentifierType
@@ -93,6 +86,7 @@ template: enum class WebCore::LayerHostingContextIdentifierType
 template: enum class WebCore::ProcessIdentifierType
 template: enum class WebCore::SWServerToContextConnectionIdentifierType
 template: enum class WebCore::SharedWorkerIdentifierType
+template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
 template: enum class WebCore::TextCheckingRequestIdentifierType
 template: enum class WebCore::TextManipulationItemIdentifierType
 template: enum class WebCore::TextManipulationTokenIdentifierType
@@ -128,7 +122,13 @@ template: enum class WebKit::VisitedLinkTableIdentifierType
 template: enum class WebKit::WCLayerTreeHostIdentifierType
 template: enum class WebKit::WebExtensionControllerIdentifierType
 template: enum class WebKit::XRDeviceIdentifierType
+template: struct WebCore::AttributedStringTextListIDType
+#if PLATFORM(COCOA)
+template: struct WebCore::AttributedStringTextTableBlockIDType
+template: struct WebCore::AttributedStringTextTableIDType
+#endif
 template: struct WebCore::BackForwardItemIdentifierType
+template: struct WebCore::DictationContextType
 template: struct WebCore::FrameIdentifierType
 template: struct WebCore::NavigationIdentifierType
 template: struct WebCore::PageIdentifierType

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -89,7 +89,7 @@ public:
     NSSet *serializableFileWrapperClasses() const final;
 #endif
 
-    WebCore::DictationContext addDictationAlternatives(PlatformTextAlternatives *) final;
+    std::optional<WebCore::DictationContext> addDictationAlternatives(PlatformTextAlternatives *) final;
     void replaceDictationAlternatives(PlatformTextAlternatives *, WebCore::DictationContext) final;
     void removeDictationAlternatives(WebCore::DictationContext) final;
     Vector<String> dictationAlternatives(WebCore::DictationContext) final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -191,7 +191,7 @@ void PageClientImplCocoa::modelProcessDidExit()
 }
 #endif
 
-WebCore::DictationContext PageClientImplCocoa::addDictationAlternatives(PlatformTextAlternatives *alternatives)
+std::optional<WebCore::DictationContext> PageClientImplCocoa::addDictationAlternatives(PlatformTextAlternatives *alternatives)
 {
     return m_alternativeTextUIController->addAlternatives(alternatives);
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -422,7 +422,7 @@ void WebPageProxy::insertDictatedTextAsync(const String& text, const EditingRang
     Vector<DictationAlternative> dictationAlternatives;
     for (const auto& alternativeWithRange : dictationAlternativesWithRange) {
         if (auto context = pageClient->addDictationAlternatives(alternativeWithRange.alternatives.get()))
-            dictationAlternatives.append({ alternativeWithRange.range, context });
+            dictationAlternatives.append({ alternativeWithRange.range, *context });
     }
 
     if (dictationAlternatives.isEmpty()) {
@@ -444,9 +444,9 @@ void WebPageProxy::addDictationAlternative(TextAlternativeWithRange&& alternativ
 
     auto nsAlternatives = alternative.alternatives.get();
     auto context = pageClient->addDictationAlternatives(nsAlternatives);
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::AddDictationAlternative { nsAlternatives.primaryString, context }, [context, weakThis = WeakPtr { *this }](bool success) {
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::AddDictationAlternative { nsAlternatives.primaryString, *context }, [context, weakThis = WeakPtr { *this }](bool success) {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && !success)
-            protectedThis->removeDictationAlternatives(context);
+            protectedThis->removeDictationAlternatives(*context);
     }, webPageIDInMainFrameProcess());
 }
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -495,7 +495,7 @@ public:
     virtual void performSwitchHapticFeedback() { }
 
 #if USE(DICTATION_ALTERNATIVES)
-    virtual WebCore::DictationContext addDictationAlternatives(PlatformTextAlternatives *) = 0;
+    virtual std::optional<WebCore::DictationContext> addDictationAlternatives(PlatformTextAlternatives *) = 0;
     virtual void replaceDictationAlternatives(PlatformTextAlternatives *, WebCore::DictationContext) = 0;
     virtual void removeDictationAlternatives(WebCore::DictationContext) = 0;
     virtual void showDictationAlternativeUI(const WebCore::FloatRect& boundingBoxOfDictatedText, WebCore::DictationContext) = 0;

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -63,7 +63,6 @@ std::optional<SharedPreferencesForWebProcess> SpeechRecognitionServer::sharedPre
 
 void SpeechRecognitionServer::start(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier, String&& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&& origin, WebCore::FrameIdentifier frameIdentifier)
 {
-    MESSAGE_CHECK(clientIdentifier);
     ASSERT(!m_requests.contains(clientIdentifier));
     auto requestInfo = WebCore::SpeechRecognitionRequestInfo { clientIdentifier, WTFMove(lang), continuous, interimResults, maxAlternatives, WTFMove(origin), frameIdentifier };
     auto& newRequest = m_requests.add(clientIdentifier, makeUnique<WebCore::SpeechRecognitionRequest>(WTFMove(requestInfo))).iterator->value;
@@ -126,8 +125,6 @@ void SpeechRecognitionServer::handleRequest(UniqueRef<WebCore::SpeechRecognition
 
 void SpeechRecognitionServer::stop(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {
-    MESSAGE_CHECK(clientIdentifier);
-
     if (m_requests.remove(clientIdentifier)) {
         sendUpdate(clientIdentifier, WebCore::SpeechRecognitionUpdateType::End);
         return;
@@ -139,7 +136,6 @@ void SpeechRecognitionServer::stop(WebCore::SpeechRecognitionConnectionClientIde
 
 void SpeechRecognitionServer::abort(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {
-    MESSAGE_CHECK(clientIdentifier);
     if (m_requests.remove(clientIdentifier)) {
         sendUpdate(clientIdentifier, WebCore::SpeechRecognitionUpdateType::End);
         return;
@@ -151,7 +147,6 @@ void SpeechRecognitionServer::abort(WebCore::SpeechRecognitionConnectionClientId
 
 void SpeechRecognitionServer::invalidate(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {
-    MESSAGE_CHECK(clientIdentifier);
     if (m_recognizer && m_recognizer->clientIdentifier() == clientIdentifier)
         m_recognizer->abort();
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -335,7 +335,7 @@ template<typename> class ProcessQualified;
 template<typename> class RectEdges;
 
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
-using DictationContext = LegacyNullableObjectIdentifier<DictationContextType>;
+using DictationContext = ObjectIdentifier<DictationContextType>;
 using FloatBoxExtent = RectEdges<float>;
 using FramesPerSecond = unsigned;
 using IntDegrees = int32_t;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8985,7 +8985,7 @@ FORWARD(toggleUnderline)
 {
     for (auto& alternativeWithRange : alternativesWithRange) {
         if (auto dictationContext = _private->m_alternativeTextUIController->addAlternatives(alternativeWithRange.alternatives.get()))
-            alternatives.append({ alternativeWithRange.range, dictationContext });
+            alternatives.append({ alternativeWithRange.range, *dictationContext });
     }
 }
 


### PR DESCRIPTION
#### e4ce578c1d5bf64131039698f1464627ff010d5e
<pre>
Port more identifier types to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=281160">https://bugs.webkit.org/show_bug.cgi?id=281160</a>

Reviewed by Sihui Liu.

* Source/WebCore/Modules/speech/SpeechRecognitionConnectionClientIdentifier.h:
* Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm:
(-[WebSpeechRecognizerTaskImpl callbackWithTranscriptions:isFinal:]):
(-[WebSpeechRecognizerTaskImpl sendSpeechStartIfNeeded]):
(-[WebSpeechRecognizerTaskImpl sendSpeechEndIfNeeded]):
(-[WebSpeechRecognizerTaskImpl sendEndIfNeeded]):
(-[WebSpeechRecognizerTaskImpl speechRecognizer:availabilityDidChange:]):
(-[WebSpeechRecognizerTaskImpl speechRecognitionTask:didFinishSuccessfully:]):
* Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.h:
* Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm:
(-[WebSpeechRecognizerTaskMock audioSamplesAvailable:]):
(-[WebSpeechRecognizerTaskMock abort]):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::timerFired):
* Source/WebCore/editing/DictationContext.h:
* Source/WebCore/editing/cocoa/AlternativeTextContextController.h:
* Source/WebCore/editing/cocoa/AlternativeTextContextController.mm:
(WebCore::AlternativeTextContextController::addAlternatives):
(WebCore::AlternativeTextContextController::alternativesForContext const):
(WebCore::AlternativeTextContextController::removeAlternativesForContext):
* Source/WebCore/editing/cocoa/AlternativeTextUIController.h:
* Source/WebCore/editing/cocoa/AlternativeTextUIController.mm:
(WebCore::AlternativeTextUIController::addAlternatives):
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::addDictationAlternatives):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::insertDictatedTextAsync):
(WebKit::WebPageProxy::addDictationAlternative):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::start):
(WebKit::SpeechRecognitionServer::stop):
(WebKit::SpeechRecognitionServer::abort):
(WebKit::SpeechRecognitionServer::invalidate):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _getWebCoreDictationAlternatives:fromTextAlternatives:]):

Canonical link: <a href="https://commits.webkit.org/284950@main">https://commits.webkit.org/284950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec631f1fd3bb78b7b0ecc10236c66cbcf5523734

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56112 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18573 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18136 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63817 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5535 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/898 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->