### PR TITLE
[UnifiedPDF][iOS] Create plugin specific viewport configuration.

### DIFF
--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -415,6 +415,22 @@ ViewportConfiguration::Parameters ViewportConfiguration::nativeWebpageParameters
     return parameters;
 }
 
+#if ENABLE(PDF_PLUGIN)
+ViewportConfiguration::Parameters ViewportConfiguration::pluginDocumentParameters()
+{
+    Parameters parameters;
+    parameters.width = ViewportArguments::ValueDeviceWidth;
+    parameters.widthIsSet = true;
+    parameters.allowsShrinkToFit = false;
+    parameters.minimumScale = 1;
+    parameters.maximumScale = 1;
+    parameters.initialScale = 1;
+    parameters.initialScaleIgnoringLayoutScaleFactor = 1;
+    parameters.initialScaleIsSet = true;
+    return parameters;
+}
+#endif
+
 ViewportConfiguration::Parameters ViewportConfiguration::webpageParameters()
 {
     Parameters parameters;

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -145,6 +145,9 @@ public:
     WEBCORE_EXPORT Parameters nativeWebpageParameters();
     static Parameters nativeWebpageParametersWithoutShrinkToFit();
     static Parameters nativeWebpageParametersWithShrinkToFit();
+#if ENABLE(PDF_PLUGIN)
+    WEBCORE_EXPORT static Parameters pluginDocumentParameters();
+#endif
     WEBCORE_EXPORT static Parameters webpageParameters();
     WEBCORE_EXPORT static Parameters textDocumentParameters();
     WEBCORE_EXPORT static Parameters imageDocumentParameters();

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -596,8 +596,12 @@ void PluginView::setParent(ScrollView* scrollView)
 {
     Widget::setParent(scrollView);
 
-    if (scrollView)
+    if (scrollView) {
         initializePlugin();
+#if PLATFORM(IOS_FAMILY)
+        protectedWebPage()->didInitializePlugin();
+#endif
+    }
 }
 
 unsigned PluginView::countFindMatches(const String& target, WebCore::FindOptions options, unsigned maxMatchCount)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -727,6 +727,11 @@ public:
 
 #if ENABLE(PDF_PLUGIN)
     void setPluginScaleFactor(double scaleFactor, WebCore::IntPoint origin);
+
+#if PLATFORM(IOS_FAMILY)
+    void didInitializePlugin();
+#endif
+
 #endif
 
     void didScalePage(double scale, const WebCore::IntPoint& origin);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4164,6 +4164,12 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
         if (m_isInFullscreenMode == IsInFullscreenMode::Yes)
             return m_viewportConfiguration.nativeWebpageParameters();
 #endif
+
+#if ENABLE(PDF_PLUGIN)
+        if (mainFramePlugIn())
+            return m_viewportConfiguration.pluginDocumentParameters();
+#endif
+
         if (shouldIgnoreMetaViewport())
             return m_viewportConfiguration.nativeWebpageParameters();
         return ViewportConfiguration::webpageParameters();
@@ -5649,6 +5655,14 @@ void WebPage::computeSelectionClipRectAndEnclosingScroller(EditorState& state, c
         state.visualData->selectionClipRect = WTFMove(innerScrollingClipRect);
     }
 }
+
+#if ENABLE(PDF_PLUGIN)
+void WebPage::didInitializePlugin()
+{
+    resetViewportDefaultConfiguration(m_mainFrame.ptr());
+    viewportConfigurationChanged();
+}
+#endif
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 4aebedeb66526aa469f882e0fae0e91b50833f99
<pre>
[UnifiedPDF][iOS] Create plugin specific viewport configuration.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281167">https://bugs.webkit.org/show_bug.cgi?id=281167</a>
<a href="https://rdar.apple.com/137627221">rdar://137627221</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

Main frame PDFs iOS currently have their viewport configuration set to ViewportConfiguration::webpageParameters
which uses defaultDesktopViewportWidth as the width of the content&apos;s viewport. This ends
up causing a number of issues that restrict us from getting any sort of scales correct
as we end up incorrectly sizing the plugin. In this patch we create a viewport configuration
that is specific to plugins so that we can tailor the parameters as appropriate for this
specific case.

This configuration is mostly the same as nativeWebpageParameters with the maximum scale
set to 1. We do this to avoid accidentally setting the page scale factor to any other
scales since the plugin is completely responsible for managing its scale. We may need to
fine tune this configuration a bit more in the future but this should hopefully serve as
a sane initial set that we can build upon.

We set this configuration when we initialize the plugin in PluginView::setParent by
informing the web page that we have initialized the plugin. The web page will then set
the viewport configuration to this new plugin specific one.

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::pluginParameters):
* Source/WebCore/page/ViewportConfiguration.h:
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::setParent):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::resetViewportDefaultConfiguration):
(WebKit::WebPage::didInitializePlugin):

Canonical link: <a href="https://commits.webkit.org/284976@main">https://commits.webkit.org/284976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf05eea7665af12cc53a3bbe30ba47ee1cd36b5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14632 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76840 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5594 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->