### PR TITLE
[scroll-animations] update effect `phase` and `activeTime` computation to account for percentage values

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -114,8 +114,7 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    std::optional<CSSNumberishTime> localTime(std::optional<CSSNumberishTime>) const;
-    double playbackRate() const;
+    AnimationEffectTiming::ResolutionData resolutionData(std::optional<CSSNumberishTime>) const;
     void normalizeSpecifiedTiming(std::variant<double, String>);
 
     AnimationEffectTiming m_timing;

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+class WebAnimation;
+
 struct ResolvedEffectTiming {
     MarkableDouble currentIteration;
     AnimationEffectPhase phase { AnimationEffectPhase::Idle };
@@ -56,9 +58,17 @@ struct AnimationEffectTiming {
     CSSNumberishTime activeDuration { 0_s };
     CSSNumberishTime endTime { 0_s };
 
+    struct ResolutionData {
+        std::optional<CSSNumberishTime> timelineTime;
+        std::optional<CSSNumberishTime> timelineDuration;
+        std::optional<CSSNumberishTime> startTime;
+        std::optional<CSSNumberishTime> localTime;
+        double playbackRate { 0 };
+    };
+
     void updateComputedProperties();
-    BasicEffectTiming getBasicTiming(std::optional<CSSNumberishTime> localTime, double playbackRate) const;
-    ResolvedEffectTiming resolve(std::optional<CSSNumberishTime> localTime, double playbackRate) const;
+    BasicEffectTiming getBasicTiming(const ResolutionData&) const;
+    ResolvedEffectTiming resolve(const ResolutionData&) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSNumberishTime.cpp
+++ b/Source/WebCore/animation/CSSNumberishTime.cpp
@@ -126,12 +126,33 @@ bool CSSNumberishTime::isZero() const
     return !m_value;
 }
 
+CSSNumberishTime CSSNumberishTime::matchingZero() const
+{
+    return { m_type, 0 };
+}
+
 bool CSSNumberishTime::approximatelyEqualTo(const CSSNumberishTime& other) const
 {
     ASSERT(m_type == other.m_type);
     if (m_type == Type::Time)
         return std::abs(time()->microseconds() - other.time()->microseconds()) < timeEpsilon.microseconds();
     return m_value == other.m_value;
+}
+
+bool CSSNumberishTime::approximatelyLessThan(const CSSNumberishTime& other) const
+{
+    ASSERT(m_type == other.m_type);
+    if (m_type == Type::Time)
+        return (*time() + timeEpsilon) < *other.time();
+    return m_value < other.m_value;
+}
+
+bool CSSNumberishTime::approximatelyGreaterThan(const CSSNumberishTime& other) const
+{
+    ASSERT(m_type == other.m_type);
+    if (m_type == Type::Time)
+        return (*time() - timeEpsilon) > *other.time();
+    return m_value > other.m_value;
 }
 
 CSSNumberishTime CSSNumberishTime::operator+(const CSSNumberishTime& other) const

--- a/Source/WebCore/animation/CSSNumberishTime.h
+++ b/Source/WebCore/animation/CSSNumberishTime.h
@@ -47,7 +47,12 @@ public:
     bool isValid() const;
     bool isInfinity() const;
     bool isZero() const;
+
+    CSSNumberishTime matchingZero() const;
+
     bool approximatelyEqualTo(const CSSNumberishTime&) const;
+    bool approximatelyLessThan(const CSSNumberishTime&) const;
+    bool approximatelyGreaterThan(const CSSNumberishTime&) const;
 
     CSSNumberishTime operator+(const CSSNumberishTime&) const;
     CSSNumberishTime operator-(const CSSNumberishTime&) const;

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -359,7 +359,15 @@ void AcceleratedEffect::apply(Seconds currentTime, AcceleratedEffectValues& valu
         return (currentTime - *m_startTime) * m_playbackRate;
     }();
 
-    auto resolvedTiming = m_timing.resolve(localTime, m_playbackRate);
+    // FIXME: when we add threaded animaiton support support for scroll-driven animations,
+    // pass in the associated timeline's current time and duration.
+    auto resolvedTiming = m_timing.resolve({
+        std::nullopt,
+        std::nullopt,
+        { m_holdTime ? *m_holdTime : *m_startTime },
+        { localTime },
+        m_playbackRate
+    });
     if (!resolvedTiming.transformedProgress)
         return;
 


### PR DESCRIPTION
#### 89612b5ede18dd364afff3070f3b09aa04b20211
<pre>
[scroll-animations] update effect `phase` and `activeTime` computation to account for percentage values
<a href="https://bugs.webkit.org/show_bug.cgi?id=281217">https://bugs.webkit.org/show_bug.cgi?id=281217</a>
<a href="https://rdar.apple.com/137668682">rdar://137668682</a>

Reviewed by Simon Fraser.

In order to compute the phases of Scroll-driven Animations we update the `phase` and `activeTime`
computations under `AnimationEffectTiming::getBasicTiming()` to work with percentage time values
by adopting the latest version of their computation procedure as defined by Web Animations Level 2.

Since additional data is needed by `AnimationEffectTiming` to compute those, namely the associated
animation&apos;s associated timeline&apos;s current time and duration, we introduce a new data structure to
pass to `AnimationEffectTiming::getBasicTiming()` and `AnimationEffectTiming::resolve()`.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::resolutionData const):
(WebCore::AnimationEffect::getBasicTiming const):
(WebCore::AnimationEffect::getComputedTiming const):
(WebCore::AnimationEffect::localTime const): Deleted.
(WebCore::AnimationEffect::playbackRate const): Deleted.
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::getBasicTiming const):
(WebCore::AnimationEffectTiming::resolve const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/animation/CSSNumberishTime.cpp:
(WebCore::CSSNumberishTime::matchingZero const):
(WebCore::CSSNumberishTime::approximatelyLessThan const):
(WebCore::CSSNumberishTime::approximatelyGreaterThan const):
* Source/WebCore/animation/CSSNumberishTime.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::apply):

Canonical link: <a href="https://commits.webkit.org/285040@main">https://commits.webkit.org/285040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98ca1f42c369856c99afff62eb978bc130ed2a9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56185 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14656 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18700 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76882 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15332 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63880 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5634 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10936 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1045 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->