### PR TITLE
Fix `scriptlevel` multipler (font-size)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt
@@ -19,10 +19,10 @@ PASS width and height properties on mi
 PASS inline-size and block-size properties on mi
 PASS width and height properties on mi (content overflowing)
 PASS width property on mi (preferred width)
-FAIL width and height properties on mmultiscripts assert_approx_equals: width expected 500 +/- 1 but got 135.15625
-FAIL inline-size and block-size properties on mmultiscripts assert_approx_equals: width expected 600 +/- 1 but got 135.15625
-FAIL width and height properties on mmultiscripts (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 135.15625
-FAIL width property on mmultiscripts (preferred width) assert_approx_equals: expected 300 +/- 1 but got 135.15625
+FAIL width and height properties on mmultiscripts assert_approx_equals: width expected 500 +/- 1 but got 132.03125
+FAIL inline-size and block-size properties on mmultiscripts assert_approx_equals: width expected 600 +/- 1 but got 132.03125
+FAIL width and height properties on mmultiscripts (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 132.03125
+FAIL width property on mmultiscripts (preferred width) assert_approx_equals: expected 300 +/- 1 but got 132.03125
 PASS width and height properties on mn
 PASS inline-size and block-size properties on mn
 PASS width and height properties on mn (content overflowing)
@@ -67,18 +67,18 @@ FAIL width and height properties on mstyle assert_approx_equals: width expected 
 FAIL inline-size and block-size properties on mstyle assert_approx_equals: width expected 600 +/- 1 but got 76.875
 FAIL width and height properties on mstyle (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 76.875
 FAIL width property on mstyle (preferred width) assert_approx_equals: expected 300 +/- 1 but got 76.875
-FAIL width and height properties on msub assert_approx_equals: width expected 500 +/- 1 but got 135.15625
-FAIL inline-size and block-size properties on msub assert_approx_equals: width expected 600 +/- 1 but got 135.15625
-FAIL width and height properties on msub (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 135.15625
-FAIL width property on msub (preferred width) assert_approx_equals: expected 300 +/- 1 but got 135.15625
-FAIL width and height properties on msubsup assert_approx_equals: width expected 500 +/- 1 but got 135.15625
-FAIL inline-size and block-size properties on msubsup assert_approx_equals: width expected 600 +/- 1 but got 135.15625
-FAIL width and height properties on msubsup (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 135.15625
-FAIL width property on msubsup (preferred width) assert_approx_equals: expected 300 +/- 1 but got 135.15625
-FAIL width and height properties on msup assert_approx_equals: width expected 500 +/- 1 but got 135.15625
-FAIL inline-size and block-size properties on msup assert_approx_equals: width expected 600 +/- 1 but got 135.15625
-FAIL width and height properties on msup (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 135.15625
-FAIL width property on msup (preferred width) assert_approx_equals: expected 300 +/- 1 but got 135.15625
+FAIL width and height properties on msub assert_approx_equals: width expected 500 +/- 1 but got 132.03125
+FAIL inline-size and block-size properties on msub assert_approx_equals: width expected 600 +/- 1 but got 132.03125
+FAIL width and height properties on msub (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 132.03125
+FAIL width property on msub (preferred width) assert_approx_equals: expected 300 +/- 1 but got 132.03125
+FAIL width and height properties on msubsup assert_approx_equals: width expected 500 +/- 1 but got 132.03125
+FAIL inline-size and block-size properties on msubsup assert_approx_equals: width expected 600 +/- 1 but got 132.03125
+FAIL width and height properties on msubsup (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 132.03125
+FAIL width property on msubsup (preferred width) assert_approx_equals: expected 300 +/- 1 but got 132.03125
+FAIL width and height properties on msup assert_approx_equals: width expected 500 +/- 1 but got 132.03125
+FAIL inline-size and block-size properties on msup assert_approx_equals: width expected 600 +/- 1 but got 132.03125
+FAIL width and height properties on msup (content overflowing) assert_approx_equals: width expected 2 +/- 1 but got 132.03125
+FAIL width property on msup (preferred width) assert_approx_equals: expected 300 +/- 1 but got 132.03125
 PASS width and height properties on mtable
 PASS inline-size and block-size properties on mtable
 PASS width property on mtable (preferred width)

--- a/LayoutTests/mathml/presentation/scripts-subsup.html
+++ b/LayoutTests/mathml/presentation/scripts-subsup.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<meta name="fuzzy" content="maxDifference=187-255; totalPixels=213-318" />
 <html>
   <head>
     <title>scripts</title>

--- a/LayoutTests/mathml/presentation/scripts-underover.html
+++ b/LayoutTests/mathml/presentation/scripts-underover.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<meta name="fuzzy" content="maxDifference=187-255; totalPixels=219-357" />
 <html>
   <head>
     <title>scripts</title>

--- a/LayoutTests/mathml/presentation/underover-nonstretchy-or-vertical.html
+++ b/LayoutTests/mathml/presentation/underover-nonstretchy-or-vertical.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=255; totalPixels=14" />
 <p>Vertical or non-stretchy operators inside an munderover element should not stretch.</p>
 <math style="font: 20px Ahem">
   <munderover>

--- a/LayoutTests/platform/glib/accessibility/math-multiscript-attributes-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/math-multiscript-attributes-expected.txt
@@ -30,8 +30,8 @@ AXPlatformAttributes: tag:mi
 AXRole: AXSubscript
 AXParent: AXSection
 AXChildren: 0
-AXPosition:  { 30.0000, -14.0000 }
-AXSize: { 11.0000, 81.0000 }
+AXPosition:  { 30.0000, -12.0000 }
+AXSize: { 10.0000, 76.0000 }
 AXTitle:
 AXDescription:
 AXValue: D
@@ -49,8 +49,8 @@ AXPlatformAttributes: multiscript-type:post, tag:mi
 AXRole: AXSuperscript
 AXParent: AXSection
 AXChildren: 0
-AXPosition:  { 30.0000, -26.0000 }
-AXSize: { 10.0000, 80.0000 }
+AXPosition:  { 30.0000, -23.0000 }
+AXSize: { 9.00000, 75.0000 }
 AXTitle:
 AXDescription:
 AXValue: C
@@ -68,8 +68,8 @@ AXPlatformAttributes: multiscript-type:post, tag:mi
 AXRole: AXSubscript
 AXParent: AXSection
 AXChildren: 0
-AXPosition:  { 8.00000, -14.0000 }
-AXSize: { 10.0000, 81.0000 }
+AXPosition:  { 8.00000, -12.0000 }
+AXSize: { 10.0000, 76.0000 }
 AXTitle:
 AXDescription:
 AXValue: B
@@ -87,8 +87,8 @@ AXPlatformAttributes: multiscript-type:pre, tag:mi
 AXRole: AXSuperscript
 AXParent: AXSection
 AXChildren: 0
-AXPosition:  { 8.00000, -26.0000 }
-AXSize: { 10.0000, 80.0000 }
+AXPosition:  { 8.00000, -23.0000 }
+AXSize: { 10.0000, 75.0000 }
 AXTitle:
 AXDescription:
 AXValue: A

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -1,20 +1,20 @@
 
 PASS automatic scriptlevel on mfrac (displaystyle=true)
 FAIL automatic scriptlevel on mfrac (displaystyle=false) assert_approx_equals: numerator expected 71 +/- 0.1 but got 100
-FAIL automatic scriptlevel on mroot assert_approx_equals: index expected 50.41 +/- 0.1 but got 56.25
-FAIL automatic scriptlevel on msub assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on msup assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on msubsup assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
+PASS automatic scriptlevel on mroot
+PASS automatic scriptlevel on msub
+PASS automatic scriptlevel on msup
+PASS automatic scriptlevel on msubsup
+PASS automatic scriptlevel on munder
+PASS automatic scriptlevel on mover
+PASS automatic scriptlevel on munderover
+PASS automatic scriptlevel on mmultiscripts
 PASS automatic scriptlevel on munder (accentunder=true)
 PASS automatic scriptlevel on mover (accent=true)
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
+PASS automatic scriptlevel on munderover (accentunder=true)
+PASS automatic scriptlevel on munderover (accent=true)
 PASS checking case-insensitivity accent/accentunder
-FAIL checking dynamic accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
+PASS checking dynamic accent/accentunder
 0
 1
 

--- a/LayoutTests/platform/glib/mathml/opentype/horizontal-expected.txt
+++ b/LayoutTests/platform/glib/mathml/opentype/horizontal-expected.txt
@@ -1,515 +1,515 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x196
-  RenderBlock {HTML} at (0,0) size 800x196
-    RenderBody {BODY} at (8,16) size 784x164
+layer at (0,0) size 800x193
+  RenderBlock {HTML} at (0,0) size 800x193
+    RenderBody {BODY} at (8,16) size 784x161
       RenderBlock {P} at (0,0) size 784x22
-        RenderMathMLMath {math} at (0,2) size 29x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2190}"
-        RenderText {#text} at (28,4) size 5x17
-          text run at (28,4) width 5: " "
-        RenderMathMLMath {math} at (32,2) size 30x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2192}"
-        RenderText {#text} at (61,4) size 5x17
-          text run at (61,4) width 5: " "
-        RenderMathMLMath {math} at (65,2) size 29x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2194}"
-        RenderText {#text} at (93,4) size 5x17
-          text run at (93,4) width 5: " "
-        RenderMathMLMath {math} at (97,2) size 30x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21A4}"
-        RenderText {#text} at (126,4) size 5x17
-          text run at (126,4) width 5: " "
-        RenderMathMLMath {math} at (130,2) size 30x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21A6}"
-        RenderText {#text} at (159,4) size 5x17
-          text run at (159,4) width 5: " "
-        RenderMathMLMath {math} at (163,3) size 29x15
+        RenderMathMLMath {math} at (0,3) size 29x15
           RenderMathMLUnderOver {mover} at (0,0) size 29x15
             RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
             RenderMathMLOperator {mo} at (0,0) size 29x8
-              RenderBlock (anonymous) at (0,0) size 12x7
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21BC}"
-        RenderText {#text} at (191,4) size 5x17
-          text run at (191,4) width 5: " "
-        RenderMathMLMath {math} at (195,5) size 30x13
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2190}"
+        RenderText {#text} at (28,4) size 5x17
+          text run at (28,4) width 5: " "
+        RenderMathMLMath {math} at (32,3) size 29x15
+          RenderMathMLUnderOver {mover} at (0,0) size 29x15
+            RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2192}"
+        RenderText {#text} at (60,4) size 5x17
+          text run at (60,4) width 5: " "
+        RenderMathMLMath {math} at (64,3) size 29x15
+          RenderMathMLUnderOver {mover} at (0,0) size 29x15
+            RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2194}"
+        RenderText {#text} at (92,4) size 5x17
+          text run at (92,4) width 5: " "
+        RenderMathMLMath {math} at (96,3) size 30x15
+          RenderMathMLUnderOver {mover} at (0,0) size 29x15
+            RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21A4}"
+        RenderText {#text} at (125,4) size 5x17
+          text run at (125,4) width 5: " "
+        RenderMathMLMath {math} at (129,3) size 29x15
+          RenderMathMLUnderOver {mover} at (0,0) size 29x15
+            RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21A6}"
+        RenderText {#text} at (157,4) size 5x17
+          text run at (157,4) width 5: " "
+        RenderMathMLMath {math} at (161,4) size 29x14
+          RenderMathMLUnderOver {mover} at (0,0) size 29x14
+            RenderMathMLSpace {mspace} at (3,11) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x7
+              RenderBlock (anonymous) at (0,0) size 11x6
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21BC}"
+        RenderText {#text} at (189,4) size 5x17
+          text run at (189,4) width 5: " "
+        RenderMathMLMath {math} at (193,5) size 29x13
           RenderMathMLUnderOver {mover} at (0,0) size 29x13
             RenderMathMLSpace {mspace} at (3,10) size 23x3 [bgcolor=#0000FF]
             RenderMathMLOperator {mo} at (0,0) size 29x6
-              RenderBlock (anonymous) at (0,0) size 12x5
-                RenderText {#text} at (0,-39) size 12x80
-                  text run at (0,-39) width 12: "\x{21BD}"
-        RenderText {#text} at (224,4) size 5x17
-          text run at (224,4) width 5: " "
-        RenderMathMLMath {math} at (228,3) size 30x15
+              RenderBlock (anonymous) at (0,0) size 11x5
+                RenderText {#text} at (0,-36) size 11x75
+                  text run at (0,-36) width 11: "\x{21BD}"
+        RenderText {#text} at (221,4) size 5x17
+          text run at (221,4) width 5: " "
+        RenderMathMLMath {math} at (225,4) size 30x14
+          RenderMathMLUnderOver {mover} at (0,0) size 29x14
+            RenderMathMLSpace {mspace} at (3,11) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x7
+              RenderBlock (anonymous) at (0,0) size 11x6
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21C0}"
+        RenderText {#text} at (254,4) size 5x17
+          text run at (254,4) width 5: " "
+        RenderMathMLMath {math} at (258,3) size 29x15
           RenderMathMLUnderOver {mover} at (0,0) size 29x15
             RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
             RenderMathMLOperator {mo} at (0,0) size 29x8
-              RenderBlock (anonymous) at (0,0) size 12x7
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21C0}"
-        RenderText {#text} at (257,4) size 5x17
-          text run at (257,4) width 5: " "
-        RenderMathMLMath {math} at (261,2) size 29x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D0}"
-        RenderText {#text} at (289,4) size 5x17
-          text run at (289,4) width 5: " "
-        RenderMathMLMath {math} at (293,2) size 30x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D2}"
-        RenderText {#text} at (322,4) size 5x17
-          text run at (322,4) width 5: " "
-        RenderMathMLMath {math} at (326,2) size 30x16
-          RenderMathMLUnderOver {mover} at (0,0) size 29x16
-            RenderMathMLSpace {mspace} at (3,13) size 23x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 29x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D4}"
-        RenderText {#text} at (355,4) size 5x17
-          text run at (355,4) width 5: " "
-        RenderMathMLMath {math} at (359,0) size 29x18
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D0}"
+        RenderText {#text} at (286,4) size 5x17
+          text run at (286,4) width 5: " "
+        RenderMathMLMath {math} at (290,3) size 29x15
+          RenderMathMLUnderOver {mover} at (0,0) size 29x15
+            RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D2}"
+        RenderText {#text} at (318,4) size 5x17
+          text run at (318,4) width 5: " "
+        RenderMathMLMath {math} at (322,3) size 30x15
+          RenderMathMLUnderOver {mover} at (0,0) size 29x15
+            RenderMathMLSpace {mspace} at (3,12) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 29x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D4}"
+        RenderText {#text} at (351,4) size 5x17
+          text run at (351,4) width 5: " "
+        RenderMathMLMath {math} at (355,0) size 29x18
           RenderMathMLUnderOver {mover} at (0,0) size 29x18
             RenderMathMLSpace {mspace} at (3,15) size 23x3 [bgcolor=#0000FF]
             RenderMathMLOperator {mo} at (0,0) size 29x11
               RenderBlock (anonymous) at (0,0) size 12x10
-                RenderText {#text} at (0,-35) size 12x80
-                  text run at (0,-35) width 12: "\x{21DA}"
-        RenderText {#text} at (387,4) size 5x17
-          text run at (387,4) width 5: " "
-        RenderMathMLMath {math} at (391,0) size 30x18
+                RenderText {#text} at (0,-32) size 12x75
+                  text run at (0,-32) width 12: "\x{21DA}"
+        RenderText {#text} at (383,4) size 5x17
+          text run at (383,4) width 5: " "
+        RenderMathMLMath {math} at (387,0) size 29x18
           RenderMathMLUnderOver {mover} at (0,0) size 29x18
             RenderMathMLSpace {mspace} at (3,15) size 23x3 [bgcolor=#0000FF]
             RenderMathMLOperator {mo} at (0,0) size 29x11
               RenderBlock (anonymous) at (0,0) size 12x10
-                RenderText {#text} at (0,-35) size 12x80
-                  text run at (0,-35) width 12: "\x{21DB}"
-        RenderText {#text} at (420,4) size 5x17
-          text run at (420,4) width 5: " "
-        RenderMathMLMath {math} at (424,7) size 23x11
-          RenderMathMLUnderOver {mover} at (0,0) size 22x11
-            RenderMathMLSpace {mspace} at (0,8) size 22x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 22x4
+                RenderText {#text} at (0,-32) size 12x75
+                  text run at (0,-32) width 12: "\x{21DB}"
+        RenderText {#text} at (415,4) size 5x17
+          text run at (415,4) width 5: " "
+        RenderMathMLMath {math} at (419,6) size 26x12
+          RenderMathMLUnderOver {mover} at (0,0) size 25x12
+            RenderMathMLSpace {mspace} at (1,9) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 25x5
               RenderBlock (anonymous) at (0,0) size 4x9
-                RenderText {#text} at (0,-34) size 4x80
-                  text run at (0,-34) width 4: "\x{23B4}"
-        RenderText {#text} at (446,4) size 5x17
-          text run at (446,4) width 5: " "
-        RenderMathMLMath {math} at (450,7) size 23x11
-          RenderMathMLUnderOver {mover} at (0,0) size 22x11
-            RenderMathMLSpace {mspace} at (0,8) size 22x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 22x4
+                RenderText {#text} at (0,-31) size 4x75
+                  text run at (0,-31) width 4: "\x{23B4}"
+        RenderText {#text} at (444,4) size 5x17
+          text run at (444,4) width 5: " "
+        RenderMathMLMath {math} at (448,7) size 26x11
+          RenderMathMLUnderOver {mover} at (0,0) size 25x11
+            RenderMathMLSpace {mspace} at (1,8) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 25x4
               RenderBlock (anonymous) at (0,0) size 4x4
-                RenderText {#text} at (0,-43) size 4x80
-                  text run at (0,-43) width 4: "\x{23B5}"
-        RenderText {#text} at (472,4) size 5x17
-          text run at (472,4) width 5: " "
-        RenderMathMLMath {math} at (476,6) size 25x12
-          RenderMathMLUnderOver {mover} at (0,0) size 24x12
-            RenderMathMLSpace {mspace} at (1,9) size 22x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 24x5
+                RenderText {#text} at (0,-40) size 4x75
+                  text run at (0,-40) width 4: "\x{23B5}"
+        RenderText {#text} at (473,4) size 5x17
+          text run at (473,4) width 5: " "
+        RenderMathMLMath {math} at (477,6) size 24x12
+          RenderMathMLUnderOver {mover} at (0,0) size 23x12
+            RenderMathMLSpace {mspace} at (0,9) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 23x5
               RenderBlock (anonymous) at (0,0) size 6x9
-                RenderText {#text} at (0,-34) size 6x80
-                  text run at (0,-34) width 6: "\x{23DC}"
+                RenderText {#text} at (0,-31) size 6x75
+                  text run at (0,-31) width 6: "\x{23DC}"
         RenderText {#text} at (500,4) size 5x17
           text run at (500,4) width 5: " "
-        RenderMathMLMath {math} at (504,5) size 25x13
-          RenderMathMLUnderOver {mover} at (0,0) size 24x13
-            RenderMathMLSpace {mspace} at (1,10) size 22x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 24x6
+        RenderMathMLMath {math} at (504,6) size 24x12
+          RenderMathMLUnderOver {mover} at (0,0) size 23x12
+            RenderMathMLSpace {mspace} at (0,9) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 23x5
               RenderBlock (anonymous) at (0,0) size 6x4
-                RenderText {#text} at (0,-43) size 6x80
-                  text run at (0,-43) width 6: "\x{23DD}"
-        RenderText {#text} at (528,4) size 5x17
-          text run at (528,4) width 5: " "
-        RenderMathMLMath {math} at (532,6) size 25x12
-          RenderMathMLUnderOver {mover} at (0,0) size 24x12
-            RenderMathMLSpace {mspace} at (1,9) size 22x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 24x5
-              RenderBlock (anonymous) at (0,0) size 6x10
-                RenderText {#text} at (0,-33) size 6x80
-                  text run at (0,-33) width 6: "\x{23DE}"
-        RenderText {#text} at (556,4) size 5x17
-          text run at (556,4) width 5: " "
-        RenderMathMLMath {math} at (560,5) size 25x13
-          RenderMathMLUnderOver {mover} at (0,0) size 24x13
-            RenderMathMLSpace {mspace} at (1,10) size 22x3 [bgcolor=#0000FF]
-            RenderMathMLOperator {mo} at (0,0) size 24x6
+                RenderText {#text} at (0,-40) size 6x75
+                  text run at (0,-40) width 6: "\x{23DD}"
+        RenderText {#text} at (527,4) size 5x17
+          text run at (527,4) width 5: " "
+        RenderMathMLMath {math} at (531,5) size 24x13
+          RenderMathMLUnderOver {mover} at (0,0) size 23x13
+            RenderMathMLSpace {mspace} at (0,10) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 23x6
+              RenderBlock (anonymous) at (0,0) size 6x9
+                RenderText {#text} at (0,-31) size 6x75
+                  text run at (0,-31) width 6: "\x{23DE}"
+        RenderText {#text} at (554,4) size 5x17
+          text run at (554,4) width 5: " "
+        RenderMathMLMath {math} at (558,5) size 24x13
+          RenderMathMLUnderOver {mover} at (0,0) size 23x13
+            RenderMathMLSpace {mspace} at (0,10) size 23x3 [bgcolor=#0000FF]
+            RenderMathMLOperator {mo} at (0,0) size 23x6
               RenderBlock (anonymous) at (0,0) size 6x5
-                RenderText {#text} at (0,-43) size 6x80
-                  text run at (0,-43) width 6: "\x{23DF}"
+                RenderText {#text} at (0,-40) size 6x75
+                  text run at (0,-40) width 6: "\x{23DF}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,38) size 784x45
-        RenderMathMLMath {math} at (0,2) size 57x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2190}"
-        RenderText {#text} at (56,4) size 5x17
-          text run at (56,4) width 5: " "
-        RenderMathMLMath {math} at (60,2) size 58x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2192}"
-        RenderText {#text} at (117,4) size 5x17
-          text run at (117,4) width 5: " "
-        RenderMathMLMath {math} at (121,2) size 57x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2194}"
-        RenderText {#text} at (177,4) size 5x17
-          text run at (177,4) width 5: " "
-        RenderMathMLMath {math} at (181,2) size 58x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21A4}"
-        RenderText {#text} at (238,4) size 5x17
-          text run at (238,4) width 5: " "
-        RenderMathMLMath {math} at (242,2) size 58x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21A6}"
-        RenderText {#text} at (299,4) size 5x17
-          text run at (299,4) width 5: " "
-        RenderMathMLMath {math} at (303,3) size 57x15
+      RenderBlock {P} at (0,38) size 784x44
+        RenderMathMLMath {math} at (0,3) size 57x15
           RenderMathMLUnderOver {mover} at (0,0) size 57x15
             RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,0) size 57x8
-              RenderBlock (anonymous) at (0,0) size 12x7
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21BC}"
-        RenderText {#text} at (359,4) size 5x17
-          text run at (359,4) width 5: " "
-        RenderMathMLMath {math} at (363,5) size 58x13
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2190}"
+        RenderText {#text} at (56,4) size 5x17
+          text run at (56,4) width 5: " "
+        RenderMathMLMath {math} at (60,3) size 57x15
+          RenderMathMLUnderOver {mover} at (0,0) size 57x15
+            RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2192}"
+        RenderText {#text} at (116,4) size 5x17
+          text run at (116,4) width 5: " "
+        RenderMathMLMath {math} at (120,3) size 57x15
+          RenderMathMLUnderOver {mover} at (0,0) size 57x15
+            RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2194}"
+        RenderText {#text} at (176,4) size 5x17
+          text run at (176,4) width 5: " "
+        RenderMathMLMath {math} at (180,3) size 58x15
+          RenderMathMLUnderOver {mover} at (0,0) size 57x15
+            RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21A4}"
+        RenderText {#text} at (237,4) size 5x17
+          text run at (237,4) width 5: " "
+        RenderMathMLMath {math} at (241,3) size 57x15
+          RenderMathMLUnderOver {mover} at (0,0) size 57x15
+            RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21A6}"
+        RenderText {#text} at (297,4) size 5x17
+          text run at (297,4) width 5: " "
+        RenderMathMLMath {math} at (301,4) size 57x14
+          RenderMathMLUnderOver {mover} at (0,0) size 57x14
+            RenderMathMLSpace {mspace} at (3,11) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x7
+              RenderBlock (anonymous) at (0,0) size 11x6
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21BC}"
+        RenderText {#text} at (357,4) size 5x17
+          text run at (357,4) width 5: " "
+        RenderMathMLMath {math} at (361,5) size 57x13
           RenderMathMLUnderOver {mover} at (0,0) size 57x13
             RenderMathMLSpace {mspace} at (3,10) size 51x3 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,0) size 57x6
-              RenderBlock (anonymous) at (0,0) size 12x5
-                RenderText {#text} at (0,-39) size 12x80
-                  text run at (0,-39) width 12: "\x{21BD}"
-        RenderText {#text} at (420,4) size 5x17
-          text run at (420,4) width 5: " "
-        RenderMathMLMath {math} at (424,3) size 58x15
+              RenderBlock (anonymous) at (0,0) size 11x5
+                RenderText {#text} at (0,-36) size 11x75
+                  text run at (0,-36) width 11: "\x{21BD}"
+        RenderText {#text} at (417,4) size 5x17
+          text run at (417,4) width 5: " "
+        RenderMathMLMath {math} at (421,4) size 58x14
+          RenderMathMLUnderOver {mover} at (0,0) size 57x14
+            RenderMathMLSpace {mspace} at (3,11) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x7
+              RenderBlock (anonymous) at (0,0) size 11x6
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21C0}"
+        RenderText {#text} at (478,4) size 5x17
+          text run at (478,4) width 5: " "
+        RenderMathMLMath {math} at (482,3) size 57x15
           RenderMathMLUnderOver {mover} at (0,0) size 57x15
             RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,0) size 57x8
-              RenderBlock (anonymous) at (0,0) size 12x7
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21C0}"
-        RenderText {#text} at (481,4) size 5x17
-          text run at (481,4) width 5: " "
-        RenderMathMLMath {math} at (485,2) size 57x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D0}"
-        RenderText {#text} at (541,4) size 5x17
-          text run at (541,4) width 5: " "
-        RenderMathMLMath {math} at (545,2) size 58x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D2}"
-        RenderText {#text} at (602,4) size 5x17
-          text run at (602,4) width 5: " "
-        RenderMathMLMath {math} at (606,2) size 58x16
-          RenderMathMLUnderOver {mover} at (0,0) size 57x16
-            RenderMathMLSpace {mspace} at (3,13) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D4}"
-        RenderText {#text} at (663,4) size 5x17
-          text run at (663,4) width 5: " "
-        RenderMathMLMath {math} at (667,0) size 57x18
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D0}"
+        RenderText {#text} at (538,4) size 5x17
+          text run at (538,4) width 5: " "
+        RenderMathMLMath {math} at (542,3) size 57x15
+          RenderMathMLUnderOver {mover} at (0,0) size 57x15
+            RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D2}"
+        RenderText {#text} at (598,4) size 5x17
+          text run at (598,4) width 5: " "
+        RenderMathMLMath {math} at (602,3) size 58x15
+          RenderMathMLUnderOver {mover} at (0,0) size 57x15
+            RenderMathMLSpace {mspace} at (3,12) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D4}"
+        RenderText {#text} at (659,4) size 5x17
+          text run at (659,4) width 5: " "
+        RenderMathMLMath {math} at (663,0) size 57x18
           RenderMathMLUnderOver {mover} at (0,0) size 57x18
             RenderMathMLSpace {mspace} at (3,15) size 51x3 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,0) size 57x11
               RenderBlock (anonymous) at (0,0) size 12x10
-                RenderText {#text} at (0,-35) size 12x80
-                  text run at (0,-35) width 12: "\x{21DA}"
+                RenderText {#text} at (0,-32) size 12x75
+                  text run at (0,-32) width 12: "\x{21DA}"
+        RenderText {#text} at (719,4) size 5x17
+          text run at (719,4) width 5: " "
+        RenderMathMLMath {math} at (723,0) size 57x18
+          RenderMathMLUnderOver {mover} at (0,0) size 57x18
+            RenderMathMLSpace {mspace} at (3,15) size 51x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 57x11
+              RenderBlock (anonymous) at (0,0) size 12x10
+                RenderText {#text} at (0,-32) size 12x75
+                  text run at (0,-32) width 12: "\x{21DB}"
         RenderText {#text} at (0,0) size 0x0
-        RenderMathMLMath {math} at (0,23) size 57x18
-          RenderMathMLUnderOver {mover} at (0,0) size 57x18
-            RenderMathMLSpace {mspace} at (3,15) size 51x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 57x11
-              RenderBlock (anonymous) at (0,0) size 12x10
-                RenderText {#text} at (0,-35) size 12x80
-                  text run at (0,-35) width 12: "\x{21DB}"
-        RenderText {#text} at (56,27) size 5x17
-          text run at (56,27) width 5: " "
-        RenderMathMLMath {math} at (60,23) size 51x18
-          RenderMathMLUnderOver {mover} at (0,0) size 50x18
-            RenderMathMLSpace {mspace} at (0,15) size 50x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 50x11
+        RenderMathMLMath {math} at (0,23) size 50x17
+          RenderMathMLUnderOver {mover} at (0,0) size 50x17
+            RenderMathMLSpace {mspace} at (0,14) size 50x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 50x10
               RenderBlock (anonymous) at (0,0) size 4x9
-                RenderText {#text} at (0,-34) size 4x80
-                  text run at (0,-34) width 4: "\x{23B4}"
-        RenderText {#text} at (110,27) size 5x17
-          text run at (110,27) width 5: " "
-        RenderMathMLMath {math} at (114,28) size 51x13
-          RenderMathMLUnderOver {mover} at (0,0) size 50x13
-            RenderMathMLSpace {mspace} at (0,10) size 50x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 50x6
+                RenderText {#text} at (0,-31) size 4x75
+                  text run at (0,-31) width 4: "\x{23B4}"
+        RenderText {#text} at (50,26) size 4x17
+          text run at (50,26) width 4: " "
+        RenderMathMLMath {math} at (54,28) size 50x12
+          RenderMathMLUnderOver {mover} at (0,0) size 50x12
+            RenderMathMLSpace {mspace} at (0,9) size 50x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 50x5
               RenderBlock (anonymous) at (0,0) size 4x4
-                RenderText {#text} at (0,-43) size 4x80
-                  text run at (0,-43) width 4: "\x{23B5}"
-        RenderText {#text} at (164,27) size 5x17
-          text run at (164,27) width 5: " "
-        RenderMathMLMath {math} at (168,23) size 51x18
+                RenderText {#text} at (0,-40) size 4x75
+                  text run at (0,-40) width 4: "\x{23B5}"
+        RenderText {#text} at (104,26) size 4x17
+          text run at (104,26) width 4: " "
+        RenderMathMLMath {math} at (108,22) size 50x18
           RenderMathMLUnderOver {mover} at (0,0) size 50x18
             RenderMathMLSpace {mspace} at (0,15) size 50x3 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,0) size 50x11
               RenderBlock (anonymous) at (0,0) size 6x9
-                RenderText {#text} at (0,-34) size 6x80
-                  text run at (0,-34) width 6: "\x{23DC}"
-        RenderText {#text} at (218,27) size 5x17
-          text run at (218,27) width 5: " "
-        RenderMathMLMath {math} at (222,28) size 51x13
+                RenderText {#text} at (0,-31) size 6x75
+                  text run at (0,-31) width 6: "\x{23DC}"
+        RenderText {#text} at (158,26) size 4x17
+          text run at (158,26) width 4: " "
+        RenderMathMLMath {math} at (162,27) size 50x13
           RenderMathMLUnderOver {mover} at (0,0) size 50x13
             RenderMathMLSpace {mspace} at (0,10) size 50x3 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,0) size 50x6
               RenderBlock (anonymous) at (0,0) size 6x4
-                RenderText {#text} at (0,-43) size 6x80
-                  text run at (0,-43) width 6: "\x{23DD}"
-        RenderText {#text} at (272,27) size 5x17
-          text run at (272,27) width 5: " "
-        RenderMathMLMath {math} at (276,22) size 51x19
-          RenderMathMLUnderOver {mover} at (0,0) size 50x19
-            RenderMathMLSpace {mspace} at (0,16) size 50x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 50x12
-              RenderBlock (anonymous) at (0,0) size 6x10
-                RenderText {#text} at (0,-33) size 6x80
-                  text run at (0,-33) width 6: "\x{23DE}"
-        RenderText {#text} at (326,27) size 5x17
-          text run at (326,27) width 5: " "
-        RenderMathMLMath {math} at (330,27) size 51x14
-          RenderMathMLUnderOver {mover} at (0,0) size 50x14
-            RenderMathMLSpace {mspace} at (0,11) size 50x3 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,0) size 50x7
+                RenderText {#text} at (0,-40) size 6x75
+                  text run at (0,-40) width 6: "\x{23DD}"
+        RenderText {#text} at (212,26) size 4x17
+          text run at (212,26) width 4: " "
+        RenderMathMLMath {math} at (216,22) size 50x18
+          RenderMathMLUnderOver {mover} at (0,0) size 50x18
+            RenderMathMLSpace {mspace} at (0,15) size 50x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 50x11
+              RenderBlock (anonymous) at (0,0) size 6x9
+                RenderText {#text} at (0,-31) size 6x75
+                  text run at (0,-31) width 6: "\x{23DE}"
+        RenderText {#text} at (266,26) size 4x17
+          text run at (266,26) width 4: " "
+        RenderMathMLMath {math} at (270,27) size 50x13
+          RenderMathMLUnderOver {mover} at (0,0) size 50x13
+            RenderMathMLSpace {mspace} at (0,10) size 50x3 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,0) size 50x6
               RenderBlock (anonymous) at (0,0) size 6x5
-                RenderText {#text} at (0,-43) size 6x80
-                  text run at (0,-43) width 6: "\x{23DF}"
+                RenderText {#text} at (0,-40) size 6x75
+                  text run at (0,-40) width 6: "\x{23DF}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,99) size 784x65
-        RenderMathMLMath {math} at (0,0) size 107x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2190}"
-        RenderText {#text} at (106,2) size 5x17
-          text run at (106,2) width 5: " "
-        RenderMathMLMath {math} at (110,0) size 108x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2192}"
-        RenderText {#text} at (217,2) size 5x17
-          text run at (217,2) width 5: " "
-        RenderMathMLMath {math} at (221,0) size 107x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{2194}"
-        RenderText {#text} at (327,2) size 5x17
-          text run at (327,2) width 5: " "
-        RenderMathMLMath {math} at (331,0) size 108x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21A4}"
-        RenderText {#text} at (438,2) size 5x17
-          text run at (438,2) width 5: " "
-        RenderMathMLMath {math} at (442,0) size 108x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21A6}"
-        RenderText {#text} at (549,2) size 5x17
-          text run at (549,2) width 5: " "
-        RenderMathMLMath {math} at (553,1) size 107x15
+      RenderBlock {P} at (0,98) size 784x63
+        RenderMathMLMath {math} at (0,0) size 107x15
           RenderMathMLUnderOver {mover} at (0,0) size 107x15
             RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 107x8
-              RenderBlock (anonymous) at (0,0) size 12x7
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21BC}"
-        RenderText {#text} at (659,2) size 5x17
-          text run at (659,2) width 5: " "
-        RenderMathMLMath {math} at (663,3) size 108x13
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2190}"
+        RenderText {#text} at (106,1) size 5x17
+          text run at (106,1) width 5: " "
+        RenderMathMLMath {math} at (110,0) size 107x15
+          RenderMathMLUnderOver {mover} at (0,0) size 107x15
+            RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2192}"
+        RenderText {#text} at (216,1) size 5x17
+          text run at (216,1) width 5: " "
+        RenderMathMLMath {math} at (220,0) size 107x15
+          RenderMathMLUnderOver {mover} at (0,0) size 107x15
+            RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{2194}"
+        RenderText {#text} at (326,1) size 5x17
+          text run at (326,1) width 5: " "
+        RenderMathMLMath {math} at (330,0) size 108x15
+          RenderMathMLUnderOver {mover} at (0,0) size 107x15
+            RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21A4}"
+        RenderText {#text} at (437,1) size 5x17
+          text run at (437,1) width 5: " "
+        RenderMathMLMath {math} at (441,0) size 107x15
+          RenderMathMLUnderOver {mover} at (0,0) size 107x15
+            RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21A6}"
+        RenderText {#text} at (547,1) size 5x17
+          text run at (547,1) width 5: " "
+        RenderMathMLMath {math} at (551,1) size 107x14
+          RenderMathMLUnderOver {mover} at (0,0) size 107x14
+            RenderMathMLSpace {mspace} at (3,11) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x7
+              RenderBlock (anonymous) at (0,0) size 11x6
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21BC}"
+        RenderText {#text} at (657,1) size 5x17
+          text run at (657,1) width 5: " "
+        RenderMathMLMath {math} at (661,2) size 107x13
           RenderMathMLUnderOver {mover} at (0,0) size 107x13
             RenderMathMLSpace {mspace} at (3,10) size 101x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 107x6
-              RenderBlock (anonymous) at (0,0) size 12x5
-                RenderText {#text} at (0,-39) size 12x80
-                  text run at (0,-39) width 12: "\x{21BD}"
+              RenderBlock (anonymous) at (0,0) size 11x5
+                RenderText {#text} at (0,-36) size 11x75
+                  text run at (0,-36) width 11: "\x{21BD}"
         RenderText {#text} at (0,0) size 0x0
-        RenderMathMLMath {math} at (0,23) size 107x15
+        RenderMathMLMath {math} at (0,23) size 107x14
+          RenderMathMLUnderOver {mover} at (0,0) size 107x14
+            RenderMathMLSpace {mspace} at (3,11) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x7
+              RenderBlock (anonymous) at (0,0) size 11x6
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21C0}"
+        RenderText {#text} at (106,23) size 5x17
+          text run at (106,23) width 5: " "
+        RenderMathMLMath {math} at (110,22) size 107x15
           RenderMathMLUnderOver {mover} at (0,0) size 107x15
             RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 107x8
-              RenderBlock (anonymous) at (0,0) size 12x7
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21C0}"
-        RenderText {#text} at (106,24) size 5x17
-          text run at (106,24) width 5: " "
-        RenderMathMLMath {math} at (110,22) size 108x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D0}"
-        RenderText {#text} at (217,24) size 5x17
-          text run at (217,24) width 5: " "
-        RenderMathMLMath {math} at (221,22) size 107x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D2}"
-        RenderText {#text} at (327,24) size 5x17
-          text run at (327,24) width 5: " "
-        RenderMathMLMath {math} at (331,22) size 108x16
-          RenderMathMLUnderOver {mover} at (0,0) size 107x16
-            RenderMathMLSpace {mspace} at (3,13) size 101x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 107x9
-              RenderBlock (anonymous) at (0,0) size 12x8
-                RenderText {#text} at (0,-36) size 12x80
-                  text run at (0,-36) width 12: "\x{21D4}"
-        RenderText {#text} at (438,24) size 5x17
-          text run at (438,24) width 5: " "
-        RenderMathMLMath {math} at (442,20) size 108x18
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D0}"
+        RenderText {#text} at (216,23) size 5x17
+          text run at (216,23) width 5: " "
+        RenderMathMLMath {math} at (220,22) size 107x15
+          RenderMathMLUnderOver {mover} at (0,0) size 107x15
+            RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D2}"
+        RenderText {#text} at (326,23) size 5x17
+          text run at (326,23) width 5: " "
+        RenderMathMLMath {math} at (330,22) size 108x15
+          RenderMathMLUnderOver {mover} at (0,0) size 107x15
+            RenderMathMLSpace {mspace} at (3,12) size 101x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 107x8
+              RenderBlock (anonymous) at (0,0) size 11x7
+                RenderText {#text} at (0,-34) size 11x75
+                  text run at (0,-34) width 11: "\x{21D4}"
+        RenderText {#text} at (437,23) size 5x17
+          text run at (437,23) width 5: " "
+        RenderMathMLMath {math} at (441,19) size 107x18
           RenderMathMLUnderOver {mover} at (0,0) size 107x18
             RenderMathMLSpace {mspace} at (3,15) size 101x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 107x11
               RenderBlock (anonymous) at (0,0) size 12x10
-                RenderText {#text} at (0,-35) size 12x80
-                  text run at (0,-35) width 12: "\x{21DA}"
-        RenderText {#text} at (549,24) size 5x17
-          text run at (549,24) width 5: " "
-        RenderMathMLMath {math} at (553,20) size 107x18
+                RenderText {#text} at (0,-32) size 12x75
+                  text run at (0,-32) width 12: "\x{21DA}"
+        RenderText {#text} at (547,23) size 5x17
+          text run at (547,23) width 5: " "
+        RenderMathMLMath {math} at (551,19) size 107x18
           RenderMathMLUnderOver {mover} at (0,0) size 107x18
             RenderMathMLSpace {mspace} at (3,15) size 101x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 107x11
               RenderBlock (anonymous) at (0,0) size 12x10
-                RenderText {#text} at (0,-35) size 12x80
-                  text run at (0,-35) width 12: "\x{21DB}"
-        RenderText {#text} at (659,24) size 5x17
-          text run at (659,24) width 5: " "
-        RenderMathMLMath {math} at (663,20) size 101x18
-          RenderMathMLUnderOver {mover} at (0,0) size 100x18
-            RenderMathMLSpace {mspace} at (0,15) size 100x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 100x11
+                RenderText {#text} at (0,-32) size 12x75
+                  text run at (0,-32) width 12: "\x{21DB}"
+        RenderText {#text} at (657,23) size 5x17
+          text run at (657,23) width 5: " "
+        RenderMathMLMath {math} at (661,20) size 101x17
+          RenderMathMLUnderOver {mover} at (0,0) size 100x17
+            RenderMathMLSpace {mspace} at (0,14) size 100x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 100x10
               RenderBlock (anonymous) at (0,0) size 4x9
-                RenderText {#text} at (0,-34) size 4x80
-                  text run at (0,-34) width 4: "\x{23B4}"
+                RenderText {#text} at (0,-31) size 4x75
+                  text run at (0,-31) width 4: "\x{23B4}"
         RenderText {#text} at (0,0) size 0x0
-        RenderMathMLMath {math} at (0,48) size 100x13
-          RenderMathMLUnderOver {mover} at (0,0) size 100x13
-            RenderMathMLSpace {mspace} at (0,10) size 100x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 100x6
+        RenderMathMLMath {math} at (0,47) size 100x12
+          RenderMathMLUnderOver {mover} at (0,0) size 100x12
+            RenderMathMLSpace {mspace} at (0,9) size 100x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 100x5
               RenderBlock (anonymous) at (0,0) size 4x4
-                RenderText {#text} at (0,-43) size 4x80
-                  text run at (0,-43) width 4: "\x{23B5}"
-        RenderText {#text} at (100,47) size 4x17
-          text run at (100,47) width 4: " "
-        RenderMathMLMath {math} at (104,43) size 100x18
+                RenderText {#text} at (0,-40) size 4x75
+                  text run at (0,-40) width 4: "\x{23B5}"
+        RenderText {#text} at (100,45) size 4x17
+          text run at (100,45) width 4: " "
+        RenderMathMLMath {math} at (104,41) size 100x18
           RenderMathMLUnderOver {mover} at (0,0) size 100x18
             RenderMathMLSpace {mspace} at (0,15) size 100x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 100x11
               RenderBlock (anonymous) at (0,0) size 6x9
-                RenderText {#text} at (0,-34) size 6x80
-                  text run at (0,-34) width 6: "\x{23DC}"
-        RenderText {#text} at (204,47) size 4x17
-          text run at (204,47) width 4: " "
-        RenderMathMLMath {math} at (208,48) size 100x13
+                RenderText {#text} at (0,-31) size 6x75
+                  text run at (0,-31) width 6: "\x{23DC}"
+        RenderText {#text} at (204,45) size 4x17
+          text run at (204,45) width 4: " "
+        RenderMathMLMath {math} at (208,46) size 100x13
           RenderMathMLUnderOver {mover} at (0,0) size 100x13
             RenderMathMLSpace {mspace} at (0,10) size 100x3 [bgcolor=#FF0000]
             RenderMathMLOperator {mo} at (0,0) size 100x6
               RenderBlock (anonymous) at (0,0) size 6x4
-                RenderText {#text} at (0,-43) size 6x80
-                  text run at (0,-43) width 6: "\x{23DD}"
-        RenderText {#text} at (308,47) size 4x17
-          text run at (308,47) width 4: " "
-        RenderMathMLMath {math} at (312,42) size 100x19
-          RenderMathMLUnderOver {mover} at (0,0) size 100x19
-            RenderMathMLSpace {mspace} at (0,16) size 100x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 100x12
-              RenderBlock (anonymous) at (0,0) size 6x10
-                RenderText {#text} at (0,-33) size 6x80
-                  text run at (0,-33) width 6: "\x{23DE}"
-        RenderText {#text} at (412,47) size 4x17
-          text run at (412,47) width 4: " "
-        RenderMathMLMath {math} at (416,47) size 100x14
-          RenderMathMLUnderOver {mover} at (0,0) size 100x14
-            RenderMathMLSpace {mspace} at (0,11) size 100x3 [bgcolor=#FF0000]
-            RenderMathMLOperator {mo} at (0,0) size 100x7
+                RenderText {#text} at (0,-40) size 6x75
+                  text run at (0,-40) width 6: "\x{23DD}"
+        RenderText {#text} at (308,45) size 4x17
+          text run at (308,45) width 4: " "
+        RenderMathMLMath {math} at (312,41) size 100x18
+          RenderMathMLUnderOver {mover} at (0,0) size 100x18
+            RenderMathMLSpace {mspace} at (0,15) size 100x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 100x11
+              RenderBlock (anonymous) at (0,0) size 6x9
+                RenderText {#text} at (0,-31) size 6x75
+                  text run at (0,-31) width 6: "\x{23DE}"
+        RenderText {#text} at (412,45) size 4x17
+          text run at (412,45) width 4: " "
+        RenderMathMLMath {math} at (416,46) size 100x13
+          RenderMathMLUnderOver {mover} at (0,0) size 100x13
+            RenderMathMLSpace {mspace} at (0,10) size 100x3 [bgcolor=#FF0000]
+            RenderMathMLOperator {mo} at (0,0) size 100x6
               RenderBlock (anonymous) at (0,0) size 6x5
-                RenderText {#text} at (0,-43) size 6x80
-                  text run at (0,-43) width 6: "\x{23DF}"
+                RenderText {#text} at (0,-40) size 6x75
+                  text run at (0,-40) width 6: "\x{23DF}"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/mathml/opentype/horizontal-munderover-expected.txt
+++ b/LayoutTests/platform/glib/mathml/opentype/horizontal-munderover-expected.txt
@@ -1,92 +1,92 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x70
-  RenderBlock {HTML} at (0,0) size 800x71
-    RenderBody {BODY} at (8,16) size 784x39
-      RenderBlock {P} at (0,0) size 784x39
-        RenderMathMLMath {math} at (0,8) size 48x19
+layer at (0,0) size 800x68
+  RenderBlock {HTML} at (0,0) size 800x69
+    RenderBody {BODY} at (8,16) size 784x37
+      RenderBlock {P} at (0,0) size 784x37
+        RenderMathMLMath {math} at (0,7) size 48x19
           RenderMathMLRow {mstyle} at (0,0) size 48x19
             RenderMathMLUnderOver {mover} at (0,0) size 48x12
               RenderMathMLOperator {mo} at (0,5) size 48x7
                 RenderBlock (anonymous) at (0,0) size 8x13
                   RenderText {#text} at (0,-44) size 8x106
                     text run at (0,-44) width 8: "\x{23DE}"
-              RenderMathMLSpace {mspace} at (0,0) size 48x2 [bgcolor=#FF0000]
-        RenderText {#text} at (48,13) size 4x17
-          text run at (48,13) width 4: " "
-        RenderMathMLMath {math} at (52,8) size 64x19
-          RenderMathMLRow {mstyle} at (0,0) size 64x19
-            RenderMathMLUnderOver {mover} at (0,0) size 64x19
-              RenderMathMLSpace {mspace} at (0,16) size 64x3 [bgcolor=#FF0000]
-              RenderMathMLOperator {mo} at (0,0) size 64x12
-                RenderBlock (anonymous) at (0,0) size 6x10
-                  RenderText {#text} at (0,-33) size 6x80
-                    text run at (0,-33) width 6: "\x{23DE}"
-        RenderText {#text} at (116,13) size 4x17
-          text run at (116,13) width 4: " "
-        RenderMathMLMath {math} at (120,13) size 48x16
+              RenderMathMLSpace {mspace} at (1,0) size 46x2 [bgcolor=#FF0000]
+        RenderText {#text} at (48,12) size 4x17
+          text run at (48,12) width 4: " "
+        RenderMathMLMath {math} at (52,8) size 64x18
+          RenderMathMLRow {mstyle} at (0,0) size 64x18
+            RenderMathMLUnderOver {mover} at (0,0) size 64x18
+              RenderMathMLSpace {mspace} at (0,15) size 64x3 [bgcolor=#FF0000]
+              RenderMathMLOperator {mo} at (0,0) size 64x11
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-31) size 6x75
+                    text run at (0,-31) width 6: "\x{23DE}"
+        RenderText {#text} at (116,12) size 4x17
+          text run at (116,12) width 4: " "
+        RenderMathMLMath {math} at (120,12) size 48x16
           RenderMathMLRow {mstyle} at (0,0) size 48x16
             RenderMathMLUnderOver {munder} at (0,0) size 48x16
               RenderMathMLOperator {mo} at (0,0) size 48x6
                 RenderBlock (anonymous) at (0,0) size 8x13
                   RenderText {#text} at (0,-44) size 8x106
                     text run at (0,-44) width 8: "\x{23DE}"
-              RenderMathMLSpace {mspace} at (0,13) size 48x3 [bgcolor=#FF0000]
-        RenderText {#text} at (168,13) size 4x17
-          text run at (168,13) width 4: " "
-        RenderMathMLMath {math} at (172,8) size 64x31
-          RenderMathMLRow {mstyle} at (0,0) size 64x31
-            RenderMathMLUnderOver {munderover} at (0,0) size 64x31
-              RenderMathMLSpace {mspace} at (0,16) size 64x3 [bgcolor=#FF0000]
-              RenderMathMLOperator {mo} at (0,18) size 64x12
-                RenderBlock (anonymous) at (0,0) size 6x10
-                  RenderText {#text} at (0,-33) size 6x80
-                    text run at (0,-33) width 6: "\x{23DE}"
-              RenderMathMLOperator {mo} at (0,0) size 64x12
-                RenderBlock (anonymous) at (0,0) size 6x10
-                  RenderText {#text} at (0,-33) size 6x80
-                    text run at (0,-33) width 6: "\x{23DE}"
-        RenderText {#text} at (236,13) size 4x17
-          text run at (236,13) width 4: " "
-        RenderMathMLMath {math} at (240,0) size 48x29
-          RenderMathMLRow {mstyle} at (0,0) size 48x29
-            RenderMathMLUnderOver {munderover} at (0,0) size 48x29
-              RenderMathMLOperator {mo} at (0,12) size 48x7
+              RenderMathMLSpace {mspace} at (1,13) size 46x3 [bgcolor=#FF0000]
+        RenderText {#text} at (168,12) size 4x17
+          text run at (168,12) width 4: " "
+        RenderMathMLMath {math} at (172,8) size 64x29
+          RenderMathMLRow {mstyle} at (0,0) size 64x29
+            RenderMathMLUnderOver {munderover} at (0,0) size 64x29
+              RenderMathMLSpace {mspace} at (0,15) size 64x3 [bgcolor=#FF0000]
+              RenderMathMLOperator {mo} at (0,17) size 64x11
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-31) size 6x75
+                    text run at (0,-31) width 6: "\x{23DE}"
+              RenderMathMLOperator {mo} at (0,0) size 64x11
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-31) size 6x75
+                    text run at (0,-31) width 6: "\x{23DE}"
+        RenderText {#text} at (236,12) size 4x17
+          text run at (236,12) width 4: " "
+        RenderMathMLMath {math} at (240,0) size 48x28
+          RenderMathMLRow {mstyle} at (0,0) size 48x28
+            RenderMathMLUnderOver {munderover} at (0,0) size 48x28
+              RenderMathMLOperator {mo} at (0,11) size 48x7
                 RenderBlock (anonymous) at (0,0) size 8x13
                   RenderText {#text} at (0,-44) size 8x106
                     text run at (0,-44) width 8: "\x{23DE}"
-              RenderMathMLSpace {mspace} at (0,26) size 48x3 [bgcolor=#FF0000]
-              RenderMathMLOperator {mo} at (0,0) size 48x6
-                RenderBlock (anonymous) at (0,0) size 6x10
-                  RenderText {#text} at (0,-33) size 6x80
-                    text run at (0,-33) width 6: "\x{23DE}"
-        RenderText {#text} at (288,13) size 4x17
-          text run at (288,13) width 4: " "
-        RenderMathMLMath {math} at (292,8) size 48x20
-          RenderMathMLRow {mstyle} at (0,0) size 48x20
-            RenderMathMLUnderOver {munderover} at (0,0) size 48x20
+              RenderMathMLSpace {mspace} at (1,25) size 46x3 [bgcolor=#FF0000]
+              RenderMathMLOperator {mo} at (1,0) size 46x5
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-31) size 6x75
+                    text run at (0,-31) width 6: "\x{23DE}"
+        RenderText {#text} at (288,12) size 4x17
+          text run at (288,12) width 4: " "
+        RenderMathMLMath {math} at (292,7) size 48x19
+          RenderMathMLRow {mstyle} at (0,0) size 48x19
+            RenderMathMLUnderOver {munderover} at (0,0) size 48x19
               RenderMathMLOperator {mo} at (0,5) size 48x7
                 RenderBlock (anonymous) at (0,0) size 8x13
                   RenderText {#text} at (0,-44) size 8x106
                     text run at (0,-44) width 8: "\x{23DE}"
-              RenderMathMLOperator {mo} at (0,13) size 48x7
-                RenderBlock (anonymous) at (0,0) size 6x10
-                  RenderText {#text} at (0,-33) size 6x80
-                    text run at (0,-33) width 6: "\x{23DE}"
-              RenderMathMLSpace {mspace} at (0,0) size 48x2 [bgcolor=#FF0000]
-        RenderText {#text} at (340,13) size 4x17
-          text run at (340,13) width 4: " "
-        RenderMathMLMath {math} at (344,8) size 48x20
-          RenderMathMLRow {mstyle} at (0,0) size 48x20
-            RenderMathMLUnderOver {munder} at (0,0) size 48x20
+              RenderMathMLOperator {mo} at (1,13) size 46x6
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-31) size 6x75
+                    text run at (0,-31) width 6: "\x{23DE}"
+              RenderMathMLSpace {mspace} at (1,0) size 46x2 [bgcolor=#FF0000]
+        RenderText {#text} at (340,12) size 4x17
+          text run at (340,12) width 4: " "
+        RenderMathMLMath {math} at (344,7) size 48x19
+          RenderMathMLRow {mstyle} at (0,0) size 48x19
+            RenderMathMLUnderOver {munder} at (0,0) size 48x19
               RenderMathMLUnderOver {mover} at (0,0) size 48x12
                 RenderMathMLOperator {mo} at (0,5) size 48x7
                   RenderBlock (anonymous) at (0,0) size 8x13
                     RenderText {#text} at (0,-44) size 8x106
                       text run at (0,-44) width 8: "\x{23DE}"
-                RenderMathMLSpace {mspace} at (0,0) size 48x2 [bgcolor=#FF0000]
-              RenderMathMLOperator {mo} at (0,13) size 48x7
-                RenderBlock (anonymous) at (0,0) size 6x10
-                  RenderText {#text} at (0,-33) size 6x80
-                    text run at (0,-33) width 6: "\x{23DE}"
+                RenderMathMLSpace {mspace} at (1,0) size 46x2 [bgcolor=#FF0000]
+              RenderMathMLOperator {mo} at (1,13) size 46x6
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-31) size 6x75
+                    text run at (0,-31) width 6: "\x{23DE}"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/mathml/opentype/opentype-stretchy-horizontal-expected.txt
+++ b/LayoutTests/platform/glib/mathml/opentype/opentype-stretchy-horizontal-expected.txt
@@ -24,12 +24,12 @@ layer at (0,0) size 800x157
               RenderMathMLSpace {mspace} at (2,0) size 16x1
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,82) size 784x43
-        RenderMathMLMath {math} at (0,0) size 150x43
-          RenderMathMLRow {mstyle} at (0,0) size 150x43
-            RenderMathMLUnderOver {mover} at (0,0) size 150x43
-              RenderMathMLOperator {mo} at (0,1) size 150x42
+        RenderMathMLMath {math} at (0,0) size 142x43
+          RenderMathMLRow {mstyle} at (0,0) size 142x43
+            RenderMathMLUnderOver {mover} at (0,0) size 142x43
+              RenderMathMLOperator {mo} at (0,1) size 142x42
                 RenderBlock (anonymous) at (0,0) size 1x4
                   RenderText {#text} at (0,-3) size 1x0
                     text run at (0,-3) width 1: "\x{219C}"
-              RenderMathMLSpace {mspace} at (0,0) size 150x1
+              RenderMathMLSpace {mspace} at (0,0) size 142x1
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/mathml/presentation/bug159513-expected.txt
+++ b/LayoutTests/platform/glib/mathml/presentation/bug159513-expected.txt
@@ -1,62 +1,62 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x111
-  RenderBlock {HTML} at (0,0) size 800x112
-    RenderBody {BODY} at (8,16) size 784x88
+layer at (0,0) size 800x110
+  RenderBlock {HTML} at (0,0) size 800x111
+    RenderBody {BODY} at (8,16) size 784x87
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 261x17
           text run at (0,0) width 261: "Test passes if horizontal operators stretch."
-      RenderBlock (anonymous) at (0,34) size 784x54
-        RenderMathMLMath {math} at (0,12) size 60x37
-          RenderMathMLUnderOver {mover} at (0,0) size 60x37
-            RenderMathMLSpace {mspace} at (0,6) size 60x31 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (7,1) size 46x6
-              RenderBlock (anonymous) at (0,0) size 13x18
-                RenderText {#text} at (0,-67) size 13x158
-                  text run at (0,-67) width 13: "^"
-        RenderText {#text} at (60,34) size 4x17
-          text run at (60,34) width 4: " "
-        RenderMathMLMath {math} at (64,18) size 60x36
+      RenderBlock (anonymous) at (0,34) size 784x53
+        RenderMathMLMath {math} at (0,10) size 60x38
+          RenderMathMLUnderOver {mover} at (0,0) size 60x38
+            RenderMathMLSpace {mspace} at (0,7) size 60x31 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (8,1) size 44x7
+              RenderBlock (anonymous) at (0,0) size 13x17
+                RenderText {#text} at (0,-64) size 13x151
+                  text run at (0,-64) width 13: "^"
+        RenderText {#text} at (60,33) size 4x17
+          text run at (60,33) width 4: " "
+        RenderMathMLMath {math} at (64,17) size 60x36
           RenderMathMLUnderOver {munder} at (0,0) size 60x36
             RenderMathMLSpace {mspace} at (0,0) size 60x30 [bgcolor=#008000]
             RenderMathMLOperator {mo} at (0,30) size 60x4
               RenderBlock (anonymous) at (0,0) size 8x4
-                RenderText {#text} at (0,-85) size 8x158
-                  text run at (0,-85) width 8: "_"
-        RenderText {#text} at (124,34) size 4x17
-          text run at (124,34) width 4: " "
-        RenderMathMLMath {math} at (128,10) size 60x39
+                RenderText {#text} at (0,-81) size 8x151
+                  text run at (0,-81) width 8: "_"
+        RenderText {#text} at (124,33) size 4x17
+          text run at (124,33) width 4: " "
+        RenderMathMLMath {math} at (128,9) size 60x39
           RenderMathMLUnderOver {mover} at (0,0) size 60x39
             RenderMathMLSpace {mspace} at (0,8) size 60x31 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (7,1) size 46x8
-              RenderBlock (anonymous) at (0,0) size 13x8
-                RenderText {#text} at (0,-77) size 13x158
-                  text run at (0,-77) width 13: "~"
-        RenderText {#text} at (188,34) size 4x17
-          text run at (188,34) width 4: " "
-        RenderMathMLMath {math} at (192,0) size 60x49
-          RenderMathMLUnderOver {mover} at (0,0) size 60x49
-            RenderMathMLSpace {mspace} at (0,18) size 60x31 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (0,1) size 60x18
-              RenderBlock (anonymous) at (0,0) size 12x15
-                RenderText {#text} at (0,-70) size 12x158
-                  text run at (0,-70) width 12: "\x{AF}"
-        RenderText {#text} at (252,34) size 4x17
-          text run at (252,34) width 4: " "
-        RenderMathMLMath {math} at (256,12) size 60x37
+            RenderMathMLOperator {mo} at (8,1) size 44x8
+              RenderBlock (anonymous) at (0,0) size 13x7
+                RenderText {#text} at (0,-74) size 13x151
+                  text run at (0,-74) width 13: "~"
+        RenderText {#text} at (188,33) size 4x17
+          text run at (188,33) width 4: " "
+        RenderMathMLMath {math} at (192,0) size 60x48
+          RenderMathMLUnderOver {mover} at (0,0) size 60x48
+            RenderMathMLSpace {mspace} at (0,17) size 60x31 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (0,1) size 60x17
+              RenderBlock (anonymous) at (0,0) size 11x15
+                RenderText {#text} at (0,-66) size 11x151
+                  text run at (0,-66) width 11: "\x{AF}"
+        RenderText {#text} at (252,33) size 4x17
+          text run at (252,33) width 4: " "
+        RenderMathMLMath {math} at (256,10) size 60x38
+          RenderMathMLUnderOver {mover} at (0,0) size 60x38
+            RenderMathMLSpace {mspace} at (0,7) size 60x31 [bgcolor=#008000]
+            RenderMathMLOperator {mo} at (8,1) size 44x7
+              RenderBlock (anonymous) at (0,0) size 11x16
+                RenderText {#text} at (0,-65) size 11x151
+                  text run at (0,-65) width 11: "\x{2C6}"
+        RenderText {#text} at (316,33) size 4x17
+          text run at (316,33) width 4: " "
+        RenderMathMLMath {math} at (320,11) size 60x37
           RenderMathMLUnderOver {mover} at (0,0) size 60x37
             RenderMathMLSpace {mspace} at (0,6) size 60x31 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (7,1) size 46x6
-              RenderBlock (anonymous) at (0,0) size 12x17
-                RenderText {#text} at (0,-68) size 12x158
-                  text run at (0,-68) width 12: "\x{2C6}"
-        RenderText {#text} at (316,34) size 4x17
-          text run at (316,34) width 4: " "
-        RenderMathMLMath {math} at (320,12) size 60x37
-          RenderMathMLUnderOver {mover} at (0,0) size 60x37
-            RenderMathMLSpace {mspace} at (0,6) size 60x31 [bgcolor=#008000]
-            RenderMathMLOperator {mo} at (7,1) size 46x6
-              RenderBlock (anonymous) at (0,0) size 12x17
-                RenderText {#text} at (0,-68) size 12x158
-                  text run at (0,-68) width 12: "\x{2C7}"
+            RenderMathMLOperator {mo} at (8,1) size 44x6
+              RenderBlock (anonymous) at (0,0) size 11x16
+                RenderText {#text} at (0,-65) size 11x151
+                  text run at (0,-65) width 11: "\x{2C7}"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -1,20 +1,20 @@
 
 PASS automatic scriptlevel on mfrac (displaystyle=true)
 FAIL automatic scriptlevel on mfrac (displaystyle=false) assert_approx_equals: numerator expected 71 +/- 0.1 but got 100
-FAIL automatic scriptlevel on mroot assert_approx_equals: index expected 50.41 +/- 0.1 but got 56.25
-FAIL automatic scriptlevel on msub assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on msup assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on msubsup assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
+PASS automatic scriptlevel on mroot
+PASS automatic scriptlevel on msub
+PASS automatic scriptlevel on msup
+PASS automatic scriptlevel on msubsup
+PASS automatic scriptlevel on munder
+PASS automatic scriptlevel on mover
+PASS automatic scriptlevel on munderover
+PASS automatic scriptlevel on mmultiscripts
 PASS automatic scriptlevel on munder (accentunder=true)
 PASS automatic scriptlevel on mover (accent=true)
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
+PASS automatic scriptlevel on munderover (accentunder=true)
+PASS automatic scriptlevel on munderover (accent=true)
 PASS checking case-insensitivity accent/accentunder
-FAIL checking dynamic accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
+PASS checking dynamic accent/accentunder
 0
 1
 
@@ -29,19 +29,19 @@ FAIL checking dynamic accent/accentunder assert_approx_equals: under expected 71
 
 0
 1
+
 0
 1
 2
-
 0
 1
 
 0
 1
+
 0
 1
 2
-
 0
 1
 2

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/size-containment-001.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/size-containment-001.tentative-expected.txt
@@ -9,8 +9,8 @@ FAIL intrinsic size of mfrac with contain: size; contain-intrinsic-inline-size: 
 FAIL inline-size of mfrac with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875
 PASS intrinsic size of mi with contain: size; contain-intrinsic-inline-size: 111px;
 PASS inline-size of mi with contain: size; contain-intrinsic-inline-size: 111px;
-FAIL intrinsic size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
+FAIL intrinsic size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
 PASS intrinsic size of mn with contain: size; contain-intrinsic-inline-size: 111px;
 PASS inline-size of mn with contain: size; contain-intrinsic-inline-size: 111px;
 PASS intrinsic size of mo with contain: size; contain-intrinsic-inline-size: 111px;
@@ -27,12 +27,12 @@ PASS intrinsic size of ms with contain: size; contain-intrinsic-inline-size: 111
 PASS inline-size of ms with contain: size; contain-intrinsic-inline-size: 111px;
 FAIL intrinsic size of mstyle with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875
 FAIL inline-size of mstyle with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875
-FAIL intrinsic size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL intrinsic size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL intrinsic size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
+FAIL intrinsic size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL intrinsic size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL intrinsic size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
 PASS intrinsic size of mtext with contain: size; contain-intrinsic-inline-size: 111px;
 PASS inline-size of mtext with contain: size; contain-intrinsic-inline-size: 111px;
 FAIL intrinsic size of munder with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875

--- a/LayoutTests/platform/ios/mathml/opentype/opentype-stretchy-horizontal-expected.txt
+++ b/LayoutTests/platform/ios/mathml/opentype/opentype-stretchy-horizontal-expected.txt
@@ -21,15 +21,15 @@ layer at (0,0) size 800x157
                 RenderBlock (anonymous) at (0,0) size 2x4
                   RenderText {#text} at (0,-3) size 2x0
                     text run at (0,-3) width 2: "\x{219C}"
-              RenderMathMLSpace {mspace} at (2,0) size 16x1
+              RenderMathMLSpace {mspace} at (3,0) size 15x1
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,82) size 784x43
-        RenderMathMLMath {math} at (0,0) size 150x42
-          RenderMathMLRow {mstyle} at (0,0) size 150x42
-            RenderMathMLUnderOver {mover} at (0,0) size 150x42
-              RenderMathMLOperator {mo} at (0,1) size 150x41
+        RenderMathMLMath {math} at (0,0) size 142x42
+          RenderMathMLRow {mstyle} at (0,0) size 142x42
+            RenderMathMLUnderOver {mover} at (0,0) size 142x42
+              RenderMathMLOperator {mo} at (0,1) size 142x41
                 RenderBlock (anonymous) at (0,0) size 2x4
                   RenderText {#text} at (0,-3) size 2x0
                     text run at (0,-3) width 2: "\x{219C}"
-              RenderMathMLSpace {mspace} at (0,0) size 150x1
+              RenderMathMLSpace {mspace} at (0,0) size 142x1
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/accessibility/math-multiscript-attributes-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/math-multiscript-attributes-expected.txt
@@ -51,7 +51,7 @@ AXChildren:
 AXChildrenInNavigationOrder:
 AXHelp:
 AXParent:
-AXSize: NSSize: {10, 13}
+AXSize: NSSize: {9, 13}
 AXTitle:
 AXDescription:
 AXValue:
@@ -153,7 +153,7 @@ AXChildren:
 AXChildrenInNavigationOrder:
 AXHelp:
 AXParent:
-AXSize: NSSize: {10, 12}
+AXSize: NSSize: {9, 12}
 AXTitle:
 AXDescription:
 AXValue:

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -1,20 +1,20 @@
 
 PASS automatic scriptlevel on mfrac (displaystyle=true)
 FAIL automatic scriptlevel on mfrac (displaystyle=false) assert_approx_equals: numerator expected 71 +/- 0.1 but got 100
-FAIL automatic scriptlevel on mroot assert_approx_equals: index expected 50.41 +/- 0.1 but got 56.25
-FAIL automatic scriptlevel on msub assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on msup assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on msubsup assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
+PASS automatic scriptlevel on mroot
+PASS automatic scriptlevel on msub
+PASS automatic scriptlevel on msup
+PASS automatic scriptlevel on msubsup
+PASS automatic scriptlevel on munder
+PASS automatic scriptlevel on mover
+PASS automatic scriptlevel on munderover
+PASS automatic scriptlevel on mmultiscripts
 PASS automatic scriptlevel on munder (accentunder=true)
 PASS automatic scriptlevel on mover (accent=true)
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
+PASS automatic scriptlevel on munderover (accentunder=true)
+PASS automatic scriptlevel on munderover (accent=true)
 PASS checking case-insensitivity accent/accentunder
-FAIL checking dynamic accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
+PASS checking dynamic accent/accentunder
 0
 1
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/size-containment-001.tentative-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/size-containment-001.tentative-expected.txt
@@ -9,8 +9,8 @@ FAIL intrinsic size of mfrac with contain: size; contain-intrinsic-inline-size: 
 FAIL inline-size of mfrac with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875
 PASS intrinsic size of mi with contain: size; contain-intrinsic-inline-size: 111px;
 PASS inline-size of mi with contain: size; contain-intrinsic-inline-size: 111px;
-FAIL intrinsic size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
+FAIL intrinsic size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of mmultiscripts with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
 PASS intrinsic size of mn with contain: size; contain-intrinsic-inline-size: 111px;
 PASS inline-size of mn with contain: size; contain-intrinsic-inline-size: 111px;
 PASS intrinsic size of mo with contain: size; contain-intrinsic-inline-size: 111px;
@@ -27,12 +27,12 @@ PASS intrinsic size of ms with contain: size; contain-intrinsic-inline-size: 111
 PASS inline-size of ms with contain: size; contain-intrinsic-inline-size: 111px;
 FAIL intrinsic size of mstyle with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875
 FAIL inline-size of mstyle with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875
-FAIL intrinsic size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL intrinsic size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL intrinsic size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
-FAIL inline-size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 135.15625
+FAIL intrinsic size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of msub with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL intrinsic size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of msubsup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL intrinsic size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
+FAIL inline-size of msup with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 132.03125
 PASS intrinsic size of mtext with contain: size; contain-intrinsic-inline-size: 111px;
 PASS inline-size of mtext with contain: size; contain-intrinsic-inline-size: 111px;
 FAIL intrinsic size of munder with contain: size; contain-intrinsic-inline-size: 111px; assert_equals: expected 111 but got 76.875

--- a/LayoutTests/platform/mac/mathml/opentype/opentype-stretchy-horizontal-expected.txt
+++ b/LayoutTests/platform/mac/mathml/opentype/opentype-stretchy-horizontal-expected.txt
@@ -21,15 +21,15 @@ layer at (0,0) size 800x155
                 RenderBlock (anonymous) at (0,0) size 2x4
                   RenderText {#text} at (0,-3) size 2x0
                     text run at (0,-3) width 2: "\x{219C}"
-              RenderMathMLSpace {mspace} at (2,0) size 16x1
+              RenderMathMLSpace {mspace} at (3,0) size 15x1
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,80) size 784x43
-        RenderMathMLMath {math} at (0,0) size 150x42
-          RenderMathMLRow {mstyle} at (0,0) size 150x42
-            RenderMathMLUnderOver {mover} at (0,0) size 150x42
-              RenderMathMLOperator {mo} at (0,1) size 150x41
+        RenderMathMLMath {math} at (0,0) size 142x42
+          RenderMathMLRow {mstyle} at (0,0) size 142x42
+            RenderMathMLUnderOver {mover} at (0,0) size 142x42
+              RenderMathMLOperator {mo} at (0,1) size 142x41
                 RenderBlock (anonymous) at (0,0) size 2x4
                   RenderText {#text} at (0,-3) size 2x0
                     text run at (0,-3) width 2: "\x{219C}"
-              RenderMathMLSpace {mspace} at (0,0) size 150x1
+              RenderMathMLSpace {mspace} at (0,0) size 142x1
         RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -167,11 +167,12 @@ mfrac > * {
 }
 
 msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
-    font-size: 0.75em; /* FIXME: MathML standard is 0.71em */
+    font-size: 0.71em;
     math-style: compact;
 }
+
 mroot > *:last-child {
-    font-size: 0.5625em; /* This 0.75^2 since the scriptlevel is incremented by 2 in the index. */
+    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
     math-style: compact;
 }
 


### PR DESCRIPTION
#### 618be985f329c157b17c026c39fc67fa47f8849b
<pre>
Fix `scriptlevel` multipler (font-size)
<a href="https://bugs.webkit.org/show_bug.cgi?id=281220">https://bugs.webkit.org/show_bug.cgi?id=281220</a>
<a href="https://rdar.apple.com/137671252">rdar://137671252</a>

Reviewed by Frédéric Wang.

The following is not defined in MathML Core specification [1] because
it has `font-size: math`, which WebKit don&apos;t implement yet and this
works as fallback (when the font has no math table).

[1] <a href="https://w3c.github.io/mathml-core/#user-agent-stylesheet">https://w3c.github.io/mathml-core/#user-agent-stylesheet</a>

This patch is to align with old specification [2] of `scriptsizemultiplier`,
which was incorrect in our current implementation.

[2] <a href="https://www.w3.org/TR/REC-MathML/chap3_3.html">https://www.w3.org/TR/REC-MathML/chap3_3.html</a> (Refer: Attributes accepted by &lt;mstyle&gt;)

It is also referred as `scriptPercentScaleDown` and `scriptScriptPercentScaleDown` as
Layout Constants in MathML Core [3].

[3] <a href="https://w3c.github.io/mathml-core/#layout-constants-mathconstants">https://w3c.github.io/mathml-core/#layout-constants-mathconstants</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt:
* LayoutTests/mathml/presentation/scripts-subsup.html:
* LayoutTests/mathml/presentation/scripts-underover.html:
* LayoutTests/mathml/presentation/underover-nonstretchy-or-vertical.html:
* LayoutTests/platform/glib/accessibility/math-multiscript-attributes-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt:
* LayoutTests/platform/glib/mathml/opentype/horizontal-expected.txt:
* LayoutTests/platform/glib/mathml/opentype/horizontal-munderover-expected.txt:
* LayoutTests/platform/glib/mathml/opentype/opentype-stretchy-horizontal-expected.txt:
* LayoutTests/platform/glib/mathml/presentation/bug159513-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt:
* LayoutTests/platform/ios/mathml/opentype/opentype-stretchy-horizontal-expected.txt:
* LayoutTests/platform/mac/accessibility/math-multiscript-attributes-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/size-containment-001.tentative-expected.txt:
* LayoutTests/platform/mac/mathml/opentype/opentype-stretchy-horizontal-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/size-containment-001.tentative-expected.txt
* Source/WebCore/css/mathml.css:
(msub &gt; * + *, msup &gt; * + *, msubsup &gt; * + *, mmultiscripts &gt; * + *, munder &gt; * + *, mover &gt; * + *, munderover &gt; * + *):
(mroot &gt; *:last-child):

Canonical link: <a href="https://commits.webkit.org/285069@main">https://commits.webkit.org/285069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aa3ce828f08884abe3ef70814fbcd19903d6f39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22491 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14911 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36890 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42835 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21013 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77297 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18567 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64149 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5938 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46680 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->