### PR TITLE
AX: Add new AXTextMarker constructor to take in AXCoreObject

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -496,7 +496,7 @@ int AXTextMarker::lineIndex() const
     AXTextMarker startMarker;
     RefPtr object = isolatedObject();
     if (object->isTextControl())
-        startMarker = { object->treeID(), object->objectID(), 0 };
+        startMarker = { *object, 0 };
     else if (auto* editableAncestor = object->editableAncestor())
         startMarker = { editableAncestor->treeID(), editableAncestor->objectID(), 0 };
     else if (RefPtr tree = std::get<RefPtr<AXIsolatedTree>>(axTreeForID(treeID())))
@@ -782,7 +782,7 @@ AXTextMarker AXTextMarker::findMarker(AXDirection direction, CoalesceObjectBreak
         if ((coalesceObjectBreaks == CoalesceObjectBreaks::Yes || shouldSkipBR) && !isolatedObject()->shouldEmitNewlinesBeforeAndAfterNode())
             startingOffset = 1;
 
-        return AXTextMarker { object->treeID(), object->objectID(), direction == AXDirection::Next ? startingOffset : object->textRuns()->lastRunLength() - startingOffset };
+        return AXTextMarker { *object, direction == AXDirection::Next ? startingOffset : object->textRuns()->lastRunLength() - startingOffset };
     }
 
     return { };
@@ -826,7 +826,7 @@ AXTextMarker AXTextMarker::findMarker(AXDirection direction, AXTextUnit textUnit
                 cumulativeOffset += currentRuns->runLength(i);
                 if (currentRuns->lineID(i) != startLineID)
                     return linePosition;
-                linePosition = AXTextMarker(currentObject->treeID(), currentObject->objectID(), computeOffset(cumulativeOffset, currentRuns->runLength(i)));
+                linePosition = AXTextMarker(*currentObject, computeOffset(cumulativeOffset, currentRuns->runLength(i)));
             }
             currentObject = findObjectWithRuns(*currentObject, direction, stopAtID);
             if (currentObject)
@@ -857,15 +857,15 @@ AXTextMarker AXTextMarker::findMarker(AXDirection direction, AXTextUnit textUnit
                 // When looking backward, the end of a word can be at the offset.
                 if (start != (int)offset || end == (int)offset) {
                     if (boundary == AXTextUnitBoundary::Start && previousWordStart < objectBorder && previousWordStart != -1)
-                        resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), previousWordStart);
+                        resultMarker = AXTextMarker(*currentObject, previousWordStart);
                     else if (boundary == AXTextUnitBoundary::End && end <= objectBorder && end != -1)
-                        resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), end);
+                        resultMarker = AXTextMarker(*currentObject, end);
                 }
             } else if ((int)offset < end) {
                 if (boundary == AXTextUnitBoundary::Start && start <= end && start != -1 && start >= objectBorder)
-                    resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), start - objectBorder);
+                    resultMarker = AXTextMarker(*currentObject, start - objectBorder);
                 else if (boundary == AXTextUnitBoundary::End && start <= end && end != -1 && end >= objectBorder)
-                    resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), end - objectBorder);
+                    resultMarker = AXTextMarker(*currentObject, end - objectBorder);
             }
         };
 
@@ -873,15 +873,15 @@ AXTextMarker AXTextMarker::findMarker(AXDirection direction, AXTextUnit textUnit
             if (boundary == AXTextUnitBoundary::Start) {
                 int start = previousSentenceStartFromPosition(flattenedRuns, offset);
                 if (direction == AXDirection::Previous && start < objectBorder && start != -1)
-                    resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), start);
+                    resultMarker = AXTextMarker(*currentObject, start);
                 else if (direction == AXDirection::Next && start != -1 && start >= objectBorder)
-                    resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), start - objectBorder);
+                    resultMarker = AXTextMarker(*currentObject, start - objectBorder);
             } else {
                 int end = nextSentenceEndFromPosition(flattenedRuns, offset);
                 if (direction == AXDirection::Previous && end <= objectBorder && end != -1)
-                    resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), end);
+                    resultMarker = AXTextMarker(*currentObject, end);
                 else if (direction == AXDirection::Next && end != -1 && end >= objectBorder)
