### PR TITLE
Remove unused BBQOSREntryMode enum value

### DIFF
--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1065,7 +1065,6 @@ static String tierName(SamplingProfiler::StackFrame& frame)
                 // Just say "Wasm" for now.
                 break;
             case Wasm::CompilationMode::BBQMode:
-            case Wasm::CompilationMode::BBQForOSREntryMode:
                 return Tiers::bbq;
             case Wasm::CompilationMode::OMGMode:
             case Wasm::CompilationMode::OMGForOSREntryMode:

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WasmToJSCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(JSToWasmICCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OptimizingJITCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OMGCallee);
-WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OSREntryCallee);
+WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OMGOSREntryCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(BBQCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(IPIntCallee);
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(LLIntCallee);
@@ -97,12 +97,8 @@ inline void Callee::runWithDowncast(const Func& func)
     case CompilationMode::BBQMode:
         func(static_cast<BBQCallee*>(this));
         break;
-    case CompilationMode::BBQForOSREntryMode:
-        func(static_cast<OSREntryCallee*>(this));
-        break;
 #else
     case CompilationMode::BBQMode:
-    case CompilationMode::BBQForOSREntryMode:
         break;
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
@@ -110,7 +106,7 @@ inline void Callee::runWithDowncast(const Func& func)
         func(static_cast<OMGCallee*>(this));
         break;
     case CompilationMode::OMGForOSREntryMode:
-        func(static_cast<OSREntryCallee*>(this));
+        func(static_cast<OMGOSREntryCallee*>(this));
         break;
 #else
     case CompilationMode::OMGMode:

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -283,12 +283,12 @@ private:
 constexpr int32_t stackCheckUnset = 0;
 constexpr int32_t stackCheckNotNeeded = -1;
 
-class OSREntryCallee final : public OptimizingJITCallee {
-    WTF_MAKE_COMPACT_TZONE_ALLOCATED(OSREntryCallee);
+class OMGOSREntryCallee final : public OptimizingJITCallee {
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(OMGOSREntryCallee);
 public:
-    static Ref<OSREntryCallee> create(CompilationMode compilationMode, FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name, uint32_t loopIndex)
+    static Ref<OMGOSREntryCallee> create(FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name, uint32_t loopIndex)
     {
-        return adoptRef(*new OSREntryCallee(compilationMode, index, WTFMove(name), loopIndex));
+        return adoptRef(*new OMGOSREntryCallee(index, WTFMove(name), loopIndex));
     }
 
     unsigned osrEntryScratchBufferSize() const { return m_osrEntryScratchBufferSize; }
@@ -315,8 +315,8 @@ public:
     }
 
 private:
-    OSREntryCallee(CompilationMode compilationMode, FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name, uint32_t loopIndex)
-        : OptimizingJITCallee(compilationMode, index, WTFMove(name))
+    OMGOSREntryCallee(FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name, uint32_t loopIndex)
+        : OptimizingJITCallee(CompilationMode::OMGForOSREntryMode, index, WTFMove(name))
         , m_loopIndex(loopIndex)
     {
     }
@@ -362,8 +362,8 @@ public:
     }
     ~BBQCallee();
 
-    OSREntryCallee* osrEntryCallee() { return m_osrEntryCallee.get(); }
-    void setOSREntryCallee(Ref<OSREntryCallee>&& osrEntryCallee, MemoryMode)
+    OMGOSREntryCallee* osrEntryCallee() { return m_osrEntryCallee.get(); }
+    void setOSREntryCallee(Ref<OMGOSREntryCallee>&& osrEntryCallee, MemoryMode)
     {
         ASSERT(!m_osrEntryCallee);
         m_osrEntryCallee = WTFMove(osrEntryCallee);
@@ -414,7 +414,7 @@ private:
     {
     }
 
-    RefPtr<OSREntryCallee> m_osrEntryCallee;
+    RefPtr<OMGOSREntryCallee> m_osrEntryCallee;
     TierUpCount m_tierUpCounter;
     std::optional<CodeLocationLabel<WasmEntryPtrTag>> m_sharedLoopEntrypoint;
     Vector<CodeLocationLabel<WasmEntryPtrTag>> m_loopEntrypoints;

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -245,10 +245,10 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
     };
 
     // This is necessary since Callees are released under `Heap::stopThePeriphery()`, but that only stops JS compiler
-    // threads and not wasm ones. So the OSREntryCallee could die between the time we collect the callsites and when
+    // threads and not wasm ones. So the OMGOSREntryCallee could die between the time we collect the callsites and when
     // we actually repatch its callsites.
     // FIXME: These inline capacities were picked semi-randomly. We should figure out if there's a better number.
-    Vector<RefPtr<OSREntryCallee>, 4> keepAliveOSREntryCallees;
+    Vector<RefPtr<OMGOSREntryCallee>, 4> keepAliveOSREntryCallees;
     Vector<Callsite, 16> callsites;
 
     auto functionSpaceIndex = toSpaceIndex(functionIndex);
@@ -345,7 +345,7 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker&, Wasm::Callee* ca
     case CompilationMode::OMGForOSREntryMode: {
         FunctionCodeIndex index = toCodeIndex(callee->index());
         if (m_osrEntryCallees.get(index).get()) {
-            // The BBQCallee really owns the OSREntryCallee so as long as that's around the OSREntryCallee is referenced.
+            // The BBQCallee really owns the OMGOSREntryCallee so as long as that's around the OMGOSREntryCallee is referenced.
             if (m_bbqCallees.at(index).get())
                 return TriState::True;
             return TriState::Indeterminate;
@@ -358,8 +358,6 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker&, Wasm::Callee* ca
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return TriState::True;
-    case CompilationMode::BBQForOSREntryMode:
-        RELEASE_ASSERT_NOT_REACHED();
     }
     return TriState::False;
 }

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -174,7 +174,7 @@ public:
         m_omgCallees[functionIndex] = WTFMove(callee);
     }
 
