### PR TITLE
Enable -Wunsafe-buffer-usage in WebKit.framework

### DIFF
--- a/Source/JavaScriptCore/API/APICast.h
+++ b/Source/JavaScriptCore/API/APICast.h
@@ -25,11 +25,17 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "Integrity.h"
 #include "JSAPIValueWrapper.h"
 #include "JSCJSValue.h"
 #include "JSCJSValueInlines.h"
 #include "HeapCellInlines.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
     class CallFrame;

--- a/Source/JavaScriptCore/JavaScriptCorePrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCorePrefix.h
@@ -27,6 +27,8 @@
 #include "cmakeconfig.h"
 #endif
 
+#include <wtf/Platform.h>
+
 #if defined(__APPLE__)
 #ifdef __cplusplus
 #define NULL __null

--- a/Source/JavaScriptCore/heap/Strong.h
+++ b/Source/JavaScriptCore/heap/Strong.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "Handle.h"
 #include "HandleSet.h"
 #include "Heap.h"
@@ -200,3 +204,5 @@ template<typename P> struct HashTraits<JSC::Strong<P>> : SimpleClassHashTraits<J
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -25,9 +25,13 @@
 
 #pragma once
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "JSCast.h"
 #include "WeakSetInlines.h"
 #include <wtf/Assertions.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_implementation.py
@@ -90,9 +90,9 @@ class CppProtocolTypesImplementationGenerator(CppGenerator):
             return []
 
         lines = []
-        lines.append('static const ASCIILiteral enum_constant_values[] = {')
+        lines.append('static const auto enum_constant_values = std::to_array<ASCIILiteral>({')
         lines.extend(['    "%s"_s,' % enum_value for enum_value in self.assigned_enum_values()])
-        lines.append('};')
+        lines.append('});')
         lines.append('')
         lines.append('String getEnumConstantValue(int code) {')
         lines.append('    return enum_constant_values[code];')
@@ -109,7 +109,7 @@ class CppProtocolTypesImplementationGenerator(CppGenerator):
             body_lines.extend([
                 'template<> std::optional<%s> parseEnumValueFromString<%s>(const String& protocolString)' % (cpp_protocol_type, cpp_protocol_type),
                 '{',
-                '    static const size_t constantValues[] = {',
+                '    static const auto constantValues = std::to_array<size_t>({',
             ])
 
             enum_values = enum_type.enum_values()
@@ -117,7 +117,7 @@ class CppProtocolTypesImplementationGenerator(CppGenerator):
                 body_lines.append('        (size_t)%s::%s,' % (cpp_protocol_type, Generator.stylized_name_for_enum_value(enum_value)))
 
             body_lines.extend([
-                '    };',
+                '    });',
                 '    for (size_t i = 0; i < %d; ++i)' % len(enum_values),
                 '        if (protocolString == enum_constant_values[constantValues[i]])',
                 '            return (%s)constantValues[i];' % cpp_protocol_type,

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -34,6 +34,8 @@
 #include <intrin.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC  {
 
 class JSWebAssemblyInstance;
@@ -421,3 +423,5 @@ template<> struct HashTraits<JSC::CallSiteIndex> : SimpleClassHashTraits<JSC::Ca
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "CachedBytecode.h"
 #include "CodeSpecializationKind.h"
 #include "SourceOrigin.h"
@@ -35,6 +39,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/text/TextPosition.h>
 #include <wtf/text/WTFString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "ArrayBufferSharingMode.h"
 #include "BufferMemoryHandle.h"
 #include "GCIncomingRefCounted.h"
@@ -456,3 +460,5 @@ private:
 } // namespace JSC
 
 using JSC::ArrayBuffer;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/ExceptionScope.h
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.h
@@ -25,8 +25,14 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "VM.h"
 #include <wtf/StackPointer.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
     

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
@@ -25,8 +25,14 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "GenericTypedArrayView.h"
 #include "JSGlobalObjectInlines.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
@@ -25,10 +25,16 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "ArrayBufferView.h"
 #include "JSArrayBufferView.h"
 #include "JSDataView.h"
 #include "TypedArrayType.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -37,6 +37,8 @@
 #include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 
 class Int32BigIntImpl;
@@ -739,3 +741,5 @@ ALWAYS_INLINE std::optional<double> JSBigInt::tryExtractDouble(JSValue value)
 }
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSCInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCInlines.h
@@ -36,6 +36,10 @@
 // In fact, it can make a lot of sense: outside of JSC, this file becomes a kind of umbrella
 // header that pulls in most (all?) of the interesting things in JSC.
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "ExceptionHelpers.h"
 #include "GCIncomingRefCountedInlines.h"
 #include "HeapInlines.h"
@@ -55,3 +59,5 @@
 #include "ThrowScope.h"
 #include "WeakGCMapInlines.h"
 #include "WeakGCSetInlines.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "CatchScope.h"
 #include "Error.h"
 #include "ExceptionHelpers.h"
@@ -40,6 +44,8 @@
 #include "MathCommon.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringImpl.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "AllocatorForMode.h"
 #include "AllocatorInlines.h"
 #include "CompleteSubspaceInlines.h"
@@ -483,3 +487,5 @@ inline bool isWebAssemblyInstance(const JSCell* cell)
 }
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -48,6 +48,8 @@
 #include "SparseArrayValueMap.h"
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 namespace DOMJIT {
 class Signature;
@@ -1811,3 +1813,5 @@ bool setterThatIgnoresPrototypeProperties(JSGlobalObject*, JSValue thisValue, JS
     static_assert(DerivedClass::destroy == BaseClass::destroy);
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -34,6 +34,8 @@
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 class StringBuilder;
 }
@@ -171,3 +173,5 @@ private:
 };
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/TypedArrays.h
+++ b/Source/JavaScriptCore/runtime/TypedArrays.h
@@ -25,5 +25,11 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "GenericTypedArrayView.h"
 #include "TypedArrayAdaptors.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "CalleeBits.h"
 #include "CodeSpecializationKind.h"
 #include "ConcurrentJSLock.h"
@@ -1183,3 +1187,5 @@ extern "C" void SYSV_ABI sanitizeStackForVMImpl(VM*);
 JS_EXPORT_PRIVATE void sanitizeStackForVM(VM&);
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -27,6 +27,10 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "WasmCalleeGroup.h"
 #include "WasmJS.h"
 #include "WasmMemory.h"
@@ -94,5 +98,7 @@ private:
 };
 
 } } // namespace JSC::Wasm
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -27,6 +27,8 @@
 #include <wtf/Assertions.h>
 #include <wtf/text/LChar.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 // The behavior of many of the functions in the <ctype.h> header is dependent
 // on the current locale. But in the WebKit project, all uses of those functions
 // are in code processing something that's not locale-specific. These equivalents
@@ -278,3 +280,5 @@ using WTF::toASCIILowerUnchecked;
 using WTF::toASCIIUpper;
 using WTF::upperNibbleToASCIIHexDigit;
 using WTF::upperNibbleToLowercaseASCIIHexDigit;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -29,6 +29,8 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 ALWAYS_INLINE bool hasFence(std::memory_order order)
@@ -498,3 +500,5 @@ using WTF::InputAndValue;
 using WTF::inputAndValue;
 using WTF::ensurePointer;
 using WTF::opaqueMixture;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <type_traits>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<size_t size>
@@ -528,3 +530,5 @@ inline void BitSet<bitSetSize, WordType>::dump(PrintStream& out) const
 } // namespace WTF
 
 // We can't do "using WTF::BitSet;" here because there is a function in the macOS SDK named BitSet() already.
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -37,6 +37,8 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 class CachedBitVector;
 }
@@ -559,3 +561,5 @@ template<> struct HashTraits<BitVector> : public CustomHashTraits<BitVector> { }
 } // namespace WTF
 
 using WTF::BitVector;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/BloomFilter.h