-                    resultMarker = AXTextMarker(currentObject->treeID(), currentObject->objectID(), end - objectBorder);
+                    resultMarker = AXTextMarker(*currentObject, end - objectBorder);
             }
         };
 

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -144,6 +144,10 @@ public:
     AXTextMarker(AXID treeID, AXID objectID, unsigned offset)
         : m_data({ treeID, objectID, offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset })
     { }
+    AXTextMarker(const AXCoreObject& object, unsigned offset)
+        : m_data({ object.treeID(), object.objectID(), offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset })
+    { }
+
     AXTextMarker() = default;
 
     operator bool() const { return !isNull(); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1555,7 +1555,7 @@ CharacterRange AXIsolatedObject::doAXRangeForLine(unsigned lineIndex) const
 {
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis())
-        return AXTextMarker { treeID(), objectID(), 0 }.characterRangeForLine(lineIndex);
+        return AXTextMarker { *this, 0 }.characterRangeForLine(lineIndex);
 #endif
 
     return Accessibility::retrieveValueFromMainThread<CharacterRange>([&lineIndex, this] () -> CharacterRange {
@@ -1624,7 +1624,7 @@ unsigned AXIsolatedObject::doAXLineForIndex(unsigned index)
 {
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis())
-        return AXTextMarker { treeID(), objectID(), 0 }.lineNumberForIndex(index);
+        return AXTextMarker { *this, 0 }.lineNumberForIndex(index);
 #endif
 
     return Accessibility::retrieveValueFromMainThread<unsigned>([&index, this] () -> unsigned {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1372,7 +1372,7 @@ AXTextMarker AXIsolatedTree::firstMarker()
     // which is the ScrollView, so that when we convert the marker to a CharacterPosition, there
     // is an associated node. Otherwise, the CharacterPosition will be null.
     RefPtr webArea = rootWebArea();
-    return webArea ? AXTextMarker { webArea->treeID(), webArea->objectID(), 0 } : AXTextMarker();
+    return webArea ? AXTextMarker { *webArea, 0 } : AXTextMarker();
 }
 
 AXTextMarker AXIsolatedTree::lastMarker()
@@ -1384,7 +1384,7 @@ AXTextMarker AXIsolatedTree::lastMarker()
     const auto& children = root->unignoredChildren();
     // Start the `findLast` traversal from the last child of the root to reduce the amount of traversal done.
     RefPtr endObject = children.isEmpty() ? root : dynamicDowncast<AXIsolatedObject>(children[children.size() - 1].get());
-    return AXTextMarker { endObject->treeID(), endObject->objectID(), 0 }.findLast();
+    return endObject ? AXTextMarker { *endObject, 0 }.findLast() : AXTextMarker();
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -155,7 +155,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
         // We would expect the returned range to be: {ID 2, offset 0} to {ID 4, offset 3}
         auto* stopObject = nextUnignoredSiblingOrParent();
 
-        auto thisMarker = AXTextMarker { tree()->treeID(), objectID(), 0 };
+        auto thisMarker = AXTextMarker { *this, 0 };
         AXTextMarkerRange range { thisMarker, thisMarker };
         auto endMarker = thisMarker.findLastBefore(stopObject ? std::make_optional(stopObject->objectID()) : std::nullopt);
         if (endMarker.isValid() && endMarker.isInTextRun()) {


### PR DESCRIPTION
#### 640ab36a2072abf61c5d5c630ff66ad0f6b6bb46
<pre>
AX: Add new AXTextMarker constructor to take in AXCoreObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=281224">https://bugs.webkit.org/show_bug.cgi?id=281224</a>
<a href="https://rdar.apple.com/137677204">rdar://137677204</a>

Reviewed by Tyler Wilcock.

As per a suggestion from Tyler Wilcock (<a href="https://github.com/WebKit/WebKit/pull/34944#discussion_r1794503510)">https://github.com/WebKit/WebKit/pull/34944#discussion_r1794503510)</a>,
add a new constructor to AXTextMarker to just take an AXCoreObject and offset.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):
(WebCore::AXTextMarker::findMarker const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::AXTextMarker):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::doAXRangeForLine const):
(WebCore::AXIsolatedObject::doAXLineForIndex):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::firstMarker):
(WebCore::AXIsolatedTree::lastMarker):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRange const):

Canonical link: <a href="https://commits.webkit.org/284994@main">https://commits.webkit.org/284994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0933a72500553b359403f37877a77c6e5533fa6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56214 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18734 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18278 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63944 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15362 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63904 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12034 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5672 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1078 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->