### PR TITLE
REGRESSION: ASSERTION FAILED: repaintRects() in WebCore::RenderLayer::recursiveUpdateLayerPositions.

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2096,26 +2096,11 @@ webkit.org/b/221021 webanimations/combining-transform-animations-with-different-
 webkit.org/b/221021 webanimations/combining-transform-animations-with-different-acceleration-capabilities-5.html [ Skip ]
 webkit.org/b/221021 webanimations/combining-transform-animations-with-different-acceleration-capabilities.html [ Skip ]
 
-webkit.org/b/281041 [ Debug ] animations/animation-direction-reverse-hardware-opacity.html [ Crash ]
-webkit.org/b/281041 [ Debug ] compositing/backing/zero-opacity-invalidation.html [ Crash ]
-webkit.org/b/281041 [ Debug ] compositing/geometry/limit-layer-bounds-opacity-transition.html [ Crash ]
-webkit.org/b/281041 [ Debug ] imported/blink/compositing/squashing/animation-repaint-crash.html [ Crash ]
-webkit.org/b/281041 [ Debug ] imported/w3c/web-platform-tests/css/css-animations/animation-before-initial-box-construction-001.html [ Crash ]
-webkit.org/b/281041 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition.html [ Crash ]
-webkit.org/b/281041 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked.html [ Crash ]
-webkit.org/b/281041 [ Debug ] imported/w3c/web-platform-tests/paint-timing/fcp-only/fcp-pseudo-element-opacity.html [ Crash ]
-webkit.org/b/281041 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative.html [ Crash ]
-webkit.org/b/281041 [ Debug ] animations/animation-followed-by-two-transitions.html [ Crash ]
-webkit.org/b/281041 [ Debug ] fullscreen/fullscreen-restore-scroll-position.html [ Crash ]
-
 webkit.org/b/281211 [ Debug ] fast/mediastream/captureStream/canvas3d.html [ Crash ]
 webkit.org/b/281211 [ Debug ] fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html [ Crash ]
 webkit.org/b/281211 [ Debug ] http/wpt/mediastream/transfer-videotrackgenerator-track.html [ Crash ]
 webkit.org/b/281211 [ Debug ] imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html [ Crash ]
 webkit.org/b/281211 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-entry.html [ Crash ]
-
-# *repaintRects() == renderer().rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes)
-webkit.org/b/281211 [ Debug ] imported/w3c/web-platform-tests/css/css-scroll-snap/snap-area-capturing-add-scroll-container.html [ Crash ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebAnimations-related bugs
@@ -4094,7 +4079,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/modify-style-via-cssom.
 imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked.html [ ImageOnlyFailure ]
-# imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-auto.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1024,9 +1024,6 @@ webkit.org/b/53675 fast/animation/request-animation-frame-during-modal.html [ Sk
 
 webkit.org/b/191584 fast/animation/css-animation-resuming-when-visible-with-style-change.html [ Pass Timeout ]
 
-webkit.org/b/281041 [ Debug ] animations/animation-direction-reverse-hardware-opacity.html [ Skip ] # Crash
-webkit.org/b/281041 [ Debug ] animations/animation-followed-by-two-transitions.html [ Skip ] # Crash
-webkit.org/b/281041 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative.html [ Skip ] # Crash
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Compositing

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -729,6 +729,7 @@ public:
     inline float textStrokeWidth() const;
     inline float opacity() const;
     inline bool hasOpacity() const;
+    inline bool hasZeroOpacity() const;
     inline StyleAppearance appearance() const;
     inline StyleAppearance usedAppearance() const;
     inline AspectRatioType aspectRatioType() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -320,6 +320,7 @@ inline bool RenderStyle::hasViewportConstrainedPosition() const { return positio
 inline bool RenderStyle::hasVisibleBorder() const { return border().hasVisibleBorder(); }
 inline bool RenderStyle::hasVisibleBorderDecoration() const { return hasVisibleBorder() || hasBorderImage(); }
 inline bool RenderStyle::hasVisitedLinkAutoCaretColor() const { return m_rareInheritedData->hasVisitedLinkAutoCaretColor; }
+inline bool RenderStyle::hasZeroOpacity() const { return m_nonInheritedData->miscData->hasZeroOpacity(); }
 inline const Length& RenderStyle::height() const { return m_nonInheritedData->boxData->height(); }
 inline short RenderStyle::hyphenationLimitAfter() const { return m_rareInheritedData->hyphenationLimitAfter; }
 inline short RenderStyle::hyphenationLimitBefore() const { return m_rareInheritedData->hyphenationLimitBefore; }

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -60,6 +60,7 @@ public:
     bool operator==(const StyleMiscNonInheritedData&) const;
 
     bool hasOpacity() const { return opacity < 1; }
+    bool hasZeroOpacity() const { return !opacity; }
     bool hasFilters() const;
     bool contentDataEquivalent(const StyleMiscNonInheritedData&) const;
 


### PR DESCRIPTION
#### b37bf876c9b79cfe225c7858c23e58e8a2cd43e6
<pre>
REGRESSION: ASSERTION FAILED: repaintRects() in WebCore::RenderLayer::recursiveUpdateLayerPositions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281041">https://bugs.webkit.org/show_bug.cgi?id=281041</a>
&lt;<a href="https://rdar.apple.com/137722495">rdar://137722495</a>&gt;

Reviewed by Simon Fraser.

The presence of repaintRects now depends on isVisibilityHiddenOrOpacityZero(),
not just hasVisibleContent.  Make sure we invalidate layer positions for opacity
changes, and change the logging to be the value that we care about.

Also switches the layer assertions to preferentially use debug asserts, so that
they are in use more often.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::outputLayerPositionTreeLegend):
(WebCore::outputLayerPositionTreeRecursive):

Canonical link: <a href="https://commits.webkit.org/285155@main">https://commits.webkit.org/285155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d11aef88bd6639f23507db8afcce238a6aa0ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75666 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56512 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14984 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19098 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77474 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64301 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15851 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6006 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->