### PR TITLE
[iPadOS 18] Unable to include header row when copy and pasting table from confluence to Notes

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -157,7 +157,7 @@ static RetainPtr<NSAttributedString> selectionAsAttributedString(const Document&
     if (ImageOverlay::isInsideOverlay(selection))
         return selectionInImageOverlayAsAttributedString(selection);
     auto range = selection.firstRange();
-    return range ? attributedString(*range).nsAttributedString() : adoptNS([[NSAttributedString alloc] init]);
+    return range ? attributedString(*range, IgnoreUserSelectNone::Yes).nsAttributedString() : adoptNS([[NSAttributedString alloc] init]);
 }
 
 template<typename PasteboardContent>

--- a/Source/WebCore/editing/cocoa/HTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.h
@@ -28,7 +28,9 @@
 
 namespace WebCore {
 
-WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&);
+enum class IgnoreUserSelectNone : bool;
+
+WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&, IgnoreUserSelectNone);
 
 // This alternate implementation of HTML conversion doesn't handle as many advanced features,
 // such as tables, and doesn't produce document attributes, but it does use TextIterator so

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -167,7 +167,7 @@ private:
 
 class HTMLConverter {
 public:
-    explicit HTMLConverter(const SimpleRange&);
+    explicit HTMLConverter(const SimpleRange&, IgnoreUserSelectNone);
     ~HTMLConverter();
 
     AttributedString convert();
@@ -254,11 +254,11 @@ private:
     void _adjustTrailingNewline();
 };
 
-HTMLConverter::HTMLConverter(const SimpleRange& range)
+HTMLConverter::HTMLConverter(const SimpleRange& range, IgnoreUserSelectNone treatment)
     : m_start(makeContainerOffsetPosition(range.start))
     , m_end(makeContainerOffsetPosition(range.end))
     , m_userSelectNoneStateCache(ComposedTree)
-    , m_ignoreUserSelectNoneContent(!range.start.document().quirks().needsToCopyUserSelectNoneQuirk())
+    , m_ignoreUserSelectNoneContent(treatment == IgnoreUserSelectNone::Yes && !range.start.document().quirks().needsToCopyUserSelectNoneQuirk())
 {
     _attrStr = adoptNS([[NSMutableAttributedString alloc] init]);
     _documentAttrs = adoptNS([[NSMutableDictionary alloc] init]);
@@ -2564,9 +2564,9 @@ static void updateAttributesForStyle(const Node* node, const RenderStyle& style,
 namespace WebCore {
 
 // This function supports more HTML features than the editing variant below, such as tables.
-AttributedString attributedString(const SimpleRange& range)
+AttributedString attributedString(const SimpleRange& range, IgnoreUserSelectNone treatment)
 {
-    return HTMLConverter { range }.convert();
+    return HTMLConverter { range, treatment }.convert();
 }
 
 // This function uses TextIterator, which makes offsets in its result compatible with HTML editing.

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -183,10 +183,10 @@ RefPtr<SharedBuffer> Editor::dataSelectionForPasteboard(const String& pasteboard
         return selectionInWebArchiveFormat();
 
     if (pasteboardType == String(legacyRTFDPasteboardType()))
-        return dataInRTFDFormat(attributedString(*adjustedSelectionRange()).nsAttributedString().get());
+        return dataInRTFDFormat(attributedString(*adjustedSelectionRange(), IgnoreUserSelectNone::Yes).nsAttributedString().get());
 
     if (pasteboardType == String(legacyRTFPasteboardType())) {
-        auto string = attributedString(*adjustedSelectionRange()).nsAttributedString();
+        auto string = attributedString(*adjustedSelectionRange(), IgnoreUserSelectNone::Yes).nsAttributedString();
         // FIXME: Why is this stripping needed here, but not in writeSelectionToPasteboard?
         if ([string containsAttachments])
             string = attributedStringByStrippingAttachmentCharacters(string.get());

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -78,6 +78,7 @@
 #import <WebCore/TextIterator.h>
 #import <WebCore/UTIRegistry.h>
 #import <WebCore/UTIUtilities.h>
+#import <WebCore/markup.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
@@ -490,8 +491,8 @@ WebPaymentCoordinator* WebPage::paymentCoordinator()
 
 void WebPage::getContentsAsAttributedString(CompletionHandler<void(const WebCore::AttributedString&)>&& completionHandler)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(Ref { *localFrame->document() })) : AttributedString());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(Ref { *localFrame->document() }), IgnoreUserSelectNone::No) : AttributedString { });
 }
 
 void WebPage::setRemoteObjectRegistry(WebRemoteObjectRegistry* registry)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -99,6 +99,7 @@
 #import <WebCore/TextIterator.h>
 #import <WebCore/VisibleUnits.h>
 #import <WebCore/WindowsKeyboardCodes.h>
