### PR TITLE
[JSC] Ignore top byte in Integrity sanity checking on ARM64

### DIFF
--- a/Source/JavaScriptCore/tools/Integrity.h
+++ b/Source/JavaScriptCore/tools/Integrity.h
@@ -98,6 +98,10 @@ private:
 ALWAYS_INLINE static bool isSanePointer(const void* pointer)
 {
     uintptr_t pointerAsInt = bitwise_cast<uintptr_t>(pointer);
+#if CPU(ARM64) && CPU(ADDRESS64)
+    // On ARM64, top byte ignore means we can ignore these bits for addresses.
+    pointerAsInt &= std::numeric_limits<uintptr_t>::max() >> CHAR_BIT;
+#endif
     if (pointerAsInt < lowestAccessibleAddress())
         return false;
 #if CPU(ADDRESS64)


### PR DESCRIPTION
#### 511b828afd0dc2c28bcd00a262e0f41cf80e48fe
<pre>
[JSC] Ignore top byte in Integrity sanity checking on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=281187">https://bugs.webkit.org/show_bug.cgi?id=281187</a>
<a href="https://rdar.apple.com/137641787">rdar://137641787</a>

Reviewed by Keith Miller.

Masks off top byte on ARM64 in Integrity::isSanePointer, since these bits
are ignored architecturally, and we don&apos;t want to fail pointer audits
if we use these bits for other things.

* Source/JavaScriptCore/tools/Integrity.h:
(JSC::Integrity::isSanePointer):

Canonical link: <a href="https://commits.webkit.org/284975@main">https://commits.webkit.org/284975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/998329aed90fe287687c7b8c9c9e29f84945566b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56150 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14629 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18647 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20558 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64136 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76836 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70261 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18196 "Found 1 new test failure: pageoverlay/overlay-small-frame-mouse-events.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63890 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5591 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92042 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46225 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20064 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->