### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make AudioMediaStreamTrackRendererInternalUnitManager ref-counted

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -29,6 +29,7 @@
 
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreAudio/CoreAudioTypes.h>
+#include <wtf/CanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -38,15 +39,23 @@ class CAAudioStreamDescription;
 class AudioMediaStreamTrackRendererInternalUnit {
 public:
     virtual ~AudioMediaStreamTrackRendererInternalUnit() = default;
-    class Client {
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
+    class Client : public CanMakeWeakPtr<Client, WeakPtrFactoryInitialization::Eager> {
     public:
         virtual ~Client() = default;
+
+        virtual void ref() const = 0;
+        virtual void deref() const = 0;
+
         virtual OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) = 0;
         virtual void reset() = 0;
     };
-    WEBCORE_EXPORT static UniqueRef<AudioMediaStreamTrackRendererInternalUnit> create(Client&);
+    WEBCORE_EXPORT static Ref<AudioMediaStreamTrackRendererInternalUnit> create(Client&);
 
-    using CreateFunction = UniqueRef<AudioMediaStreamTrackRendererInternalUnit>(*)(AudioMediaStreamTrackRendererInternalUnit::Client&);
+    using CreateFunction = Ref<AudioMediaStreamTrackRendererInternalUnit>(*)(AudioMediaStreamTrackRendererInternalUnit::Client&);
     WEBCORE_EXPORT static void setCreateFunction(CreateFunction);
     virtual void start() = 0;
     virtual void stop() = 0;

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -51,7 +51,7 @@ AudioMediaStreamTrackRendererUnit::~AudioMediaStreamTrackRendererUnit()
 
 void AudioMediaStreamTrackRendererUnit::setAudioOutputDevice(const String& deviceID)
 {
-    m_internalUnit->setAudioOutputDevice(deviceID);
+    protectedInternalUnit()->setAudioOutputDevice(deviceID);
 }
 
 void AudioMediaStreamTrackRendererUnit::addSource(Ref<AudioSampleDataSource>&& source)
@@ -101,7 +101,7 @@ void AudioMediaStreamTrackRendererUnit::start()
     RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::start");
     ASSERT(isMainThread());
 
-    m_internalUnit->start();
+    protectedInternalUnit()->start();
 }
 
 void AudioMediaStreamTrackRendererUnit::stop()
@@ -109,7 +109,7 @@ void AudioMediaStreamTrackRendererUnit::stop()
     RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::stop");
     ASSERT(isMainThread());
 
-    m_internalUnit->stop();
+    protectedInternalUnit()->stop();
 }
 
 void AudioMediaStreamTrackRendererUnit::reset()
@@ -131,7 +131,7 @@ void AudioMediaStreamTrackRendererUnit::reset()
 void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)
 {
     ASSERT(isMainThread());
-    m_internalUnit->retrieveFormatDescription(WTFMove(callback));
+    protectedInternalUnit()->retrieveFormatDescription(WTFMove(callback));
 }
 
 void AudioMediaStreamTrackRendererUnit::updateRenderSourcesIfNecessary()

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -50,12 +50,16 @@ class AudioSampleDataSource;
 class AudioSampleBufferList;
 class CAAudioStreamDescription;
 
-class AudioMediaStreamTrackRendererUnit : public BaseAudioMediaStreamTrackRendererUnit, public CanMakeWeakPtr<AudioMediaStreamTrackRendererUnit, WeakPtrFactoryInitialization::Eager>, AudioMediaStreamTrackRendererInternalUnit::Client {
+class AudioMediaStreamTrackRendererUnit : public BaseAudioMediaStreamTrackRendererUnit, public AudioMediaStreamTrackRendererInternalUnit::Client {
 public:
     WEBCORE_EXPORT static AudioMediaStreamTrackRendererUnit& singleton();
 
     AudioMediaStreamTrackRendererUnit();
     ~AudioMediaStreamTrackRendererUnit();
+
+    // Since AudioMediaStreamTrackRendererUnit is a singleton, its ref/deref do nothing.
+    void ref() const final { }
+    void deref() const final { }
 
     // AudioMediaStreamTrackRendererInternalUnit
     OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) final;
@@ -76,12 +80,14 @@ private:
     void createAudioUnitIfNeeded();
     void updateRenderSourcesIfNecessary();
 
+    Ref<AudioMediaStreamTrackRendererInternalUnit> protectedInternalUnit() { return m_internalUnit; }
+
     HashSet<Ref<AudioSampleDataSource>> m_sources;
     Vector<Ref<AudioSampleDataSource>> m_pendingRenderSources WTF_GUARDED_BY_LOCK(m_pendingRenderSourcesLock);
     Vector<Ref<AudioSampleDataSource>> m_renderSources;
     bool m_hasPendingRenderSources WTF_GUARDED_BY_LOCK(m_pendingRenderSourcesLock) { false };
     Lock m_pendingRenderSourcesLock;
-    UniqueRef<AudioMediaStreamTrackRendererInternalUnit> m_internalUnit;
+    Ref<AudioMediaStreamTrackRendererInternalUnit> m_internalUnit;
     WeakHashSet<ResetObserver> m_resetObservers;
 };
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
@@ -69,7 +69,7 @@ private:
     HashMap<AudioMediaStreamTrackRendererInternalUnitIdentifier, WeakPtr<AudioMediaStreamTrackRendererInternalUnitManagerProxy>> m_proxies;
 };
 
-UniqueRef<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(WebCore::AudioMediaStreamTrackRendererInternalUnit::Client&);
+Ref<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(WebCore::AudioMediaStreamTrackRendererInternalUnit::Client&);
 
 }
 


### PR DESCRIPTION
#### 71ca97e249546e4c37cd7988764047a98719ad7e
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make AudioMediaStreamTrackRendererInternalUnitManager ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281260">https://bugs.webkit.org/show_bug.cgi?id=281260</a>
<a href="https://rdar.apple.com/137714138">rdar://137714138</a>

Reviewed by Chris Dumez.

Remove IsDeprecatedWeakRefSmartPointerException by making
AudioMediaStreamTrackRendererInternalUnitManager ref-counted.

* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::render):
(WebCore::AudioMediaStreamTrackRendererInternalUnit::create):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::setAudioOutputDevice):
(WebCore::AudioMediaStreamTrackRendererUnit::start):
(WebCore::AudioMediaStreamTrackRendererUnit::stop):
(WebCore::AudioMediaStreamTrackRendererUnit::retrieveFormatDescription):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
(WebCore::AudioMediaStreamTrackRendererUnit::protectedInternalUnit):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::protectedLocalUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::stop):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::setAudioOutputDevice):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitIsStarting):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitHasStopped):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::beginAudioSessionInterruption):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::endAudioSessionInterruption):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::createRemoteAudioMediaStreamTrackRendererInternalUnitProxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::startThread):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::reset):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h:

Canonical link: <a href="https://commits.webkit.org/285139@main">https://commits.webkit.org/285139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1b46f16eb38d84656ec5bd5b497aa8ea0ff516f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24460 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22711 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15101 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61750 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77520 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15920 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12494 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6122 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46899 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->