### PR TITLE
[css-anchor-position-1] Properly handle anchor elements with multiple anchor names

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-005-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+#green {
+  position: relative;
+  top: 10px;
+  left: 10px;
+
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+  <p>The test passes if there is only one green square with no red.</p>
+  <div id="green"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-005.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/anchor-name-005-ref.html">
+<meta name="assert" content="An anchor element with multiple anchor names can be referenced using both names">
+<style>
+#anchor {
+  position: relative;
+  top: 10px;
+  left: 10px;
+
+  anchor-name: --a1, --a2;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#target {
+  position: absolute;
+  /* if this fails, the target (green) box is displayed below the anchor (red) box */
+  top: anchor(--a1 top);
+  /* if this fails, the target box will not fully cover the anchor box */
+  left: anchor(--a2 left);
+
+  width: 100px;
+  height: 100px;
+  background: green;
+  z-index: 1;
+}
+</style>
+<body>
+  <p>The test passes if there is only one green square with no red.</p>
+  <div>
+    <div>
+        <div id="anchor"></div>
+    </div>
+    <div id="target"></div>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-name-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-name-005-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+#green {
+  position: relative;
+  top: 10px;
+  left: 10px;
+
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+  <p>The test passes if there is only one green square with no red.</p>
+  <div id="green"></div>
+</body>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1341,8 +1341,10 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
 
     // Mark anchor as eligible target for anchor-positioned elements
     if (isAnchor) {
-        for (auto& anchorName : style->anchorNames()) {
-            if (m_document->styleScope().anchorElements().add(element).isNewEntry) {
+        bool isNewAnchor = m_document->styleScope().anchorElements().add(element).isNewEntry;
+
+        if (isNewAnchor) {
+            for (auto& anchorName : style->anchorNames()) {
                 m_document->styleScope().anchorsForAnchorName().ensure(anchorName, [&] {
                     return Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>> { };
                 }).iterator->value.append(element);


### PR DESCRIPTION
#### aafd675c6a611d09090e6c575448a71778ead010
<pre>
[css-anchor-position-1] Properly handle anchor elements with multiple anchor names
<a href="https://rdar.apple.com/137567711">rdar://137567711</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=281119">https://bugs.webkit.org/show_bug.cgi?id=281119</a>

Reviewed by Antti Koivisto.

This fixes a bug where an anchor element with multiple anchor names can only
be referred to by the first name.

An element is an anchor element when it has one or more anchor names.
(e.g: `anchor-name: --a1, --a2, --a3`) During style resolution, if the
current element is an anchor, we perform the following logic to
register it:

    for each anchor name of the element:
        if this element is not in the known anchor element set:
            add this element to the known anchor element set
            [perform steps to register the anchor name]

This logic has a bug: on the first anchor name, the element is not in
the anchor set, so the first name is registered. On subsequent names,
the element is already in the set, so the names aren&apos;t registered.
Consequently, only the first anchor name is registered and can be
referred to by anchor().

This patches changes the logic to ensure all anchor names are registered
and could be used:

    if this element is not in the known anchor element set:
        add this element to the known anchor element set
        for each anchor name of the element:
            [perform steps to register the anchor name]

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-name-005-ref.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateAnchorPositioningState):

Canonical link: <a href="https://commits.webkit.org/285030@main">https://commits.webkit.org/285030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/031480335e8aded2d048343849bc702b37724782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56277 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36709 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20733 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77015 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63967 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15777 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5741 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1180 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->