### PR TITLE
[Cocoa] WebPreferencesStore::defaults() can differ between (Mobile)Safari and auxiliary processes

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -68,8 +68,19 @@ static void disableAdditionalSDKAlignedBehaviors(SDKAlignedBehaviors&)
 
 static SDKAlignedBehaviors computeSDKAlignedBehaviors()
 {
+    ASSERT(!isInAuxiliaryProcess());
+
     SDKAlignedBehaviors behaviors;
     behaviors.setAll();
+
+    // This can be removed once Safari calls _setLinkedOnOrAfterEverything everywhere that WebKit deploys.
+#if PLATFORM(IOS_FAMILY)
+    bool isSafari = WTF::IOSApplication::isMobileSafari();
+#elif PLATFORM(MAC)
+    bool isSafari = WTF::MacApplication::isSafari();
+#endif
+    if (isSafari)
+        return behaviors;
 
     auto disableBehavior = [&] (SDKAlignedBehavior behavior) {
         behaviors.clear(static_cast<size_t>(behavior));

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -80,7 +80,12 @@ void AuxiliaryProcess::initialize(const AuxiliaryProcessInitializationParameters
 {
     WTF::RefCountedBase::enableThreadingChecksGlobally();
 
+#if PLATFORM(COCOA)
+    // On Cocoa platforms, setAuxiliaryProcessType() is called in XPCServiceInitializer().
+    ASSERT(processType() == parameters.processType);
+#else
     setAuxiliaryProcessType(parameters.processType);
+#endif
 
     RELEASE_ASSERT_WITH_MESSAGE(parameters.processIdentifier, "Unable to initialize child process without a WebCore process identifier");
     Process::setIdentifier(*parameters.processIdentifier);

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -212,9 +212,6 @@ struct AuxiliaryProcessInitializationParameters {
     IPC::Connection::Identifier connectionIdentifier;
     HashMap<String, String> extraInitializationData;
     WTF::AuxiliaryProcessType processType;
-#if PLATFORM(COCOA)
-    SDKAlignedBehaviors clientSDKAlignedBehaviors;
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -101,7 +101,6 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
     [[NSFileManager defaultManager] changeCurrentDirectoryPath:[[NSBundle mainBundle] bundlePath]];
 
     setApplicationBundleIdentifier(parameters.clientBundleIdentifier);
-    setSDKAlignedBehaviors(parameters.clientSDKAlignedBehaviors);
 
 #if PLATFORM(MAC)
     disableDowngradeToLayoutManager();

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -116,6 +116,19 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
         setJSCOptions(initializerMessage, enableLockdownMode ? EnableLockdownMode::Yes : EnableLockdownMode::No, isWebContentProcess);
     }
 
+    // InitializeWebKit2() calls linkedOnOrAfterSDKWithBehavior(), so SDK-aligned behaviors must be
+    // configured beforehand.
+    SDKAlignedBehaviors clientSDKAlignedBehaviors;
+    delegate.getClientSDKAlignedBehaviors(clientSDKAlignedBehaviors);
+    setSDKAlignedBehaviors(clientSDKAlignedBehaviors);
+
+    // computeSDKAlignedBehaviors() asserts that it is not called in an auxiliary process, so
+    // setAuxiliaryProcessType() should be called before the first call to
+    // linkedOnOrAfterSDKWithBehavior() to ensure the assertion will catch bugs where
+    // setSDKAlignedBehaviors() isn't called at the right time.
+    parameters.processType = XPCServiceType::processType;
+    setAuxiliaryProcessType(parameters.processType);
+
     InitializeWebKit2();
 
     if (!delegate.checkEntitlements())
@@ -129,8 +142,6 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
 
     // The host process may not have a bundle identifier (e.g. a command line app), so don't require one.
     delegate.getClientBundleIdentifier(parameters.clientBundleIdentifier);
-    
-    delegate.getClientSDKAlignedBehaviors(parameters.clientSDKAlignedBehaviors);
 
     std::optional<WebCore::ProcessIdentifier> processIdentifier;
     if (!delegate.getProcessIdentifier(processIdentifier))
@@ -147,8 +158,6 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
     if (parameters.extraInitializationData.contains("always-runs-at-background-priority"_s))
         Thread::setGlobalMaxQOSClass(QOS_CLASS_UTILITY);
 #endif
-
-    parameters.processType = XPCServiceType::processType;
 
     initializeAuxiliaryProcess<XPCServiceType>(WTFMove(parameters));
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -256,16 +256,6 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
         WTF::setProcessPrivileges(allPrivileges());
         WebCore::NetworkStorageSession::permitProcessToUseCookieAPI(true);
         Process::setIdentifier(WebCore::ProcessIdentifier::generate());
-#if PLATFORM(COCOA)
-        // This can be removed once Safari calls _setLinkedOnOrAfterEverything everywhere that WebKit deploys.
-#if PLATFORM(IOS_FAMILY)
-        bool isSafari = WTF::IOSApplication::isMobileSafari();
-#elif PLATFORM(MAC)
-        bool isSafari = WTF::MacApplication::isSafari();
-#endif
-        if (isSafari)
-            enableAllSDKAlignedBehaviors();
-#endif
     }
 
     for (auto& scheme : m_configuration->alwaysRevalidatedURLSchemes())


### PR DESCRIPTION
#### 234c5f7ab5b983500d575cc73eefce863f36a82d
<pre>
[Cocoa] WebPreferencesStore::defaults() can differ between (Mobile)Safari and auxiliary processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=281163">https://bugs.webkit.org/show_bug.cgi?id=281163</a>
<a href="https://rdar.apple.com/137624686">rdar://137624686</a>

Reviewed by Sihui Liu.

WebPreferencesStore::defaults() are computed lazily on first access, and some default values are
computed based on SDK-aligned behaviors. SDK-aligned behaviors are computed in the UI process based
on the SDK version the process is linked against then sent to auxiliary processes at launch time.
Additionally, SDK-aligned behaviors can change at any time when clients call
-_setLinkedOnOrBeforeEverythingForTesting, -_setLinkedOnOrAfterEverythingForTesting, or
-_setLinkedOnOrAfterEverything on WKProcessPool. Finally, in WebProcessPool&apos;s constructor, Safari
and MobileSafari were special-cased to enable all SDK-aligned behaviors.

This arrangement led to a bug where WebPreferencesStore::defaults() could differ between
(Mobile)Safari and auxiliary processes in the following sequence:
1. WebPreferencesStore::defaults() is called, which computes SDK-aligned behaviors (possibly triggering bug #281166).
2. WebProcessPool::WebProcessPool() is called, which enables all SDK-aligned behaviors.
3. A new auxiliary process launches and is sent the now all-enabled SDK-aligned behaviors.

Because WebPreferencesStore::defaults() had already been called by the time
WebProcessPool::WebProcessPool() enabled all SDK-aligned behaviors, its defaults are based on
outdated values. However, WebPreferencesStore::defaults() in the new auxiliary process will be
based on the updated SDK-aligned behaviors set in (2).

A second, related bug exists in auxiliary processes where InitializeWebKit2() (which calls
linkedOnOrAfterSDKWithBehavior()) is called before the SDK-aligned behaviors sent from the UI
process were set.

Addressed the first bug by moving the special-casing of Safari and MobileSafari from
WebProcessPool::WebProcessPool() to computeSDKAlignedBehaviors(). This ensures that SDK-aligned
behaviors are in the correct state as soon as they are first accessed in the UI process. Addressed
the second bug by ensuring SDK-aligned behaviors are set in auxiliary processes prior to calling
InitializeWebKit2().

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::initialize):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::platformInitialize):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):
* Source/WebKit/UIProcess/WebProcessPool.cpp:

Canonical link: <a href="https://commits.webkit.org/284952@main">https://commits.webkit.org/284952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/855f1eddcc2a6c7dc85b58693ef5f2885e0a22b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22152 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56119 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14599 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20493 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64071 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70196 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18160 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5555 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91977 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/935 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20050 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->