-    void recordOSREntryCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, OSREntryCallee& callee) WTF_REQUIRES_LOCK(m_lock)
+    void recordOMGOSREntryCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, OMGOSREntryCallee& callee) WTF_REQUIRES_LOCK(m_lock)
     {
         auto result = m_osrEntryCallees.add(functionIndex, callee);
         ASSERT_UNUSED(result, result.isNewEntry);
@@ -242,7 +242,7 @@ private:
     HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
 #if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
     // FIXME: We should probably find some way to prune dead entries periodically.
-    HashMap<uint32_t, ThreadSafeWeakPtr<OSREntryCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_osrEntryCallees;
+    HashMap<uint32_t, ThreadSafeWeakPtr<OMGOSREntryCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_osrEntryCallees;
 #endif
     // functionCodeIndex -> functionCodeIndex of internal functions that have direct JIT callsites to the lhs.
     // Note, this can grow over time since OMG inlining can add to the set of callers.

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -33,7 +33,6 @@ enum class CompilationMode : uint8_t {
     LLIntMode,
     IPIntMode,
     BBQMode,
-    BBQForOSREntryMode,
     OMGMode,
     OMGForOSREntryMode,
     JSToWasmEntrypointMode,
@@ -41,29 +40,10 @@ enum class CompilationMode : uint8_t {
     WasmToJSMode,
 };
 
-constexpr inline bool isOSREntry(CompilationMode compilationMode)
-{
-    switch (compilationMode) {
-    case CompilationMode::LLIntMode:
-    case CompilationMode::IPIntMode:
-    case CompilationMode::BBQMode:
-    case CompilationMode::OMGMode:
-    case CompilationMode::JSToWasmEntrypointMode:
-    case CompilationMode::JSToWasmICMode:
-    case CompilationMode::WasmToJSMode:
-        return false;
-    case CompilationMode::BBQForOSREntryMode:
-    case CompilationMode::OMGForOSREntryMode:
-        return true;
-    }
-    RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-}
-
 constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
 {
     switch (compilationMode) {
     case CompilationMode::BBQMode:
-    case CompilationMode::BBQForOSREntryMode:
         return true;
     case CompilationMode::OMGForOSREntryMode:
     case CompilationMode::LLIntMode:
@@ -84,7 +64,6 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::OMGForOSREntryMode:
         return true;
     case CompilationMode::BBQMode:
-    case CompilationMode::BBQForOSREntryMode:
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
     case CompilationMode::JSToWasmEntrypointMode:

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1461,7 +1461,7 @@ OMGIRGenerator::OMGIRGenerator(CalleeGroup& calleeGroup, const ModuleInformation
                 AllowMacroScratchRegisterUsage allowScratch(jit);
                 GPRReg contextInstance = params[0].gpr();
                 GPRReg fp = params[1].gpr();
-                if (isOSREntry(m_compilationMode))
+                if (m_compilationMode == CompilationMode::OMGForOSREntryMode)
                     jit.checkWasmStackOverflow(contextInstance, CCallHelpers::TrustedImm32(checkSize), fp).linkThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(crashDueToOMGStackOverflowGenerator).code()), &jit);
                 else
                     jit.checkWasmStackOverflow(contextInstance, CCallHelpers::TrustedImm32(checkSize), fp).linkThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwStackOverflowFromWasmThunkGenerator).code()), &jit);
