### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make more WebAuthentication classes RefCounted or equivalent

### DIFF
--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp
@@ -44,7 +44,7 @@ Ref<WebAuthenticationPanel> WebAuthenticationPanel::create(const AuthenticatorMa
 
 WebAuthenticationPanel::WebAuthenticationPanel()
     : m_manager(AuthenticatorManager::create())
-    , m_client(makeUniqueRef<WebAuthenticationPanelClient>())
+    , m_client(WebAuthenticationPanelClient::create())
 {
     protectedManager()->enableNativeSupport();
 }
@@ -55,7 +55,7 @@ RefPtr<WebKit::AuthenticatorManager> WebAuthenticationPanel::protectedManager() 
 }
 
 WebAuthenticationPanel::WebAuthenticationPanel(const AuthenticatorManager& manager, const WTF::String& rpId, const TransportSet& transports, ClientDataType type, const WTF::String& userName)
-    : m_client(makeUniqueRef<WebAuthenticationPanelClient>())
+    : m_client(WebAuthenticationPanelClient::create())
     , m_weakManager(manager)
     , m_rpId(rpId)
     , m_clientDataType(type)
@@ -103,7 +103,7 @@ void WebAuthenticationPanel::setMockConfiguration(WebCore::MockWebAuthentication
     m_manager = WTFMove(manager);
 }
 
-void WebAuthenticationPanel::setClient(UniqueRef<WebAuthenticationPanelClient>&& client)
+void WebAuthenticationPanel::setClient(Ref<WebAuthenticationPanelClient>&& client)
 {
     m_client = WTFMove(client);
 }

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
@@ -66,7 +66,7 @@ public:
     void setMockConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
 
     const WebAuthenticationPanelClient& client() const { return m_client.get(); }
-    void setClient(UniqueRef<WebAuthenticationPanelClient>&&);
+    void setClient(Ref<WebAuthenticationPanelClient>&&);
 
     // FIXME: <rdar://problem/71509848> Remove the following deprecated methods.
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;
@@ -77,13 +77,13 @@ public:
     WTF::String userName() const { return m_userName; }
 
 private:
-    RefPtr<WebKit::AuthenticatorManager> protectedManager() const;
-
     // FIXME: <rdar://problem/71509848> Remove the following deprecated method.
     WebAuthenticationPanel(const WebKit::AuthenticatorManager&, const WTF::String& rpId, const TransportSet&, WebCore::ClientDataType, const WTF::String& userName);
 
+    RefPtr<WebKit::AuthenticatorManager> protectedManager() const;
+
     RefPtr<WebKit::AuthenticatorManager> m_manager; // FIXME: <rdar://problem/71509848> Change to Ref.
-    UniqueRef<WebAuthenticationPanelClient> m_client;
+    Ref<WebAuthenticationPanelClient> m_client;
 
     // FIXME: <rdar://problem/71509848> Remove the following deprecated fields.
     WeakPtr<WebKit::AuthenticatorManager> m_weakManager;

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
@@ -43,9 +43,10 @@ class AuthenticatorAssertionResponse;
 
 namespace API {
 
-class WebAuthenticationPanelClient {
+class WebAuthenticationPanelClient : public RefCounted<WebAuthenticationPanelClient> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WebAuthenticationPanelClient);
 public:
+    static Ref<WebAuthenticationPanelClient> create() { return adoptRef(*new WebAuthenticationPanelClient); }
     virtual ~WebAuthenticationPanelClient() = default;
 
     virtual void updatePanel(WebKit::WebAuthenticationStatus) const { }
@@ -54,6 +55,9 @@ public:
     virtual void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&&, WebKit::WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&& completionHandler) const { completionHandler(nullptr); }
     virtual void decidePolicyForLocalAuthenticator(CompletionHandler<void(WebKit::LocalAuthenticatorPolicy)>&& completionHandler) const { completionHandler(WebKit::LocalAuthenticatorPolicy::Disallow); }
     virtual void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&& completionHandler) const { completionHandler(nullptr); }