+#import <WebCore/markup.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
@@ -762,7 +763,7 @@ void WebPage::handleSelectionServiceClick(FrameSelection& selection, const Vecto
     if (!range)
         return;
 
-    auto selectionString = attributedString(*range);
+    auto selectionString = attributedString(*range, IgnoreUserSelectNone::Yes);
     if (selectionString.isNull())
         return;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
@@ -31,6 +31,7 @@
 #import <WebCore/FrameSelection.h>
 #import <WebCore/HTMLConverter.h>
 #import <WebCore/Range.h>
+#import <WebCore/markup.h>
 #import <pal/spi/mac/NSSharingServiceSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -53,7 +54,7 @@ void WebSelectionServiceController::handleSelectionServiceClick(WebCore::FrameSe
     if (!range)
         return;
 
-    auto attributedSelection = attributedString(*range).nsAttributedString();
+    auto attributedSelection = attributedString(*range, WebCore::IgnoreUserSelectNone::Yes).nsAttributedString();
     if (!attributedSelection)
         return;
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -7026,7 +7026,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     if (!startContainer || !endContainer)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
     return attributedString(WebCore::SimpleRange { { *core(startContainer), static_cast<unsigned>(startOffset) },
-        { *core(endContainer), static_cast<unsigned>(endOffset) } }).nsAttributedString().autorelease();
+        { *core(endContainer), static_cast<unsigned>(endOffset) } }, WebCore::IgnoreUserSelectNone::Yes).nsAttributedString().autorelease();
 }
 
 - (NSAttributedString *)attributedString
@@ -7035,7 +7035,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     if (!document)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
     auto range = makeRangeSelectingNodeContents(*document);
-    if (auto result = attributedString(range).nsAttributedString())
+    if (auto result = attributedString(range, WebCore::IgnoreUserSelectNone::Yes).nsAttributedString())
         return result.autorelease();
     return editingAttributedString(range).nsAttributedString().autorelease();
 }
@@ -7048,7 +7048,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     auto range = frame->selection().selection().firstRange();
     if (!range)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
-    if (auto result = attributedString(*range).nsAttributedString())
+    if (auto result = attributedString(*range, WebCore::IgnoreUserSelectNone::Yes).nsAttributedString())
         return result.autorelease();
     return editingAttributedString(*range).nsAttributedString().autorelease();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -562,3 +562,12 @@ TEST(WKWebView, AttributedStringAndCDATASection)
 
     TestWebKitAPI::Util::run(&finished);
 }
+
+TEST(WKWebView, AttributedStringIncludesUserSelectNoneContent)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
+    [webView synchronouslyLoadHTMLString:@"<body><p style='-webkit-user-select: none;'>Hello</p></body>"];
+
+    RetainPtr string = [[webView _contentsAsAttributedString] string];
+    EXPECT_WK_STREQ("Hello", [string stringByTrimmingCharactersInSet:NSCharacterSet.newlineCharacterSet]);
+}


### PR DESCRIPTION
#### 1b4675b62ba332657e2461a9e45e6068c391a3df
<pre>
[iPadOS 18] Unable to include header row when copy and pasting table from confluence to Notes
<a href="https://bugs.webkit.org/show_bug.cgi?id=281230">https://bugs.webkit.org/show_bug.cgi?id=281230</a>
<a href="https://rdar.apple.com/137088450">rdar://137088450</a>

Reviewed by Aditya Keerthi.

On Confluence, table header content is styled with `-webkit-user-select: none;`, which (in addition
to text selection) normally prevents the text from being serialized when writing content to the
system pasteboard when copying. This policy decision is overridden by a site-specific quirk (added
in 265939@main) which makes us *not* ignore `user-select: none;` when copying on this website. This
quirk works by detecting Confluence via the presence of a `meta` tag with `confluence-request-time`
and making `HTMLConverter` and `serializePreservingVisualAppearance` not ignore content inside of
`-webkit-user-select: none;` subtrees. When pasting into Notes, Notes asks for attributed string
data, which contains this `user-select: none;` content when copied from Confluence.

On iPad running iOS 18 and later, however, we no longer write `NSAttributedString` data directly to
the pasteboard when copying in WebKit apps, and instead defer to `UIFoundation` to perform this
conversion only if needed when pasting. Underneath the hood, this ultimately still uses WebKit
through `nsattributedstringagent`, which receives either web archive or HTML markup data and
generates an equivalent `NSAttributedString` / RTF data. Because the offscreen web view in
`nsattributedstringagent` only converts web archive data to an attributed string (and importantly,
doesn&apos;t load Confluence), it doesn&apos;t enable the aforementioned quirk, and so table header content
ends up getting dropped from the converted attributed string.

To fix this, we adjust `-[WKWebView _getContentsAsAttributedStringWithCompletionHandler:]` (and all
upstream API/SPIs) to *not* ignore `-webkit-user-select: none;` when converting webpage content
into attributed strings.

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::selectionAsAttributedString):
* Source/WebCore/editing/cocoa/HTMLConverter.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::HTMLConverter):
(WebCore::attributedString):

Add more plumbing for the `IgnoreUserSelectNone` flag, through attributed string serialization
codepaths.

* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::dataSelectionForPasteboard):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:

Implement the fix by passing `IgnoreUserSelectNone::No` into `attributedString()`. See above for
more details.

(WebKit::WebPage::getContentsAsAttributedString):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleSelectionServiceClick):
* Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm:
(WebSelectionServiceController::handleSelectionServiceClick):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _legacyAttributedStringFrom:offset:to:offset:]):
(-[WebHTMLView attributedString]):
(-[WebHTMLView selectedAttributedString]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TEST(WKWebView, AttributedStringIncludesUserSelectNoneContent)):

Add an API test to exercise the new behavior (see above for more details).

Canonical link: <a href="https://commits.webkit.org/284993@main">https://commits.webkit.org/284993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84befa1cb136168c32a1fa55d0cb0fe8fe4ad55c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56216 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14690 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18738 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76916 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18283 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15365 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15750 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5676 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1081 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->