### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make WebRemoteObjectRegistry ref-counted

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
@@ -47,6 +47,9 @@ class RemoteObjectRegistry : public IPC::MessageReceiver {
 public:
     virtual ~RemoteObjectRegistry();
 
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
     virtual void sendInvocation(const RemoteObjectInvocation&);
     void sendReplyBlock(uint64_t replyID, const UserData& blockInvocation);
     void sendUnusedReply(uint64_t replyID);
@@ -56,8 +59,8 @@ protected:
     using MessageSender = std::variant<std::reference_wrapper<WebProcessProxy>, std::reference_wrapper<WebPage>>;
 private:
     virtual RefPtr<ProcessThrottler::BackgroundActivity> backgroundActivity(ASCIILiteral) { return nullptr; }
-    virtual MessageSender messageSender() = 0;
-    virtual uint64_t messageDestinationID() = 0;
+    virtual std::optional<MessageSender> messageSender() = 0;
+    virtual std::optional<uint64_t> messageDestinationID() = 0;
     template<typename M> void send(M&&);
 
     // IPC::MessageReceiver

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
@@ -48,8 +48,13 @@ RemoteObjectRegistry::~RemoteObjectRegistry() = default;
 
 template<typename M> void RemoteObjectRegistry::send(M&& message)
 {
-    WTF::switchOn(messageSender(), [&] (auto sender) {
-        sender.get().send(WTFMove(message), messageDestinationID());
+    auto messageSender = this->messageSender();
+    auto messageDestinationID = this->messageDestinationID();
+    if (!messageSender || !messageDestinationID)
+        return;
+
+    WTF::switchOn(*messageSender, [&] (auto sender) {
+        sender.get().send(WTFMove(message), *messageDestinationID);
     });
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
@@ -26,28 +26,37 @@
 #pragma once
 
 #include "RemoteObjectRegistry.h"
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
-class UIRemoteObjectRegistry final : public RemoteObjectRegistry {
+class UIRemoteObjectRegistry final : public RemoteObjectRegistry, public RefCounted<UIRemoteObjectRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(UIRemoteObjectRegistry);
 public:
-    UIRemoteObjectRegistry(_WKRemoteObjectRegistry *, WebPageProxy&);
+    static Ref<UIRemoteObjectRegistry> create(_WKRemoteObjectRegistry *remoteObjectRegistry, WebPageProxy& page)
+    {
+        return adoptRef(*new UIRemoteObjectRegistry(remoteObjectRegistry, page));
+    }
+
     ~UIRemoteObjectRegistry();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void sendInvocation(const RemoteObjectInvocation&) final;
 
 private:
-    Ref<WebPageProxy> protectedPage();
-    MessageSender messageSender() final;
-    uint64_t messageDestinationID() final;
+    UIRemoteObjectRegistry(_WKRemoteObjectRegistry *, WebPageProxy&);
+
+    std::optional<MessageSender> messageSender() final;
+    std::optional<uint64_t> messageDestinationID() final;
     RefPtr<ProcessThrottler::BackgroundActivity> backgroundActivity(ASCIILiteral) final;
 
-    WeakRef<WebPageProxy> m_page;
+    WeakPtr<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
@@ -50,21 +50,28 @@ WebRemoteObjectRegistry::~WebRemoteObjectRegistry()
 
 void WebRemoteObjectRegistry::close()
 {
-    Ref page { m_page.get() };
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
     if (page->remoteObjectRegistry() == this) {
         WebProcess::singleton().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), page->identifier());
         page->setRemoteObjectRegistry(nullptr);
     }
 }
 
-auto WebRemoteObjectRegistry::messageSender() -> MessageSender
+auto WebRemoteObjectRegistry::messageSender() -> std::optional<MessageSender>
 {
-    return m_page.get();
+    if (m_page)
+        return *m_page;
+    return std::nullopt;
 }
 
-uint64_t WebRemoteObjectRegistry::messageDestinationID()
+std::optional<uint64_t> WebRemoteObjectRegistry::messageDestinationID()
 {
-    return m_page.get().webPageProxyIdentifier().toUInt64();
+    if (m_page)
+        return m_page->webPageProxyIdentifier().toUInt64();
+    return std::nullopt;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### b15f86cdf39f27860179698c6d67898c43dce4f4
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make WebRemoteObjectRegistry ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281263">https://bugs.webkit.org/show_bug.cgi?id=281263</a>
<a href="https://rdar.apple.com/137716730">rdar://137716730</a>

Reviewed by Chris Dumez.

Remove IsDeprecatedWeakRefSmartPointerException] by making
WebRemoteObjectRegistry ref-counted.

* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm:
(WebKit::RemoteObjectRegistry::send):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _initWithWebPage:]):
(-[_WKRemoteObjectRegistry _initWithWebPageProxy:]):
(-[_WKRemoteObjectRegistry _sendInvocation:interface:]):
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
(WebKit::UIRemoteObjectRegistry::sendInvocation):
(WebKit::UIRemoteObjectRegistry::messageSender):
(WebKit::UIRemoteObjectRegistry::messageDestinationID):
(WebKit::UIRemoteObjectRegistry::protectedPage): Deleted.
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp:
(WebKit::WebRemoteObjectRegistry::close):
(WebKit::WebRemoteObjectRegistry::messageSender):
(WebKit::WebRemoteObjectRegistry::messageDestinationID):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h:

Canonical link: <a href="https://commits.webkit.org/285150@main">https://commits.webkit.org/285150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95e3e03111e1c2d622a322a50fc1c345e30e0baf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24475 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61767 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43034 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77535 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12503 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46914 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->