+++ b/Source/WTF/wtf/BloomFilter.h
@@ -28,6 +28,8 @@
 #include <array>
 #include <wtf/text/AtomString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(BloomFilter);
@@ -264,3 +266,5 @@ bool CountingBloomFilter<keyBits>::isClear() const
 
 using WTF::BloomFilter;
 using WTF::CountingBloomFilter;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Brigand.h
+++ b/Source/WTF/wtf/Brigand.h
@@ -64,6 +64,8 @@
 #include <boost/variant.hpp>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace brigand
 {
   template <class... T> struct list {};
@@ -2486,3 +2488,5 @@ namespace brigand
   template<std::uint64_t Value>
   struct double_ : real_<double, std::uint64_t,Value> {};
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -592,3 +592,17 @@
 #else
 #define WTF_UNREACHABLE(...) __builtin_unreachable();
 #endif
+
+/* WTF_ALLOW_UNSAFE_BUFFER_USAGE */
+
+#if COMPILER(CLANG)
+#define WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage\"")
+
+#define WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
+    _Pragma("clang diagnostic pop")
+#else
+#define WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#define WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+#endif

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -44,6 +44,8 @@
 #include <wtf/TypeTraits.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 struct CrossThreadCopierBaseHelper {
@@ -369,3 +371,5 @@ using WTF::CrossThreadCopierBaseHelper;
 using WTF::CrossThreadCopierBase;
 using WTF::CrossThreadCopier;
 using WTF::crossThreadCopy;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -36,6 +36,8 @@
 #include <iterator>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<typename T, size_t inlineCapacity> class DequeIteratorBase;
@@ -814,3 +816,5 @@ inline T* DequeIteratorBase<T, inlineCapacity>::before() const
 }
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -44,6 +44,8 @@
 #include <wtf/RetainPtr.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(CF)
 typedef const struct __CFData* CFDataRef;
 #endif
@@ -343,3 +345,5 @@ WTF_EXPORT_PRIVATE void finalizeMappedFileData(MappedFileData&, size_t);
 } // namespace WTF
 
 namespace FileSystem = WTF::FileSystemImpl;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -27,6 +27,8 @@
 
 #include <wtf/EmbeddedFixedVector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<typename T>
@@ -268,3 +270,5 @@ FixedVector<ReturnType> map(const FixedVector<T>& source, MapFunction&& mapFunct
 } // namespace WTF
 
 using WTF::FixedVector;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -20,10 +20,16 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <initializer_list>
 #include <wtf/Forward.h>
 #include <wtf/HashTable.h>
 #include <wtf/IteratorRange.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WTF {
 

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <initializer_list>
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
@@ -569,3 +573,5 @@ inline void HashSet<T, U, V, W>::checkConsistency() const
 } // namespace WTF
 
 using WTF::HashSet;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -23,6 +23,8 @@
 #include <array>
 #include <wtf/text/StringImpl.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 enum HexConversionMode { Lowercase, Uppercase };
@@ -92,3 +94,5 @@ WTF_EXPORT_PRIVATE void printInternal(PrintStream&, HexNumberBuffer);
 
 using WTF::hex;
 using WTF::Lowercase;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/IteratorAdaptors.h
+++ b/Source/WTF/wtf/IteratorAdaptors.h
@@ -26,6 +26,9 @@
 #pragma once
 
 #include <type_traits>
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -108,3 +111,5 @@ inline TransformIterator<Transform, Iterator> makeTransformIterator(Transform&& 
 }
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <mutex>
 #include <wtf/Assertions.h>
 #include <wtf/Atomics.h>
@@ -35,6 +39,8 @@
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ThreadSanitizerSupport.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WTF {
 

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -25,10 +25,16 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <wtf/HashTraits.h>
 #include <wtf/UUID.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WTF {
 

--- a/Source/WTF/wtf/PageBlock.h
+++ b/Source/WTF/wtf/PageBlock.h
@@ -28,6 +28,8 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 // We attempt to guess a value that is *AT LEAST* as large as the system's actual page size.
@@ -105,3 +107,5 @@ using WTF::CeilingOnPageSize;
 using WTF::pageSize;
 using WTF::isPageAligned;
 using WTF::isPowerOfTwo;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -20,10 +20,16 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <wtf/Assertions.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/MainThread.h>
 #include <wtf/Noncopyable.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WTF {
 

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -54,6 +54,8 @@
 #include <wtf/HashTable.h>
 #include <wtf/text/StringHash.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy>
@@ -934,3 +936,5 @@ struct FastRobinHoodHashTableTraits {
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -24,6 +24,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <bit>
 #include <optional>
 #include <wtf/StdLibExtras.h>
@@ -542,3 +546,5 @@ ALWAYS_INLINE const CharacterType* findInterleaved(std::span<const CharacterType
 }
 
 namespace SIMD = WTF::SIMD;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -28,6 +28,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <wtf/text/StringView.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 // SortedArrayMap is a map like HashMap, but it's read-only. It uses much less memory than HashMap.
@@ -424,3 +426,5 @@ using WTF::PackedLettersLiteral;
 using WTF::SortedArrayMap;
 using WTF::SortedArraySet;
 using WTF::makeOptionalFromPointer;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -49,6 +49,8 @@
 #include <wtf/win/DbgHelperWin.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 class PrintStream;
@@ -197,3 +199,5 @@ void StackTrace::forEachFrame(Functor functor) const
 using WTF::StackTrace;
 using WTF::StackTraceSymbolResolver;
 using WTF::StackTracePrinter;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -43,6 +43,8 @@
 #include <wtf/IterationStatus.h>
 #include <wtf/TypeCasts.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #define SINGLE_ARG(...) __VA_ARGS__ // useful when a macro argument includes a comma
 
 // Use this macro to declare and define a debug-only global variable that may have a
@@ -1032,3 +1034,5 @@ using WTF::valueOrCompute;
 using WTF::valueOrDefault;
 using WTF::toTwosComplement;
 using WTF::Invocable;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/TZoneMallocInlines.h
+++ b/Source/WTF/wtf/TZoneMallocInlines.h
@@ -28,6 +28,8 @@
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Platform.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(SYSTEM_MALLOC) || !USE(TZONE_MALLOC)
 
 #include <wtf/FastMalloc.h>
@@ -94,3 +96,5 @@
 #define WTF_MAKE_COMPACT_TZONE_OR_ISO_ALLOCATED_IMPL_TEMPLATE(name) MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(name, CompactTZoneHeap)
 
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -30,6 +30,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <mutex>
 #include <stdint.h>
 #include <wtf/Atomics.h>
@@ -51,6 +55,8 @@
 #include <wtf/Vector.h>
 #include <wtf/WordLock.h>
 #include <wtf/text/AtomStringTable.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if USE(PTHREADS) && !OS(DARWIN)
 #include <signal.h>

--- a/Source/WTF/wtf/TrailingArray.h
+++ b/Source/WTF/wtf/TrailingArray.h
@@ -30,6 +30,8 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 // TrailingArray offers the feature trailing array in the derived class.
@@ -179,3 +181,5 @@ protected:
 } // namespace WTF
 
 using WTF::TrailingArray;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -37,6 +37,8 @@
 #include <wtf/text/StringConcatenate.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #ifdef __OBJC__
 @class NSUUID;
 #endif
@@ -220,3 +222,5 @@ private:
 using WTF::createVersion4UUIDString;
 using WTF::createVersion4UUIDStringWeak;
 using WTF::bootSessionUUIDString;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/UniqueArray.h
+++ b/Source/WTF/wtf/UniqueArray.h
@@ -29,6 +29,8 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(UniqueArray);
@@ -123,3 +125,5 @@ UniqueArray<T> makeUniqueArray(size_t size)
 
 using WTF::UniqueArray;
 using WTF::makeUniqueArray;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -43,6 +43,8 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 class LLIntOffsetsExtractor;
 }