@@ -1469,7 +1469,7 @@ OMGIRGenerator::OMGIRGenerator(CalleeGroup& calleeGroup, const ModuleInformation
         });
     }
 
-    if (isOSREntry(m_compilationMode))
+    if (m_compilationMode == CompilationMode::OMGForOSREntryMode)
         m_currentBlock = m_proc.addBlock();
 }
 
@@ -6049,14 +6049,14 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
     result->stackmaps = irGenerator.takeStackmaps();
     result->exceptionHandlers = irGenerator.takeExceptionHandlers();
 
-    if (isOSREntry(compilationMode)) {
+    if (compilationMode == CompilationMode::OMGForOSREntryMode) {
         int32_t checkSize = 0;
         bool needsOverflowCheck = false;
         irGenerator.computeStackCheckSize(needsOverflowCheck, checkSize);
         ASSERT(checkSize || !needsOverflowCheck);
         if (!needsOverflowCheck)
             checkSize = stackCheckNotNeeded;
-        static_cast<OSREntryCallee*>(&callee)->setStackCheckSize(checkSize);
+        static_cast<OMGOSREntryCallee*>(&callee)->setStackCheckSize(checkSize);
     }
 
     return result;

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -103,13 +103,12 @@ void OSREntryPlan::work(CompilationEffort)
     TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
     const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
 
-    CompilationMode targetCompilationMode = CompilationMode::OMGForOSREntryMode;
-    Ref<OSREntryCallee> callee = OSREntryCallee::create(targetCompilationMode, functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), m_loopIndex);
+    Ref<OMGOSREntryCallee> callee = OMGOSREntryCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), m_loopIndex);
 
     beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
