### PR TITLE
[scroll-animations] Update view timeline progress calculation to use localToContainerPoint for subject offset calculation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS View timeline delay
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html id="top">
+<meta charset="utf-8">
+<title>View timeline delay</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#viewtimeline-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="/scroll-animations/scroll-timelines/testcommon.js"></script>
+<script src="/scroll-animations/view-timelines/testcommon.js"></script>
+<style>
+  #container {
+    overflow-x: scroll;
+    height:  200px;
+    width: 200px;
+  }
+  #content {
+    translate: 50px;
+    width:  1800px;
+    margin: 0;
+  }
+  .spacer {
+    width:  800px;
+    display:  inline-block;
+  }
+  #target {
+    background-color:  green;
+    height:  100px;
+    width:  100px;
+    display:  inline-block;
+    font-size: 10px;
+  }
+</style>
+<body>
+<div id="container">
+    <div id="content">
+      <div class="spacer"></div>
+      <div id="target"></div>
+      <div class="spacer"></div>
+    </div>
+  </div>
+</body>
+<script type="text/javascript">
+  promise_test(async t => {
+    const timeline = new ViewTimeline({
+      subject: target,
+      axis: "inline"
+    });
+    const anim = target.animate({ backgroundColor: ['green', 'red' ] },
+                                { timeline: timeline });
+    await new Promise(requestAnimationFrame);
+    assert_px_equals(timeline.startOffset, 654, 'startOffset');
+    assert_px_equals(timeline.endOffset, 954, 'endOffset');
+  });
+</script>

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -54,13 +54,13 @@ public:
     static Ref<ViewTimeline> createFromCSSValue(Style::BuilderState&, const CSSViewValue&);
 
     Element* subject() const { return m_subject.get(); }
-    const CSSNumericValue& startOffset() const;
-    const CSSNumericValue& endOffset() const;
+    const CSSNumericValue& startOffset();
+    const CSSNumericValue& endOffset();
     const ViewTimelineInsets& insets() const { return m_insets; }
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
     AnimationTimelinesController* controller() const override;
 
-    RenderBox* sourceRenderer() const;
+    RenderBox* sourceScrollerRenderer() const;
     Element* source() const override;
 
 private:
@@ -75,6 +75,8 @@ private:
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
     ViewTimelineInsets m_insets;
+    Ref<CSSNumericValue> m_startOffset;
+    Ref<CSSNumericValue> m_endOffset;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d7cae82b7c21b6b64e56ffb8ba43c0e8bb1a0ba2
<pre>
[scroll-animations] Update view timeline progress calculation to use localToContainerPoint for subject offset calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=281259">https://bugs.webkit.org/show_bug.cgi?id=281259</a>
<a href="https://rdar.apple.com/137715213">rdar://137715213</a>

Reviewed by Simon Fraser.

Update view timeline progress calculation to use localToContainerPoint for subject offset calculation, as offsetTop doesn&apos;t
calculate the offset from the source, but from the offsetParent. Also add a simple test to ensure that intermediate transformations
are taken into account.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html: Added.
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::ViewTimeline):
(WebCore::ViewTimeline::source const):
(WebCore::ViewTimeline::sourceScrollerRenderer const):
(WebCore::ViewTimeline::computeTimelineData const):
(WebCore::ViewTimeline::startOffset):
(WebCore::ViewTimeline::endOffset):
(WebCore::ViewTimeline::sourceRenderer const): Deleted.
(WebCore::ViewTimeline::startOffset const): Deleted.
(WebCore::ViewTimeline::endOffset const): Deleted.
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/285132@main">https://commits.webkit.org/285132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57da888fe931e371999e71bd6ae69c0f83ba81f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14931 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36910 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19046 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21037 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77321 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64175 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64171 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5956 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1483 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->