### PR TITLE
[Win] Fix problems of SystemInfo.cpp

### DIFF
--- a/Source/WebCore/platform/win/SystemInfo.h
+++ b/Source/WebCore/platform/win/SystemInfo.h
@@ -23,48 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SystemInfo_h
-#define SystemInfo_h
+#pragma once
 
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// NOTE: Keep these in order so callers can do things like
-// "if (windowsVersion() >= WindowsVista) ...". It's OK to change or add values,
-// though.
-enum WindowsVersion {
-    // CE-based versions
-    WindowsCE1 = 0,
-    WindowsCE2,
-    WindowsCE3,
-    WindowsCE4,
-    WindowsCE5,
-    WindowsCE6,
-    WindowsCE7,
-    // 3.x-based versions
-    Windows3_1,
-    // 9x-based versions
-    Windows95,
-    Windows98,
-    WindowsME,
-    // NT-based versions
-    WindowsNT3,
-    WindowsNT4,
-    Windows2000,
-    WindowsXP,
-    WindowsServer2003,
-    WindowsVista,
-    WindowsServer2008,
-    Windows7,
-};
-
-// If supplied, |major| and |minor| are set to the OSVERSIONINFO::dwMajorVersion
-// and dwMinorVersion field values, respectively.
-WindowsVersion windowsVersion(int* major = 0, int* minor = 0);
-
 WEBCORE_EXPORT String windowsVersionForUAString();
 
 } // namespace WebCore
-
-#endif // SystemInfo_h

--- a/Source/WebKit/win/WebKit.manifest
+++ b/Source/WebKit/win/WebKit.manifest
@@ -13,4 +13,10 @@
                 type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
         </dependentAssembly>
     </dependency>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 and Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
 </assembly>

--- a/Tools/MiniBrowser/win/MiniBrowser.exe.manifest
+++ b/Tools/MiniBrowser/win/MiniBrowser.exe.manifest
@@ -13,4 +13,10 @@
                 type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
         </dependentAssembly>
     </dependency>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 and Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
 </assembly>

--- a/Tools/WebKitTestRunner/win/WebKitTestRunner.exe.manifest
+++ b/Tools/WebKitTestRunner/win/WebKitTestRunner.exe.manifest
@@ -13,4 +13,10 @@
                 type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
         </dependentAssembly>
     </dependency>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 and Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
 </assembly>


### PR DESCRIPTION
#### d0795f0c2fa2986c03472c1ed35bf7d17c02fe5a
<pre>
[Win] Fix problems of SystemInfo.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=280295">https://bugs.webkit.org/show_bug.cgi?id=280295</a>

Reviewed by Ross Kirsling.

GetVersionEx API always returned the Windows 8 version number.
&lt;<a href="https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa">https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa</a>&gt;
Added supportedOS to application manifests to make the API work as
expected on newer Windows.

GetNativeSystemInfo API is available after Windows XP and Windows
Server 2003.
&lt;<a href="https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo">https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo</a>&gt;
We no longer need to use GetProcAddress for it.

Removed the code for old Windows in WebCore::createSharedCursor.

* Source/WebCore/platform/win/CursorWin.cpp:
(WebCore::createSharedCursor):
* Source/WebCore/platform/win/SystemInfo.cpp:
(WebCore::windowsVersion):
(WebCore::processorArchitecture):
(WebCore::architectureTokenForUAString):
(WebCore::windowsVersionForUAString):
(WebCore::osVersionForUAString): Deleted.
* Source/WebCore/platform/win/SystemInfo.h:
* Source/WebKit/win/WebKit.manifest:
* Tools/MiniBrowser/win/MiniBrowser.exe.manifest:
* Tools/WebKitTestRunner/win/WebKitTestRunner.exe.manifest:

Canonical link: <a href="https://commits.webkit.org/285009@main">https://commits.webkit.org/285009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7613efca66af51129e2f105e1a0b7d5929ff7da4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56168 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14644 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76863 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63864 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11971 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5609 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10919 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->