### PR TITLE
Simplify Web Extension scripting options parsing.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -308,7 +308,10 @@ void WebExtensionContext::loadRegisteredContentScripts()
         }
 
         Vector<WebExtensionRegisteredScriptParameters> parametersVector;
-        WebExtensionAPIScripting::parseRegisteredContentScripts(scripts, FirstTimeRegistration::Yes, parametersVector);
+        if (!WebExtensionAPIScripting::parseRegisteredContentScripts(scripts, FirstTimeRegistration::Yes, parametersVector, &errorMessage)) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to parse injected content data for extension %{private}@. Error: %{public}@", (NSString *)m_uniqueIdentifier, errorMessage);
+            return;
+        }
 
         DynamicInjectedContentsMap injectedContentsMap;
         createInjectedContentForScripts(parametersVector, FirstTimeRegistration::Yes, injectedContentsMap, nil, &errorMessage);

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -65,8 +65,8 @@ static constexpr auto contentScriptsAllFramesManifestKey = "all_frames"_s;
 static constexpr auto contentScriptsJSManifestKey = "js"_s;
 static constexpr auto contentScriptsCSSManifestKey = "css"_s;
 static constexpr auto contentScriptsWorldManifestKey = "world"_s;
-static constexpr auto contentScriptsIsolatedManifestKey = "ISOLATED"_s;
-static constexpr auto contentScriptsMainManifestKey = "MAIN"_s;
+static constexpr auto contentScriptsIsolatedManifestKey = "isolated"_s;
+static constexpr auto contentScriptsMainManifestKey = "main"_s;
 static constexpr auto contentScriptsCSSOriginManifestKey = "css_origin"_s;
 static constexpr auto contentScriptsAuthorManifestKey = "author"_s;
 static constexpr auto contentScriptsUserManifestKey = "user"_s;
@@ -1047,18 +1047,18 @@ void WebExtension::populateContentScriptPropertiesIfNeeded()
 
         auto contentWorldType = WebExtensionContentWorldType::ContentScript;
         auto worldString = injectedContentObject->getString(contentScriptsWorldManifestKey);
-        if (!worldString || worldString == contentScriptsIsolatedManifestKey)
+        if (!worldString || equalIgnoringASCIICase(worldString, contentScriptsIsolatedManifestKey))
             contentWorldType = WebExtensionContentWorldType::ContentScript;
-        else if (worldString == contentScriptsMainManifestKey)
+        else if (equalIgnoringASCIICase(worldString, contentScriptsMainManifestKey))
             contentWorldType = WebExtensionContentWorldType::Main;
         else
             recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `world` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'world' value")));
 
         auto styleLevel = WebCore::UserStyleLevel::Author;
         auto cssOriginString = injectedContentObject->getString(contentScriptsCSSOriginManifestKey);
-        if (!cssOriginString || cssOriginString == contentScriptsAuthorManifestKey)
+        if (!cssOriginString || equalIgnoringASCIICase(cssOriginString, contentScriptsAuthorManifestKey))
             styleLevel = WebCore::UserStyleLevel::Author;