@@ -2105,3 +2107,5 @@ using WTF::copyToVectorSpecialization;
 using WTF::compactMap;
 using WTF::flatMap;
 using WTF::removeRepeatedElements;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <wtf/Assertions.h>
 #include <wtf/Atomics.h>
 #include <wtf/ExportMacros.h>
@@ -32,6 +36,8 @@
 #include <wtf/PtrTag.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/threads/Signals.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if USE(SYSTEM_MALLOC)
 namespace Gigacage {

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -33,6 +33,8 @@
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template <typename A, typename... B>
@@ -195,5 +197,7 @@ using WTF::createCFArray;
 using WTF::makeVector;
 using WTF::span;
 using WTF::toCFData;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -33,7 +33,10 @@ inline std::span<const uint8_t> span(NSData *data)
 {
     if (!data)
         return { };
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return { static_cast<const uint8_t*>(data.bytes), data.length };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #ifdef __OBJC__

--- a/Source/WTF/wtf/text/ASCIIFastPath.h
+++ b/Source/WTF/wtf/text/ASCIIFastPath.h
@@ -30,6 +30,8 @@
 #include <emmintrin.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template <uintptr_t mask>
@@ -160,3 +162,5 @@ inline bool charactersAreAllLatin1(std::span<const CharacterType> span)
 } // namespace WTF
 
 using WTF::charactersAreAllASCII;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <span>
 #include <string>
 #include <type_traits>
@@ -153,3 +157,5 @@ constexpr std::span<const LChar> operator"" _span(const char* characters, size_t
 } // namespace WTF
 
 using namespace WTF::StringLiterals;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -33,6 +33,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CStringBuffer);
@@ -146,3 +148,5 @@ inline size_t CString::length() const
 } // namespace WTF
 
 using WTF::CString;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/MakeString.h
+++ b/Source/WTF/wtf/text/MakeString.h
@@ -32,6 +32,8 @@
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/StringView.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<typename StringTypeAdapter> constexpr bool makeStringSlowPathRequiredForAdapter = requires(const StringTypeAdapter& adapter) {
@@ -170,3 +172,5 @@ using WTF::makeStringByInserting;
 using WTF::tryMakeAtomString;
 using WTF::tryMakeString;
 using WTF::SerializeUsingMakeString;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -29,6 +29,8 @@
 #include <wtf/SaturatedArithmetic.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 class StringBuilder {
@@ -365,3 +367,5 @@ struct SerializeUsingStringBuilder {
 
 using WTF::StringBuilder;
 using WTF::SerializeUsingStringBuilder;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -37,6 +37,8 @@
 #include <wtf/text/ASCIIFastPath.h>
 #include <wtf/text/ASCIILiteral.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 inline std::span<const LChar> span(const LChar& character)
@@ -1175,3 +1177,5 @@ using WTF::isLatin1;
 using WTF::span;
 using WTF::span8;
 using WTF::charactersContain;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -32,6 +32,8 @@
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringView.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if defined(NDEBUG)
 #define WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING() do { } while (0)
 #else
@@ -659,3 +661,5 @@ using WTF::asASCIILowercase;
 using WTF::asASCIIUppercase;
 using WTF::interleave;
 using WTF::pad;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <wtf/dtoa.h>
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringConcatenate.h>
@@ -167,3 +171,5 @@ private:
 
 using WTF::FormattedNumber;
 using WTF::FormattedCSSNumber;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -25,6 +25,8 @@
 #include <wtf/text/SuperFastHash.h>
 #include <wtf/text/WYHash.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 template<typename T, typename Converter>
@@ -134,3 +136,5 @@ inline unsigned StringHasher::hashWithTop8BitsMasked()
 } // namespace WTF
 
 using WTF::StringHasher;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <limits.h>
 #include <unicode/ustring.h>
 #include <wtf/ASCIICType.h>
@@ -1447,3 +1451,5 @@ using WTF::equal;
 using WTF::isUnicodeWhitespace;
 using WTF::deprecatedIsSpaceOrNewline;
 using WTF::deprecatedIsNotSpaceOrNewline;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -45,6 +45,8 @@
 
 OBJC_CLASS NSString;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 class AdaptiveStringSearcherTables;
@@ -1501,3 +1503,5 @@ using WTF::StringViewWithUnderlyingString;
 using WTF::hasUnpairedSurrogate;
 using WTF::nullStringView;
 using WTF::emptyStringView;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -34,6 +34,8 @@
 #include <wtf/text/NullTextBreakIterator.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 #if PLATFORM(COCOA)
@@ -387,3 +389,5 @@ using WTF::NonSharedCharacterBreakIterator;
 using WTF::TextBreakIterator;
 using WTF::TextBreakIteratorCache;
 using WTF::isWordTextBreak;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -24,6 +24,10 @@
 // This file would be called String.h, but that conflicts with <string.h>
 // on systems without case-sensitive file systems.
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringImpl.h>
 
@@ -591,3 +595,5 @@ using WTF::reverseFind;
 using WTF::codePointCompareLessThan;
 
 #include <wtf/text/AtomString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -26,6 +26,8 @@
 #include <wtf/text/icu/UTextProviderUTF16.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 class TextBreakIteratorICU {
@@ -196,3 +198,5 @@ private:
 };
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
@@ -42,6 +42,10 @@ typedef struct __DDResult *DDResultRef;
 
 #else // !USE(APPLE_INTERNAL_SDK)
 
+#import <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #import <Foundation/Foundation.h>
 
 typedef enum {
@@ -197,5 +201,7 @@ void DDScannerSetQOS(DDScannerRef, DDQOS);
 #endif
 
 WTF_EXTERN_C_END
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
@@ -30,6 +30,8 @@
 #include "SettingsBase.h"
 #include <wtf/RefCounted.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class Page;
@@ -120,3 +122,5 @@ private:
 };
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "AXGeometryManager.h"
 #include "AXIsolatedTree.h"
 #include "AXTextMarker.h"
@@ -41,6 +45,8 @@
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/MakeString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 OBJC_CLASS NSMutableArray;
 

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "BufferSource.h"
 #include "StringAdaptors.h"
 #include <JavaScriptCore/HandleTypes.h>
@@ -40,6 +44,8 @@
 #include "WebGLAny.h"
 #include "WebGLExtensionAny.h"
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 class ArrayBuffer;

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <span>
@@ -36,6 +40,8 @@
 #include <wtf/cocoa/SpanCocoa.h>
 OBJC_CLASS NSData;
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -21,9 +21,15 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "JSDOMGlobalObject.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMConvertBase.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertBase.h
@@ -25,10 +25,16 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "JSDOMConvertResult.h"
 #include "JSDOMExceptionHandling.h"
 #include <JavaScriptCore/Error.h>
 #include <concepts>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -26,9 +26,15 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/WeakGCMap.h>
 #include <wtf/Forward.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 

--- a/Source/WebCore/bindings/js/JSDOMWrapper.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.h
@@ -21,11 +21,17 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "JSDOMGlobalObject.h"
 #include "NodeConstants.h"
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/StructureInlines.h>
 #include <wtf/SignedPtr.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -28,6 +28,8 @@
 #include <wtf/FixedVector.h>
 #include <wtf/TZoneMalloc.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class CSSSelectorList;
@@ -450,3 +452,5 @@ inline void CSSSelector::setMatch(Match match)
 }
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -31,6 +31,8 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueArray.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class MutableCSSSelector;
@@ -109,3 +111,5 @@ inline const CSSSelector* CSSSelectorList::next(const CSSSelector* current)
 }
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -33,6 +33,8 @@
 #include "CSSTokenizer.h"
 #include <wtf/Forward.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class StyleSheetContents;
@@ -115,3 +117,5 @@ private:
 };
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -29,6 +29,8 @@
 #include "SpaceSplitString.h"
 #include <wtf/TypeCasts.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class Attr;
