### PR TITLE
[MotionMark] Remove `SDKAlignedBehavior::DoesNotAddIntrinsicMarginsToFormControls`

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -51,7 +51,6 @@ enum class SDKAlignedBehavior {
     DisallowsSettingAnyXHRHeaderFromFileURLs,
     DoesNotDrainTheMicrotaskQueueWhenCallingObjC,
     DoesNotParseStringEndingWithFullStopAsFloatingPointNumber,
-    DoesNotAddIntrinsicMarginsToFormControls,
     DOMWindowReuseRestriction,
     DownloadDelegatesCalledOnTheMainThread,
     DropToNavigateDisallowedByDefault,

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -185,7 +185,6 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
 
     if (linkedBefore(dyld_spring_2023_os_versions, DYLD_IOS_VERSION_16_4, DYLD_MACOSX_VERSION_13_3)) {
         disableBehavior(SDKAlignedBehavior::NoShowModalDialog);
-        disableBehavior(SDKAlignedBehavior::DoesNotAddIntrinsicMarginsToFormControls);
         disableBehavior(SDKAlignedBehavior::ProgrammaticFocusDuringUserScriptShowsInputViews);
         disableBehavior(SDKAlignedBehavior::DefaultsToExcludingBackgroundsWhenPrinting);
         disableBehavior(SDKAlignedBehavior::InspectableDefaultsToDisabled);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -97,30 +97,6 @@ Adjuster::Adjuster(const Document& document, const RenderStyle& parentStyle, con
 {
 }
 
-#if PLATFORM(COCOA)
-static void addIntrinsicMargins(RenderStyle& style)
-{
-    // Intrinsic margin value.
-    const int intrinsicMargin = clampToInteger(2 * style.usedZoom());
-
-    // FIXME: Using width/height alone and not also dealing with min-width/max-width is flawed.
-    // FIXME: Using "hasQuirk" to decide the margin wasn't set is kind of lame.
-    if (style.width().isIntrinsicOrAuto()) {
-        if (style.marginLeft().hasQuirk())
-            style.setMarginLeft(WebCore::Length(intrinsicMargin, LengthType::Fixed));
-        if (style.marginRight().hasQuirk())
-            style.setMarginRight(WebCore::Length(intrinsicMargin, LengthType::Fixed));
-    }
-
-    if (style.height().isAuto()) {
-        if (style.marginTop().hasQuirk())
-            style.setMarginTop(WebCore::Length(intrinsicMargin, LengthType::Fixed));
-        if (style.marginBottom().hasQuirk())
-            style.setMarginBottom(WebCore::Length(intrinsicMargin, LengthType::Fixed));
-    }
-}
-#endif
-
 // https://www.w3.org/TR/css-display-3/#transformations
 static DisplayType equivalentBlockDisplay(const RenderStyle& style)
 {
@@ -665,19 +641,6 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     // Do the same for scroll-timeline and view-timeline longhands.
     style.adjustScrollTimelines();
     style.adjustViewTimelines();
-
-#if PLATFORM(COCOA)
-    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DoesNotAddIntrinsicMarginsToFormControls)) {
-        // Important: Intrinsic margins get added to controls before the theme has adjusted the style, since the theme will
-        // alter fonts and heights/widths.
-        if (is<HTMLFormControlElement>(m_element) && style.computedFontSize() >= 11) {
-            // Don't apply intrinsic margins to image buttons. The designer knows how big the images are,
-            // so we have to treat all image buttons as though they were explicitly sized.
-            if (RefPtr input = dynamicDowncast<HTMLInputElement>(*m_element); !input || !input->isImageButton())
-                addIntrinsicMargins(style);
-        }
-    }
-#endif
 
     // Let the theme also have a crack at adjusting the style.
     if (style.hasAppearance())


### PR DESCRIPTION
#### 7d92b57f12de8cec337e70697aea370e0aa5fa27
<pre>
[MotionMark] Remove `SDKAlignedBehavior::DoesNotAddIntrinsicMarginsToFormControls`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281181">https://bugs.webkit.org/show_bug.cgi?id=281181</a>
<a href="https://rdar.apple.com/137640626">rdar://137640626</a>

Reviewed by NOBODY (OOPS!).

This shows up on MotionMark traces as 5% of Style::Adjuster::adjust.

This was added in 253424@main.

The effective change is that there is no longer a 2px margin added by default on apps linked against an older SDK,
when the button uses quirky ems as margins, which seems like a rare use case.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::addIntrinsicMargins): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d92b57f12de8cec337e70697aea370e0aa5fa27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56143 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14622 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20534 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64112 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76808 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70237 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63881 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63842 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5579 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/976 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20057 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->