-        else if (cssOriginString == contentScriptsUserManifestKey)
+        else if (equalIgnoringASCIICase(cssOriginString, contentScriptsUserManifestKey))
             styleLevel = WebCore::UserStyleLevel::User;
         else
             recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `css_origin` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'css_origin' value")));

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -49,28 +49,22 @@ public:
     void insertCSS(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void removeCSS(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void registerContentScripts(NSObject *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getRegisteredContentScripts(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void updateContentScripts(NSObject *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void unregisterContentScripts(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void registerContentScripts(NSArray *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getRegisteredContentScripts(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void updateContentScripts(NSArray *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void unregisterContentScripts(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
 private:
     friend class WebExtensionContext;
 
-    bool hasValidExecutionWorld(NSDictionary *script, NSString **outExceptionString);
+    static bool validateFilter(NSDictionary *filter, NSString **outExceptionString);
 
-    bool validateScript(NSDictionary *, NSString **outExceptionString);
-    bool validateTarget(NSDictionary *, NSString **outExceptionString);
-    bool validateCSS(NSDictionary *, NSString **outExceptionString);
-
-    bool validateRegisteredScripts(NSArray *, FirstTimeRegistration, NSString **outExceptionString);
-    bool validateFilter(NSDictionary *filter, NSString **outExceptionString);
-
-    void parseCSSInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
-    void parseTargetInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
-    void parseScriptInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
-    static void parseRegisteredContentScripts(NSArray *, FirstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>&);
-
+    static bool parseStyleLevel(NSDictionary *, NSString *key, std::optional<WebCore::UserStyleLevel>&, NSString **outExceptionString);
+    static bool parseExecutionWorld(NSDictionary *, std::optional<WebExtensionContentWorldType>&, NSString **outExceptionString);
+    static bool parseCSSInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
+    static bool parseTargetInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
+    static bool parseScriptInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
+    static bool parseRegisteredContentScripts(NSArray *, FirstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>&, NSString **outExceptionString);
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -1136,7 +1136,7 @@ ${indentString}}
 EOF
     }
 
-    if ($signature->type->name eq "any" && $signature->extendedAttributes->{"NSArray"}) {
+    if ($signature->type->name eq "array") {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1234,7 +1234,7 @@ EOF
 EOF
     }
 
-    if ($signature->type->name eq "any" && $signature->extendedAttributes->{"NSArray"} && !$signature->extendedAttributes->{"Optional"}) {
+    if ($signature->type->name eq "array" && !$signature->extendedAttributes->{"Optional"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1370,7 +1370,6 @@ sub _javaScriptTypeCondition
     return "isDictionary(context, ${argument}) || JSValueIsString(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"DOMString"};
     return "(!JSValueIsNull(context, ${argument}) && !JSValueIsUndefined(context, ${argument}) && !JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr)))${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"Serialization"};
     return "isDictionary(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSDictionary"};
-    return "JSValueIsArray(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSArray"};
     return "JSValueIsObject(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSObject"};
     return "JSValueIsObject(context, ${argument})${nullOrUndefined}" if $idlTypeName eq "any" && !$signature->extendedAttributes->{"ValuesAllowed"};
     return "(JSValueIsObject(context, ${argument}) && JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr)))${nullOrUndefined}" if $idlTypeName eq "function";
@@ -1391,7 +1390,7 @@ sub _platformType
     $idlTypeName = $idlType->name if ref($idlType) eq "IDLType";
 
     return "RefPtr<WebExtensionCallbackHandler>" if $idlTypeName eq "function" && $signature->extendedAttributes->{"CallbackHandler"};
-    return "NSArray" if $idlTypeName eq "array" && $signature && $signature->extendedAttributes->{"NSArray"};
+    return "NSArray" if $idlTypeName eq "array";
     return "NSString" if $idlTypeName eq "any" && $signature->extendedAttributes->{"Serialization"};
     return "NSDictionary" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSDictionary"};
     return "NSObject" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSObject"};
@@ -1424,8 +1423,6 @@ sub _platformTypeConstructor
         return "toNSDictionary(context, $argumentName, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"NSDictionary"} && $signature->extendedAttributes->{"NSDictionary"} eq "StopAtTopLevel";
         return "toNSDictionary(context, $argumentName, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"NSDictionary"} && $signature->extendedAttributes->{"NSDictionary"} eq "NullAllowed";
         return "toNSDictionary(context, $argumentName, NullValuePolicy::NotAllowed)" if $signature->extendedAttributes->{"NSDictionary"};
-        return "toNSArray(context, $argumentName, $arrayType.class)" if $signature->extendedAttributes->{"NSArray"} && $arrayType;
-        return "toNSArray(context, $argumentName)" if $signature->extendedAttributes->{"NSArray"};
         return "toNSObject(context, $argumentName, Nil, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"NSObject"} eq "StopAtTopLevel";
         return "toNSObject(context, $argumentName, Nil, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"NSObject"} eq "NullAllowed";
         return "toNSObject(context, $argumentName)" if $signature->extendedAttributes->{"NSObject"};

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
@@ -33,8 +33,8 @@
     [RaisesException] void insertCSS([NSDictionary] any details, [Optional, CallbackHandler] function callback);
     [RaisesException] void removeCSS([NSDictionary] any details, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void registerContentScripts([NSObject] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void registerContentScripts([NSArray=NSDictionary] array scripts, [Optional, CallbackHandler] function callback);
     [RaisesException] void getRegisteredContentScripts([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
     [RaisesException] void unregisterContentScripts([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
-    [RaisesException] void updateContentScripts([NSObject] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void updateContentScripts([NSArray=NSDictionary] array scripts, [Optional, CallbackHandler] function callback);
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -58,27 +58,27 @@ TEST(WKWebExtensionAPIScripting, ErrorsExecuteScript)
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.scripting.executeScript(), /a required argument is missing/i)",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({}), /missing required keys: 'target'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target' : {}}), /missing required keys: 'tabId'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 'j'}}), /'tabId' is expected to be a number, but a string was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target' : { }}), /missing required keys: 'tabId'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 'bad'}}), /'tabId' is expected to be a number, but a string was provided./i)",
 
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0}, 'func': () => { console.log('function') }, 'function': () => {console.log('function')}}), /it cannot specify both 'func' and 'function'. Please use 'func'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: ['args'], func: () => 'function', arguments: ['arguments']}), /it cannot specify both 'args' and 'arguments'. Please use 'args'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: ['args'], files: ['path/to/file']}), /it must specify both 'func' and 'args'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, 'func': () => { console.log('function') }, 'function': () => {console.log('function')}}), /it cannot specify both 'func' and 'function'. Please use 'func'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, args: ['args'], func: () => 'function', arguments: ['arguments']}), /it cannot specify both 'args' and 'arguments'. Please use 'args'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, args: ['args'], files: ['path/to/file']}), /it must specify both 'func' and 'args'./i)",
 
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: 0, func: () => 'function' }), /'args' is expected to be an array, but a number was provided./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, func: () => 'function', args: [ () => 'arguments' ] }), /it is not JSON-serializable./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, args: 0, func: () => 'function' }), /'args' is expected to be an array, but a number was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, func: () => 'function', args: [ () => 'arguments' ] }), /it is not JSON-serializable./i)",
 
         @"const notAFunction = null",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, func: 'not a function' }), /is expected to be a value, but a string was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, func: 'not a function' }), /is expected to be a value, but a string was provided./i)",
 
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }}), /it must specify either 'func' or 'files'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: ['args'], files: [0]}), /'files' is expected to be an array of strings, but a number was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }}), /it must specify either 'func' or 'files'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, args: ['args'], files: [0]}), /'files' is expected to be an array of strings, but a number was provided./i)",
 
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0, allFrames: true, frameIds: [0] }, files: ['path/to/file']}), /it cannot specify both 'allFrames' and 'frameIds'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0, frameIds: ['0'] }, files: ['path/to/file']}), /'frameIds' is expected to be an array of numbers, but a string was provided./i)",
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0, frameIds: [-1] }, files: ['path/to/file']}), /'-1' is not a frame identifier./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1, allFrames: true, frameIds: [0] }, files: ['path/to/file']}), /it cannot specify both 'allFrames' and 'frameIds'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1, frameIds: ['0'] }, files: ['path/to/file']}), /'frameIds' is expected to be an array of numbers, but a string was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1, frameIds: [-1] }, files: ['path/to/file']}), /'-1' is not a frame identifier./i)",
 
