### PR TITLE
Change `display: none` early return to ASSERT in `Style::TreeResolver::resolvePseudoElement`

### DIFF
--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -326,7 +326,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
         update.style->addCachedPseudoStyle(WTFMove(pseudoElementUpdate->style));
         return pseudoElementUpdate->change;
     };
-    
+
     if (resolveAndAddPseudoElementStyle({ PseudoId::FirstLine }) != Change::None)
         descendantsToResolve = DescendantsToResolve::All;
     if (resolveAndAddPseudoElementStyle({ PseudoId::FirstLetter }) != Change::None)
@@ -378,8 +378,8 @@ inline bool supportsFirstLineAndLetterPseudoElement(const RenderStyle& style)
 
 std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element, const PseudoElementIdentifier& pseudoElementIdentifier, const ElementUpdate& elementUpdate, IsInDisplayNoneTree isInDisplayNoneTree)
 {
-    if (elementUpdate.style->display() == DisplayType::None)
-        return { };
+    ASSERT(elementUpdate.style->display() != DisplayType::None);
+
     if (pseudoElementIdentifier.pseudoId == PseudoId::Backdrop && !element.isInTopLayer())
         return { };
     if (pseudoElementIdentifier.pseudoId == PseudoId::Marker && elementUpdate.style->display() != DisplayType::ListItem)


### PR DESCRIPTION
#### bc1340bda30991fddf11553c24cf4297708f711c
<pre>
Change `display: none` early return to ASSERT in `Style::TreeResolver::resolvePseudoElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281179">https://bugs.webkit.org/show_bug.cgi?id=281179</a>
<a href="https://rdar.apple.com/137637992">rdar://137637992</a>

Reviewed by NOBODY (OOPS!).

We should never reach this code if the display is none, since `TreeResolver::resolveElement` should early return way before that in this specific case.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolvePseudoElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc1340bda30991fddf11553c24cf4297708f711c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21991 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56131 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14612 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36579 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42429 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18610 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20514 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64369 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18971 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76788 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15200 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18173 "Found 60 new test failures: accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/animated-dropdown.html accessibility/aria-invalid.html accessibility/aria-labelledby-overrides-aria-labeledby.html accessibility/combobox/combobox-linked-listbox-destroyed.html accessibility/display-contents/end-text-marker.html accessibility/mac/active-descendant-after-visibility-change.html accessibility/mac/aria-menu-closed-notification.html accessibility/mac/aria-modal-auto-focus.html accessibility/mac/child-update-during-ax-request.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63870 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11919 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5567 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->