@@ -357,3 +359,5 @@ SPECIALIZE_TYPE_TRAITS_END()
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::UniqueElementData)
     static bool isType(const WebCore::ElementData& elementData) { return elementData.isUnique(); }
 SPECIALIZE_TYPE_TRAITS_END()
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -24,6 +24,8 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class SpaceSplitStringData {
@@ -151,3 +153,5 @@ inline SpaceSplitString::SpaceSplitString(const AtomString& string, ShouldFoldCa
 }
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -35,6 +35,8 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 class MessagePortChannelRegistry;
@@ -83,3 +85,5 @@ private:
 };
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/page/StructuredSerializeOptions.h
+++ b/Source/WebCore/page/StructuredSerializeOptions.h
@@ -25,9 +25,15 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
 #include <wtf/Vector.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -31,6 +31,8 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 template <typename T>
@@ -188,3 +190,5 @@ public:
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -52,6 +52,8 @@ typedef struct _GBytes GBytes;
 #include "GStreamerCommon.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(FOUNDATION)
 OBJC_CLASS NSArray;
 OBJC_CLASS NSData;
@@ -426,3 +428,5 @@ RefPtr<SharedBuffer> utf8Buffer(const String&);
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SharedBuffer)
     static bool isType(const WebCore::FragmentedSharedBuffer& buffer) { return buffer.isContiguous(); }
 SPECIALIZE_TYPE_TRAITS_END()
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -42,6 +42,8 @@
 #include <wtf/MachSendRight.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if PLATFORM(COCOA)
 OBJC_CLASS NSData;
 #endif
@@ -151,3 +153,5 @@ private:
 };
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -35,6 +35,8 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 // An AudioChannel represents a buffer of non-interleaved floating-point audio samples.
@@ -137,5 +139,7 @@ private:
 };
 
 } // WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // AudioChannel_h

--- a/Source/WebCore/platform/graphics/FontTaggedSettings.h
+++ b/Source/WebCore/platform/graphics/FontTaggedSettings.h
@@ -33,6 +33,8 @@
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 class TextStream;
 }
@@ -144,3 +146,5 @@ TextStream& operator<<(TextStream&, const FontTaggedSettings<int>&);
 TextStream& operator<<(TextStream&, const FontTaggedSettings<float>&);
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/FourCC.h
+++ b/Source/WebCore/platform/graphics/FourCC.h
@@ -27,6 +27,8 @@
 
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 struct FourCC {
@@ -72,3 +74,5 @@ template<> struct LogArgument<WebCore::FourCC> {
 };
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -38,6 +38,8 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
@@ -279,3 +281,5 @@ private:
 };
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -27,8 +27,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GlyphPage_h
-#define GlyphPage_h
+#pragma once
 
 #include "Font.h"
 #include "Glyph.h"
@@ -38,6 +37,8 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -144,4 +145,4 @@ private:
 
 } // namespace WebCore
 
-#endif // GlyphPage_h
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -37,6 +37,8 @@
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WYHash.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 struct GlyphOverflow;
@@ -238,3 +240,5 @@ private:
 } // namespace WebCore
 
 #endif // WidthCache_h
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -35,6 +35,8 @@
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(CA)
 typedef struct CATransform3D CATransform3D;
 #endif
@@ -484,3 +486,5 @@ private:
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const TransformationMatrix&);
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -27,6 +27,10 @@
 
 #if USE(LIBWEBRTC)
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "LibWebRTCMacros.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "WebRTCProvider.h"
@@ -47,6 +51,8 @@ IGNORE_CLANG_WARNINGS_END
 ALLOW_COMMA_END
 ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_UNUSED_PARAMETERS_END
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace rtc {
 class NetworkManager;

--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -30,6 +30,8 @@
 #include <utility>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 // FIXME: Not every header fits into a map. Notably, multiple Set-Cookie header fields are needed to set multiple cookies.
@@ -215,3 +217,5 @@ private:
 };
 
 } // namespace WebCore
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "FetchOptions.h"
 #include "WorkerThreadType.h"
 #include <JavaScriptCore/Debugger.h>
@@ -36,6 +40,8 @@
 #include <wtf/MessageQueue.h>
 #include <wtf/NakedPtr.h>
 #include <wtf/TZoneMalloc.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 class AbstractModuleRecord;

--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -85,7 +85,7 @@ GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 OTHER_MIGFLAGS = -F$(BUILT_PRODUCTS_DIR);
 PREBINDING = NO;
-WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled;
+WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled -Wunsafe-buffer-usage;
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 WK_FIXME_WARNING_CFLAGS = -Wno-unused-parameter;

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -30,6 +30,8 @@
 #import "WKBase.h"
 #import "XPCServiceEntryPoint.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if ENABLE(GPU_PROCESS)
 
 namespace WebKit {
@@ -70,3 +72,5 @@ void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializ
 
     JSC::Config::finalize();
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -46,6 +46,8 @@
 #include "RemoteVideoFrameObjectHeap.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -457,3 +459,5 @@ Ref<RemoteVideoFrameObjectHeap> RemoteGraphicsContextGL::protectedVideoFrameObje
 } // namespace WebKit
 
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -158,7 +158,11 @@ protected:
     using GCGLContext = WebCore::GraphicsContextGLTextureMapperANGLE;
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "RemoteGraphicsContextGLFunctionsGenerated.h" // NOLINT
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 private:
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -44,6 +44,8 @@
 #include <WebCore/WebAudioBufferList.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, &connection->connection(), message)
 #define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection->connection(), completion)
 
@@ -282,5 +284,7 @@ std::optional<SharedPreferencesForWebProcess> RemoteAudioDestinationManager::sha
 } // namespace WebKit
 
 #undef MESSAGE_CHECK
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -73,6 +73,8 @@
 
 #include <wtf/NativePromise.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -1325,5 +1327,7 @@ void RemoteMediaPlayerProxy::audioOutputDeviceChanged(String&& deviceId)
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -59,6 +59,8 @@ ALLOW_COMMA_END
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <WebCore/CoreVideoSoftLink.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -559,5 +561,7 @@ void LibWebRTCCodecsProxy::updateSharedPreferencesForWebProcess(SharedPreference
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -30,6 +30,8 @@
 #include "Logging.h"
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #define DOWNLOAD_MONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - DownloadMonitor::" fmt, this, ##__VA_ARGS__)
 
 namespace WebKit {
@@ -129,3 +131,5 @@ void DownloadMonitor::timerFired()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -36,6 +36,8 @@
 #import "WebPushDaemonConstants.h"
 #import <wtf/spi/darwin/XPCSPI.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::WebPushD { 
 
 void Connection::newConnectionWasInitialized() const
@@ -83,5 +85,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
 }
 
 } // namespace WebKit::WebPushD
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(COCOA) && ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -36,6 +36,8 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::PCM {
 
 constexpr auto setUnattributedPrivateClickMeasurementAsExpiredQuery = "UPDATE UnattributedPrivateClickMeasurement SET timeOfAdClick = -1.0"_s;
@@ -733,3 +735,5 @@ void Database::addDestinationTokenColumnsIfNecessary()
 }
 
 } // namespace WebKit::PCM
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -45,6 +45,8 @@
 #include <WebCore/ServiceWorkerContextData.h>
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -443,3 +445,5 @@ void WebSWServerToContextConnection::setInspectable(ServiceWorkerIsInspectable i
 
 #undef MESSAGE_CHECK
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -31,6 +31,8 @@
 #import <sys/mman.h>
 #import <sys/stat.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 namespace NetworkCache {
 
@@ -118,3 +120,5 @@ RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const
 
 }
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -37,6 +37,8 @@
 #include <wtf/WorkQueue.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -266,3 +268,5 @@ void BackgroundFetchStoreManager::retrieveResponseBody(const String& identifier,
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -38,6 +38,8 @@
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 static constexpr auto saltFileName = "salt"_s;
@@ -540,3 +542,4 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
 
 } // namespace WebKit
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -36,6 +36,8 @@
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 static constexpr auto cachesListFileName = "cacheslist"_s;
@@ -545,3 +547,5 @@ String CacheStorageManager::representationString()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -46,6 +46,8 @@
 #include <pal/spi/cocoa/NetworkSPI.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 #define RTC_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkRTCMonitor::" fmt, this, ##__VA_ARGS__)
