### PR TITLE
[visionOS] WebKit incorrectly disables some SDK-aligned behaviors in apps linked against 2024-era SDKs

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -48,6 +48,8 @@ static bool linkedBefore(dyld_build_version_t version, uint32_t fallbackIOSVersi
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+    // FIXME: On iOS-family platforms that are not iOS itself, this comparison is incorrect
+    // (e.g., it's wrong to compare a visionOS SDK version to a DYLD_IOS_VERSION_*).
     UNUSED_PARAM(fallbackMacOSVersion);
     return dyld_get_program_sdk_version() < fallbackIOSVersion;
 #else
@@ -183,7 +185,7 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::UIBackForwardSkipsHistoryItemsWithoutUserGesture);
     }
 
-    if (linkedBefore(dyld_spring_2023_os_versions, DYLD_IOS_VERSION_16_4, DYLD_MACOSX_VERSION_13_3)) {
+    if (linkedBefore(dyld_2022_SU_E_os_versions, DYLD_IOS_VERSION_16_4, DYLD_MACOSX_VERSION_13_3)) {
         disableBehavior(SDKAlignedBehavior::NoShowModalDialog);
         disableBehavior(SDKAlignedBehavior::DoesNotAddIntrinsicMarginsToFormControls);
         disableBehavior(SDKAlignedBehavior::ProgrammaticFocusDuringUserScriptShowsInputViews);
@@ -210,7 +212,7 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::ThrowIfCanDeclareGlobalFunctionFails);
     }
 
-    if (linkedBefore(dyld_spring_2024_os_versions, DYLD_IOS_VERSION_17_4, DYLD_MACOSX_VERSION_14_4)) {
+    if (linkedBefore(dyld_2023_SU_E_os_versions, DYLD_IOS_VERSION_17_4, DYLD_MACOSX_VERSION_14_4)) {
         disableBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision);
         disableBehavior(SDKAlignedBehavior::DoNotLoadStyleSheetIfHTTPStatusIsNotOK);
         disableBehavior(SDKAlignedBehavior::ScrollViewSubclassImplementsAddGestureRecognizer);

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -293,8 +293,8 @@ WTF_EXTERN_C_BEGIN
 #define dyld_fall_2022_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
-#ifndef dyld_spring_2023_os_versions
-#define dyld_spring_2023_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#ifndef dyld_2022_SU_E_os_versions
+#define dyld_2022_SU_E_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 #ifndef dyld_fall_2023_os_versions
@@ -305,8 +305,8 @@ WTF_EXTERN_C_BEGIN
 #define dyld_2023_SU_C_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
-#ifndef dyld_spring_2024_os_versions
-#define dyld_spring_2024_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#ifndef dyld_2023_SU_E_os_versions
+#define dyld_2023_SU_E_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 #ifndef dyld_fall_2024_os_versions


### PR DESCRIPTION
#### 5c4f26d0f5166c942f774fe09bbf5fe4043457f4
<pre>
[visionOS] WebKit incorrectly disables some SDK-aligned behaviors in apps linked against 2024-era SDKs
<a href="https://bugs.webkit.org/show_bug.cgi?id=281166">https://bugs.webkit.org/show_bug.cgi?id=281166</a>
<a href="https://rdar.apple.com/137627482">rdar://137627482</a>

Reviewed by Sihui Liu.

Starting in 2023-era SDKs, dyld stopped defining dyld_spring_* version macros, instead using macros
formatted as dyld_&lt;major-release-year&gt;_SU_&lt;minor-version&gt;_os_versions (e.g.,
dyld_2022_SU_E_os_versions, representing releases aligned with macOS 13.3 and iOS 16.4). Since
dyld_spring_2023_os_versions and dyld_spring_2024_os_versions were not defined in dyld_priv.h,
WebKit would fall back to comparing dyld_get_program_sdk_version() to DYLD_IOS_VERSION_16_4 and
DYLD_IOS_VERSION_17_4 respectively on visionOS. Since visionOS SDK versions are not aligned with
iOS versions, linkedBefore() would incorrectly return true and cause us to incorrectly disable some
SDK-aligned behaviors in apps where they should have been enabled.

Resolved this by replacing dyld_spring_2023_os_versions and dyld_spring_2024_os_versions with
dyld_2022_SU_E_os_versions and dyld_2023_SU_E_os_versions respectively. Added a FIXME to address
the issue where we compare dyld_get_program_sdk_version() to unaligned iOS versions on watchOS and
visionOS in Public SDK builds.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/spi/darwin/dyldSPI.h:

Canonical link: <a href="https://commits.webkit.org/284936@main">https://commits.webkit.org/284936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89ac42cf913dd0c7747d847b374b22ac156b77c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23711 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22143 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21961 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61158 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18592 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/64062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76757 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70187 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18158 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61217 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5551 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91968 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46151 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20048 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->