### PR TITLE
Assert failure in BuilderConverter::convertLength function call

### DIFF
--- a/LayoutTests/fast/css/css-crash-convertLength-expected.txt
+++ b/LayoutTests/fast/css/css-crash-convertLength-expected.txt
@@ -1,0 +1,1 @@
+test passes if no crash

--- a/LayoutTests/fast/css/css-crash-convertLength.html
+++ b/LayoutTests/fast/css/css-crash-convertLength.html
@@ -1,0 +1,10 @@
+<div id=foo>
+</div>
+test passes if no crash
+<script>
+if (window.testRunner)
+     testRunner.dumpAsText();
+const node = document.getElementById("foo");
+node.attributeStyleMap.set('column-gap', ...node.computedStyleMap().getAll('mask-border-slice'));
+</script>
+

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1840,7 +1840,9 @@ inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation
 
 inline GapLength BuilderConverter::convertGapLength(BuilderState& builderState, const CSSValue& value)
 {
-    return (value.valueID() == CSSValueNormal) ? GapLength() : GapLength(convertLength(builderState, value));
+    if (!value.isPrimitiveValue())
+        return { };
+    return value.valueID() == CSSValueNormal ? GapLength() : convertLength(builderState, value);
 }
 
 inline OffsetRotation BuilderConverter::convertOffsetRotate(BuilderState& builderState, const CSSValue& value)


### PR DESCRIPTION
#### 6ff0559430edd5fea323b7a68812e7d92c9318dc
<pre>
Assert failure in BuilderConverter::convertLength function call
<a href="https://bugs.webkit.org/show_bug.cgi?id=281236">https://bugs.webkit.org/show_bug.cgi?id=281236</a>
<a href="https://rdar.apple.com/137176081">rdar://137176081</a>

Reviewed by NOBODY (OOPS!).

The crash was because of type mismatch in downConvert function called by convertLength. The function was  being called for an object which had no length.

* LayoutTests/fast/css/css-crash-convertLength-expected.txt: Added.
* LayoutTests/fast/css/css-crash-convertLength.html: Added.
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
(WebCore::InlineStylePropertyMap::setProperty):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff0559430edd5fea323b7a68812e7d92c9318dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22597 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64106 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12255 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5886 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1384 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47676 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->