### PR TITLE
AX: Implement TextUnit::Sentence (current) off the main thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav-expected.txt
@@ -1,0 +1,33 @@
+This tests that sentence navigation is working correctly.
+
+Current character is: T
+Current sentence is: This is a sentence, right?
+
+Current character is: t
+Current sentence is: test audio [ATTACHMENT]file.
+
+Current character is: 巧
+Current sentence is: 巧克力 是食物吗?
+
+Current character is: ك
+Current sentence is: كيف حالك؟
+
+Current character is: b
+Current sentence is: both   spaces
+
+Current character is: i
+Current sentence is: line breaks.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a sentence, right? Yes!
+test audio file.
+巧克力 是食物吗? 是的。
+كيف حالك؟
+both   spaces
+line breaks. Right?
+This is my first sentence.
+
+This is my second sentence. This is my third sentence. This is my fourth sentence.

--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav.html
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is a modern-style rewrite of mac/text-marker-sentence-nav.html, and should replace it after AccessibilityThreadTextApisEnabled is enabled by default. -->
+<html>
+<head>
+<meta charset="utf-8"> 
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body id="body">
+
+<div id="text1" tabindex="0">
+This i<span>s a sen</span>tence,
+right? Yes!
+</div>
+
+<div id="text2">
+test audio <audio controls><source src="test.mp3" type="audio/mpeg"></audio>file.
+</div>
+
+<div id="text3">
+巧克力
+是食物吗? 是的。
+</div>
+
+<div id="text3a">
+كيف حالك؟
+</div>
+
+<pre id="text4">
+both   spaces
+line breaks. Right?
+</pre>
+
+<div id="text5">
+This is my first sentence.<br><br>
+This is my second sentence. This is my third sentence.
+This is my fourth sentence.
+</div>
+
+<script>
+var output = "This tests that sentence navigation is working correctly.\n\n"
+
+if (window.accessibilityController) {
+
+    // Check that we can get the paragraph range with span tag.
+    var text = accessibilityController.accessibleElementById("text1");
+    var textMarkerRange = text.textMarkerRangeForElement(text);
+    var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    var currentMarker = advanceAndVerify(startMarker, 1, text);
+    
+    // Audio tag.
+    text = accessibilityController.accessibleElementById("text2");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    
+    // Multi-languages.
+    text = accessibilityController.accessibleElementById("text3");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    
+    text = accessibilityController.accessibleElementById("text3a");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    
+    // Check the case with pre tag.
+    text = accessibilityController.accessibleElementById("text4");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    currentMarker = advanceAndVerify(currentMarker, 15, text);
+    
+    // Check getting the correct sentences.
+    text = accessibilityController.accessibleElementById("text5");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+
+    // FIXME: Add in verifySentences() to match the original test once next/previous sentence
+    // are implemented.
+
+    debug(output);
+    
+    function advanceAndVerify(currentMarker, offset, obj) {
+        var previousMarker = currentMarker;
+        for (var i = 0; i < offset; i++) {
+            previousMarker = currentMarker;
+            currentMarker = obj.nextTextMarker(previousMarker);
+        }
+        verifySentenceRangeForTextMarker(previousMarker, currentMarker, obj);
+        output += "\n";
+        return currentMarker;
+    }
+    
+    function replaceAttachmentInString(str) {
+        str =  str.replace(String.fromCharCode(65532), "[ATTACHMENT]");
+        return str;
+    }
+    
+    function verifySentenceRangeForTextMarker(preMarker, textMarker, obj) {
+        var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
+        var currentCharacter = replaceAttachmentInString(obj.stringForTextMarkerRange(markerRange));
+        output += `Current character is: ${currentCharacter}\n`;
+        
+        var range = obj.sentenceTextMarkerRangeForTextMarker(textMarker);
+        var sentence = replaceAttachmentInString(obj.stringForTextMarkerRange(range));
+        output += `Current sentence is: ${sentence}\n`;
+        
+        // FIXME: Add "Pre sentence start to next sentence end" to match original test once 
+        // previousSentenceStartTextMarkerForTextMarker and nextSentenceEndTextMarkerForTextMarker
+        // are implemented off the main thread.
+    }
+}
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -54,6 +54,12 @@ enum class WordRangeType : uint8_t {
     Right,
 };
 
+enum class SentenceRangeType : uint8_t {
+    Current,
+    Left,
+    Right,
+};
+
 // Options for findMarker
 enum class CoalesceObjectBreaks : bool { No, Yes };
 enum class IgnoreBRs : bool { No, Yes };
@@ -181,11 +187,15 @@ public:
     AXTextMarker nextWordEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Word, AXTextUnitBoundary::End, stopAtID); }
     AXTextMarker previousWordStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Word, AXTextUnitBoundary::Start, stopAtID); }
     AXTextMarker previousWordEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Word, AXTextUnitBoundary::End, stopAtID); }
+    AXTextMarker previousSentenceStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Sentence, AXTextUnitBoundary::Start, stopAtID); }
+    AXTextMarker nextSentenceEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Sentence, AXTextUnitBoundary::End, stopAtID); }
 
     // Creates a range for the line this marker points to.
     AXTextMarkerRange lineRange(LineRangeType) const;
     // Creates a range for the word specified by the line range type.
     AXTextMarkerRange wordRange(WordRangeType) const;
+    // Creates a range for the sentence specified by the sentence range type;
+    AXTextMarkerRange sentenceRange(SentenceRangeType) const;
     // Given a character offset relative to this marker, find the next marker the offset points to.
     AXTextMarker nextMarkerFromOffset(unsigned) const;
     // Returns the number of intermediate text markers between this and the root.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3062,6 +3062,8 @@ enum class TextUnit {
             return inputMarker.wordRange(WordRangeType::Left).platformData().autorelease();
         case TextUnit::RightWord:
             return inputMarker.wordRange(WordRangeType::Right).platformData().autorelease();
+        case TextUnit::Sentence:
+            return inputMarker.sentenceRange(SentenceRangeType::Current).platformData().autorelease();
         default:
             // TODO: Not implemented!
             break;


### PR DESCRIPTION
#### 57e3f9bf4e22d7ff0ba3f08344782a277fbeca38
<pre>
AX: Implement TextUnit::Sentence (current) off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=281182">https://bugs.webkit.org/show_bug.cgi?id=281182</a>
<a href="https://rdar.apple.com/134579696">rdar://134579696</a>

Reviewed by Tyler Wilcock.

This patch supports calculating the current TextUnit::Sentence on the accessibility thread. Building
off of the work done for supporting LeftWord/RightWord, I reuse that existing infrastructure, and
abstract out the calculations for word and sentence text units into lambdas.

The partially ported test, text-marker-sentence-nav.html, only verifies the current-sentence API.
This test will be expanded once more Sentence APIs are implemented on the accessibility thread
(see &quot;FIXME&quot;s in the test).

* LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/text-marker-sentence-nav.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::previousSentenceStartFromPosition):
(WebCore::nextSentenceEndFromPosition):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::sentenceRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::previousSentenceStart const):
(WebCore::AXTextMarker::nextSentenceEnd const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper textMarkerRangeAtTextMarker:forUnit:]):

Canonical link: <a href="https://commits.webkit.org/284951@main">https://commits.webkit.org/284951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2145234063d6daf72411e0b36b1f59959b304abb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22003 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14614 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61185 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20526 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15212 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61244 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11928 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/968 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->