-    auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, targetCompilationMode, m_functionIndex, m_hasExceptionHandlers, m_loopIndex);
+    auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGForOSREntryMode, m_functionIndex, m_hasExceptionHandlers, m_loopIndex);
     endCompilerSignpost(callee.get());
 
     if (UNLIKELY(!parseAndCompileResult)) {
@@ -141,7 +140,7 @@ void OSREntryPlan::work(CompilationEffort)
     callee->setEntrypoint(WTFMove(omgEntrypoint), internalFunction->osrEntryScratchBufferSize, WTFMove(unlinkedCalls), WTFMove(internalFunction->stackmaps), WTFMove(internalFunction->exceptionHandlers), WTFMove(exceptionHandlerLocations));
     {
         Locker locker { m_calleeGroup->m_lock };
-        m_calleeGroup->recordOSREntryCallee(locker, m_functionIndex, callee.get());
+        m_calleeGroup->recordOMGOSREntryCallee(locker, m_functionIndex, callee.get());
         m_calleeGroup->reportCallees(locker, callee.ptr(), internalFunction->outgoingJITDirectCallees);
 
         for (auto& call : callee->wasmToWasmCallsites()) {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -775,7 +775,7 @@ void loadValuesIntoBuffer(Probe::Context& context, const StackMap& values, uint6
 }
 
 SUPPRESS_ASAN
-static void doOSREntry(JSWebAssemblyInstance* instance, Probe::Context& context, BBQCallee& callee, OSREntryCallee& osrEntryCallee, OSREntryData& osrEntryData)
+static void doOSREntry(JSWebAssemblyInstance* instance, Probe::Context& context, BBQCallee& callee, OMGOSREntryCallee& osrEntryCallee, OSREntryData& osrEntryData)
 {
     auto returnWithoutOSREntry = [&] {
         context.gpr(GPRInfo::nonPreservedNonArgumentGPR0) = 0;
@@ -913,7 +913,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
         context.gpr(GPRInfo::nonPreservedNonArgumentGPR0) = 0;
     };
 
-    auto doStackCheck = [instance](OSREntryCallee* callee) -> bool {
+    auto doStackCheck = [instance](OMGOSREntryCallee* callee) -> bool {
         uintptr_t stackPointer = reinterpret_cast<uintptr_t>(currentStackPointer());
         ASSERT(callee->stackCheckSize());
         if (callee->stackCheckSize() == stackCheckNotNeeded)
@@ -1002,7 +1002,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
         return returnWithoutOSREntry();
     }
 
-    if (OSREntryCallee* osrEntryCallee = callee.osrEntryCallee()) {
+    if (OMGOSREntryCallee* osrEntryCallee = callee.osrEntryCallee()) {
         if (osrEntryCallee->loopIndex() == loopIndex) {
             if (!doStackCheck(osrEntryCallee))
                 return returnWithoutOSREntry();
@@ -1020,7 +1020,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
             return returnWithoutOSREntry();
     }
 
-    if (OSREntryCallee* osrEntryCallee = callee.osrEntryCallee()) {
+    if (OMGOSREntryCallee* osrEntryCallee = callee.osrEntryCallee()) {
         if (osrEntryCallee->loopIndex() == loopIndex) {
             if (!doStackCheck(osrEntryCallee))
                 return returnWithoutOSREntry();
@@ -1099,7 +1099,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
             tierUp.setOptimizationThresholdBasedOnCompilationResult(functionIndex, CompilationDeferred);
     }
 
-    OSREntryCallee* osrEntryCallee = callee.osrEntryCallee();
+    OMGOSREntryCallee* osrEntryCallee = callee.osrEntryCallee();
     if (!osrEntryCallee) {
         tierUp.setOptimizationThresholdBasedOnCompilationResult(functionIndex, CompilationDeferred);
         return returnWithoutOSREntry();


### PR DESCRIPTION
#### ec784454fec521f28ae46569e4e82a5f466f6365
<pre>
Remove unused BBQOSREntryMode enum value
<a href="https://bugs.webkit.org/show_bug.cgi?id=281188">https://bugs.webkit.org/show_bug.cgi?id=281188</a>
<a href="https://rdar.apple.com/137643324">rdar://137643324</a>

Reviewed by Yusuke Suzuki.

Now that we no longer support compiling BBQ with B3/Air the
BBQOSREntryMode CompilationMode enum value is effectively unused.
This patch removes it. Also, rename OSREntryCallee to OMGOSREntryCallee
as it&apos;s limited to OMG code now.

* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::tierName):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::updateCallsitesToCallUs):
(JSC::Wasm::CalleeGroup::calleeIsReferenced const):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
(JSC::Wasm::isOSREntry): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::doOSREntry):
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/284944@main">https://commits.webkit.org/284944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/476a8acc5bd0ab29a97c211132abc31b35b72b27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23776 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74069 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61205 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/64127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18999 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70252 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15235 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/76826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61264 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/76826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15712 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/11939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5589 "Build is in progress. Recent messages:") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46216 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/20062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48571 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->