@@ -472,5 +474,7 @@ void NetworkRTCMonitor::deref()
 } // namespace WebKit
 
 #undef RTC_RELEASE_LOG
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -45,6 +45,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_COMMA_END
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -290,5 +292,7 @@ void NetworkRTCTCPSocketCocoa::getInterfaceName(NetworkRTCProvider& rtcProvider,
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC) && PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -40,6 +40,8 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -422,5 +424,7 @@ void NetworkRTCUDPSocketCocoaConnections::sendTo(std::span<const uint8_t> data, 
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC) && PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm
@@ -28,6 +28,8 @@
 
 #import "NetworkTransportSession.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 NetworkTransportReceiveStream::NetworkTransportReceiveStream(NetworkTransportSession& session, nw_connection_t connection)
@@ -65,3 +67,5 @@ void NetworkTransportReceiveStream::receiveLoop()
     }).get());
 }
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -35,6 +35,8 @@
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 NetworkTransportSession::NetworkTransportSession(NetworkConnectionToWebProcess& connection, nw_connection_group_t connectionGroup, nw_endpoint_t endpoint)
@@ -214,3 +216,5 @@ void NetworkTransportSession::createOutgoingUnidirectionalStream(CompletionHandl
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -52,6 +52,8 @@
 #include "ArgumentCodersUnix.h"
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 
 template<typename T, size_t Extent> struct ArgumentCoder<std::span<T, Extent>> {
@@ -811,3 +813,5 @@ template<typename T, typename Traits> struct ArgumentCoder<WTF::Markable<T, Trai
 };
 
 } // namespace IPC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -38,6 +38,8 @@
 #include <wtf/spi/cocoa/SecuritySPI.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::Daemon {
 
 void Coder<WTF::WallTime>::encode(Encoder& encoder, const WTF::WallTime& instance)
@@ -310,3 +312,5 @@ std::optional<WebCore::RegistrableDomain> Coder<WebCore::RegistrableDomain, void
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -33,6 +33,8 @@
 #include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 struct ExceptionData;
 class CertificateInfo;
@@ -191,3 +193,5 @@ template<> struct Coder<WTF::String> {
 
 } // namespace Daemon
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "DaemonDecoder.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 namespace Daemon {
@@ -61,3 +63,5 @@ std::span<const uint8_t> Decoder::decodeFixedLengthReference(size_t size)
 } // namespace Daemon
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -33,6 +33,8 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 
 static uint8_t* copyBuffer(std::span<const uint8_t> buffer)
@@ -178,3 +180,5 @@ std::optional<Attachment> Decoder::takeLastAttachment()
 }
 
 } // namespace IPC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -37,6 +37,8 @@
 #include <sys/mman.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 
 static constexpr uint8_t defaultMessageFlags = 0;
@@ -199,3 +201,5 @@ bool Encoder::hasAttachments() const
 }
 
 } // namespace IPC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -35,6 +35,8 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 
 enum class MessageFlags : uint8_t;
@@ -134,3 +136,5 @@ inline void Encoder::encodeObject(const T& object)
 }
 
 } // namespace IPC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -27,6 +27,10 @@
 
 #if ENABLE(IPC_TESTING_API)
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "Decoder.h"
 #include "HandleMessage.h"
 #include <JavaScriptCore/JSArray.h>
@@ -38,6 +42,8 @@
 #include <WebCore/SharedMemory.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/text/WTFString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WTF {
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -31,6 +31,8 @@
 #include <wtf/Atomics.h>
 #include <wtf/Ref.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -144,3 +146,5 @@ protected:
 };
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -29,6 +29,8 @@
 #include "MessageNames.h"
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 
 template<typename, typename> struct ArgumentCoder;
@@ -104,3 +106,5 @@ private:
 };
 
 } // namespace IPC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -48,8 +48,9 @@
 
 #if PLATFORM(IOS_FAMILY)
 #import "ProcessAssertion.h"
-
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace IPC {
 
@@ -635,3 +636,5 @@ std::optional<Connection::ConnectionIdentifierPair> Connection::createConnection
 }
 
 } // namespace IPC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -32,6 +32,8 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 namespace Daemon {
@@ -124,3 +126,5 @@ template class ConnectionToMachService<WebPushD::ConnectionTraits>;
 } // namespace Daemon
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1527,6 +1527,8 @@ def generate_message_names_header(receivers):
     result.append('#include <wtf/EnumTraits.h>\n')
     result.append('#include <wtf/text/ASCIILiteral.h>\n')
     result.append('\n')
+    result.append('WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN\n')
+    result.append('\n')
     result.append('namespace IPC {\n')
     result.append('\n')
     result.append('enum class ReceiverName : uint8_t {')
@@ -1595,6 +1597,8 @@ def generate_message_names_header(receivers):
     result.append('}\n')
     result.append('\n')
     result.append('} // namespace WTF\n')
+    result.append('\n')
+    result.append('WTF_ALLOW_UNSAFE_BUFFER_USAGE_END\n')
     return ''.join(result)
 
 

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -28,6 +28,8 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/text/ASCIILiteral.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace IPC {
 
 enum class ReceiverName : uint8_t {
@@ -282,3 +284,5 @@ template<> constexpr bool isValidEnum<IPC::MessageName, void>(std::underlying_ty
 }
 
 } // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -32,6 +32,8 @@
 #include <wtf/RetainPtr.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 OBJC_CLASS NSData;
 
 namespace API {
@@ -103,3 +105,5 @@ private:
 } // namespace API
 
 SPECIALIZE_TYPE_TRAITS_API_OBJECT(Data);
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -43,6 +43,8 @@
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/CString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 @interface NSURLError : NSError
 @end
 
@@ -1177,3 +1179,5 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 }
 
 @end
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
@@ -33,6 +33,8 @@
 #import <wtf/Vector.h>
 #import <wtf/text/CString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 extern "C"
 const char *_protocol_getMethodTypeEncoding(Protocol *p, SEL sel, BOOL isRequiredMethod, BOOL isInstanceMethod);
 
