### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make SampleBufferDisplayLayerManager ref-counted

### DIFF
--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -188,8 +188,13 @@ void GPUProcessConnection::didReceiveInvalidMessage(IPC::Connection&, IPC::Messa
 SampleBufferDisplayLayerManager& GPUProcessConnection::sampleBufferDisplayLayerManager()
 {
     if (!m_sampleBufferDisplayLayerManager)
-        m_sampleBufferDisplayLayerManager = makeUnique<SampleBufferDisplayLayerManager>();
+        m_sampleBufferDisplayLayerManager = makeUniqueWithoutRefCountedCheck<SampleBufferDisplayLayerManager>(*this);
     return *m_sampleBufferDisplayLayerManager;
+}
+
+Ref<SampleBufferDisplayLayerManager> GPUProcessConnection::protectedSampleBufferDisplayLayerManager()
+{
+    return sampleBufferDisplayLayerManager();
 }
 
 void GPUProcessConnection::resetAudioMediaStreamTrackRendererInternalUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
@@ -243,7 +248,7 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
     }
 
     if (decoder.messageReceiverName() == Messages::SampleBufferDisplayLayer::messageReceiverName()) {
-        sampleBufferDisplayLayerManager().didReceiveLayerMessage(connection, decoder);
+        protectedSampleBufferDisplayLayerManager()->didReceiveLayerMessage(connection, decoder);
         return true;
     }
 #endif // PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -88,6 +88,7 @@ public:
     Ref<RemoteSharedResourceCacheProxy> sharedResourceCache();
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     SampleBufferDisplayLayerManager& sampleBufferDisplayLayerManager();
+    Ref<SampleBufferDisplayLayerManager> protectedSampleBufferDisplayLayerManager();
     void resetAudioMediaStreamTrackRendererInternalUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
 #endif
 #if ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -79,8 +79,8 @@ void SampleBufferDisplayLayer::setLogIdentifier(String&& logIdentifier)
 SampleBufferDisplayLayer::~SampleBufferDisplayLayer()
 {
     m_connection->send(Messages::RemoteSampleBufferDisplayLayerManager::ReleaseLayer { identifier() }, 0);
-    if (m_manager)
-        m_manager->removeLayer(*this);
+    if (RefPtr manager = m_manager.get())
+        manager->removeLayer(*this);
 }
 
 bool SampleBufferDisplayLayer::didFail() const

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -27,6 +27,7 @@
 #include "SampleBufferDisplayLayerManager.h"
 
 #include "Decoder.h"
+#include "GPUProcessConnection.h"
 #include <WebCore/IntSize.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -36,6 +37,11 @@ namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SampleBufferDisplayLayerManager);
+
+SampleBufferDisplayLayerManager::SampleBufferDisplayLayerManager(GPUProcessConnection& gpuProcessConnection)
+    : m_gpuProcessConnection(gpuProcessConnection)
+{
+}
 
 void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
@@ -62,6 +68,16 @@ void SampleBufferDisplayLayerManager::removeLayer(SampleBufferDisplayLayer& laye
 {
     ASSERT(m_layers.contains(layer.identifier()));
     m_layers.remove(layer.identifier());
+}
+
+void SampleBufferDisplayLayerManager::ref() const
+{
+    m_gpuProcessConnection.get()->ref();
+}
+
+void SampleBufferDisplayLayerManager::deref() const
+{
+    m_gpuProcessConnection.get()->deref();
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
@@ -30,23 +30,20 @@
 #include "SampleBufferDisplayLayer.h"
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebKit {
-class SampleBufferDisplayLayerManager;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::SampleBufferDisplayLayerManager> : std::true_type { };
-}
-
-namespace WebKit {
+class GPUProcessConnection;
 
 class SampleBufferDisplayLayerManager : public CanMakeWeakPtr<SampleBufferDisplayLayerManager> {
     WTF_MAKE_TZONE_ALLOCATED(SampleBufferDisplayLayerManager);
 public:
-    SampleBufferDisplayLayerManager() = default;
+    SampleBufferDisplayLayerManager(GPUProcessConnection&);
     ~SampleBufferDisplayLayerManager() = default;
+
+    void ref() const;
+    void deref() const;
 
     void addLayer(SampleBufferDisplayLayer&);
     void removeLayer(SampleBufferDisplayLayer&);
@@ -55,6 +52,7 @@ public:
     RefPtr<WebCore::SampleBufferDisplayLayer> createLayer(WebCore::SampleBufferDisplayLayerClient&);
 
 private:
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     HashMap<SampleBufferDisplayLayerIdentifier, WeakPtr<SampleBufferDisplayLayer>> m_layers;
 };
 


### PR DESCRIPTION
#### 7fd8860065303c1f5a14252916b24a1b5e57a27f
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make SampleBufferDisplayLayerManager ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281248">https://bugs.webkit.org/show_bug.cgi?id=281248</a>
<a href="https://rdar.apple.com/137706376">rdar://137706376</a>

Reviewed by Ryosuke Niwa.

SampleBufferDisplayLayerManager is owned by GPUProcessConnection, so we forward
the ref/deref&apos;ing to GPUProcessConnection.

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::sampleBufferDisplayLayerManager):
(WebKit::GPUProcessConnection::protectedSampleBufferDisplayLayerManager):
(WebKit::GPUProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::~SampleBufferDisplayLayer):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp:
(WebKit::SampleBufferDisplayLayerManager::SampleBufferDisplayLayerManager):
(WebKit::SampleBufferDisplayLayerManager::ref const):
(WebKit::SampleBufferDisplayLayerManager::deref const):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h:

Canonical link: <a href="https://commits.webkit.org/285025@main">https://commits.webkit.org/285025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6cecbbadb1d958f387b764fe5e0ef6b69fa40a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22415 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56287 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42665 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64005 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5758 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1202 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->