-        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, world: 'world', files: ['path/to/file']}), /it must specify either 'ISOLATED' or 'MAIN'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 1 }, world: 'world', files: ['path/to/file']}), /it must specify either 'isolated' or 'main'./i)",
 
         @"browser.test.notifyPass()"
     ]);
@@ -92,17 +92,17 @@ TEST(WKWebExtensionAPIScripting, ErrorsCSS)
         @"browser.test.assertThrows(() => browser.scripting.insertCSS(), /a required argument is missing./i)",
         @"browser.test.assertThrows(() => browser.scripting.insertCSS({}), /missing required keys: 'target'./i)",
         @"browser.test.assertThrows(() => browser.scripting.insertCSS({ target: {} }), /missing required keys: 'tabId'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: 0 }, files: ['path/to/file'], css: 'css'}), /it cannot specify both 'css' and 'files'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: 0 }}), /it must specify either 'css' or 'files'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: '0' }, files: ['path/to/file'], css: 'css'}), /'tabId' is expected to be a number, but a string was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: 1 }, files: ['path/to/file'], css: 'css'}), /it cannot specify both 'css' and 'files'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: 1 }}), /it must specify either 'css' or 'files'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: '1' }, files: ['path/to/file'], css: 'css'}), /'tabId' is expected to be a number, but a string was provided./i)",
         @"browser.test.assertThrows(() => browser.scripting.insertCSS({target: { tabId: 1 }, css: 'body { color: red }', origin: 'bad' }), /'origin' value is invalid, because it must specify either 'AUTHOR' or 'USER'/i);",
 
         @"browser.test.assertThrows(() => browser.scripting.removeCSS(), /a required argument is missing./i)",
         @"browser.test.assertThrows(() => browser.scripting.removeCSS({}), /missing required keys: 'target'./i)",
         @"browser.test.assertThrows(() => browser.scripting.removeCSS({ target: {} }), /missing required keys: 'tabId'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.removeCSS({target: { tabId: 0 }, files: ['path/to/file'], css: 'css'}), /it cannot specify both 'css' and 'files'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.removeCSS({target: { tabId: 0 } }), /it must specify either 'css' or 'files'./i)",
