### PR TITLE
REGRESSION(283463@main?): [ Debug iOS iPad ] 61x TestWebKitAPI.DragAndDropTests*(api-tests) are constant asserts

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -75,7 +75,7 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 - (UIDropInteraction *)dropInteraction;
 #if USE(BROWSERENGINEKIT)
 - (id<BEDragInteractionDelegate>)dragInteractionDelegate;
-- (BEDragInteraction *)dragInteraction;
+- (id)dragInteraction;
 #else
 - (id<UIDragInteractionDelegate>)dragInteractionDelegate;
 - (UIDragInteraction *)dragInteraction;

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -108,11 +108,6 @@ InteractionType *findInteractionOfType(UIView *view)
     return (id<BEDragInteractionDelegate>)self._dragDropInteractionView;
 }
 
-- (BEDragInteraction *)dragInteraction
-{
-    return findInteractionOfType<BEDragInteraction>(self._dragDropInteractionView);
-}
-
 #else
 
 - (id<UIDragInteractionDelegate>)dragInteractionDelegate
@@ -120,16 +115,16 @@ InteractionType *findInteractionOfType(UIView *view)
     return (id<UIDragInteractionDelegate>)self._dragDropInteractionView;
 }
 
-- (UIDragInteraction *)dragInteraction
-{
-    return findInteractionOfType<UIDragInteraction>(self._dragDropInteractionView);
-}
-
 #endif
 
 - (UIDropInteraction *)dropInteraction
 {
     return findInteractionOfType<UIDropInteraction>(self._dragDropInteractionView);
+}
+
+- (id)dragInteraction
+{
+    return findInteractionOfType<UIDragInteraction>(self._dragDropInteractionView);
 }
 
 @end


### PR DESCRIPTION
#### 4b1807e408da8f0c5b34a4f653db8cadb3cb2fcf
<pre>
REGRESSION(283463@main?): [ Debug iOS iPad ] 61x TestWebKitAPI.DragAndDropTests*(api-tests) are constant asserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=281168">https://bugs.webkit.org/show_bug.cgi?id=281168</a>
<a href="https://rdar.apple.com/137627811">rdar://137627811</a>

Reviewed by Abrar Rahman Protyasha.

Tests that use DragAndDropSimulator currently hit debug assertions on iOS 17.*, and only on iPad.
That&apos;s because iPad on iOS 17.4+ is the one remaining configuration where `USE(BROWSERENGINEKIT)` is
defined, but the OS feature flag `UIKit/async_text_input_ipad` is disabled by default.

Under this configuration, `-[WKWebView(DragAndDropTesting) dragInteraction]` currently returns `nil`
because the underlying drag interaction is a `UIDragInteraction` instead of `BEDragInteraction`.
In release builds, this is actually innocuous since this it&apos;s only used to pass the drag interaction
instance back to the delegate methods on the content view, where it&apos;s unused. However, on debug
builds, we use the incoming `interaction` only to `ASSERT` that it&apos;s equal to `_dragInteraction`.

Work around the issue above by making this return a `UIInteraction` of type `UIDragInteraction`
instead of `BEDragInteraction`. To keep this building, we also need to make the return type `id`
instead of `UIDragInteraction`, otherwise the build will fail when passing `-dragInteraction` into
the `BEDragInteractionDelegate` methods.

* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[WKWebView dragInteraction]):

Canonical link: <a href="https://commits.webkit.org/284946@main">https://commits.webkit.org/284946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beb54ecda7eff4fe011d20830d908500b603b7d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21978 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14603 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18163 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61226 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5558 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46168 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->