### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for AuthenticatorObserver

### DIFF
--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
@@ -77,10 +77,12 @@ public:
     WTF::String userName() const { return m_userName; }
 
 private:
+    RefPtr<WebKit::AuthenticatorManager> protectedManager() const;
+
     // FIXME: <rdar://problem/71509848> Remove the following deprecated method.
     WebAuthenticationPanel(const WebKit::AuthenticatorManager&, const WTF::String& rpId, const TransportSet&, WebCore::ClientDataType, const WTF::String& userName);
 
-    std::unique_ptr<WebKit::AuthenticatorManager> m_manager; // FIXME: <rdar://problem/71509848> Change to UniqueRef.
+    RefPtr<WebKit::AuthenticatorManager> m_manager; // FIXME: <rdar://problem/71509848> Change to Ref.
     UniqueRef<WebAuthenticationPanelClient> m_client;
 
     // FIXME: <rdar://problem/71509848> Remove the following deprecated fields.

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1648,7 +1648,7 @@ Inspector::Protocol::ErrorStringOr<String /* authenticatorId */> WebAutomationSe
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
         SYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
-    return page->protectedWebsiteDataStore()->virtualAuthenticatorManager().createAuthenticator({
+    return page->protectedWebsiteDataStore()->protectedVirtualAuthenticatorManager()->createAuthenticator({
         .protocol = protocol,
         .transport = toAuthenticatorTransport(parsedTransport.value()),
         .hasResidentKey = *hasResidentKey,
@@ -1667,7 +1667,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::removeVirtualAuth
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
         SYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
-    if (!page->protectedWebsiteDataStore()->virtualAuthenticatorManager().removeAuthenticator(authenticatorId))
+    if (!page->protectedWebsiteDataStore()->protectedVirtualAuthenticatorManager()->removeAuthenticator(authenticatorId))
         SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InvalidParameter, "No such authenticator exists."_s);
     return { };
 #else

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -38,15 +38,6 @@
 
 OBJC_CLASS LAContext;
 
-namespace WebKit {
-class AuthenticatorObserver;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::AuthenticatorObserver> : std::true_type { };
-}
-
 namespace WebCore {
 class AuthenticatorAssertionResponse;
 }
@@ -67,6 +58,9 @@ public:
     virtual void decidePolicyForLocalAuthenticator(CompletionHandler<void(LocalAuthenticatorPolicy)>&&) = 0;
     virtual void requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&&) = 0;
     virtual void cancelRequest() = 0;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 };
 
 class Authenticator : public RefCounted<Authenticator>, public CanMakeWeakPtr<Authenticator> {

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -179,6 +179,11 @@ const size_t AuthenticatorManager::maxTransportNumber = 5;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorManager);
 
+Ref<AuthenticatorManager> AuthenticatorManager::create()
+{
+    return adoptRef(*new AuthenticatorManager);
+}
+
 AuthenticatorManager::AuthenticatorManager()
     : m_requestTimeOutTimer(RunLoop::main(), this, &AuthenticatorManager::timeOutTimerFired)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -57,7 +57,7 @@ class WebAuthenticationPanel;
 
 namespace WebKit {
 
-class AuthenticatorManager : public AuthenticatorTransportServiceObserver, public AuthenticatorObserver {
+class AuthenticatorManager : public RefCounted<AuthenticatorManager>, public AuthenticatorTransportServiceObserver, public AuthenticatorObserver {
     WTF_MAKE_TZONE_ALLOCATED(AuthenticatorManager);
     WTF_MAKE_NONCOPYABLE(AuthenticatorManager);
 public:
@@ -69,7 +69,7 @@ public:
 
     const static size_t maxTransportNumber;
 
-    AuthenticatorManager();
+    static Ref<AuthenticatorManager> create();
     virtual ~AuthenticatorManager() = default;
 
     void handleRequest(WebAuthenticationRequestData&&, Callback&&);
@@ -82,7 +82,12 @@ public:
 
     void enableNativeSupport();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 protected:
+    AuthenticatorManager();
+
     RunLoop::Timer& requestTimeOutTimer() { return m_requestTimeOutTimer; }
     void clearStateAsync(); // To void cyclic dependence.
     void clearState();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -270,7 +270,7 @@ void LocalAuthenticator::makeCredential()
         }
     }
 
-    if (auto* observer = this->observer()) {
+    if (RefPtr observer = this->observer()) {
         auto callback = [weakThis = WeakPtr { *this }] (LAContext *context) {
             ASSERT(RunLoop::isMain());
             if (!weakThis)
@@ -635,7 +635,7 @@ void LocalAuthenticator::getAssertion()
     // Step 6-7. User consent is implicitly acquired by selecting responses.
     m_connection->filterResponses(assertionResponses);
 
-    if (auto* observer = this->observer()) {
+    if (RefPtr observer = this->observer()) {
         auto callback = [this, weakThis = WeakPtr { *this }] (AuthenticatorAssertionResponse* response) {
             RELEASE_ASSERT(RunLoop::isMain());
             if (!weakThis)
@@ -774,7 +774,7 @@ void LocalAuthenticator::receiveException(ExceptionData&& exception, WebAuthenti
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't delete provisional credential while handling error: %d", status);
     }
 
-    if (auto* observer = this->observer())
+    if (RefPtr observer = this->observer())
         observer->authenticatorStatusUpdated(status);
 
     receiveRespond(WTFMove(exception));
@@ -809,7 +809,7 @@ void LocalAuthenticator::deleteDuplicateCredential() const
 bool LocalAuthenticator::validateUserVerification(LocalConnection::UserVerification verification) const
 {
     if (verification == LocalConnection::UserVerification::Cancel) {
-        if (auto* observer = this->observer())
+        if (RefPtr observer = this->observer())
             observer->cancelRequest();
         return false;
     }

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
@@ -30,6 +30,11 @@
 
 namespace WebKit {
 
+Ref<MockAuthenticatorManager> MockAuthenticatorManager::create(WebCore::MockWebAuthenticationConfiguration&& configuration)
+{
+    return adoptRef(*new MockAuthenticatorManager(WTFMove(configuration)));
+}
+
 MockAuthenticatorManager::MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&& configuration)
     : m_testConfiguration(WTFMove(configuration))
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
@@ -34,12 +34,14 @@ namespace WebKit {
 
 class MockAuthenticatorManager final : public AuthenticatorManager {
 public:
-    explicit MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&&);
+    static Ref<MockAuthenticatorManager> create(WebCore::MockWebAuthenticationConfiguration&&);
 
     bool isMock() const final { return true; }
     void setTestConfiguration(WebCore::MockWebAuthenticationConfiguration&& configuration) { m_testConfiguration = WTFMove(configuration); }
 
 private:
+    explicit MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&&);
+
     UniqueRef<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
     void respondReceivedInternal(Respond&&) final;
     void filterTransports(TransportSet&) const;
@@ -49,5 +51,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::MockAuthenticatorManager)
+static bool isType(const WebKit::AuthenticatorManager& manager) { return manager.isMock(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
@@ -35,10 +35,12 @@ namespace WebKit {
 
 struct VirtualCredential;
 
-VirtualAuthenticatorManager::VirtualAuthenticatorManager()
-    : AuthenticatorManager()
+Ref<VirtualAuthenticatorManager> VirtualAuthenticatorManager::create()
 {
+    return adoptRef(*new VirtualAuthenticatorManager);
 }
+
+VirtualAuthenticatorManager::VirtualAuthenticatorManager() = default;
 
 String VirtualAuthenticatorManager::createAuthenticator(const VirtualAuthenticatorConfiguration& config)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
@@ -46,7 +46,7 @@ struct VirtualCredential;
 
 class VirtualAuthenticatorManager final : public AuthenticatorManager {
 public:
-    explicit VirtualAuthenticatorManager();
+    static Ref<VirtualAuthenticatorManager> create();
 
     String createAuthenticator(const VirtualAuthenticatorConfiguration& /*config/*/);
     bool removeAuthenticator(const String& /*authenticatorId*/);
@@ -62,6 +62,8 @@ protected:
     
     
 private:
+    VirtualAuthenticatorManager();
+
     UniqueRef<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
     void runPanel() override;
     void filterTransports(TransportSet&) const override { };
@@ -71,5 +73,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::VirtualAuthenticatorManager)
+static bool isType(const WebKit::AuthenticatorManager& manager) { return manager.isVirtual(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
@@ -127,9 +127,9 @@ void VirtualHidConnection::parseRequest()
 {
     if (!m_requestMessage)
         return;
-    if (!m_manager)
+    RefPtr manager = m_manager.get();
+    if (!manager)
         return;
-    auto* manager = m_manager.get();
     m_currentChannel = m_requestMessage->channelId();
     switch (m_requestMessage->cmd()) {
     case FidoHidDeviceCommand::kInit: {
@@ -293,7 +293,7 @@ void VirtualHidConnection::parseRequest()
                     }
                 }
             }
-            auto matchingCredentials = m_manager->credentialsMatchingList(m_authenticatorId, rpId, allowList);
+            auto matchingCredentials = manager->credentialsMatchingList(m_authenticatorId, rpId, allowList);
             if (matchingCredentials.isEmpty()) {
                 recieveResponseCode(CtapDeviceResponseCode::kCtap2ErrNoCredentials);
                 return;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -372,7 +372,7 @@ void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uin
     CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived: Remaining responses: %lu", m_remainingAssertionResponses);
 
     if (!m_remainingAssertionResponses) {
-        if (auto* observer = this->observer()) {
+        if (RefPtr observer = this->observer()) {
             observer->selectAssertionResponse(Vector { m_assertionResponses }, WebAuthenticationSource::External, [this, weakThis = WeakPtr { *this }] (AuthenticatorAssertionResponse* response) {
                 RELEASE_ASSERT(RunLoop::isMain());
                 if (!weakThis)
@@ -442,7 +442,7 @@ void CtapAuthenticator::continueRequestPinAfterGetKeyAgreement(Vector<uint8_t>&&
         return;
     }
 
-    if (auto* observer = this->observer()) {
+    if (RefPtr observer = this->observer()) {
         CTAP_RELEASE_LOG("continueRequestPinAfterGetKeyAgreement: Requesting pin from observer.");
         observer->requestPin(retries, [weakThis = WeakPtr { *this }, this, keyAgreement = WTFMove(*keyAgreement)] (const String& pin) {
             RELEASE_ASSERT(RunLoop::isMain());
@@ -465,7 +465,7 @@ void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, co
     auto pinUTF8 = pin::validateAndConvertToUTF8(pin);
     if (!pinUTF8) {
         // Fake a pin invalid response from the authenticator such that clients could show some error to the user.
-        if (auto* observer = this->observer())
+        if (RefPtr observer = this->observer())
             observer->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
         tryRestartPin(CtapDeviceResponseCode::kCtap2ErrPinInvalid);
         return;
@@ -495,7 +495,7 @@ void CtapAuthenticator::continueRequestAfterGetPinToken(Vector<uint8_t>&& data, 
         auto error = getResponseCode(data);
 
         if (isPinError(error)) {
-            if (auto* observer = this->observer())
+            if (RefPtr observer = this->observer())
                 observer->authenticatorStatusUpdated(toStatus(error));
             if (tryRestartPin(error))
                 return;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -228,7 +228,7 @@ void U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived(Ap
     U2F_RELEASE_LOG("continueBogusCommandNoCredentialsAfterResponseReceived: Status %hu", enumToUnderlyingType(apduResponse.status()));
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
-        if (auto* observer = this->observer())
+        if (RefPtr observer = this->observer())
             observer->authenticatorStatusUpdated(WebAuthenticationStatus::NoCredentialsFound);
         receiveRespond(ExceptionData { ExceptionCode::NotAllowedError, "No credentials from the allowCredentials list is found in the authenticator."_s });
         return;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -326,6 +326,7 @@ public:
     AuthenticatorManager& authenticatorManager() { return m_authenticatorManager.get(); }
     void setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
     VirtualAuthenticatorManager& virtualAuthenticatorManager();
+    Ref<VirtualAuthenticatorManager> protectedVirtualAuthenticatorManager();
 #endif
 
     const WebsiteDataStoreConfiguration& configuration() const { return m_configuration.get(); }
@@ -587,7 +588,7 @@ private:
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    UniqueRef<AuthenticatorManager> m_authenticatorManager;
+    Ref<AuthenticatorManager> m_authenticatorManager;
 #endif
 
 #if ENABLE(DEVICE_ORIENTATION)


### PR DESCRIPTION
#### 4498b1b0bb68bb1554a25dce7792d3414e0b81e3
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for AuthenticatorObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=281184">https://bugs.webkit.org/show_bug.cgi?id=281184</a>

Reviewed by Sihui Liu.

* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp:
(API::WebAuthenticationPanel::WebAuthenticationPanel):
(API::WebAuthenticationPanel::protectedManager const):
(API::WebAuthenticationPanel::handleRequest):
(API::WebAuthenticationPanel::cancel const):
(API::WebAuthenticationPanel::setMockConfiguration):
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::create):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp:
(WebKit::MockAuthenticatorManager::create):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h:
(isType):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp:
(WebKit::VirtualAuthenticatorManager::create):
(WebKit::VirtualAuthenticatorManager::VirtualAuthenticatorManager): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h:
(isType):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp:
(WebKit::VirtualHidConnection::parseRequest):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::WebsiteDataStore):
(WebKit::WebsiteDataStore::setMockWebAuthenticationConfiguration):
(WebKit::WebsiteDataStore::virtualAuthenticatorManager):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/284972@main">https://commits.webkit.org/284972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b563393226789d84dd9f651f93ce514334a826c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22275 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22093 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14676 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/61271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42544 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15302 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15346 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63891 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12013 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47355 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->