-        @"browser.test.assertThrows(() => browser.scripting.removeCSS({target: { tabId: '0' }, files: ['path/to/file'], css: 'css'}), /'tabId' is expected to be a number, but a string was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.removeCSS({target: { tabId: 1 }, files: ['path/to/file'], css: 'css'}), /it cannot specify both 'css' and 'files'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.removeCSS({target: { tabId: 1 } }), /it must specify either 'css' or 'files'./i)",
+        @"browser.test.assertThrows(() => browser.scripting.removeCSS({target: { tabId: 'bad' }, files: ['path/to/file'], css: 'css'}), /'tabId' is expected to be a number, but a string was provided./i)",
 
         @"browser.test.notifyPass()"
     ]);
@@ -126,12 +126,12 @@ TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)
 
         @"browser.test.assertThrows(() => browser.scripting.registerContentScripts([{ id: '0', matches: [ '*://*/*' ] }]), /it must specify at least one 'css' or 'js' file/i)",
         @"browser.test.assertThrows(() => browser.scripting.registerContentScripts([{ id: '0', matches: [ '*://*/*' ], js: ['path/to/file'], runAt: 'invalid_runAt' }]), /it must specify either 'document_start', 'document_end', or 'document_idle'/i)",
-        @"browser.test.assertThrows(() => browser.scripting.registerContentScripts([{ id: '0', matches: [ '*://*/*' ], js: ['path/to/file'], world: 'invalid_world' }]), /it must specify either 'ISOLATED' or 'MAIN'/i)",
+        @"browser.test.assertThrows(() => browser.scripting.registerContentScripts([{ id: '0', matches: [ '*://*/*' ], js: ['path/to/file'], world: 'invalid_world' }]), /it must specify either 'isolated' or 'main'/i)",
         @"browser.test.assertThrows(() => browser.scripting.registerContentScripts([{ id: '0', matches: [ '*://*/*' ], css: ['style.css'], cssOrigin: 'bad' }]), /'cssOrigin' value is invalid, because it must specify either 'author' or 'user'/i)",
 
         @"browser.test.assertThrows(() => browser.scripting.updateContentScripts([{ id: '_0' }]), /it must not start with '_'/i)",
         @"browser.test.assertThrows(() => browser.scripting.updateContentScripts([{ id: '0', matches: [ ], js: ['path/to/file'] }]), /it must not be empty/i)",
-        @"browser.test.assertThrows(() => browser.scripting.updateContentScripts([{ id: '0', matches: [ '*://*/*' ], js: ['path/to/file'], world: 'invalid_world' }]), /it must specify either 'ISOLATED' or 'MAIN'/i)",
+        @"browser.test.assertThrows(() => browser.scripting.updateContentScripts([{ id: '0', matches: [ '*://*/*' ], js: ['path/to/file'], world: 'invalid_world' }]), /it must specify either 'isolated' or 'main'/i)",
 
         @"browser.test.assertThrows(() => browser.scripting.getRegisteredContentScripts([]), /an object is expected/i)",
         @"browser.test.assertThrows(() => browser.scripting.getRegisteredContentScripts({ ids: 0 }), /'ids' is expected to be an array of strings, but a number was provided/i)",
@@ -659,13 +659,10 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScripts)
         @"  const tabId = details.tabId",
 
         @"  var expectedResults = [{",
-        @"    allFrames: false,",
         @"    id: '1',",
         @"    js: ['changeBackgroundColorScript.js', 'changeBackgroundFontScript.js'],",
         @"    matches: ['*://localhost/*'],",
         @"    persistAcrossSessions: true,",
-        @"    runAt: 'document_idle',",
-        @"    world: 'ISOLATED'",
         @"  }]",
 
         @"  var results",
@@ -847,13 +844,10 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
         @"  const tabId = details.tabId",
 
         @"  var expectedResults = [{",
-        @"    allFrames: false,",
         @"    id: '1',",
         @"    js: ['changeBackgroundColorScript.js'],",
         @"    matches: ['*://localhost/*'],",
         @"    persistAcrossSessions: true,",
-        @"    runAt: 'document_idle',",
-        @"    world: 'ISOLATED'",
         @"  }]",
 
         @"  var results",
@@ -865,7 +859,7 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
         @"  expectedResults[0].allFrames = true",
         @"  expectedResults[0].persistAcrossSessions = false",
         @"  expectedResults[0].runAt = 'document_start'",
-        @"  expectedResults[0].world = 'MAIN'",
+        @"  expectedResults[0].world = 'main'",
 
         @"  browser.test.assertDeepEq(results, expectedResults)",
 