@@ -319,3 +321,5 @@ static HashSet<CFTypeRef>& classesForSelectorArgument(_WKRemoteObjectInterface *
 }
 
 @end
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKArray.cpp
@@ -29,6 +29,8 @@
 #include "APIArray.h"
 #include "WKAPICast.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 WKTypeID WKArrayGetTypeID()
 {
     return WebKit::toAPI(API::Array::APIType);
@@ -59,3 +61,5 @@ size_t WKArrayGetSize(WKArrayRef arrayRef)
 {
     return WebKit::toImpl(arrayRef)->size();
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKData.cpp
+++ b/Source/WebKit/Shared/API/c/WKData.cpp
@@ -29,6 +29,8 @@
 #include "APIData.h"
 #include "WKAPICast.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 WKTypeID WKDataGetTypeID()
 {
     return WebKit::toAPI(API::Data::APIType);
@@ -48,3 +50,5 @@ size_t WKDataGetSize(WKDataRef dataRef)
 {
     return WebKit::toImpl(dataRef)->size();
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKDictionary.cpp
+++ b/Source/WebKit/Shared/API/c/WKDictionary.cpp
@@ -30,6 +30,8 @@
 #include "APIDictionary.h"
 #include "WKAPICast.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 WKTypeID WKDictionaryGetTypeID()
 {
     return WebKit::toAPI(API::Dictionary::APIType);
@@ -59,3 +61,5 @@ WKArrayRef WKDictionaryCopyKeys(WKDictionaryRef dictionaryRef)
 {
     return WebKit::toAPI(&WebKit::toImpl(dictionaryRef)->keys().leakRef());
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -33,6 +33,8 @@
 #include <WebCore/WebCoreJITOperations.h>
 #include <wtf/unicode/UTF8Conversion.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 WKTypeID WKStringGetTypeID()
 {
     return WebKit::toAPI(API::String::APIType);
@@ -144,3 +146,5 @@ JSStringRef WKStringCopyJSString(WKStringRef stringRef)
     WebCore::populateJITOperations();
     return OpaqueJSString::tryCreate(WebKit::toImpl(stringRef)->string()).leakRef();
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/API/c/WKURLRequest.cpp
+++ b/Source/WebKit/Shared/API/c/WKURLRequest.cpp
@@ -31,6 +31,8 @@
 #include "WKData.h"
 #include <wtf/URL.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 WKTypeID WKURLRequestGetTypeID()
 {
     return WebKit::toAPI(API::URLRequest::APIType);
@@ -67,3 +69,5 @@ void WKURLRequestSetDefaultTimeoutInterval(double timeoutInterval)
 {
     API::URLRequest::setDefaultTimeoutInterval(timeoutInterval);
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFCharacterSet.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFCharacterSet.h
@@ -30,6 +30,8 @@
 #include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 class CoreIPCCFCharacterSet {
@@ -77,5 +79,7 @@ private:
 };
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "CoreIPCDateComponents.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 NSUInteger calendarUnitForComponentIndex[] = {
@@ -80,3 +82,4 @@ bool CoreIPCDateComponents::hasCorrectNumberOfComponentValues(const Vector<NSInt
 
 } // namespace WebKit
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -35,6 +35,8 @@
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/CString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
@@ -427,5 +429,7 @@ bool SandboxExtension::consumePermanently(const Vector<Handle>& handleArray)
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(SANDBOX_EXTENSIONS)

--- a/Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "SandboxInitializationParameters.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 SandboxInitializationParameters::SandboxInitializationParameters()
@@ -99,3 +101,5 @@ const char* SandboxInitializationParameters::value(size_t index) const
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -33,6 +33,8 @@
 #include <wtf/Atomics.h>
 #include <wtf/Function.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 class SharedCARingBufferBase : public WebCore::CARingBuffer {
@@ -79,3 +81,5 @@ protected:
 }
 
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -42,6 +42,8 @@
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 // FIXME: Add daemon plist to repository.
 
 namespace WebKit {
@@ -152,3 +154,5 @@ int PCMDaemonMain(int argc, const char** argv)
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #import "AuxiliaryProcess.h"
 #import "WebKit2Initialize.h"
 #import <JavaScriptCore/ExecutableAllocator.h>
@@ -42,6 +46,8 @@
 #else
 extern "C" OS_NOTHROW void voucher_replace_default_voucher(void);
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #define WEBCONTENT_SERVICE_INITIALIZER WebContentServiceInitializer
 #define NETWORK_SERVICE_INITIALIZER NetworkServiceInitializer

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -36,6 +36,8 @@
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 XPCServiceInitializerDelegate::~XPCServiceInitializerDelegate()
@@ -238,3 +240,5 @@ void XPCServiceExit()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -49,6 +49,8 @@
 #import <WebKitAdditions/DyldCallbackAdditions.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 static Vector<String>& overrideLanguagesFromBootstrap()
@@ -278,3 +280,5 @@ int XPCServiceMain(int, const char**)
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -32,12 +32,16 @@
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 ALLOW_COMMA_BEGIN
 
 #include <webrtc/rtc_base/socket_address.h>
 #include <webrtc/rtc_base/network.h>
 
 ALLOW_COMMA_END
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/RTCWebKitEncodedFrameInfo.h
+++ b/Source/WebKit/Shared/RTCWebKitEncodedFrameInfo.h
@@ -27,10 +27,16 @@
 
 #if USE(LIBWEBRTC)
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 ALLOW_COMMA_BEGIN
 
 #include <webrtc/webkit_sdk/WebKit/WebKitEncoder.h>
 
 ALLOW_COMMA_END
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -30,6 +30,8 @@
 #include <wtf/PageBlock.h>
 #include <wtf/StdLibExtras.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -210,3 +212,5 @@ void SharedStringHashStore::processPendingOperations()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
@@ -28,6 +28,8 @@
 
 #include <WebCore/SharedMemory.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -111,3 +113,5 @@ SharedStringHash* SharedStringHashTableReadOnly::findSlot(SharedStringHash share
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/cf/CoreIPCSecAccessControl.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecAccessControl.h
@@ -30,6 +30,8 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 class CoreIPCSecAccessControl {
@@ -77,5 +79,7 @@ private:
 };
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // HAVE(SEC_ACCESS_CONTROL)

--- a/Source/WebKit/Shared/cf/CoreIPCSecCertificate.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecCertificate.h
@@ -30,6 +30,8 @@
 #import <Security/SecCertificate.h>
 #import <wtf/RetainPtr.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 class CoreIPCSecCertificate {
@@ -77,5 +79,7 @@ private:
 };
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CF)

--- a/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h
@@ -31,6 +31,8 @@
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 // For now, the only way to serialize/deserialize SecKeychainItem objects is via
@@ -100,5 +102,7 @@ private:
 };
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // HAVE(SEC_KEYCHAIN)

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.h
@@ -30,6 +30,8 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 // For now, the only way to serialize/deserialize SecTrust objects is via
@@ -74,5 +76,7 @@ private:
 };
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CF)

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -70,6 +70,8 @@
 #import <WebKitAdditions/DyldCallbackAdditions.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 SOFT_LINK_SYSTEM_LIBRARY(libsystem_info)
 SOFT_LINK_OPTIONAL(libsystem_info, mbr_close_connections, int, (), ());
 SOFT_LINK_OPTIONAL(libsystem_info, lookup_close_connections, int, (), ());
@@ -830,5 +832,7 @@ void AuxiliaryProcess::openDirectoryCacheInvalidated(SandboxExtension::Handle&& 
 #endif // PLATFORM(MAC)
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
+++ b/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
@@ -39,6 +39,8 @@
 #import <notify.h>
 #import <wtf/WallTime.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
     
 struct SystemMallocStats {
@@ -182,6 +184,8 @@ void WebMemorySampler::sendMemoryPressureEvent()
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif
 

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -51,6 +51,8 @@
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace API {
 using namespace WebKit::NetworkCache;
 using namespace FileSystem;
@@ -646,5 +648,7 @@ const std::error_category& contentRuleListStoreErrorCategory()
 }
 
 } // namespace API
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -47,6 +47,8 @@
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 _WKOverlayScrollbarStyle toAPIScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> coreScrollbarStyle)
 {
     if (!coreScrollbarStyle)
@@ -1812,5 +1814,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return [[NSImage alloc] initWithCGImage:snapshot.get() size:NSZeroSize];
 }
 @end
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -65,6 +65,8 @@
 #include <WebCore/AuthenticatorTransport.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace Inspector;
@@ -2575,3 +2577,5 @@ std::optional<String> WebAutomationSession::platformGenerateLocalFilePathForRemo
 #endif // !PLATFORM(COCOA)
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -37,6 +37,8 @@
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/NeverDestroyed.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -248,5 +250,7 @@ void UIGamepadProvider::platformStartMonitoringInput()
 #endif // !PLATFORM(COCOA) && !(USE(MANETTE) && OS(LINUX))
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -40,6 +40,8 @@
 #include <WebCore/NotificationData.h>
 #include <WebCore/SecurityOriginData.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -387,3 +389,5 @@ void WebNotificationManagerProxy::getNotifications(const URL& url, const String&
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -62,6 +62,8 @@
 #include <WebCore/ScreenCaptureKitCaptureSource.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -1172,3 +1174,5 @@ String convertEnumerationToString(UserMediaPermissionRequestManagerProxy::Reques
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
@@ -29,6 +29,8 @@
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/text/StringHash.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -235,3 +237,5 @@ bool UserMediaPermissionRequestProxy::canRequestDisplayCapturePermission()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -33,6 +33,8 @@
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace fido;
 
@@ -160,5 +162,6 @@ void HidConnection::registerDataReceivedCallbackInternal()
 
 } // namespace WebKit
 
-#endif // ENABLE(WEB_AUTHN)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -39,6 +39,8 @@
 
 #import "LocalAuthenticationSoftLink.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -177,5 +179,7 @@ RetainPtr<NSArray> MockLocalConnection::getExistingCredentials(const String& rpI
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -35,6 +35,8 @@
 #include <wtf/WeakRandomNumber.h>
 #include <wtf/text/Base64.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace fido;
 
@@ -270,5 +272,7 @@ void CtapHidDriver::cancel()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -422,6 +422,8 @@
 #include <wtf/glib/RunLoopSourcePriority.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_URL_COROUTINE(process, url) MESSAGE_CHECK_BASE_COROUTINE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
@@ -15417,3 +15419,5 @@ Ref<BrowsingContextGroup> WebPageProxy::protectedBrowsingContextGroup() const
 #undef MESSAGE_CHECK_COMPLETION
 #undef MESSAGE_CHECK_URL
 #undef MESSAGE_CHECK
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/_WKTouchEventGenerator.mm
+++ b/Source/WebKit/UIProcess/_WKTouchEventGenerator.mm
@@ -36,6 +36,8 @@
 #import <wtf/RunLoop.h>
 #import <wtf/SoftLinking.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 SOFT_LINK_PRIVATE_FRAMEWORK(BackBoardServices)
 SOFT_LINK(BackBoardServices, BKSHIDEventSetDigitizerInfo, void, (IOHIDEventRef digitizerEvent, uint32_t contextID, uint8_t systemGestureisPossible, uint8_t isSystemGestureStateChangeEvent, CFStringRef displayUUID, CFTimeInterval initialTouchTimestamp, float maxForce), (digitizerEvent, contextID, systemGestureisPossible, isSystemGestureStateChangeEvent, displayUUID, initialTouchTimestamp, maxForce));
 
@@ -390,5 +392,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
 }
 
 @end
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -216,6 +216,8 @@
 #define UIWKDocumentRequestAutocorrectedRanges (1 << 7)
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(BROWSERENGINEKIT)
 
 @interface WKUITextSelectionRect : UITextSelectionRect
@@ -15279,5 +15281,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 @end
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm
@@ -445,8 +445,8 @@ static WKNumberPadKey alternateKeyAtPosition(WKNumberPadButtonPosition position)
     _keypad = adoptNS([[UIView alloc] init]);
     [_keypad setUserInteractionEnabled:YES];
 
-    CGFloat xAnchors[] = { 0.0, 0.5, 1.0 };
-    CGFloat yAnchors[] = { 0.0, 0.5, 0.5, 1.0 };
+    auto xAnchors = std::to_array<CGFloat>({ 0.0, 0.5, 1.0 });
+    auto yAnchors = std::to_array<CGFloat>({ 0.0, 0.5, 0.5, 1.0 });
 
     for (unsigned x = 0; x < 3; ++x) {
         for (unsigned y = 0; y < 4; ++y) {

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -36,6 +36,8 @@
 #include <wtf/cf/VectorCF.h>
 #include <wtf/text/StringView.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 // Session state keys.
@@ -1181,3 +1183,5 @@ bool decodeLegacySessionState(std::span<const uint8_t> data, SessionState& sessi
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -172,6 +172,8 @@
 #import <pal/cocoa/WritingToolsUISoftLink.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 SOFT_LINK_FRAMEWORK(AVKit)
 SOFT_LINK_CLASS(AVKit, AVTouchBarPlaybackControlsProvider)
@@ -6745,5 +6747,7 @@ Ref<WebPageProxy> WebViewImpl::protectedPage() const
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -70,6 +70,8 @@
 #include <WebCore/HTMLDataListElement.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -1067,3 +1069,5 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -319,6 +319,8 @@ EOF
 #include "WebExtensionUtilities.h"
 #include <wtf/GetPtr.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 ${implementationClassName}* to${implementationClassName}(JSContextRef context, JSValueRef value)
@@ -965,6 +967,9 @@ EOF
     push(@contents, <<EOF);
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 EOF
 
     push(@contents, <<EOF) if $conditionalString;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -32,6 +32,8 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoderProxy);
@@ -123,5 +125,7 @@ void RemoteComputePassEncoderProxy::setLabelInternal(const String& label)
 }
 
 } // namespace WebKit::WebGPU
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -33,6 +33,8 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderBundleEncoderProxy);
@@ -178,5 +180,7 @@ Ref<ConvertToBackingContext> RemoteRenderBundleEncoderProxy::protectedConvertToB
 }
 
 } // namespace WebKit::WebGPU
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -32,6 +32,8 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoderProxy);
@@ -222,5 +224,7 @@ Ref<ConvertToBackingContext> RemoteRenderPassEncoderProxy::protectedConvertToBac
 }
 
 } // namespace WebKit::WebGPU
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -39,6 +39,8 @@
 #import <WebCore/PlatformCALayer.h>
 #import <WebCore/PlatformCALayerDelegatedContents.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 namespace {
