### PR TITLE
[JSC] B3 should emit AddZeroExtend64 and AddSignExtend64 for Add(@x, ZExt(@y)) etc.

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -3057,12 +3057,12 @@ private:
             Value* left = m_value->child(0);
             Value* right = m_value->child(1);
 
-            auto tryMultiplyAdd = [&] () -> bool {
+            auto tryMultiplyAdd = [&]() -> bool {
                 if (imm(right) && !m_valueToTmp[right])
                     return false;
 
                 // MADD: d = n * m + a
-                auto tryAppendMultiplyAdd = [&] (Value* left, Value* right) -> bool {
+                auto tryAppendMultiplyAdd = [&](Value* left, Value* right) -> bool {
                     if (left->opcode() != Mul || !canBeInternal(left) || m_locked.contains(right))
                         return false;
                     Value* multiplyLeft = left->child(0);
@@ -3103,7 +3103,7 @@ private:
                 return;
 
             // add-with-shift Pattern: left + (right ShiftType amount)
-            auto tryAppendAddWithShift = [&] (Value* left, Value* right) -> bool {
+            auto tryAppendAddWithShift = [&](Value* left, Value* right) -> bool {
                 Air::Opcode opcode = opcodeBasedOnShiftKind(right->opcode(),
                     AddLeftShift32, AddLeftShift64,
                     AddRightShift32, AddRightShift64,
@@ -3112,6 +3112,30 @@ private:
             };
 
             if (tryAppendAddWithShift(left, right) || tryAppendAddWithShift(right, left))
+                return;
+
+            auto tryAppendAddWithExtend = [&](Value* left, Value* right) -> bool {
+                if constexpr (isARM64()) {
+                    if (!canBeInternal(right))
+                        return false;
+
+                    if (isMergeableValue(right, ZExt32) && !imm(left)) {
+                        append(AddZeroExtend64, tmp(left), tmp(right->child(0)), tmp(m_value));
+                        commitInternal(right);
+                        return true;
+                    }
+
+                    if (isMergeableValue(right, SExt32) && !imm(left)) {
+                        append(AddSignExtend64, tmp(left), tmp(right->child(0)), tmp(m_value));
+                        commitInternal(right);
+                        return true;
+                    }
+                }
+                return false;
+
+            };
+
+            if (tryAppendAddWithExtend(left, right) || tryAppendAddWithExtend(right, left))
                 return;
 
             appendBinOp<Add32, Add64, AddDouble, AddFloat, Commutative>(left, right);

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -627,6 +627,8 @@ void testSubWithUnsignedRightShift32();
 void testSubWithLeftShift64();
 void testSubWithRightShift64();
 void testSubWithUnsignedRightShift64();
+void testAddZeroExtend64();
+void testAddSignExtend64();
 
 void testAndLeftShift32();
 void testAndRightShift32();


### PR DESCRIPTION
#### 4939b1d69f5a1ede063aebc217da5d4116581cc4
<pre>
[JSC] B3 should emit AddZeroExtend64 and AddSignExtend64 for Add(@x, ZExt(@y)) etc.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281195">https://bugs.webkit.org/show_bug.cgi?id=281195</a>
<a href="https://rdar.apple.com/137648194">rdar://137648194</a>

Reviewed by Keith Miller.

When there is Add(@x, ZExt(@y)), we should lower it to
AddZeroExtend64(@x, @y) form.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_2.cpp:
(testAddZeroExtend64):
(testAddSignExtend64):
(addBitTests):

Canonical link: <a href="https://commits.webkit.org/284958@main">https://commits.webkit.org/284958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3d2a72d80dde3a775a9bfdfa4419b1183560c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23790 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22222 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22040 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14630 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61217 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20563 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/64141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76841 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70266 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18198 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63849 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11952 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92047 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10894 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46230 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1006 "Build is in progress. Recent messages:") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20065 "Found 40 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/verbose-failure-dont-graph-dump-availability-already-freed.js.default, wasm.yaml/wasm/spec-tests/throw_ref.wast.js.wasm-bbq, wasm.yaml/wasm/spec-tests/try_table.wast.js.wasm-bbq, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/try-table-all-ref-simple.js.default-wasm, wasm.yaml/wasm/stress/try-table-all-ref-simple.js.wasm-bbq, wasm.yaml/wasm/stress/try-table-all-ref-simple.js.wasm-collect-continuously, wasm.yaml/wasm/stress/try-table-all-ref-simple.js.wasm-eager, wasm.yaml/wasm/stress/try-table-all-ref-simple.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->