@@ -928,13 +922,10 @@ TEST(WKWebExtensionAPIScripting, GetContentScripts)
         @"browser.webNavigation.onCompleted.addListener(async () => {",
 
         @"  var expectedResults = [{",
-        @"    allFrames: false,",
         @"    id: '1',",
         @"    js: ['changeBackgroundColorScript.js'],",
         @"    matches: ['*://localhost/*'],",
         @"    persistAcrossSessions: true,",
-        @"    runAt: 'document_idle',",
-        @"    world: 'ISOLATED'",
         @"  }]",
 
         @"  var results",
@@ -954,7 +945,7 @@ TEST(WKWebExtensionAPIScripting, GetContentScripts)
         @"  await browser.scripting.registerContentScripts([{ id: '2', matches: ['*://localhost/*'], js: ['changeBackgroundFontScript.js'], runAt: 'document_start', world: 'MAIN' }])",
 
         @"  results = await browser.scripting.getRegisteredContentScripts({ 'ids': ['1', '2'] })",
-        @"  expectedResults.push({ allFrames: false, id: '2', js: ['changeBackgroundFontScript.js'], matches: ['*://localhost/*'], persistAcrossSessions: true, runAt: 'document_start', world: 'MAIN' })",
+        @"  expectedResults.push({ id: '2', js: ['changeBackgroundFontScript.js'], matches: ['*://localhost/*'], persistAcrossSessions: true, runAt: 'document_start', world: 'main' })",
         @"  browser.test.assertDeepEq(results, expectedResults)",
 
         @"  await browser.scripting.unregisterContentScripts()",


### PR DESCRIPTION
#### cd1dcbdc10539d2af3dfd48185ebefd6b429d811
<pre>
Simplify Web Extension scripting options parsing.
<a href="https://webkit.org/b/281264">https://webkit.org/b/281264</a>
<a href="https://rdar.apple.com/problem/137716833">rdar://problem/137716833</a>

Reviewed by Brian Weinstein.

We were touching the options dictionaries twice, in a validate and parse call. These can be combined
to reduce the distance from the two steps and prevent errors — since we always do both steps together.
This is in preparation for adding `documentIds` support.

Also fixed a regression, where we were not case-insensitive comparing the `world` and `css_origin` values
when parsing the manifest. And just change them to lowercase in the keys for consistency and based on
agreement to do this in the WECG.

Some tests needed new baselines for these changes, where `tabId` was throwing an invalid error for `0`
before the expected error was hit due to changes in parsing order.

Also don&apos;t output optional keys that were not originally set when calling `getRegisteredContentScripts()`.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::loadRegisteredContentScripts):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIScripting::executeScript):
(WebKit::WebExtensionAPIScripting::insertCSS):
(WebKit::WebExtensionAPIScripting::removeCSS):
(WebKit::WebExtensionAPIScripting::registerContentScripts):
(WebKit::WebExtensionAPIScripting::getRegisteredContentScripts):
(WebKit::WebExtensionAPIScripting::updateContentScripts):
(WebKit::WebExtensionAPIScripting::unregisterContentScripts):
(WebKit::WebExtensionAPIScripting::validateFilter):
(WebKit::WebExtensionAPIScripting::parseStyleLevel):
(WebKit::WebExtensionAPIScripting::parseExecutionWorld):
(WebKit::WebExtensionAPIScripting::parseTargetInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseScriptInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseCSSInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts):
(WebKit::WebExtensionAPIScripting::validateScript): Deleted.
(WebKit::WebExtensionAPIScripting::validateTarget): Deleted.
(WebKit::WebExtensionAPIScripting::validateCSS): Deleted.
(WebKit::WebExtensionAPIScripting::validateRegisteredScripts): Deleted.
(WebKit::WebExtensionAPIScripting::hasValidExecutionWorld): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_installArgumentTypeExceptions):
(_installAutomaticExceptions):
(_javaScriptTypeCondition):
(_platformType):
(_platformTypeConstructor):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ErrorsExecuteScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ErrorsCSS)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScripts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, UpdateContentScripts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, GetContentScripts)):

Canonical link: <a href="https://commits.webkit.org/285033@main">https://commits.webkit.org/285033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4317e922ca27880c04164dbdc14f48d2ae23f1de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71350 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/50763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/24123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73465 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58563 "Failed to checkout and rebase branch from PR 35015") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/22374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74416 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/58563 "Failed to checkout and rebase branch from PR 35015") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/24123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/58563 "Failed to checkout and rebase branch from PR 35015") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/24123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/58563 "Failed to checkout and rebase branch from PR 35015") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/24123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/15584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/22374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/15627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/24123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/24123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10931 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/46563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->