+
+protected:
+    WebAuthenticationPanelClient() = default;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2166,6 +2166,11 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         {
             class PanelClient final : public API::WebAuthenticationPanelClient {
             public:
+                static Ref<PanelClient> create()
+                {
+                    return adoptRef(*new PanelClient);
+                }
+
                 void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&& responses, WebKit::WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&& completionHandler) const final
                 {
                     ASSERT(!responses.isEmpty());
@@ -2176,6 +2181,9 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 {
                     completionHandler(WebKit::LocalAuthenticatorPolicy::Allow);
                 }
+
+            private:
+                PanelClient() = default;
             };
 
             if (!m_client.runWebAuthenticationPanel) {
@@ -2183,7 +2191,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 return;
             }
 
-            panel.setClient(WTF::makeUniqueRef<PanelClient>());
+            panel.setClient(PanelClient::create());
             completionHandler(WebKit::WebAuthenticationPanelResult::Presented);
         }
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -154,15 +154,16 @@ NSString * const _WKLocalAuthenticatorCredentialLastUsedDateKey = @"_WKLocalAuth
 
 - (id <_WKWebAuthenticationPanelDelegate>)delegate
 {
-    if (!_client)
+    RefPtr client = _client.get();
+    if (!client)
         return nil;
-    return _client->delegate().autorelease();
+    return client->delegate().autorelease();
 }
 
 - (void)setDelegate:(id<_WKWebAuthenticationPanelDelegate>)delegate
 {
-    auto client = WTF::makeUniqueRef<WebKit::WebAuthenticationPanelClient>(self, delegate);
-    _client = client.get();
+    Ref client = WebKit::WebAuthenticationPanelClient::create(self, delegate);
+    _client = client.ptr();
     _panel->setClient(WTFMove(client));
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp
@@ -49,9 +49,8 @@ void Authenticator::handleRequest(const WebAuthenticationRequestData& data)
 void Authenticator::receiveRespond(AuthenticatorObserverRespond&& respond) const
 {
     ASSERT(RunLoop::isMain());
-    if (!m_observer)
-        return;
-    m_observer->respondReceived(WTFMove(respond));
+    if (RefPtr observer = m_observer.get())
+        observer->respondReceived(WTFMove(respond));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -281,8 +281,8 @@ void AuthenticatorManager::authenticatorAdded(Ref<Authenticator>&& authenticator
 void AuthenticatorManager::serviceStatusUpdated(WebAuthenticationStatus status)
 {
     // This is for the new UI.
-    if (m_presenter) {
-        m_presenter->updatePresenter(status);
+    if (RefPtr presenter = m_presenter) {
+        presenter->updatePresenter(status);
         return;
     }
 
@@ -331,8 +331,8 @@ void AuthenticatorManager::authenticatorStatusUpdated(WebAuthenticationStatus st
     m_pendingRequestData.cachedPin = String();
 
     // This is for the new UI.
-    if (m_presenter) {
-        m_presenter->updatePresenter(status);
+    if (RefPtr presenter = m_presenter) {
+        presenter->updatePresenter(status);
         return;
     }
 
@@ -361,8 +361,8 @@ void AuthenticatorManager::requestPin(uint64_t retries, CompletionHandler<void(c
     };
 
     // This is for the new UI.
-    if (m_presenter) {
-        m_presenter->requestPin(retries, WTFMove(callback));
+    if (RefPtr presenter = m_presenter) {
+        presenter->requestPin(retries, WTFMove(callback));
         return;
     }
 
@@ -374,8 +374,8 @@ void AuthenticatorManager::requestPin(uint64_t retries, CompletionHandler<void(c
 void AuthenticatorManager::selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&& responses, WebAuthenticationSource source, CompletionHandler<void(AuthenticatorAssertionResponse*)>&& completionHandler)
 {
     // This is for the new UI.
-    if (m_presenter) {
-        m_presenter->selectAssertionResponse(WTFMove(responses), source, WTFMove(completionHandler));
+    if (RefPtr presenter = m_presenter) {
+        presenter->selectAssertionResponse(WTFMove(responses), source, WTFMove(completionHandler));
         return;
     }
 
@@ -393,8 +393,8 @@ void AuthenticatorManager::decidePolicyForLocalAuthenticator(CompletionHandler<v
 
 void AuthenticatorManager::requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&& completionHandler)
 {
-    if (m_presenter) {
-        m_presenter->requestLAContextForUserVerification(WTFMove(completionHandler));
+    if (RefPtr presenter = m_presenter) {
+        presenter->requestLAContextForUserVerification(WTFMove(completionHandler));
         return;
     }
 
@@ -508,7 +508,7 @@ void AuthenticatorManager::runPresenter()
 void AuthenticatorManager::runPresenterInternal(const TransportSet& transports)
 {
     auto& options = m_pendingRequestData.options;
-    m_presenter = makeUnique<AuthenticatorPresenterCoordinator>(*this, getRpId(options), transports, getClientDataType(options), getUserName(options));
+    m_presenter = AuthenticatorPresenterCoordinator::create(*this, getRpId(options), transports, getClientDataType(options), getUserName(options));
 }
 
 void AuthenticatorManager::invokePendingCompletionHandler(Respond&& respond)
@@ -516,8 +516,8 @@ void AuthenticatorManager::invokePendingCompletionHandler(Respond&& respond)
     auto result = std::holds_alternative<Ref<AuthenticatorResponse>>(respond) ? WebAuthenticationResult::Succeeded : WebAuthenticationResult::Failed;
 
     // This is for the new UI.
-    if (m_presenter)
-        m_presenter->dimissPresenter(result);
+    if (RefPtr presenter = m_presenter)
+        presenter->dimissPresenter(result);
     else {
         dispatchPanelClientCall([result] (const API::WebAuthenticationPanel& panel) {
             panel.client().dismissPanel(result);

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -42,15 +42,6 @@
 
 OBJC_CLASS LAContext;
 
-namespace WebKit {
-class AuthenticatorManager;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::AuthenticatorManager> : std::true_type { };
-}
-
 namespace API {
 class WebAuthenticationPanel;
 }
@@ -134,7 +125,7 @@ private:
     WebAuthenticationRequestData m_pendingRequestData;
     Callback m_pendingCompletionHandler; // Should not be invoked directly, use invokePendingCompletionHandler.
     RunLoop::Timer m_requestTimeOutTimer;
-    std::unique_ptr<AuthenticatorPresenterCoordinator> m_presenter;
+    RefPtr<AuthenticatorPresenterCoordinator> m_presenter;
 
     Vector<UniqueRef<AuthenticatorTransportService>> m_services;
     HashSet<Ref<Authenticator>> m_authenticators;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
@@ -33,9 +33,9 @@
 #include <WebCore/WebAuthenticationConstants.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 OBJC_CLASS ASCAppleIDCredential;
 OBJC_CLASS ASCAuthorizationPresentationContext;
@@ -46,26 +46,17 @@ OBJC_CLASS NSError;
 OBJC_CLASS WKASCAuthorizationPresenterDelegate;
 
 namespace WebKit {
-class AuthenticatorPresenterCoordinator;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::AuthenticatorPresenterCoordinator> : std::true_type { };
-}
-
-namespace WebKit {
 
 class AuthenticatorManager;
 
-class AuthenticatorPresenterCoordinator : public CanMakeWeakPtr<AuthenticatorPresenterCoordinator> {
+class AuthenticatorPresenterCoordinator : public RefCountedAndCanMakeWeakPtr<AuthenticatorPresenterCoordinator> {
     WTF_MAKE_TZONE_ALLOCATED(AuthenticatorPresenterCoordinator);
     WTF_MAKE_NONCOPYABLE(AuthenticatorPresenterCoordinator);
 public:
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;
     using CredentialRequestHandler = Function<void(ASCAppleIDCredential *, NSError *)>;
 
-    AuthenticatorPresenterCoordinator(const AuthenticatorManager&, const String& rpId, const TransportSet&, WebCore::ClientDataType, const String& username);
+    static Ref<AuthenticatorPresenterCoordinator> create(const AuthenticatorManager&, const String& rpId, const TransportSet&, WebCore::ClientDataType, const String& username);
     ~AuthenticatorPresenterCoordinator();
 
     void updatePresenter(WebAuthenticationStatus);
@@ -80,6 +71,8 @@ public:
     void setPin(const String&);
 
 private:
+    AuthenticatorPresenterCoordinator(const AuthenticatorManager&, const String& rpId, const TransportSet&, WebCore::ClientDataType, const String& username);
+
     WeakPtr<AuthenticatorManager> m_manager;
     RetainPtr<ASCAuthorizationPresentationContext> m_context;
     RetainPtr<ASCAuthorizationPresenter> m_presenter;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -41,6 +41,11 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorPresenterCoordinator);
 
+Ref<AuthenticatorPresenterCoordinator> AuthenticatorPresenterCoordinator::create(const AuthenticatorManager& manager, const String& rpId, const AuthenticatorPresenterCoordinator::TransportSet& transports, WebCore::ClientDataType type, const String& username)
+{
+    return adoptRef(*new AuthenticatorPresenterCoordinator(manager, rpId, transports, type, username));
+}
+
 AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator(const AuthenticatorManager& manager, const String& rpId, const TransportSet& transports, ClientDataType type, const String& username)
     : m_manager(manager)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
@@ -34,15 +34,6 @@
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
-namespace WebKit {
-class WebAuthenticationPanelClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebAuthenticationPanelClient> : std::true_type { };
-}
-
 @class _WKWebAuthenticationPanel;
 @protocol _WKWebAuthenticationPanelDelegate;
 
@@ -50,11 +41,13 @@ namespace WebKit {
 
 class WebAuthenticationPanelClient final : public API::WebAuthenticationPanelClient, public CanMakeWeakPtr<WebAuthenticationPanelClient> {
 public:
-    WebAuthenticationPanelClient(_WKWebAuthenticationPanel *, id <_WKWebAuthenticationPanelDelegate>);
+    static Ref<WebAuthenticationPanelClient> create(_WKWebAuthenticationPanel *, id<_WKWebAuthenticationPanelDelegate>);
 
-    RetainPtr<id <_WKWebAuthenticationPanelDelegate> > delegate();
+    RetainPtr<id<_WKWebAuthenticationPanelDelegate>> delegate() const;
 
 private:
+    WebAuthenticationPanelClient(_WKWebAuthenticationPanel *, id <_WKWebAuthenticationPanelDelegate>);
+
     // API::WebAuthenticationPanelClient
     void updatePanel(WebAuthenticationStatus) const final;
     void dismissPanel(WebAuthenticationResult) const final;
@@ -64,7 +57,7 @@ private:
     void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&) const final;
 
     _WKWebAuthenticationPanel *m_panel;
-    WeakObjCPtr<id <_WKWebAuthenticationPanelDelegate> > m_delegate;
+    WeakObjCPtr<id<_WKWebAuthenticationPanelDelegate>> m_delegate;
 
     struct {
         bool panelUpdateWebAuthenticationPanel : 1;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -41,7 +41,12 @@
 
 namespace WebKit {
 
-WebAuthenticationPanelClient::WebAuthenticationPanelClient(_WKWebAuthenticationPanel *panel, id <_WKWebAuthenticationPanelDelegate> delegate)
+Ref<WebAuthenticationPanelClient> WebAuthenticationPanelClient::create(_WKWebAuthenticationPanel *panel, id<_WKWebAuthenticationPanelDelegate> delegate)
+{
+    return adoptRef(*new WebAuthenticationPanelClient(panel, delegate));
+}
+
+WebAuthenticationPanelClient::WebAuthenticationPanelClient(_WKWebAuthenticationPanel *panel, id<_WKWebAuthenticationPanelDelegate> delegate)
     : m_panel(panel)
     , m_delegate(delegate)
 {
@@ -53,7 +58,7 @@ WebAuthenticationPanelClient::WebAuthenticationPanelClient(_WKWebAuthenticationP
     m_delegateMethods.panelRequestLAContextForUserVerificationCompletionHandler = [delegate respondsToSelector:@selector(panel:requestLAContextForUserVerificationWithCompletionHandler:)];
 }
 
-RetainPtr<id <_WKWebAuthenticationPanelDelegate> > WebAuthenticationPanelClient::delegate()
+RetainPtr<id<_WKWebAuthenticationPanelDelegate>> WebAuthenticationPanelClient::delegate() const
 {
     return m_delegate.get();
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2114,9 +2114,14 @@ VirtualAuthenticatorManager& WebsiteDataStore::virtualAuthenticatorManager()
     return downcast<VirtualAuthenticatorManager>(m_authenticatorManager.get());
 }
 
+Ref<AuthenticatorManager> WebsiteDataStore::protectedAuthenticatorManager()
+{
+    return authenticatorManager();
+}
+
 Ref<VirtualAuthenticatorManager> WebsiteDataStore::protectedVirtualAuthenticatorManager()
 {
-return virtualAuthenticatorManager();
+    return virtualAuthenticatorManager();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -324,6 +324,7 @@ public:
 
 #if ENABLE(WEB_AUTHN)
     AuthenticatorManager& authenticatorManager() { return m_authenticatorManager.get(); }
+    Ref<AuthenticatorManager> protectedAuthenticatorManager();
     void setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
     VirtualAuthenticatorManager& virtualAuthenticatorManager();
     Ref<VirtualAuthenticatorManager> protectedVirtualAuthenticatorManager();


### PR DESCRIPTION
#### baf68af71e1f9fb6f560653be5d2185b053d60bd
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make more WebAuthentication classes RefCounted or equivalent
<a href="https://bugs.webkit.org/show_bug.cgi?id=281178">https://bugs.webkit.org/show_bug.cgi?id=281178</a>

Reviewed by Chris Dumez.

Make following classes refCounted or equivalent because they are subclass of CanMakeWeakPtr:
- Authenticator
- AuthenticatorManager
- AuthenticatorPresenterCoordinator
- WebAuthenticationPanelClient

Other classes for WebAuthentication are treated in the next patch.

* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp:
(API::WebAuthenticationPanel::WebAuthenticationPanel):
(API::WebAuthenticationPanel::setClient):
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(-[_WKWebAuthenticationPanel delegate]):
(-[_WKWebAuthenticationPanel setDelegate:]):
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp:
(WebKit::Authenticator::receiveRespond const):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::serviceStatusUpdated):
(WebKit::AuthenticatorManager::authenticatorStatusUpdated):
(WebKit::AuthenticatorManager::requestPin):
(WebKit::AuthenticatorManager::selectAssertionResponse):
(WebKit::AuthenticatorManager::requestLAContextForUserVerification):
(WebKit::AuthenticatorManager::runPresenterInternal):
(WebKit::AuthenticatorManager::invokePendingCompletionHandler):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::create):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::WebAuthenticationPanelClient::create):
(WebKit::WebAuthenticationPanelClient::WebAuthenticationPanelClient):
(WebKit::WebAuthenticationPanelClient::delegate const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::protectedAuthenticatorManager):
(WebKit::WebsiteDataStore::protectedVirtualAuthenticatorManager):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/285204@main">https://commits.webkit.org/285204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e99e48b1c39822acf5ddc6aa32da8942e209139a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24615 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23046 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22866 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74907 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61895 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43169 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21396 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15881 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12616 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6262 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1844 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->