### PR TITLE
[css-view-transitions] Implement 'auto' value for view-transition-name.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7627,9 +7627,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/transition-t
 imported/w3c/web-platform-tests/css/css-view-transitions/nested/ [ Skip ]
 
 # 'auto' transition name
-imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-from-id-shadow.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-from-id.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/auto-name.html [ ImageOnlyFailure ]
+# Fails due to position:relative on view transition root.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/auto-name-from-id.html [ ImageOnlyFailure ]
 
 # Depends on overflow-clip-margin (unimplemented).

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid-expected.txt
@@ -3,5 +3,5 @@ PASS e.style['view-transition-name'] = "none" should set the property value
 PASS e.style['view-transition-name'] = "foo" should set the property value
 PASS e.style['view-transition-name'] = "bar" should set the property value
 PASS e.style['view-transition-name'] = "baz" should set the property value
-FAIL e.style['view-transition-name'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['view-transition-name'] = "auto" should set the property value
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2546,6 +2546,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/TextDecorationThickness.h
     rendering/style/TextSizeAdjustment.h
     rendering/style/TextUnderlineOffset.h
+    rendering/style/ViewTransitionName.h
     rendering/style/WillChangeData.h
 
     rendering/svg/legacy/LegacyRenderSVGModelObject.h

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4095,7 +4095,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<ScrollSnapStop>(CSSPropertyScrollSnapStop, &RenderStyle::scrollSnapStop, &RenderStyle::setScrollSnapStop),
         new DiscretePropertyWrapper<ScrollSnapType>(CSSPropertyScrollSnapType, &RenderStyle::scrollSnapType, &RenderStyle::setScrollSnapType),
         new DiscretePropertyWrapper<const Vector<Style::ScopedName>&>(CSSPropertyViewTransitionClass, &RenderStyle::viewTransitionClasses, &RenderStyle::setViewTransitionClasses),
-        new DiscretePropertyWrapper<std::optional<Style::ScopedName>>(CSSPropertyViewTransitionName, &RenderStyle::viewTransitionName, &RenderStyle::setViewTransitionName),
+        new DiscretePropertyWrapper<Style::ViewTransitionName>(CSSPropertyViewTransitionName, &RenderStyle::viewTransitionName, &RenderStyle::setViewTransitionName),
         new DiscretePropertyWrapper<FieldSizing>(CSSPropertyFieldSizing, &RenderStyle::fieldSizing, &RenderStyle::setFieldSizing),
         new DiscretePropertyWrapper<const Vector<AtomString>&>(CSSPropertyAnchorName, &RenderStyle::anchorNames, &RenderStyle::setAnchorNames),
         new DiscretePropertyWrapper<const AtomString&>(CSSPropertyPositionAnchor, &RenderStyle::positionAnchor, &RenderStyle::setPositionAnchor),

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9339,9 +9339,7 @@
         "view-transition-name": {
             "codegen-properties": {
                 "converter": "ViewTransitionName",
-                "parser-function": "consumeViewTransitionName",
-                "parser-grammar-unused": "none | <custom-ident>",
-                "parser-grammar-unused-reason": "Needs support for applying restrictions to <custom-ident>. The <custom-ident> production used here excludes the keyword auto.",
+                "parser-grammar": "none | auto | <custom-ident>",
                 "settings-flag": "viewTransitionsEnabled"
             },
             "specification": {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4288,9 +4288,11 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
     case CSSPropertyViewTransitionName: {
         auto viewTransitionName = style.viewTransitionName();
-        if (!viewTransitionName)
+        if (viewTransitionName.isNone())
             return CSSPrimitiveValue::create(CSSValueNone);
-        return valueForScopedName(*viewTransitionName);
+        if (viewTransitionName.isAuto())
+            return CSSPrimitiveValue::create(CSSValueAuto);
+        return CSSPrimitiveValue::createCustomIdent(viewTransitionName.customIdent());
     }
     case CSSPropertyVisibility:
         return createConvertingToCSSValueID(style.visibility());

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
@@ -62,20 +62,6 @@ RefPtr<CSSValue> consumeViewTransitionClass(CSSParserTokenRange& range, const CS
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-RefPtr<CSSValue> consumeViewTransitionName(CSSParserTokenRange& range, const CSSParserContext&)
-{
-    // <'view-transition-name'> = none | <custom-ident>
-    // https://drafts.csswg.org/css-view-transitions-1/#propdef-view-transition-name
-
-    // NOTE: The values none and auto are excluded from <custom-ident>.
-
-    if (auto noneValue = consumeIdent<CSSValueNone>(range))
-        return noneValue;
-    if (identMatches<CSSValueAuto>(range.peek().id()))
-        return nullptr;
-    return consumeCustomIdent(range);
-}
-
 RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range, const CSSParserContext&)
 {
     // <'types'> = none | <custom-ident>+

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.h
@@ -37,7 +37,6 @@ struct CSSParserContext;
 namespace CSSPropertyParserHelpers {
 
 RefPtr<CSSValue> consumeViewTransitionClass(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeViewTransitionName(CSSParserTokenRange&, const CSSParserContext&);
 
 // For @view-transition descriptor
 RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -215,13 +215,15 @@ private:
     // ActiveDOMObject.
     void stop() final;
 
+    bool isCrossDocument() { return m_isCrossDocument; }
+
     OrderedNamedElementsMap m_namedElements;
     ViewTransitionPhase m_phase { ViewTransitionPhase::PendingCapture };
     FloatSize m_initialLargeViewportSize;
     float m_initialPageZoom;
 
     RefPtr<ViewTransitionUpdateCallback>  m_updateCallback;
-    bool m_shouldCallUpdateCallback { false };
+    bool m_isCrossDocument { false };
 
     using PromiseAndWrapper = std::pair<Ref<DOMPromise>, Ref<DeferredPromise>>;
     PromiseAndWrapper m_ready;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2113,7 +2113,7 @@ bool RenderElement::hasSelfPaintingLayer() const
 
 bool RenderElement::hasViewTransitionName() const
 {
-    return !!style().viewTransitionName();
+    return !style().viewTransitionName().isNone();
 }
 
 bool RenderElement::requiresRenderingConsolidationForViewTransition() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -286,6 +286,7 @@ using LayoutBoxExtent = RectEdges<LayoutUnit>;
 
 namespace Style {
 class CustomPropertyRegistry;
+class ViewTransitionName;
 struct PseudoElementIdentifier;
 struct ScopedName;
 }
@@ -1140,7 +1141,7 @@ public:
     inline MathStyle mathStyle() const;
 
     inline const Vector<Style::ScopedName>& viewTransitionClasses() const;
-    inline std::optional<Style::ScopedName> viewTransitionName() const;
+    inline Style::ViewTransitionName viewTransitionName() const;
 
     void setDisplay(DisplayType value)
     {
@@ -1794,7 +1795,7 @@ public:
     void setQuotes(RefPtr<QuotesData>&&);
 
     inline void setViewTransitionClasses(const Vector<Style::ScopedName>&);
-    inline void setViewTransitionName(std::optional<Style::ScopedName>);
+    inline void setViewTransitionName(Style::ViewTransitionName);
 
     inline WillChangeData* willChange() const;
     void setWillChange(RefPtr<WillChangeData>&&);
@@ -1901,7 +1902,7 @@ public:
     static inline ListStyleType initialListStyleType();
     static constexpr OptionSet<TextTransform> initialTextTransform();
     static inline Vector<Style::ScopedName> initialViewTransitionClasses();
-    static inline std::optional<Style::ScopedName> initialViewTransitionName();
+    static inline Style::ViewTransitionName initialViewTransitionName();
     static constexpr Visibility initialVisibility();
     static constexpr WhiteSpaceCollapse initialWhiteSpaceCollapse();
     static float initialHorizontalBorderSpacing() { return 0; }

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -516,7 +516,7 @@ constexpr UserSelect RenderStyle::initialUserSelect() { return UserSelect::Text;
 constexpr VerticalAlign RenderStyle::initialVerticalAlign() { return VerticalAlign::Baseline; }
 inline Vector<ViewTimelineInsets> RenderStyle::initialViewTimelineInsets() { return { }; }
 inline Vector<Style::ScopedName> RenderStyle::initialViewTransitionClasses() { return { }; }
-inline std::optional<Style::ScopedName> RenderStyle::initialViewTransitionName() { return std::nullopt; }
+inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { return Style::ViewTransitionName::createWithNone(); }
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
 inline const TimelineScope RenderStyle::initialTimelineScope() { return { }; }
 constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
@@ -756,7 +756,7 @@ inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelec
 inline VerticalAlign RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
 inline const Length& RenderStyle::verticalAlignLength() const { return m_nonInheritedData->boxData->verticalAlignLength(); }
 inline const Vector<Style::ScopedName>& RenderStyle::viewTransitionClasses() const { return m_nonInheritedData->rareData->viewTransitionClasses; }
-inline std::optional<Style::ScopedName> RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
+inline Style::ViewTransitionName RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
 inline const StyleColor& RenderStyle::visitedLinkBackgroundColor() const { return m_nonInheritedData->miscData->visitedLinkColor->background; }
 inline const StyleColor& RenderStyle::visitedLinkBorderBottomColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderBottom; }
 inline const StyleColor& RenderStyle::visitedLinkBorderLeftColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderLeft; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -337,7 +337,7 @@ inline void RenderStyle::setUserDrag(UserDrag value) { SET_NESTED(m_nonInherited
 inline void RenderStyle::setUserModify(UserModify value) { SET(m_rareInheritedData, userModify, static_cast<unsigned>(value)); }
 inline void RenderStyle::setUserSelect(UserSelect value) { SET(m_rareInheritedData, userSelect, static_cast<unsigned>(value)); }
 inline void RenderStyle::setViewTransitionClasses(const Vector<Style::ScopedName>& value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionClasses, value); }
-inline void RenderStyle::setViewTransitionName(std::optional<Style::ScopedName> value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionName, value); }
+inline void RenderStyle::setViewTransitionName(Style::ViewTransitionName value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionName, value); }
 inline void RenderStyle::setVisitedLinkBackgroundColor(const StyleColor& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, background, value); }
 inline void RenderStyle::setVisitedLinkBorderBottomColor(const StyleColor& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderBottom, value); }
 inline void RenderStyle::setVisitedLinkBorderLeftColor(const StyleColor& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderLeft, value); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -71,7 +71,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , offsetPath(RenderStyle::initialOffsetPath())
     // containerNames
     , viewTransitionClasses(RenderStyle::initialViewTransitionClasses())
-    // viewTransitionName
+    , viewTransitionName(RenderStyle::initialViewTransitionName())
     , columnGap(RenderStyle::initialColumnGap())
     , rowGap(RenderStyle::initialRowGap())
     , offsetDistance(RenderStyle::initialOffsetDistance())

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -51,6 +51,7 @@
 #include "TouchAction.h"
 #include "TranslateTransformOperation.h"
 #include "ViewTimeline.h"
+#include "ViewTransitionName.h"
 #include "WillChangeData.h"
 #include <memory>
 #include <wtf/DataRef.h>
@@ -162,7 +163,7 @@ public:
     Vector<Style::ScopedName> containerNames;
 
     Vector<Style::ScopedName> viewTransitionClasses;
-    std::optional<Style::ScopedName> viewTransitionName;
+    Style::ViewTransitionName viewTransitionName;
 
     GapLength columnGap;
     GapLength rowGap;

--- a/Source/WebCore/rendering/style/ViewTransitionName.h
+++ b/Source/WebCore/rendering/style/ViewTransitionName.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleScopeOrdinal.h"
+
+namespace WebCore::Style {
+
+class ViewTransitionName {
+public:
+    enum class Type : uint8_t {
+        None,
+        Auto,
+        CustomIdent,
+    };
+
+    static ViewTransitionName createWithNone()
+    {
+        return ViewTransitionName(Type::None);
+    }
+
+    static ViewTransitionName createWithAuto(ScopeOrdinal ordinal)
+    {
+        return ViewTransitionName(Type::Auto, ordinal);
+    }
+
+    static ViewTransitionName createWithCustomIdent(ScopeOrdinal ordinal, AtomString ident)
+    {
+        return ViewTransitionName(ordinal, ident);
+    }
+
+    bool isNone() const
+    {
+        return m_type == Type::None;
+    }
+
+    bool isAuto() const
+    {
+        return m_type == Type::Auto;
+    }
+
+    bool isCustomIdent() const
+    {
+        return m_type == Type::CustomIdent;
+    }
+
+    AtomString customIdent() const
+    {
+        ASSERT(isCustomIdent());
+        return m_customIdent;
+    }
+
+    ScopeOrdinal scopeOrdinal() const
+    {
+        ASSERT(isCustomIdent() || isAuto());
+        return m_scopeOrdinal;
+    }
+
+    bool operator==(const ViewTransitionName& other) const = default;
+private:
+    Type m_type;
+    ScopeOrdinal m_scopeOrdinal;
+    AtomString m_customIdent;
+
+    ViewTransitionName(Type type, ScopeOrdinal scopeOrdinal = ScopeOrdinal::Element)
+        : m_type(type)
+        , m_scopeOrdinal(scopeOrdinal)
+    {
+    }
+
+    ViewTransitionName(ScopeOrdinal scopeOrdinal, AtomString ident)
+        : m_type(Type::CustomIdent)
+        , m_scopeOrdinal(scopeOrdinal)
+        , m_customIdent(ident)
+    {
+    }
+
+};
+
+inline TextStream& operator<<(TextStream& ts, const ViewTransitionName& name)
+{
+    if (name.isAuto())
+        ts << "auto"_s;
+    else if (name.isNone())
+        ts << "none"_s;
+    else
+        ts << name.customIdent();
+    return ts;
+}
+
+} // namespace WebCore::Style

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -699,7 +699,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             || style.hasMask()
             || style.hasBackdropFilter()
             || style.hasBlendMode()
-            || style.viewTransitionName();
+            || !style.viewTransitionName().isNone();
         if (RefPtr element = m_element) {
             auto styleable = Styleable::fromElement(*element);
             forceToFlat |= styleable.capturedInViewTransition();

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -222,7 +222,7 @@ public:
     static std::optional<WebCore::Length> convertBlockStepSize(BuilderState&, const CSSValue&);
 
     static Vector<Style::ScopedName> convertViewTransitionClass(BuilderState&, const CSSValue&);
-    static std::optional<Style::ScopedName> convertViewTransitionName(BuilderState&, const CSSValue&);
+    static Style::ViewTransitionName convertViewTransitionName(BuilderState&, const CSSValue&);
     static RefPtr<WillChangeData> convertWillChange(BuilderState&, const CSSValue&);
     
     static Vector<AtomString> convertScrollTimelineName(BuilderState&, const CSSValue&);
@@ -2022,16 +2022,19 @@ inline Vector<Style::ScopedName> BuilderConverter::convertViewTransitionClass(Bu
     });
 }
 
-inline std::optional<Style::ScopedName> BuilderConverter::convertViewTransitionName(BuilderState& state, const CSSValue& value)
+inline Style::ViewTransitionName BuilderConverter::convertViewTransitionName(BuilderState& state, const CSSValue& value)
 {
     auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
     if (!primitiveValue)
-        return { };
+        return Style::ViewTransitionName::createWithNone();
 
     if (value.valueID() == CSSValueNone)
-        return std::nullopt;
+        return Style::ViewTransitionName::createWithNone();
 
-    return Style::ScopedName { AtomString { primitiveValue->stringValue() }, state.styleScopeOrdinal() };
+    if (value.valueID() == CSSValueAuto)
+        return Style::ViewTransitionName::createWithAuto(state.styleScopeOrdinal());
+
+    return Style::ViewTransitionName::createWithCustomIdent(state.styleScopeOrdinal(), AtomString { primitiveValue->stringValue() });
 }
 
 inline RefPtr<WillChangeData> BuilderConverter::convertWillChange(BuilderState& builderState, const CSSValue& value)


### PR DESCRIPTION
#### 5aed448416d432a624ec51b3a77fafc418f6683d
<pre>
[css-view-transitions] Implement &apos;auto&apos; value for view-transition-name.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281203">https://bugs.webkit.org/show_bug.cgi?id=281203</a>
&lt;<a href="https://rdar.apple.com/137656730">rdar://137656730</a>&gt;

Reviewed by Tim Nguyen.

Support the &apos;auto&apos; value by using the Element&apos;s ID if available, otherwise a generated string.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp:
(WebCore::CSSPropertyParserHelpers::consumeViewTransitionName): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionName):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::isCrossDocument):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::hasViewTransitionName const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialViewTransitionName):
(WebCore::RenderStyle::viewTransitionName const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setViewTransitionName):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/style/ViewTransitionName.h: Added.
(WebCore::ViewTransitionName::createWithNone):
(WebCore::ViewTransitionName::createWithAuto):
(WebCore::ViewTransitionName::createWithCustomIdent):
(WebCore::ViewTransitionName::isNone const):
(WebCore::ViewTransitionName::isAuto const):
(WebCore::ViewTransitionName::isCustomIdent const):
(WebCore::ViewTransitionName::customIdent const):
(WebCore::ViewTransitionName::scopeOrdinal const):
(WebCore::ViewTransitionName::ViewTransitionName):
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertViewTransitionName):

Canonical link: <a href="https://commits.webkit.org/285041@main">https://commits.webkit.org/285041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41e65146783a4aa5cfe24f8cb254a0403d359684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56362 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77126 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18455 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5831 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1288 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->