@@ -200,5 +202,7 @@ Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(c
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -45,6 +45,8 @@
 #include <mach/mach_time.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 #if PLATFORM(COCOA)
@@ -268,5 +270,7 @@ void RemoteAudioDestinationProxy::gpuProcessConnectionDidClose(GPUProcessConnect
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -57,6 +57,8 @@ ALLOW_COMMA_END
 
 #include <pal/cf/CoreMediaSoftLink.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -927,5 +929,7 @@ inline RefPtr<RemoteVideoFrameObjectHeapProxy> LibWebRTCCodecs::protectedVideoFr
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -39,6 +39,8 @@
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(LIBWEBRTC)
 
 ALLOW_COMMA_BEGIN
@@ -312,5 +314,7 @@ bool SharedVideoFrameReader::setSharedMemory(SharedMemory::Handle&& handle)
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h
@@ -27,6 +27,10 @@
 
 #if USE(LIBWEBRTC)
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include <WebCore/LibWebRTCMacros.h>
 
 ALLOW_COMMA_BEGIN
@@ -35,6 +39,8 @@ ALLOW_COMMA_END
 
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -31,6 +31,10 @@
 // renaming of more LibWebRTC-prefixed files in WebKit.
 // https://bugs.webkit.org/show_bug.cgi?id=243774
 
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if USE(LIBWEBRTC)
 
 #include <wtf/TZoneMalloc.h>
@@ -46,6 +50,8 @@
 #else // !USE(LIBWEBRTC) && !USE(GSTREAMER_WEBRTC)
 #include <WebCore/WebRTCProvider.h>
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -40,6 +40,8 @@
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCSocket);
@@ -179,5 +181,7 @@ void LibWebRTCSocket::suspend()
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -45,6 +45,8 @@
 
 #import "PDFKitSoftLink.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -864,5 +866,7 @@ void PDFIncrementalLoader::logState(TextStream& ts)
 #endif
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(PDF_PLUGIN) && HAVE(INCREMENTAL_PDF_APIS)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -76,6 +76,8 @@
 
 #import "PDFKitSoftLink.h"
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -1245,5 +1247,7 @@ std::optional<FrameIdentifier> PDFPluginBase::rootFrameID() const
 }
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
@@ -36,6 +36,8 @@
 #import <wtf/text/StringView.h>
 #import <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::PDFScriptEvaluation {
 
 static bool isPrintScript(const String& script)
