### PR TITLE
Support setting IBL in WKSRKEntity

### DIFF
--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -58,6 +58,8 @@ typedef struct {
 
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
+- (void)applyIBLData:(NSData *)data;
+- (void)removeIBL;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 05055da95c4f2fd33e16ce11393085acc98c0d54
<pre>
Support setting IBL in WKSRKEntity
<a href="https://bugs.webkit.org/show_bug.cgi?id=281185">https://bugs.webkit.org/show_bug.cgi?id=281185</a>
<a href="https://rdar.apple.com/137003306">rdar://137003306</a>

Reviewed by Mike Wyrzykowski.

Create a CGImage from the image data, then create a TextureResource from it,
and create an EnvironmentResource from that texture resource.
Then set up the environment lighting for the model entity with that
environment resource via RealityKit ImageBasedLight component.

* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity.applyIBL(_:)):
(WKSRKEntity.removeIBL):
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:

Canonical link: <a href="https://commits.webkit.org/284966@main">https://commits.webkit.org/284966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c146357cdff94670446edc4d0bc70b746333933

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14639 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42474 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20582 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18218 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5616 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1025 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->