@@ -141,5 +143,7 @@ void runScripts(CGPDFDocumentRef document, PrintingCallback&& callback)
 }
 
 } // namespace WebKit::PDFScriptEvaluation
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -68,6 +68,8 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit::IPCTestingAPI {
 
 class JSIPC;
@@ -3150,3 +3152,5 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* glob
 } // namespace IPC
 
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -34,6 +34,8 @@
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 
 static constexpr Seconds deltaHistoryMaximumAge = 500_ms;
@@ -679,5 +681,7 @@ void MomentumEventDispatcher::flushLog()
 #endif
 
 } // namespace WebKit
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -463,6 +463,8 @@
 #include <pal/cf/CoreTextSoftLink.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebKit {
 using namespace JSC;
 using namespace WebCore;
@@ -10132,3 +10134,5 @@ void WebPage::updateOpener(WebCore::FrameIdentifier frameID, WebCore::FrameIdent
 
 #undef WEBPAGE_RELEASE_LOG
 #undef WEBPAGE_RELEASE_LOG_ERROR
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -191,6 +191,8 @@
 #import <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #import <pal/cocoa/MediaToolboxSoftLink.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #define RELEASE_LOG_SESSION_ID (m_sessionID ? m_sessionID->toUInt64() : 0)
 #define WEBPROCESS_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
 #define WEBPROCESS_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
@@ -1532,3 +1534,5 @@ void WebProcess::postObserverNotification(const String& message)
 #undef RELEASE_LOG_SESSION_ID
 #undef WEBPROCESS_RELEASE_LOG
 #undef WEBPROCESS_RELEASE_LOG_ERROR
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -80,6 +80,8 @@
 #define GET_ALLOWED_BUNDLE_IDENTIFIER_ADDITIONS_1
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if PLATFORM(IOS)
 
 // FIXME: This is only here temporarily for staging purposes.
@@ -1189,5 +1191,7 @@ void WebPushDaemon::getAppBadgeForTesting(PushClientConnection& connection, Comp
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 
 } // namespace WebPushD
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -41,6 +41,8 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebPushTool {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Connection);
@@ -193,5 +195,6 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
 
 } // namespace WebPushTool
 
-#endif // ENABLE(WEB_PUSH_NOTIFICATIONS)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+#endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKitLegacy/mac/WebKitPrefix.h
+++ b/Source/WebKitLegacy/mac/WebKitPrefix.h
@@ -30,6 +30,8 @@
 #include "cmakeconfig.h"
 #endif
 
+#include <wtf/Platform.h>
+
 #include <TargetConditionals.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
#### 8012a2ef24887940831a4ddc777d5d757f523c99
<pre>
Enable -Wunsafe-buffer-usage in WebKit.framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=281252">https://bugs.webkit.org/show_bug.cgi?id=281252</a>
<a href="https://rdar.apple.com/137710184">rdar://137710184</a>

Reviewed by Ryosuke Niwa.

This patch enables -Wunsafe-buffer-usage by default in WebKit.framework.

This is our bounds safety strategy for Safer C++ in WebKit.

For the time being, files that do not conform to safe buffer usage opt out,
using a new macro. The next step is to burn down the opt out list.

In cases where a header triggers a warning, we either opt out in a chokepoint
header that includes that header, or opt out the header directly, whichever is
more expedient.

I also fixed exactly one unsafe case, to try it out, and also to work around
a header #include path issue I couldn&apos;t figure out.

* Source/JavaScriptCore/API/APICast.h:
* Source/JavaScriptCore/JavaScriptCorePrefix.h:
* Source/JavaScriptCore/heap/Strong.h:
* Source/JavaScriptCore/heap/WeakInlines.h:
* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/ExceptionScope.h:
* Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h:
* Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h:
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
* Source/JavaScriptCore/runtime/JSCellInlines.h:
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/Options.h:
* Source/JavaScriptCore/runtime/TypedArrays.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/wasm/WasmModule.h:
* Source/WTF/wtf/ASCIICType.h:
* Source/WTF/wtf/Atomics.h:
* Source/WTF/wtf/BitSet.h:
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/BloomFilter.h:
* Source/WTF/wtf/Brigand.h:
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/Deque.h:
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/FixedVector.h:
* Source/WTF/wtf/HashMap.h:
* Source/WTF/wtf/HashSet.h:
* Source/WTF/wtf/HexNumber.h:
* Source/WTF/wtf/IteratorAdaptors.h:
* Source/WTF/wtf/Locker.h:
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WTF/wtf/PageBlock.h:
* Source/WTF/wtf/RefCounted.h:
* Source/WTF/wtf/RobinHoodHashTable.h:
* Source/WTF/wtf/SIMDHelpers.h:
* Source/WTF/wtf/SortedArrayMap.h:
* Source/WTF/wtf/StackTrace.h:
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/TZoneMallocInlines.h:
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/TrailingArray.h:
* Source/WTF/wtf/UUID.h:
* Source/WTF/wtf/Vector.h:
* Source/WTF/wtf/WTFConfig.h:
* Source/WTF/wtf/cf/VectorCF.h:
* Source/WTF/wtf/cocoa/SpanCocoa.h:
(WTF::span):
* Source/WTF/wtf/text/ASCIIFastPath.h:
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/text/MakeString.h:
* Source/WTF/wtf/text/StringBuilder.h:
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringConcatenate.h:
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
* Source/WTF/wtf/text/StringHasherInlines.h:
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/TextBreakIterator.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
* Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb:
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/BufferSource.h:
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
* Source/WebCore/bindings/js/JSDOMConvertBase.h:
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMWrapper.h:
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/dom/ElementData.h:
* Source/WebCore/dom/SpaceSplitString.h:
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/page/StructuredSerializeOptions.h:
* Source/WebCore/platform/ProcessQualified.h:
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/platform/SharedMemory.h:
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/graphics/FontTaggedSettings.h:
* Source/WebCore/platform/graphics/FourCC.h:
* Source/WebCore/platform/graphics/GlyphBuffer.h:
* Source/WebCore/platform/graphics/GlyphPage.h:
* Source/WebCore/platform/graphics/WidthCache.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
* Source/WebCore/platform/network/HTTPHeaderMap.h:
* Source/WebKit/Configurations/Base.xcconfig:
* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportReceiveStreamCocoa.mm:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
* Source/WebKit/Platform/IPC/DaemonCoders.h:
* Source/WebKit/Platform/IPC/DaemonDecoder.cpp:
* Source/WebKit/Platform/IPC/Decoder.cpp:
* Source/WebKit/Platform/IPC/Encoder.cpp:
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_names_header):
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Shared/API/APIData.h:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm:
* Source/WebKit/Shared/API/c/WKArray.cpp:
* Source/WebKit/Shared/API/c/WKData.cpp:
* Source/WebKit/Shared/API/c/WKDictionary.cpp:
* Source/WebKit/Shared/API/c/WKString.cpp:
* Source/WebKit/Shared/API/c/WKURLRequest.cpp:
* Source/WebKit/Shared/Cocoa/CoreIPCCFCharacterSet.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm:
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
* Source/WebKit/Shared/RTCNetwork.h:
* Source/WebKit/Shared/RTCWebKitEncodedFrameInfo.h:
* Source/WebKit/Shared/SharedStringHashStore.cpp:
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
* Source/WebKit/Shared/cf/CoreIPCSecAccessControl.h:
* Source/WebKit/Shared/cf/CoreIPCSecCertificate.h:
* Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h:
* Source/WebKit/Shared/cf/CoreIPCSecTrust.h:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
* Source/WebKit/Shared/mac/WebMemorySampler.mac.mm:
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/webpushd/WebPushDaemon.mm:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
* Source/WebKitLegacy/mac/WebKitPrefix.h:

Canonical link: <a href="https://commits.webkit.org/285046@main">https://commits.webkit.org/285046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d20b73796f5fa115cdff4f2ffaf6eefb68ef0ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71380 "15 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24153 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22404 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46117 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/61500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/70888 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/64505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19330 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70629 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61539 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12251 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92415 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10939 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46593 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20380 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48947 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->