### PR TITLE
[WebGPU] ASTC textures have wrong bytesPerRow when computed automatically

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281271-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281271-expected.txt
@@ -1,0 +1,153 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 785x991
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x991
+  RenderBlock {HTML} at (0,0) size 785x991 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x975
+      RenderText {#text} at (0,137) size 97x17
+        text run at (0,137) width 97: "\x{4468}\x{113C}\x{14DE}\x{BF15}\x{D83E}\x{DFB3}\x{C112}\x{DF8}"
+      RenderText {#text} at (396,137) size 45x17
+        text run at (396,137) width 45: "\x{B75F}\x{4B1}\x{D06}"
+      RenderText {#text} at (440,137) size 86x17
+        text run at (440,137) width 86: "\x{16EC}\x{AC93}\x{BEDA}\x{4339}\x{D83D}\x{DE86}\x{9CDE}"
+      RenderText {#text} at (525,137) size 92x17
+        text run at (525,137) width 12: "\x{ADB}"
+        text run at (536,137) width 14 RTL: "\x{8B8}"
+        text run at (549,137) width 68: "\x{8EDA}\x{5396}\x{F773}\x{D83F}\x{DC1C}\x{6C53}"
+      RenderText {#text} at (616,137) size 31x17
+        text run at (616,137) width 31: "\x{CC21}\x{4064}"
+      RenderText {#text} at (646,137) size 113x17
+        text run at (646,137) width 61: "\x{1F12}\x{9F14}\x{C770}\x{D83D}\x{DF00}\x{D83F}\x{DD8A}"
+        text run at (706,137) width 12 RTL: "\x{5ED}"
+        text run at (717,137) width 42: "\x{3705}\x{D83E}\x{DDA9}\x{3F2}"
+      RenderText {#text} at (0,354) size 79x17
+        text run at (0,354) width 79: "\x{D83F}\x{DF4F}\x{B89E}\x{8FA3}\x{D83D}\x{DF1A}\x{B8DB}\x{19}"
+      RenderText {#text} at (78,354) size 97x17
+        text run at (78,354) width 97: "\x{3947}\x{6B59}\x{3A5C}\x{5FFF}\x{C380}\x{194}\x{D83F}\x{DF33}"
+      RenderText {#text} at (385,354) size 127x17
+        text run at (385,354) width 18 RTL: "\x{7D3}\x{FAA}"
+        text run at (402,354) width 110: "\x{54F7}\x{1CA}\x{105}\x{C0AA}\x{D382}\x{1B32}\x{D83D}\x{DE9C}\x{E02}"
+      RenderText {#text} at (511,354) size 135x17
+        text run at (511,354) width 135: "\x{150}\x{D83E}\x{DCBB}\x{E1F2}\x{666D}\x{D83F}\x{DD69}\x{A783}\x{7767}\x{D83D}\x{DE44}\x{E4F2}\x{513}\x{D83F}\x{DEF9}"
+      RenderText {#text} at (645,354) size 47x17
+        text run at (645,354) width 47: "\x{40C9}\x{E09}\x{D83D}\x{DFEE}\x{D83F}\x{DF65}"
+      RenderText {#text} at (691,354) size 67x17
+        text run at (691,354) width 67: "\x{3CAC}\x{8D6}\x{5FCF}\x{6D1B}\x{F10F}\x{D83F}\x{DCD2}"
+      RenderText {#text} at (0,354) size 769x47
+        text run at (757,354) width 12: "\x{A7F}"
+        text run at (0,384) width 130: "\x{BA1D}\x{B87}\x{B54E}\x{C02D}\x{2209}\x{62FB}\x{D83F}\x{DC0D}\x{D83E}\x{DF1C}\x{CEF}\x{4B2B}"
+      RenderText {#text} at (129,384) size 43x17
+        text run at (129,384) width 43: "\x{6126}\x{1079}\x{D83D}\x{DFF2}"
+      RenderText {#text} at (171,384) size 62x17
+        text run at (171,384) width 21: "\x{D83E}\x{DDE3}"
+        text run at (191,384) width 12 RTL: "\x{FB22}"
+        text run at (202,384) width 31: "\x{8406}\x{B45E}"
+      RenderText {#text} at (232,384) size 128x17
+        text run at (232,384) width 112: "\x{AE5F}\x{AC04}\x{C898}\x{B488}\x{4068}\x{D83F}\x{DD7D}\x{D83D}\x{DFF6}\x{AE22}"
+        text run at (343,384) width 6 RTL: "\x{5D5}"
+        text run at (348,384) width 12: "\x{230}"
+      RenderText {#text} at (359,384) size 41x17
+        text run at (359,384) width 41: "\x{D83D}\x{DF24}\x{F31F}\x{9ABB}"
+      RenderText {#text} at (399,384) size 91x17
+        text run at (399,384) width 91: "\x{BDD0}\x{4A2}\x{67E3}\x{191}\x{C565}\x{DC8B}\x{15AA}\x{9E8}"
+      RenderText {#text} at (300,553) size 108x17
+        text run at (300,553) width 108: "\x{8D1}\x{E1C7}\x{46C0}\x{4C8C}\x{477}\x{F189}\x{D83E}\x{DE0E}\x{D83D}\x{DF8A}\x{32A3}"
+      RenderText {#text} at (407,553) size 119x17
+        text run at (407,553) width 82: "\x{42D}\x{9AB}\x{89E}\x{B6B4}\x{7894}\x{D83F}\x{DFDE}\x{DAF}"
+        text run at (488,553) width 5 RTL: "\x{673}"
+        text run at (492,553) width 34: "\x{3F2B}\x{F85}\x{EAF5}"
+      RenderText {#text} at (525,553) size 138x17
+        text run at (525,553) width 10: "\x{F8F}"
+        text run at (534,553) width 14 RTL: "\x{806}"
+        text run at (547,553) width 98: "\x{D83E}\x{DD91}\x{C8D2}\x{C11E}\x{D83F}\x{DEBE}\x{D83D}\x{DE69}\x{C50}\x{9423}"
+        text run at (644,553) width 8 RTL: "\x{8AE}"
+        text run at (651,553) width 12: "\x{EAC}"
+      RenderText {#text} at (662,553) size 76x17
+        text run at (662,553) width 76: "\x{4993}\x{6CC2}\x{D83F}\x{DE51}\x{387}\x{BDA8}\x{8F95}"
+      RenderText {#text} at (0,553) size 753x108
+        text run at (737,553) width 16: "\x{BC30}"
+        text run at (0,644) width 64: "\x{158A}\x{D83D}\x{DF82}\x{3F35}\x{347F}\x{D83E}\x{DC05}"
+      RenderText {#text} at (63,644) size 56x17
+        text run at (63,644) width 56: "\x{5F23}\x{B049}\x{289C}\x{B379}"
+      RenderText {#text} at (118,644) size 89x17
+        text run at (118,644) width 83: "\x{6295}\x{249F}\x{9746}\x{D83E}\x{DC8D}\x{D83F}\x{DD62}\x{D415}"
+        text run at (200,644) width 7 RTL: "\x{7D4}"
+      RenderText {#text} at (206,644) size 82x17
+        text run at (206,644) width 82: "\x{E0A}\x{4DDA}\x{D83D}\x{DE0F}\x{1376}\x{768D}\x{CC3F}\x{F19}\x{5AE}"
+      RenderImage {IMG} at (0,666) size 196x248
+      RenderText {#text} at (237,901) size 86x17
+        text run at (237,901) width 86: "\x{1F6}\x{D83E}\x{DDBA}\x{CDA5}\x{2B5}\x{7CB4}\x{8930}"
+      RenderText {#text} at (322,901) size 34x17
+        text run at (322,901) width 16: "\x{FE69}"
+        text run at (337,901) width 14 RTL: "\x{FEB6}"
+        text run at (350,901) width 6: "\x{A1}"
+      RenderText {#text} at (355,901) size 77x17
+        text run at (355,901) width 21: "\x{DE39}\x{E22}"
+        text run at (375,901) width 16 RTL: "\x{60B}\x{66D}"
+        text run at (390,901) width 42: "\x{65AD}\x{6F5E}\x{D83F}\x{DE54}"
+      RenderText {#text} at (431,901) size 71x17
+        text run at (431,901) width 29: "\x{4AC}\x{2B1E}\x{93A9}"
+        text run at (459,901) width 1 RTL: "\x{61C}"
+        text run at (459,901) width 43: "\x{D83D}\x{DE15}\x{F86B}\x{A5E4}"
+      RenderText {#text} at (501,901) size 127x17
+        text run at (501,901) width 127: "\x{94CE}\x{96F6}\x{9504}\x{1887}\x{3AFB}\x{C9C0}\x{804C}\x{6D89}\x{CDAD}"
+      RenderText {#text} at (627,901) size 47x17
+        text run at (627,901) width 47: "\x{FF79}\x{D83F}\x{DE7B}\x{1D07}\x{D83E}\x{DDEB}"
+      RenderText {#text} at (673,901) size 52x17
+        text run at (673,901) width 11: "\x{DA9}"
+        text run at (683,901) width 10 RTL: "\x{70A}"
+        text run at (692,901) width 33: "\x{B9E5}\x{9F1}\x{B5}"
+      RenderText {#text} at (0,901) size 762x41
+        text run at (724,901) width 38: "\x{F9C2}\x{D83F}\x{DFFE}\x{E975}"
+        text run at (0,925) width 56: "\x{4A71}\x{C68F}\x{9EE0}\x{FB1B}"
+      RenderText {#text} at (55,925) size 26x17
+        text run at (55,925) width 15 RTL: "\x{8A1}"
+        text run at (69,925) width 12: "\x{F6D}"
+      RenderText {#text} at (80,925) size 138x17
+        text run at (80,925) width 138: "\x{2F97}\x{AE1}\x{ADD3}\x{184E}\x{4E1D}\x{5EE2}\x{981}\x{A12F}\x{D83E}\x{DCFA}\x{CB22}\x{93FC}"
+      RenderText {#text} at (217,925) size 120x17
+        text run at (217,925) width 95: "\x{D83F}\x{DEAD}\x{67B9}\x{D83E}\x{DFD0}\x{3AFF}\x{19C}\x{2A5D}\x{4178}"
+        text run at (311,925) width 15 RTL: "\x{725}"
+        text run at (325,925) width 12: "\x{D83F}\x{DD92}"
+      RenderText {#text} at (336,925) size 102x17
+        text run at (336,925) width 65: "\x{815D}\x{6CFD}\x{D83D}\x{DF5E}\x{1B80}\x{3A5}"
+        text run at (400,925) width 14 RTL: "\x{84F}"
+        text run at (413,925) width 25: "\x{D2A}\x{386}"
+      RenderText {#text} at (437,925) size 22x17
+        text run at (437,925) width 22: "\x{DDF9}\x{E182}"
+      RenderText {#text} at (458,925) size 138x17
+        text run at (458,925) width 138: "\x{10D0}\x{9C26}\x{92E8}\x{C6DD}\x{84BB}\x{9D2C}\x{D83F}\x{DD9B}\x{D83F}\x{DFC8}\x{D83F}\x{DFF1}\x{31F}\x{E74A}"
+      RenderText {#text} at (595,925) size 129x17
+        text run at (595,925) width 129: "\x{5C6E}\x{828C}\x{F7A}\x{7C56}\x{F84E}\x{B2DF}\x{9FA6}\x{ED6}\x{5A13}\x{D83E}\x{DF47}"
+      RenderText {#text} at (0,925) size 766x45
+        text run at (723,925) width 17 RTL: "\x{790}"
+        text run at (739,925) width 27: "\x{F692}\x{C57F}"
+        text run at (0,953) width 48: "\x{EA76}\x{E30}\x{8FEC}\x{FF1B}"
+        text run at (47,953) width 12 RTL: "\x{8C6}"
+        text run at (58,953) width 27: "\x{D83E}\x{DE41}\x{AD46}"
+      RenderText {#text} at (84,953) size 86x17
+        text run at (84,953) width 86: "\x{55D9}\x{24D6}\x{3488}\x{B653}\x{FAA}\x{526D}"
+      RenderText {#text} at (169,953) size 55x17
+        text run at (169,953) width 55: "\x{D83E}\x{DE67}\x{D83E}\x{DEB0}\x{D256}\x{241}"
+      RenderText {#text} at (223,953) size 53x17
+        text run at (223,953) width 53: "\x{B836}\x{543D}\x{D83F}\x{DCE8}\x{D83F}\x{DE2B}"
+      RenderText {#text} at (275,953) size 130x17
+        text run at (275,953) width 16: "\x{6616}"
+        text run at (290,953) width 16 RTL: "\x{851}"
+        text run at (305,953) width 100: "\x{74F0}\x{D83F}\x{DC0E}\x{58E}\x{5EBD}\x{4BEC}\x{8C06}\x{3AEA}"
+      RenderText {#text} at (404,953) size 71x17
+        text run at (404,953) width 71: "\x{EEB3}\x{EEA}\x{E123}\x{48D}\x{974A}\x{CF66}\x{20EB}"
+      RenderText {#text} at (474,953) size 118x17
+        text run at (474,953) width 118: "\x{248}\x{D83D}\x{DEDF}\x{337C}\x{4CAB}\x{D83D}\x{DFB7}\x{D83F}\x{DE66}\x{93AA}\x{FF75}\x{7AFB}"
+layer at (104,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (96,0) size 301x150
+layer at (182,164) size 211x211
+  RenderVideo {VIDEO} at (174,156) size 212x211
+layer at (8,424) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,416) size 300x150
+layer at (295,583) size 481x82
+  RenderHTMLCanvas {CANVAS} at (287,575) size 482x82
+layer at (204,881) size 41x41
+  RenderVideo {VIDEO} at (196,873) size 41x41

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281271.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281271.html
@@ -1,0 +1,24312 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAADsxtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAAK5KAGvMIECQQDmVRIR0OprE3zy/7QkP/TcLIgSkYCW3cqRB+Ysc55SnvgCNkitMJJgwCp7ziPmqcTfIJvMGxQOHeCQ9+/cAAADAFCnSCgwauupZ8i3gwadFBp5ZB//QMEKEQABeUyOgNE1Y66GP6lVMgON+ki9Y47273P45yWZRNKr6Cy3Ptz0XIckdtUjTxEO7ID1E2r8SsZP6zv5B54vjBTckJRXh1AGZ6ifOCSYArxC+f8BtGNTchfnHy5KyEDhlnn2a6sJpbMDJfnbSYmQ369jVJGFJw4JLRl7ePTbQbkj//8uXGzfTj2xI7Qqvwb178x2FKHlDqNbhVDRyziy96nGo2+NuttBSrBXjmwVp0gM7yFiFO612uEej9nFJDw5FXhJaxeiPY/D7PS/A/Ogd1pepcTjbfT0mrijo44MStF4INzDMRe3FjnSPdtDDuK6B3MsiKRnQZM3iTzH+dFqSwal7gdXMI+ZL6cEcrXRmWeamg3mrz4fCUoklnMBvUx5v0ZBp9yQq5JeRr7CH4DYArh24t6AI4tTvthnplfYF20WbO58Pe4VwzTZqEbrsktMWSpiT53iexEBt1XvPsxiawaVFAfgkPBOsIMHgQ4+g1skfCnbITwSx7vELwT2xwkDueFG7b5Vd/GkTT4aPnqSwajyDyuOEfMl9OqOVrn7MGfb8prgeU/un5i721ue5+ORyplsGsZLGfua95svDcaoDYbcpBs+PEokJprjECAXWdh8sLD8jtHe90LDtXmXh5zroZh/qFOtqzj7I4k7r5LAc8aXikGhL5xntF8uJhTlMSfqH1INdzkJkgXfYN9Rb8wkxKWVgTMjqU4DnU6ksGotj8q7hHzJfTyjla5s/CZaaDeavTh8Jna9EsmfMksiysuTIkPDUyh4Vw27kFn+hLwdR2wEgj3QplKQWAAAAB9OCQUaR1ZK3FxMQz+U78URPNFDqAPuAADuAgADX/+AAAAASygJk+IJsu7K0Pn93/4a0XbcwlM8tgOVDayYZ/T0ybreIAFuxsg6zystAjsZ99cAiYAD/OuAAFTABcAAAAloAAADAACpgAAAAwAHRAAABAkCAdB4KB4vkECQIBAGBo27nPD3dCoFDJN4AM2AAAAVMD+NaY0AAmpJkg/1OPS7/+U0dH/3SsO0Dm99Xfws+r1rdZGK1vKvpmbAtydGcs5Uvg8JNDLdjt1hedmQp0Qz/tNV06r+47zw/wkogmspfNe5LUmK6A9s2Cd28mx+ngMYnvaeAkqz+kHA1j0YMkn0iNsPGLV5ZmIQIULJgVN/5erA4Qe/DvEm205PblhlwB2zXnJXfdxKzftLzhN6d+89rP+p1ANSQVXWCWGmbZWQliK1/SjfMXnV3R8sif+zCVWxFDqRcsSWXbkE03keHpVYF5rmxX6ZaPKugyRSDY4s9VAXWF2EutOcBBNFewYY+tPKXAfsW+itna6U+nuVhVMVRl/W4rcBXU7KtS4AvFQ+SQ9b8csJ9xtfQzaeCjmWlUyPhsmcgAczQFf/3N60u+os5TI4L/nnUsQFq279XMIp756Qm2iklQEDrqa084NFRKqioPV80F5qFgb58utHEoYqjrmGx/1qg+yQjT+79kREOHaqDzm0Z/HeCT7kTDQNwqRijf3bhZPVuFERBFWSgsVev5Ik88av+zaC6Fg4TV19e6A2t8COiFVw3CHgKqwyeErrTEVNvyeDbWCIP+427vmEMogwTaL8jPxlkCqosd3qEihLq01lM9lCuQJNUL9w0qY7BiwkBKWRXtqvrcxi8FYan7mglKGC3VOQwz5jhrI3NiDziE+klRr86OzPro+PoN3uMnngCZHWf/+U000cvtiOxpsWQ/x/1FiZZi2jGZZ8qHX1Zi/kCTzxq/7OTPmgPJ9ZF4Dtvzb/bxFkCEJqRyOL/q+29I7nnIzIzTNWO08ZD6G6L4Fln13LzYmcANvAndt7rC5A1JtKtxP4E+q8kqm34vBtXbs3689VKCC9fiWl9+32GPSqia85eJy10/KbUjmoWPJD7vVrCuQL9w0qf24lJus2JBGkRfbPyvlWmUEuwt9MkLXJNGGfMc5ofEVIWXMhBuRmhLn6u5jU+hujN1YN91C792ic+nB03CA+UkU/o8moC7W/Iokw5tahoB4FsBad//8F7WmM5pYm26CZDlKbXhgFyzqTabhifxGGiKRoSb3BhoiYCvMXVBnmo9xEO6qY1RxoG04ZJIQjSEt3mnjpTi7RoePWmF6wGZEwTzkYG17erSWZ8gsKjG7iqZ914XB1KtPrFQk2h90I5LsPy6RdJ22+R0BRfuGlTHV0zGbXjXaOPCpxUa9vGrTKDMebSEwnoLDQHccy3KJ926QQg0BMgR8JlQbCLvTieYWUiVLh8gUr4ndRZ3SEWWFVG6Em+cu3zcFR2bl2o3tUdvb00XA8Gmj43HxHY0m51rkyCdgNFgJvGg4Q5hKTrsCAAAAAKgIJpB4KB4vxDkbSUPIlgAR8WAAATUAAAAW8AAA4IAABmQAHLAAZMABJQAAAAUYCAeDwkDyDy+kEHBAgQSpMhZKE9AAKSAAb8KS8ABQQxOb3BjWfrh+WcLwWKTtPCVQREpFyZIEP17j9Mp9+KfPrTHYheTFf2N6Crlpiu3wJSn3e/Rwh7EY9zIf6H9Sxl4r305897GwLn6Xi/weeriHOv92J0HrML9wZ+8m2MSEvbnzrm8Wpl2j9Mp9+KfPrca6278dnouCi93/1eoI6EitKX87HxPrw8N/8RXz2lK8tscz9lWuNDStWFcdS2jrBG9a9gvLX+L6/xGX1P0yn4Ls7XWBBkLNGz7y2bLlpiu3wCaJlM3VEx5si9sh/of0p1L0lTGx72VXUwQkwpMz+he5rWS8N6IKCA86cBh1eOvplPwXZ4TSJbCbHI37E+tXeFiLLH/5zOhqrPvPr/lkP9D+fBYMq1bN73oIDJc0wpG3lQV2gI7rX4AAAACUCCag8JA8g8vsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAACQwIB4HiYeh6Dw+mECAICAgqVg4CAkgf4AA24ACPgpoqmN0j52nzKr7BaeEFnlrLHK/D3ld6ArYyl8PUGGiAmPo88byv1EMfXmyD9z/DlDA+Nes0wzYg9qAa5beI10XyhbGYdVDLjnTNPzAzgQzz2acO54es20J45YdnOfmjdTWSXpTBAVv2iHzpru80mDwBzlHgctuWCupHfwrpX+av/9ehHh68L6wdMO9qw+twWeFVKmSY++C3tuuTAecGIJjVsvvq1ECxTSRfqIY+vNkH7n+HKGB8agJphmxEvUA1y28QRovq5aV/BpFy7lC0/LkuBDPH9ijbgnMnStSPU3O5z8gbZS34DCteo3zch84m7vNJg9284q4HLY/grqR38KYV9sz/ha8qedeF9WsGHm0gf+BnkRA016YWq5D229JDxUzV5h0B0is0TS879RDH15sg97Oot6i6ftZIKbcb3WA6XcTiZj72Na4M9JppTblC0/LkuBC3Qtt0ep8EwfHmnilpMli+wAkkj8SBPcGmwv+cTd3oUkNZ9recVhlclSJ54W4jRtuj1u9o2ngs37g8d6csMDCbaxXjzFHnb4Ob2FFQbkp3icaSLemsga/Kex9ebFT3P8W8MD416zTDNWz2oYLlt4gjRfVy0r+DSvEXKFp+XJaIGeT6lG3GcZOlakeqEdzn5A2ylvwBtGXeZNhf84m4HSpKmKsmvM/ZITvDFB74U0r8QV2RYKtP14X1awMKRUuV7aodZkTuNRoEOPbdcj/71q2NXgAAAACYCCageJh6HoPD7ELqqgJOAmIAAAe8AB0wAFHAALuAAVcAArYABYQAAAyUCAeFo0HoPAevphAgCAgIK5KW2gJIH+AANuAAj4KaKpjdI+dp8yq+wUaDdnSZfUUOdTC2+9C7nhuH4QnudxsPkcTmeYwlyKdku5DqN7izU3m8kfOGv3zjYn+OCOEErdPTkBOiXMIY6/2t+qaDvG/BKliZBxV69YWary12TtgsQn4FPpLaGMEPXavOJaMSvM3syQ61uipMDEbtggtg2M5e0UrSW6UmcPBHdk2knjZWeXncZ/ZMb33J7nr3VM/rb+OY9+g1L7pw8HrXnPX3mnVaIOc52SHN1BAcw1TU1ZfNguDYov6t2UCO6G6pdVGI+J0NxVhdEE9XbVjzxDIZePbQJj861+IDdX/HYIISRoBeKV4eOJedSrg4TfV2xVOoAjL9wDZ2pj5fMnh5wuhLygxGCgFRfGZav8sIlKiVE2zn24WNpddmsPb9tt9ZrEduGwEStfuLqvGTobOVtWzBxvZv/q/aOoujafDzqzww7hwQvaYZ1AbEpzDfeGsXyGSzwUR0w3Wb5E8w9R8H/uxK9RFxWoW3E/NEmZZRzZO+/YFsLK5rJtHI9gv9h6W6YnoC2Qg4pn+obbXojoE+dDZNg4OyyLm4WlvnZjZbFZzP4eratmDjezf/V+0dRdG0+HnVnhh3EWIok18uevBc/JHt5+DVJlgtTG/LOZiAqmNnsyahyrPBhP3iJLssdi/LSj/k20zZQyGWAAuzrqMhzoCpHd2if8KlcQ5uz5Miw7PgpYx80vsyTLd6rKDguTEL+ntQkMUTsZPS51PwmadY9yOmn+ZmUKhxUvLv4YG4zbstrTiGYVKnDTwpfVC4VutAbPHi1ODKjT7Q5xr6ODVJlgan9+2TnJSCneoTDyxShcvbYXTXt0SgkDNanKaKmU+yQ+IhLKkvruMqI1dranp+hpyW+TbG1qxsbMwVN+glXuNX0t1X0gwyPxObpSWN70Y0hzVJCgkYPIldvftwrf8ZR+WBgT6oUO4jjuQspCvxiP5A8CYMoNGEjFvMqANl18E5D4/WUgcnI9zFkblRiSam4qo1TIDMjVSdP9amQt1w3yPP6LyTz6j2msllwAAAAJgIJqFo0HoPAevsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAElW1vb3YAAABsbXZoZAAAAADi56x74uesewAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAQhdHJhawAAAFx0a2hkAAAAD+LnrHvi56x7AAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAANVbWRpYQAAACBtZGhkAAAAAOLnrHvi56x7AAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAvxtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAoRzdGJsAAABQnN0c2QAAAAAAAAAAQAAATJodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAumh2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALBKAAAQAnQAEMEf//AWAAAAMAsAAAAwAAAwBaFcC/WggACDAoUoCAAIBQBhXpoQACACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUMEQkAgACJCCQEBYAAAAwCwAAADAAADAFpIAgIBAWIFe5FlU3DBEJAIogACAAdEAcAsvBTJAAhECUgCixgpkicAAQAJTgGlBBAAf5CAAAAAEmNvbHJuY2xjAAwAEQAJAAAADGFsbW8AAAECAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAA1IAAAQ7AAABcwAAAnEAAANTAAAAJHN0Y28AAAAAAAAABQAAACQAAAN2AAAHsQAACSQAAAuV`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAiRtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAABqKAGvMILxBzZKWOprE3fevAL/hxD/uPrIgSkpn/+m7mmJ0eSrSAVAkQfmLSq+FKe+AjZI3DPkmDADaQPLTAe8EPaL/9DEL6hhXC5+TXV//2tnEngHwVt28dsHMCO3gxYAAPTsSMAAA0mDagAAAEACAdB4KB4vkEER0pVS93QqBQyTfA7rbqo9oAAfH88jPf+kOKR3jF1Q6mBAekpIloABhgkbZTAEbfgzUAdf+aPgAAAAegIB4PCQPIPL6QQYIUUmgwyAkoT0AokItOQsBG2mfNWAo0hnIHfo8fPShHQPeF/+zacPpHsOS1repkgI0/umX11oW4oFT6sKWvs+UB+lzbfu/KKUivlreOsNVtc7OzlxVhBBM7Y8NVtc7OzlUaAT4To2PDVbXOzs5VvgAAAAPgIB4HiYeh6Dw+mEEJUmEOCSB/gDBMjuF3wFQPXsYaRAYgpaU2nmVjyOqzNLU1H0RMAIawo9hhJko5MWG1/RAAAAgwIB4WjQeg8B6+mEGCFEJoPPgJIH+AMEyO4XfAVA9exhpEBiClpTaeZWPHAPeM3/tzrN6lZQdZW7+/WCSn+lNS0Vh7PHs9Mcg9wyQvRy3WtFSsgUh3SuOVH4Ci6RVrjOuKctLhJQWQ8X0pqWirXGdcU4SsAWUEoPF9Kaloq1xnXFOF3AAAAEPm1vb3YAAABsbXZoZAAAAADi56oz4ueqMwAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAPKdHJhawAAAFx0a2hkAAAAD+LnqjPi56ozAAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAAL+bWRpYQAAACBtZGhkAAAAAOLnqjPi56ozAAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAqVtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAi1zdGJsAAAA63N0c2QAAAAAAAAAAQAAANtodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAb2h2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALA6AAAQAYQAEMAf//AWAAAAMAsAAAAwAAAwBaFcCQoQABACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUWAgcAgogABAAdEAcAsvBTJAAAAEmNvbHJuY2xjABYAAgAHAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAJEAAABEAAAAfgAAAEIAAACHAAAAJHN0Y28AAAAAAAAABQAAACQAAAC1AAAA+QAAAXcAAAG5`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAS9tZGF0AAAAHgYFGkdWStxcTEM/lO/FETzRQ6gB/8zM/wIABr//gAAAAEsluCAf3gh1HQn/BbRJYdsk7JcH5ahxnr5z9+1iusu4hg5+tQZEUPCfmAAA0AR/7qoEGaq63LJtnblsVKt/qwp5y3N/UAax5nglJIAAAAAxIeEIX8SZ2xbfTceN/BuU0pSauQIstT76pgVHeHGgV7gMzP4T6uvQa9VO+FiFfGNTSQAAACoBqIGJv+raal2u43ywApSgHQ5GcR1jNT4CdtW+gsCQUMnaCJuWDzvUnisAAAAkIeIQRP8EJBj6s86zBuYK9HFeKH3SXM9TTcijRTubnwemhPxgAAAAJwGow4//9Jn3wAQ7USAACgbsLWDliBKYU2a64LWPKZu8wXHFvO7fQAAAA7xtb292AAAAbG12aGQAAAAA4ueqLuLnqi4AAAJYAAALuAABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAADSHRyYWsAAABcdGtoZAAAAA/i56ou4ueqLgAAAAEAAAAAAAALuAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAABAAAAAQAAAAAAAER0YXB0AAAAFGNsZWYAAAAAAQAAAAEAAAAAAAAUcHJvZgAAAAABAAAAAQAAAAAAABRlbm9mAAAAAAEAAAABAAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAALuAAAAAAAAQAAAAACfG1kaWEAAAAgbWRoZAAAAADi56ou4ueqLgAAAlgAAAu4VcQAAAAAADFoZGxyAAAAAG1obHJ2aWRlYXBwbAAAAAAAAAAAEENvcmUgTWVkaWEgVmlkZW8AAAIjbWluZgAAABR2bWhkAAAAAQBAgACAAIAAAAAAOGhkbHIAAAAAZGhscmFsaXNhcHBsAAAAAAAAAAAXQ29yZSBNZWRpYSBEYXRhIEhhbmRsZXIAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMYWxpcwAAAAEAAAGrc3RibAAAAKZzdHNkAAAAAAAAAAEAAACWYXZjMQAAAAAAAAABAAAAAAAAAAAAAAIAAAACAAEAAQAASAAAAEgAAAAAAAAAAQVILjI2NAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAACphdmNDAWQADf/hAA8nZAAN8VigQCGm4MIgIEABAAQo7jyw/Pj4AAAAABJjb2xybmNsYwAGABEAAQAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAACWAAAAAH///2oAAAAAQAAAlgAAAAB///9qAAAACBjc2xnAAAAAAAAAlj///2oAAACWAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBgQGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAHEAAAA1AAAALgAAACgAAAArAAAAJHN0Y28AAAAAAAAABQAAACQAAACVAAAAygAAAPgAAAEg`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAtVtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAADAKAGvMIOWEh0UoUIg6msTf/CCv9Zw/65UyIEpKZ/41hjOIBWRB+Ys9mt22H1AAjZIz0px4XMqe84kr8Qr3WlvT/qcZsAKtkVtV81+he0MLgFEZuJwwAAB/TUQzxbAwcj47IXezVGIwxhuPf6FpKzIqlYUEVDj/sMrAO6537HnfGLJJYJOW1ZwHihJbH0Qb2SMCYTgrUnwyxSFrVBJJvEnlNXByEzBC1z8Pzd6A3fsAAOD4Ohm6BAwAAmjDf1ebFLAAAAAH04JBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAABLKAmT4gmy7srQ+f3f/hrRdtzCUzy2A5UNrJhn9PTJut4gAW7GyDrPKy0COxn31wCJgAP864AAVMAFwAAACWgAAAMAAKmAAAADAAdEAAAALgIB0HgoHi+QQ5G8lPd0KgUMk3gAzYAAABUwAACPgABP0qaG94AAEFAAOqAAoYAAAAAqAgmkHgoHi/EORtJQ8iWABHxYAABNQAAABbwAADggAAGZAAcsABkwAElAAAAAIgIB4PCQPIPL6QQqqWCShPQACkgAG/AAQcAAlYABCwH7Ay4AAAAlAgmoPCQPIPL7ELqqgJOAmIAAAe8AB0wAFHAALuAAVcAArYABYQAAACkCAeB4mHoeg8PphDSSiUCSB/gADbgAI+AAVUAODxOM6BZF6hv9bBHDQAAAACYCCageJh6HoPD7ELqqgJOAmIAAAe8AB0wAFHAALuAAVcAArYABYQAAAEACAeFo0HoPAevqEFEIQtCFkoP2AAh4ABqwAD/AL7WslD4+8A0/GqJBqsdB9JqdMd1nsC7SmP9AB0lkDEQQDXjgAAAAJgIJqFo0HoPAevsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAElW1vb3YAAABsbXZoZAAAAADi56pB4ueqQQAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAQhdHJhawAAAFx0a2hkAAAAD+LnqkHi56pBAAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAANVbWRpYQAAACBtZGhkAAAAAOLnqkHi56pBAAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAvxtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAoRzdGJsAAABQnN0c2QAAAAAAAAAAQAAATJodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAumh2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALBKAAAQAnQAEMEf//AWAAAAMAsAAAAwAAAwBaFcC/WggACDAoUoCAAIBQBhXpoQACACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTULAgkAgACJCCQEBYAAAAwCwAAADAAADAFpIAgIBAWIFe5FlU3CwIJAIogACAAdEAcAsvBTJAAhECUgCixgpkicAAQAJTgGlBBAAf5CAAAAAEmNvbHJuY2xjAAsAAgAJAAAADGFsbW8AAAECAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAVkAAABgAAAATwAAAFcAAABuAAAAJHN0Y28AAAAAAAAABQAAACQAAAF9AAAB3QAAAiwAAAKD`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAABAptZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAACXKAGvMIM+QPLAMNDqaxN//vLa/7QkP/TcLIgSkpnwv1XCm+FgNPY2etIBUJEH5i0qvhSnvgI2SNwz5JgwKnvOL8ia/Xd0Orr5meyhVoIT3OYCmkJ30lyUl2+40s4bstuYX8BB7lJd4X6dXihE9NVLbD0BXaogYSM65Q/scrfnCP5mJYAABNNn/AtoAA5Z0mhwQAABWiEb8AAAAB9OCQUaR1ZK3FxMQz+U78URPNFDqAPuAADuAgADX/+AAAAASygJk+IJsu7K0Pn93/4a0XbcwlM8tgOVDayYZ/T0ybreIAFuxsg6zystAjsZ99cAiYAD/OuAAFTABcAAAAloAAADAACpgAAAAwAHRAAAAMUCAdB4KB4vkEGjfe3MDDjnaJyvXWgpDzkTBqDh8UtBRyJ/AHJv4WsP5sLAlcuIYMKl0TuQ04h6ctODkjBqs+NzWMBs7oj0OHAf0ESHEPAPf2eCwlU1TfRVIVIxcW/9GdCsSriNfxrU76/ELLgDIgCAIaAN+d17aMdILiYqJ0kX+7AhTVWZ0mqc5NlhGg+wdKdvIuyiXVpO+1d4uEx4MabAzxtlPhkvtmAH5CQWLnrZfZiqVSvoBvw4hrc7AIKK4AGt6rdBYgAAACoCCaQeCgeL8Q5G0lDyJYAEfFgAAE1AAAAFvAAAOCAAAZkABywAGTAASUAAAABwAgHg8JA8g8vpBBZPdgYhQEkA9aM+KLKTYgPVFFJ4U6f1MzAf6qe9EwhVbTVpgyirYRmnBgF6CJVCWlz2aCmbZDEFFGW9oF/AXpcYRvmAj5j8PZ6CoB8lEu0lVHJKssYCKW0DpSwFx+NbxeS2vDfxqAAAACUCCag8JA8g8vsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAAMAIB4HiYeh6Dw+mENpZpQEVTDnhjBRQAI2CmWYFzH2/ABBWvgBc1nB+LSBwX5/c4XAAAACYCCageJh6HoPD7ELqqgJOAmIAAAe8AB0wAFHAALuAAVcAArYABYQAAALICAeFo0HoPAevphBmXW9wwwoBJGeiHRT3+n4G7hbCwkwRAralAgqVf02nCIBvxtUiWW76umSebpL4Kac1pcjH9QnrrJDtQ6AdRMwGtRE+it1rPeEAAeALK6bf9L4+E/6zGBYB1Dthmlwfl9Uw/ZqFfKKLVtCUs3dmR7MkSirwTkKiOVFTLiaVQvKZhQ33jIUar+pqX2n41B/QA9TSbgHHCoxIH8KiACkELBWOamP+uehL3AAAAJgIJqFo0HoPAevsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAElW1vb3YAAABsbXZoZAAAAADi56lD4uepQwAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAQhdHJhawAAAFx0a2hkAAAAD+LnqUPi56lDAAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAANVbWRpYQAAACBtZGhkAAAAAOLnqUPi56lDAAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAvxtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAoRzdGJsAAABQnN0c2QAAAAAAAAAAQAAATJodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAumh2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALBKAAAQAnQAEMEf//AWAAAAMAsAAAAwAAAwBaFcC/WggACDAoUoCAAIBQBhXpoQACACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUGEQYAgACJCCQEBYAAAAwCwAAADAAADAFpIAgIBAWIFe5FlU3BhEGAIogACAAdEAcAsvBTJAAhECUgCixgpkicAAQAJTgGlBBAAf5CAAAAAEmNvbHJuY2xjAAYAEQAGAAAADGFsbW8AAAECAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAATAAAAD3AAAAnQAAAF4AAADgAAAAJHN0Y28AAAAAAAAABQAAACQAAAFUAAACSwAAAugAAANG`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAnBtZGF0AAAAHgYFGkdWStxcTEM/lO/FETzRQ6gB/8zM/wIABr//gAAAAK8luCAf3gjkdIJ/8FkN8xPMquG53I7zKlBV7mPS0cjwHNYojHSeqmGzK1ithrcA9sBYVzGNAE7IutM/Z6siYELPn1Gjt83x532iA0vTdpNLEH3rBxfc3Prq6TpmqNXLqamHfhP80i2aF8WxKIP1QlV3bCCgfov5NvfpVL47XNkjRh5IHc8vUf7XwnOzsYO+SUu+WiUp51SSt+GuJPi3bbWg/hzPxvSkxxL0xM2txBFQAAAAuCHhCF8BCiSBNYLgmz0HwAO7gj0DgwztLTT3uj52TeZALQrpshFaoem5K1fR4YumpfbxuOjF0NZTAXOIuXgnBnPsW5BpahPe2miPbo+DCfBL/tDGuMXhx6kB0wxM+gJzu7gaimszysP+W3TBSJ8Ofv9w9TmhzXIO6L9HqVzMXeEOWx0ebjRQu3y8S9Y9s0LqayXyA5mRwX5avT2rvQwNetgDgFTdcoO+rpRozoDlxD2gRTU/5AGhluQAAAAxAaiBib/0nMMwAAADABpQAABMwFOKGuTqjmewK9rRN6oO28ABkgFIoWGBcEFDAV03oAAAAG8h4hBL/wCwskCy4Msms9w0qmA5B3OiCEBh/fU5ZLIhgAlgBrE+yMdXshN0ARuaBuFYc7jWOAtd6I13Mji3Ek7RWzG7YmIU6pRnrwKgjrG+9EbuxlIz4g4CCQfkeORo3rY+o9uwlnr5m6q1sC0oA7kAAAArAajDiT/zwmkgAAADAAu4AAAk4CkEST5lthNZ4QEQAK8DTh2xAgmwZQQILAAAA7xtb292AAAAbG12aGQAAAAA4uesc+LnrHMAAAJYAAALuAABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAADSHRyYWsAAABcdGtoZAAAAA/i56xz4uescwAAAAEAAAAAAAALuAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAABAAAAAQAAAAAAAER0YXB0AAAAFGNsZWYAAAAAAQAAAAEAAAAAAAAUcHJvZgAAAAABAAAAAQAAAAAAABRlbm9mAAAAAAEAAAABAAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAALuAAAAAAAAQAAAAACfG1kaWEAAAAgbWRoZAAAAADi56xz4uescwAAAlgAAAu4VcQAAAAAADFoZGxyAAAAAG1obHJ2aWRlYXBwbAAAAAAAAAAAEENvcmUgTWVkaWEgVmlkZW8AAAIjbWluZgAAABR2bWhkAAAAAQBAgACAAIAAAAAAOGhkbHIAAAAAZGhscmFsaXNhcHBsAAAAAAAAAAAXQ29yZSBNZWRpYSBEYXRhIEhhbmRsZXIAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMYWxpcwAAAAEAAAGrc3RibAAAAKZzdHNkAAAAAAAAAAEAAACWYXZjMQAAAAAAAAABAAAAAAAAAAAAAAIAAAACAAEAAQAASAAAAEgAAAAAAAAAAQVILjI2NAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAACphdmNDAWQADf/hAA8nZAANrFYoEAhpqAiQOBABAAQo7jyw/fj4AAAAABJjb2xybmNsYwABABIABwAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAACWAAAAAH///2oAAAAAQAAAlgAAAAB///9qAAAACBjc2xnAAAAAAAAAlj///2oAAACWAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBgQGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAANUAAAC8AAAANQAAAHMAAAAvAAAAJHN0Y28AAAAAAAAABQAAACQAAAD5AAABtQAAAeoAAAJd`,
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let adapter1 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let device0 = await adapter1.requestDevice({
+  label: '\uecc2\u{1faee}\ub06c\u0b8b',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    maxUniformBufferBindingSize: 13436501,
+    maxStorageBufferBindingSize: 160571991,
+  },
+});
+let imageData0 = new ImageData(60, 68);
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let texture0 = device0.createTexture({
+  size: {width: 1, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.04,
+  maxAnisotropy: 15,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 475,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder0 = device0.createCommandEncoder({});
+let textureView0 = texture0.createView({label: '\u06f6\u{1f95e}\ue5df\u05a1\u0059\u{1fc23}', baseArrayLayer: 0});
+let texture1 = device0.createTexture({size: [64, 64, 12], mipLevelCount: 2, format: 'astc-4x4-unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let textureView1 = texture1.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+let promise0 = device0.queue.onSubmittedWorkDone();
+await gc();
+let buffer0 = device0.createBuffer({size: 4769, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView2 = texture1.createView({label: '\u{1fce0}\u{1fd45}\u37b8\uf502\u03d2', mipLevelCount: 1, arrayLayerCount: 3});
+let sampler1 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 60.48,
+  compare: 'never',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(14_980).fill(59), /* required buffer size: 14_980 */
+{offset: 30, bytesPerRow: 57, rowsPerImage: 130}, {width: 4, height: 12, depthOrArrayLayers: 3});
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture2 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'eac-r11snorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler2 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.10,
+  lodMaxClamp: 83.25,
+  maxAnisotropy: 3,
+});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'iec61966-2-1'} });
+let commandEncoder1 = device0.createCommandEncoder({label: '\u24a5\u734b\uab77\u9a3e\u{1f6ce}\u0d38\u010e'});
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 784 */
+  offset: 784,
+  buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 4, y: 4, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView0}]});
+let buffer1 = device0.createBuffer({
+  label: '\u{1f834}\ucac0\u{1fddd}\u1777\u037e\u2ac5\ucb46\u8eca\u{1f871}\ud1d6\u67a9',
+  size: 24272,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView3 = texture2.createView({label: '\u86dc\u84a2\u9b39\u{1f7e9}\u801a\u5f69\u40ce\u501f\u71c9\u{1faae}\u9c24', dimension: '2d'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+let textureView4 = texture1.createView({dimension: 'cube', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView5 = texture2.createView({dimension: 'cube-array', baseArrayLayer: 0, arrayLayerCount: 6});
+let promise2 = device0.queue.onSubmittedWorkDone();
+let bindGroup1 = device0.createBindGroup({
+  label: '\ued67\u{1fefe}\uad13\u0b4b\u{1fa4b}\u05a0\u077a\ub76e\u9167\uf628\u2cfc',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView0}],
+});
+let texture3 = device0.createTexture({size: {width: 10}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let sampler3 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 47.24,
+  lodMaxClamp: 67.74,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(1651), 340, 0);
+} catch {}
+await gc();
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView6 = texture3.createView({label: '\u0125\u9ac1\u7b86\u06ad\u{1fabe}\u5b72\u8e59\u4ba4', baseArrayLayer: 0});
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u{1f84c}\u{1fade}\udbd9\u0fea\ua528\ue28b\u0557'});
+let sampler4 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.44,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(351), 17, 0);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2160 */
+  offset: 2160,
+  bytesPerRow: 768,
+  buffer: buffer0,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 2},
+  aspect: 'all',
+}, {width: 36, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer2 = device0.createBuffer({
+  size: 35862,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture5 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder4.beginComputePass({});
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 25, y: 12, z: 0},
+  aspect: 'all',
+}, new Uint8Array(212).fill(149), /* required buffer size: 212 */
+{offset: 212}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer3 = device0.createBuffer({
+  size: 5310,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView7 = texture4.createView({label: '\u{1f71b}\u53af\u0658\u{1fc6a}\u5249\u01ca', dimension: '2d', mipLevelCount: 1});
+let sampler5 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 7.520,
+  lodMaxClamp: 78.71,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(3612), 64, 0);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler2}, {binding: 0, resource: textureView7}],
+});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0]});
+let textureView8 = texture1.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({label: '\ub765\u0001\u373e\ua270\u{1fa08}', colorFormats: ['rgba16uint'], depthReadOnly: true});
+let sampler6 = device0.createSampler({addressModeV: 'clamp-to-edge', minFilter: 'linear', lodMinClamp: 61.61, lodMaxClamp: 95.26});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup1, new Uint32Array(4535), 118, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler6}, {binding: 0, resource: textureView7}],
+});
+let commandEncoder5 = device0.createCommandEncoder({});
+let sampler7 = device0.createSampler({
+  label: '\u{1fdf6}\ubbe8\u09f7\u{1f86f}\u0a2f\u53c1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.92,
+  lodMaxClamp: 86.92,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(4, buffer2, 0, 3_423);
+} catch {}
+try {
+commandEncoder2.insertDebugMarker('\ucdb9');
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer3, offset: 4608, size: 72}}],
+});
+let buffer4 = device0.createBuffer({size: 43065, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let sampler8 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.53,
+  lodMaxClamp: 83.53,
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup4, new Uint32Array(615), 66, 0);
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder();
+let texture6 = device0.createTexture({
+  label: '\u80bf\u{1fe62}\u39b5\u{1f899}\u{1f80c}\u{1f7d5}\u03bf\u7a42\uc621',
+  size: [40, 23, 319],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView9 = texture5.createView({dimension: '2d', aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder4 = commandEncoder6.beginComputePass({});
+let renderPassEncoder0 = commandEncoder5.beginRenderPass({
+  label: '\u047e\u3972\u{1fb4d}\u0141\u{1ff55}\u5a88',
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: 658.3, g: -90.78, b: 96.37, a: -283.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let promise3 = device0.queue.onSubmittedWorkDone();
+let sampler9 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', magFilter: 'nearest', lodMaxClamp: 43.17});
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint32', 408, 2_714);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(1, buffer2);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u0225\u0c94\uc85a\u053c\u0850\u{1fd88}\u01d6\uca85\u4efc\u960b',
+  code: `
+requires packed_4x8_integer_dot_product;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<private> vp0: VertexOutput0 = VertexOutput0(vec2f(), vec2f(), vec2i(), vec4i(), u32(), vec4f(), vec4f());
+
+@group(1) @binding(103) var tex1: texture_multisampled_2d<u32>;
+
+@group(0) @binding(0) var tex0: texture_2d<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput0 {
+  @location(8) @interpolate(perspective, centroid) f0: vec2f,
+  @location(13) @interpolate(flat, centroid) f1: vec2f,
+  @location(15) @interpolate(flat) f2: vec2i,
+  @location(3) @interpolate(flat, sample) f3: vec4i,
+  @location(14) @interpolate(flat) f4: u32,
+  @builtin(position) f5: vec4f,
+  @location(7) f6: vec4f,
+}
+
+struct T1 {
+  @align(2) @size(12) f0: array<u32>,
+}
+
+struct T0 {
+  f0: vec2h,
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw1: bool;
+
+var<workgroup> vw0: array<mat2x4h, 6>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput0 {
+  @location(3) @interpolate(flat, centroid) f0: u32,
+  @location(0) @interpolate(flat, sample) f1: vec4u,
+}
+
+@group(0) @binding(27) var sam0: sampler;
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  var vf0: i32 = vp0.f2[0];
+  var vf1: vec4i = firstTrailingBit(vec4i(unconst_i32(135), unconst_i32(250), unconst_i32(381), unconst_i32(309)));
+  var vf2: vec2h = inverseSqrt(bitcast<vec2h>(pack2x16unorm(vec2f(unconst_f32(0.05973), unconst_f32(0.04387)))));
+  let vf3: vec4f = quantizeToF16(vec4f(unconst_f32(0.1401), unconst_f32(0.00344), unconst_f32(0.1048), unconst_f32(0.04067)));
+  let vf4: vec4i = firstTrailingBit(vec4i(unconst_i32(73), unconst_i32(-184), unconst_i32(93), unconst_i32(392)));
+  let ptr0: ptr<private, u32> = &vp0.f4;
+  vf2 *= vec2h(transpose(mat4x2f(unconst_f32(0.08672), unconst_f32(0.03720), unconst_f32(0.2505), unconst_f32(-0.1246), unconst_f32(0.1465), unconst_f32(0.2534), unconst_f32(0.01946), unconst_f32(0.00381)))[1].zy);
+  out.f6 += vec4f(acosh(f32(dot4I8Packed(u32(unconst_u32(217)), u32(unconst_u32(60))))));
+  let vf5: vec2f = step(inverseSqrt(vec3f(unconst_f32(0.2316), unconst_f32(0.1783), unconst_f32(0.1497))).yz, bitcast<vec2f>(vp0.f2));
+  let ptr1: ptr<function, vec4i> = &vf1;
+  out.f4 &= bitcast<u32>(vf3[3]);
+  var vf6: vec4h = acosh(vec4h(f16(vp0.f3[u32(vf2[0])])));
+  out.f3 *= vec4i(i32(vf6[1]));
+  let ptr2: ptr<private, u32> = &vp0.f4;
+  out.f5 = refract(vf5.yyx, vec3f(unconst_f32(0.04575), unconst_f32(0.02499), unconst_f32(0.03025)), f32(unconst_f32(0.1329))).rgrg;
+  let ptr3: ptr<function, vec4h> = &vf6;
+  let vf7: i32 = vf1[1];
+  out.f6 *= vec4f(f32(vf2[u32(unconst_u32(153))]));
+  out.f6 = inverseSqrt(vec3f(distance(vec3f(unconst_f32(0.1687), unconst_f32(0.1038), unconst_f32(0.02390)), vec3f(unconst_f32(0.01667), unconst_f32(0.3908), unconst_f32(0.06733))))).gggr;
+  let ptr4: ptr<private, u32> = &(*ptr2);
+  let vf8: f32 = vp0.f0[bitcast<vec3u>(refract(vec3f(f32(vf4[1])), vec3f(unconst_f32(0.06974), unconst_f32(0.2456), unconst_f32(0.04078)), f32(unconst_f32(0.2245))))[2]];
+  var vf9: vec3f = refract(vec3f(unconst_f32(0.07923), unconst_f32(0.2709), unconst_f32(0.03345)), vec3f((*ptr3).zzx), f32(unconst_f32(0.3138)));
+  let ptr5: ptr<private, vec4f> = &vp0.f6;
+  let vf10: f32 = vp0.f0[0];
+  return out;
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 = pack4x8unorm(vp0.f5);
+  let ptr6: ptr<private, VertexOutput0> = &vp0;
+  vp0.f6 -= (*ptr6).f5;
+  out.f0 = pack2x16float((*ptr6).f0);
+  let ptr7: ptr<private, vec2f> = &(*ptr6).f0;
+  var vf11: f32 = (*ptr6).f6[3];
+  out.f1 >>= vec4u(bitcast<u32>(vp0.f5[0]));
+  var vf12: i32 = (*ptr6).f2[0];
+  let vf13: vec3f = mix(vec3f(unconst_f32(0.1897), unconst_f32(0.2510), unconst_f32(0.02165)), vec3f(unconst_f32(0.3292), unconst_f32(0.1538), unconst_f32(0.09331)), vp0.f6.ywz);
+  out.f0 -= bitcast<vec3u>(mix(vec3f(vp0.f1[u32(unconst_u32(209))]), mix(vec3f(f32(all(bool(vf13[0])))), vec3f(vp0.f6[3]), vec3f(unconst_f32(0.1743), unconst_f32(0.4985), unconst_f32(0.2215))), vec3f(unconst_f32(0.4104), unconst_f32(0.1141), unconst_f32(0.2235)))).g;
+  vf12 = i32(vf11);
+  vf12 -= bitcast<i32>(vp0.f5[0]);
+  let vf14: f32 = (*ptr7)[max(vec2u(trunc(vec2h(unconst_f16(15574.5), unconst_f16(4530.0)))), max(vec2u(unconst_u32(174), unconst_u32(376)), vec2u(unconst_u32(54), unconst_u32(37))))[0]];
+  var vf15: f32 = (*ptr6).f1[u32((*ptr6).f3[2])];
+  out.f1 = bitcast<vec4u>(vp0.f6);
+  vp0.f3 = vec4i(reverseBits(i32(unconst_i32(110))));
+  vp0.f2 = vec2i(i32(select(textureDimensions(tex0).r, u32(step(vec4h(unconst_f16(16196.6), unconst_f16(10844.5), unconst_f16(13087.3), unconst_f16(-12123.5)), vec4h(trunc(vp0.f6.xxx).grrb))[3]), bool(vp0.f6[u32(unconst_u32(113))]))));
+  let vf16: f32 = (*ptr6).f1[1];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+  vp0 = VertexOutput0(bitcast<vec2f>(vw0[5][u32(vw0[5][0][1])]), bitcast<vec2f>(vw0[5][u32(vw0[5][0][1])]), bitcast<vec2i>(vw0[5][u32(vw0[5][0][1])]), vec4i(vw0[5][u32(vw0[5][0][1])]), pack4xU8(vec4u(vw0[5][u32(vw0[5][0][1])])), vec4f(vw0[5][u32(vw0[5][0][1])]), vec4f(vw0[5][u32(vw0[5][0][1])]));
+  var vf17: vec4i = textureLoad(tex0, vec2i(unconst_i32(395), unconst_i32(61)), i32(acos(f16(length(vec3f(unconst_f32(0.00418), unconst_f32(0.1292), unconst_f32(0.1247)))))));
+}`,
+  hints: {},
+});
+let buffer5 = device0.createBuffer({
+  label: '\u94d4\u{1fefb}\u{1fb88}\u0e2c',
+  size: 5314,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder5 = commandEncoder2.beginComputePass({});
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer3, 444, 1_037);
+} catch {}
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.00,
+  lodMaxClamp: 96.57,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 8_856, 17_875);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer3, 0, 331);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 632, new BigUint64Array(2015), 523, 124);
+} catch {}
+let buffer6 = device0.createBuffer({size: 11472, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture7 = device0.createTexture({size: [20, 11, 21], sampleCount: 1, format: 'rgba16uint', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 432, 3_693);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'hlg'} });
+let commandEncoder7 = device0.createCommandEncoder({});
+let renderPassEncoder1 = commandEncoder7.beginRenderPass({colorAttachments: [{view: textureView9, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer2, 3_628, 3_533);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(3415), 170, 0);
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\ueacd');
+} catch {}
+let buffer7 = device0.createBuffer({
+  size: 13317,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler11 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 49.45,
+  lodMaxClamp: 71.51,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup4, new Uint32Array(4916), 67, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer7, 0);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint32', 4_128, 7_679);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+}, new Uint8Array(202).fill(92), /* required buffer size: 202 */
+{offset: 10}, {width: 48, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  label: '\u92ac\u0eb5',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer4, offset: 27648, size: 5108}}],
+});
+let textureView10 = texture4.createView({mipLevelCount: 1, arrayLayerCount: 2});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup2, new Uint32Array(30), 10, 0);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint32', 608, 950);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let textureView11 = texture4.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+let renderPassEncoder2 = commandEncoder8.beginRenderPass({colorAttachments: [{view: textureView9, loadOp: 'load', storeOp: 'store'}]});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+renderPassEncoder0.setStencilReference(1382);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(37).fill(236), /* required buffer size: 37 */
+{offset: 37}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(369), 119, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer1, 'uint32', 1_964, 3_965);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let texture8 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 39},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(1148), 56, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint16', 7_860, 1_343);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(3, buffer2, 2_776, 12_475);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView12 = texture1.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder2.setIndexBuffer(buffer7, 'uint32', 92, 1_135);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3136 */
+  offset: 3136,
+  bytesPerRow: 9728,
+  buffer: buffer3,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup6 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView0}]});
+let commandEncoder10 = device0.createCommandEncoder();
+let textureView13 = texture5.createView({dimension: 'cube', mipLevelCount: 1});
+let computePassEncoder6 = commandEncoder10.beginComputePass({});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(719), 194, 0);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder();
+let textureView14 = texture0.createView({baseArrayLayer: 0});
+let renderPassEncoder3 = commandEncoder9.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -611.8, g: -264.4, b: -183.0, a: 99.34, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 79221479,
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint16', 3_550, 3_517);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 5684, new BigUint64Array(1621), 13, 216);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let buffer8 = device0.createBuffer({size: 9839, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup5, new Uint32Array(159), 50, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(14.133295217919581, 13.26636659257576, 4.354110551257299, 6.552404066584471, 0.2778048269561093, 0.9319604349819669);
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler5}],
+});
+let textureView15 = texture5.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let textureView16 = texture0.createView({dimension: '2d', baseMipLevel: 0});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1504 */
+  offset: 1504,
+  bytesPerRow: 1792,
+  rowsPerImage: 83,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 12, height: 32, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder11.insertDebugMarker('\u2865');
+} catch {}
+try {
+  await promise4;
+} catch {}
+let textureView17 = texture2.createView({dimension: '2d', baseArrayLayer: 2});
+let computePassEncoder7 = commandEncoder11.beginComputePass();
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+let buffer9 = device0.createBuffer({
+  size: 6470,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 6_304, 101);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer7, 104, 5_143);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer10 = device0.createBuffer({size: 9109, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let textureView18 = texture4.createView({dimension: 'cube', mipLevelCount: 1});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer8, 'uint32', 1_880, 4_102);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer7, 5_844, 85);
+} catch {}
+await gc();
+let textureView19 = texture1.createView({
+  label: '\u{1fad5}\u0ba3\ua63b\u{1fddb}\u0459\u0842\udb84\u7ef9\u0a0f',
+  dimension: 'cube-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 4,
+  arrayLayerCount: 6,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup3, new Uint32Array(1759), 607, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 40, 2_029);
+} catch {}
+try {
+adapter1.label = '\u0d02\u0c37\u{1ff00}\u{1fb9e}\u{1fb17}\u0c6d\u8f93\u{1f810}\u898b';
+} catch {}
+let buffer11 = device0.createBuffer({size: 11415, usage: GPUBufferUsage.STORAGE});
+let commandEncoder13 = device0.createCommandEncoder({});
+let textureView20 = texture4.createView({label: '\u644d\u35e6', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let renderPassEncoder4 = commandEncoder13.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -948.9, g: 490.1, b: -400.8, a: -792.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler12 = device0.createSampler({
+  label: '\u1156\u{1fd7f}\u8229\u6add\u{1fc3d}\u{1fd7b}\u7582',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.173,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(528), 102, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(1418), 67, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer9, 'uint32', 480, 626);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 2416, new BigUint64Array(36716), 1389, 108);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder();
+let computePassEncoder9 = commandEncoder14.beginComputePass();
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup5, new Uint32Array(3526), 26, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 12_304, 2_760);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer2, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(247).fill(60), /* required buffer size: 247 */
+{offset: 247, rowsPerImage: 37}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let sampler13 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.27,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup4, new Uint32Array(2448), 251, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await promise0;
+} catch {}
+let imageData1 = new ImageData(100, 12);
+let commandEncoder15 = device0.createCommandEncoder();
+let textureView21 = texture0.createView({dimension: '2d'});
+let renderPassEncoder5 = commandEncoder15.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -764.9, g: -512.2, b: -20.09, a: -567.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let buffer12 = device0.createBuffer({
+  size: 7853,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let computePassEncoder10 = commandEncoder16.beginComputePass({});
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle0, renderBundle1]);
+} catch {}
+let textureView22 = texture6.createView({mipLevelCount: 1});
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 1_234, 2_068);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 188, new Int16Array(35674), 7646, 1092);
+} catch {}
+try {
+device0.label = '\u{1f6da}\ub33f\u0def\u{1f64a}\ub4a2\u{1f906}\u{1fefc}\u{1f96a}';
+} catch {}
+let textureView23 = texture4.createView({dimension: 'cube', mipLevelCount: 1});
+let texture9 = device0.createTexture({
+  size: [20, 11, 11],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView24 = texture9.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 2});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u{1f6d1}\u8f84\u{1f814}\u0ee0\u{1ff84}\u0724\u{1fb00}\u0077',
+  colorFormats: ['rgba16uint'],
+  depthReadOnly: false,
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup5, new Uint32Array(1970), 721, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer7);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer8, 'uint32', 936, 694);
+} catch {}
+let promise6 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {topology: 'triangle-strip', unclippedDepth: true},
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup6, new Uint32Array(1334), 194, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer8, 'uint16', 378, 2_045);
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer12, offset: 1792, size: 1220}}],
+});
+let buffer13 = device0.createBuffer({size: 4357, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder17 = device0.createCommandEncoder({});
+let renderPassEncoder6 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -278.9, g: -150.9, b: -886.2, a: -40.53, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(7, 0, 8, 17);
+} catch {}
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.313,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer7, 364);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 2080, new Float32Array(7214), 177, 48);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let renderPassEncoder7 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: 250.6, g: -153.2, b: 207.9, a: -742.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 158577849,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.setViewport(2.945012927308099, 31.25288679415101, 3.3885800551537586, 0.24673693512844005, 0.7725500024328534, 0.9880019614820622);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer4, offset: 19456, size: 1764}}],
+});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u0191\u3ed8\uc4e2\u{1fb44}\u5257'});
+let textureView25 = texture1.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 2});
+let renderPassEncoder8 = commandEncoder19.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -203.9, g: 72.98, b: 894.2, a: 445.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler15 = device0.createSampler({
+  label: '\u6722\u0397\u0e31\u{1fee5}\u{1f84a}\u2eb5\u0e28',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 84.45,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup3, new Uint32Array(1530), 92, 0);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  label: '\u1613\u5444\ubbae\u23c7\u5206\ue95a\u050e\u9b3a\u0994',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer12, offset: 256, size: 1576}}],
+});
+let texture10 = device0.createTexture({
+  size: [40, 23, 39],
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup7, new Uint32Array(113), 15, 0);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(137);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer4, 'uint32', 20_828, 3_708);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+computePassEncoder4.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+await gc();
+let imageData2 = new ImageData(200, 48);
+try {
+externalTexture3.label = '\u096d\u93d6\u0966\u079f\u3488\u{1f905}\u5e1f\u{1ff3d}\u0372';
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder20.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer3);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler0}],
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.81,
+  lodMaxClamp: 99.98,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer12, 'uint32', 856, 48);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(368, 72);
+let bindGroup12 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler9}],
+});
+let buffer14 = device0.createBuffer({size: 3414, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(1, bindGroup9, new Uint32Array(143), 68, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let buffer15 = device0.createBuffer({
+  size: 1194,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let textureView26 = texture1.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let renderPassEncoder9 = commandEncoder21.beginRenderPass({colorAttachments: [{view: textureView15, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint32', 2_716, 708);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 344, new Int16Array(3860), 209, 1372);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle2]);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture11 = device0.createTexture({
+  label: '\u517b\u0cf3\u63ba\uf69d\u03fd\u0393\u1a8c\u96f7\u{1f79f}',
+  size: {width: 40, height: 23, depthOrArrayLayers: 65},
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup5, new Uint32Array(57), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer12, 'uint32', 1_896, 38);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer7, 0);
+} catch {}
+let imageData3 = new ImageData(4, 180);
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer14, offset: 0, size: 496}}],
+});
+let buffer16 = device0.createBuffer({
+  label: '\u24c9\u7ad4\u{1f953}\u0aad\u0390\u0bb8',
+  size: 5518,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder22 = device0.createCommandEncoder({});
+let textureView27 = texture6.createView({label: '\u0b9f\u0c6d\u0628\u{1f75a}\uf4b3\u408e\u{1fb51}\u1fb1\u1765', mipLevelCount: 1});
+let renderPassEncoder10 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -253.6, g: -695.9, b: 329.8, a: 922.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 83.77,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup3, new Uint32Array(522), 98, 0);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u6fd8\uedd1\u3def\u088a\u9011\u387b'});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup11, new Uint32Array(160), 79, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer15, 'uint32', 320, 92);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1184 */
+  offset: 1184,
+  bytesPerRow: 1024,
+  rowsPerImage: 1845,
+  buffer: buffer9,
+}, {
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder24 = device0.createCommandEncoder();
+let textureView28 = texture5.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let renderPassEncoder11 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: 626.9, g: -652.6, b: 928.9, a: -981.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler18 = device0.createSampler({
+  label: '\u3e36\u{1f8a0}\u5490\u006c',
+  addressModeU: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 15.86,
+  lodMaxClamp: 97.36,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer3, 0, 228);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder4.setBindGroup(0, bindGroup9, new Uint32Array(321), 40, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(88).fill(199), /* required buffer size: 88 */
+{offset: 88, bytesPerRow: 76}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\ub324\u{1fed2}\u031a\u04c9',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView21}],
+});
+let buffer17 = device0.createBuffer({
+  size: 18801,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+let renderPassEncoder12 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -878.9, g: 996.6, b: -785.6, a: 374.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+await gc();
+let imageBitmap0 = await createImageBitmap(videoFrame1);
+let commandEncoder26 = device0.createCommandEncoder({});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup9, new Uint32Array(6312), 26, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint32', 304, 794);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer10, 4856, 436);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer15, offset: 0, size: 204}}],
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let textureView29 = texture6.createView({mipLevelCount: 1});
+let computePassEncoder12 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup5, new Uint32Array(23), 5, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint16', 796, 34);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u8374\u0d7a\u{1f6d4}\u{1fedb}\ue815\u0e34',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView21}],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView30 = texture11.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 20});
+let computePassEncoder13 = commandEncoder26.beginComputePass({});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup10, new Uint32Array(550), 20, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer2);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let computePassEncoder14 = commandEncoder27.beginComputePass({});
+let renderPassEncoder13 = commandEncoder29.beginRenderPass({colorAttachments: [{view: textureView30, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle2, renderBundle1, renderBundle2, renderBundle2, renderBundle2, renderBundle0]);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 4, y: 8, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 6144,
+  buffer: buffer10,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'unspecified', transfer: 'unspecified'} });
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder15 = commandEncoder28.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 904 */
+  offset: 904,
+  bytesPerRow: 4608,
+  rowsPerImage: 289,
+  buffer: buffer9,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer7, 2304, 5120);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(115, 125);
+let bindGroup17 = device0.createBindGroup({
+  label: '\ud03b\u{1ffab}\u{1f6fc}\u6951\uae5e\u0b2c\u{1fb93}\u{1fb74}\uae84',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer14, offset: 0, size: 124}}],
+});
+let buffer18 = device0.createBuffer({
+  label: '\u5b50\u43de\u0d99',
+  size: 2903,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 3646});
+let renderPassEncoder14 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 687.9, g: -818.2, b: 157.9, a: -317.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer7, 0);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView20}, {binding: 27, resource: sampler0}],
+});
+let texture13 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(469), 124, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer17, 'uint32', 808, 4_113);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer2, 1_424, 4_549);
+} catch {}
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView0}]});
+let textureView31 = texture1.createView({label: '\uba4d\u55e0\u0082', dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup8, new Uint32Array(2007), 70, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.setViewport(3.392328904494992, 3.52204135081427, 15.596184711524174, 9.290001121354045, 0.7409862293283602, 0.9148304177003581);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint16', 1_330, 966);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer17, 0, 4_835);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1796, new Int16Array(13690), 644, 1228);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise1;
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1, []);
+} catch {}
+let textureView32 = texture8.createView({label: '\u069e\u{1fa21}\u8f7a'});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 20, y: 16, z: 2},
+  aspect: 'all',
+}, new Uint8Array(213).fill(148), /* required buffer size: 213 */
+{offset: 213, bytesPerRow: 112}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let bindGroup20 = device0.createBindGroup({
+  label: '\u6073\ue549\u080a',
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView20}, {binding: 27, resource: sampler16}],
+});
+let texture14 = device0.createTexture({
+  size: [10, 5, 79],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView33 = texture0.createView({label: '\u0f00\u5e6f\ud09b\u0bd7', baseMipLevel: 0});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup14, new Uint32Array(514), 97, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u8da0');
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let commandEncoder31 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  label: '\u0bdc\u{1fe47}\ub296\u6d0c\u0e2c\u00f0\u9993\u92f4',
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder16 = commandEncoder31.beginComputePass();
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u661a');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput1 {
+  @location(1) @interpolate(flat, centroid) f7: vec2f,
+  @location(10) @interpolate(flat, sample) f8: f16,
+  @builtin(position) f9: vec4f,
+  @location(3) @interpolate(flat, sample) f10: vec2u,
+  @location(6) @interpolate(flat, centroid) f11: vec2f,
+  @location(2) f12: vec4f,
+}
+
+@group(1) @binding(103) var tex3: texture_multisampled_2d<u32>;
+
+var<private> vp2: VertexOutput1 = VertexOutput1(vec2f(), f16(), vec4f(), vec2u(), vec2f(), vec4f());
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp1 = modf(vec3h());
+
+var<private> vp4: vec4u = vec4u();
+
+var<private> vp3: VertexOutput1 = VertexOutput1(vec2f(), f16(), vec4f(), vec2u(), vec2f(), vec4f());
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(0) var tex2: texture_2d<i32>;
+
+@group(0) @binding(27) var sam1: sampler;
+
+@vertex
+fn vertex1(@builtin(vertex_index) a0: u32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  vp1 = modf(vec3h(f16(vp4[vp2.f10[0]])));
+  let vf18: f32 = vp2.f12[3];
+  vp4 >>= vec4u(bitcast<u32>(vf18));
+  let ptr8: ptr<private, vec4f> = &vp3.f9;
+  let ptr9: ptr<private, vec2u> = &vp3.f10;
+  let ptr10: ptr<private, vec2f> = &vp3.f11;
+  let ptr11: ptr<private, vec2f> = &(*ptr10);
+  let vf19: u32 = vp3.f10[bitcast<u32>(vp3.f9[bitcast<u32>(vp2.f11[0])])];
+  vp4 -= vec4u(u32(vp3.f12[u32(unconst_u32(141))]));
+  vp1 = modf(vec3h(vp2.f9.arg));
+  let ptr12: ptr<private, vec2u> = &vp3.f10;
+  let vf20: bool = all(vec3<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true)));
+  return out;
+}`,
+  hints: {},
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+let sampler19 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 40.95,
+  lodMaxClamp: 87.21,
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup7, new Uint32Array(2449), 46, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup18, new Uint32Array(331), 30, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle2, renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer17, 'uint16', 696, 2_428);
+} catch {}
+try {
+commandEncoder32.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2096 */
+  offset: 2096,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise5;
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let sampler20 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 88.56,
+  lodMaxClamp: 89.05,
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup20, new Uint32Array(631), 15, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(15.784264075888974, 22.015160148199737, 14.889521607642909, 9.789526275983313, 0.25691509038631855, 0.45394092240777106);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer12, 2_488, 1_096);
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 688 */
+  offset: 688,
+  rowsPerImage: 283,
+  buffer: buffer9,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder17 = commandEncoder32.beginComputePass({});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+  await promise3;
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'gamma28curve'} });
+let commandEncoder33 = device0.createCommandEncoder();
+let texture16 = device0.createTexture({size: [64, 64, 12], format: 'rgba16uint', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let renderPassEncoder15 = commandEncoder33.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 29,
+  clearValue: { r: 230.7, g: -929.6, b: 563.8, a: 833.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.43,
+  lodMaxClamp: 89.67,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer8, 'uint16', 578, 2_057);
+} catch {}
+let texture17 = device0.createTexture({
+  size: [5],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView34 = texture11.createView({mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 10});
+let sampler22 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.83,
+  lodMaxClamp: 68.45,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup10, new Uint32Array(1408), 46, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle2, renderBundle0]);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let textureView35 = texture15.createView({});
+try {
+renderPassEncoder8.executeBundles([renderBundle2]);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise8;
+} catch {}
+let imageData4 = new ImageData(16, 56);
+let buffer19 = device0.createBuffer({size: 11777, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder34 = device0.createCommandEncoder({});
+let textureView36 = texture3.createView({label: '\u{1f768}\u8dc1\u0f41\ubcb9\u3659\ucab3\u0273\u7ed2\u55f0', aspect: 'all'});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(5, 5, 0, 4);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1192 */
+  offset: 1192,
+  buffer: buffer17,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 8, y: 4, z: 1},
+  aspect: 'all',
+}, new Uint8Array(299).fill(171), /* required buffer size: 299 */
+{offset: 47, bytesPerRow: 3, rowsPerImage: 42}, {width: 0, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let imageData5 = new ImageData(8, 56);
+let texture18 = device0.createTexture({
+  size: [5, 2, 39],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView37 = texture1.createView({label: '\u02a5\u05aa\u{1f614}', dimension: 'cube', mipLevelCount: 1});
+let renderPassEncoder16 = commandEncoder34.beginRenderPass({
+  label: '\u{1fc8d}\u5d94\u2385\u040a\u{1fe03}',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 407.2, g: -684.3, b: -258.5, a: -116.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle1, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(336);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer14, 'uint16', 110, 191);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  label: '\u0a93\ubc62\u0d97\ub7b6\u570e',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer5, offset: 1024, size: 684}}],
+});
+let texture19 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 20},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+device0.queue.writeBuffer(buffer9, 860, new Int16Array(30118), 2364, 208);
+} catch {}
+try {
+externalTexture3.label = '\u{1febe}\ua4f4\u{1f6d7}\u946d\u5e24\u5b63\u064d\u79ce\u0a3f\u08b1';
+} catch {}
+try {
+sampler7.label = '\ubaf6\u0fcd\ua159';
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView38 = texture10.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let computePassEncoder18 = commandEncoder35.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup16, new Uint32Array(2406), 123, 0);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(131);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer12, 1_340, 801);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 21, y: 3, z: 4},
+  aspect: 'all',
+}, new Uint8Array(124).fill(185), /* required buffer size: 124 */
+{offset: 124, bytesPerRow: 280}, {width: 17, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+let textureView39 = texture5.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder19 = commandEncoder36.beginComputePass({});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup19, new Uint32Array(205), 9, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(419);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.append(canvas0);
+let buffer20 = device0.createBuffer({
+  label: '\u{1ff88}\u7082',
+  size: 2863,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup3, new Uint32Array(1037), 0, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 5_022, 1_407);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 4032, new BigUint64Array(11370), 53, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(168).fill(72), /* required buffer size: 168 */
+{offset: 168}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let sampler23 = device0.createSampler({addressModeV: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 50.56, compare: 'not-equal'});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup11, new Uint32Array(2504), 145, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView20}, {binding: 27, resource: sampler20}],
+});
+let commandEncoder37 = device0.createCommandEncoder({});
+let computePassEncoder20 = commandEncoder37.beginComputePass({});
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+document.body.prepend(canvas0);
+await gc();
+let bindGroup23 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer14, offset: 512, size: 440}}],
+});
+let buffer21 = device0.createBuffer({size: 1924, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture20 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView40 = texture1.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder21 = commandEncoder21.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer18, 0, 79);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 568, new Int16Array(1243), 128, 96);
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+  label: '\u4598\u7c00\u{1fd18}\u{1fc07}\ue8bb\u044b\u{1f82e}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, constants: {}},
+});
+document.body.append(canvas0);
+let commandEncoder38 = device0.createCommandEncoder({});
+let textureView41 = texture0.createView({mipLevelCount: 1});
+let computePassEncoder22 = commandEncoder38.beginComputePass({});
+let sampler24 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 77.62,
+  lodMaxClamp: 84.37,
+});
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle2, renderBundle1, renderBundle1, renderBundle2]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 612, new Float32Array(1109), 46, 292);
+} catch {}
+document.body.append(canvas0);
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'gamma22curve'} });
+let texture21 = device0.createTexture({
+  size: [40, 23, 319],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView42 = texture2.createView({dimension: '2d-array', baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler25 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.03,
+  lodMaxClamp: 72.54,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(764);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(7, 9, 20, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer20, 60, 14);
+} catch {}
+let buffer22 = device0.createBuffer({size: 4366, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder39 = device0.createCommandEncoder({label: '\u{1fc50}\u{1ff51}\u{1ff47}\u3412\u025f\u0c71'});
+let renderPassEncoder17 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -295.8, g: -495.1, b: 511.3, a: 585.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.48,
+  lodMaxClamp: 46.09,
+  compare: 'never',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\ub282\ue234\u3d98\ucd73\ub3a2\u0b23\ua95c'});
+let texture22 = device0.createTexture({
+  label: '\u2f29\u8544\u690a\u4115\u2c2a\u{1ff0d}\u4094\u01ed',
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder23 = commandEncoder40.beginComputePass();
+try {
+computePassEncoder14.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer20, 132);
+} catch {}
+let buffer23 = device0.createBuffer({
+  label: '\u8128\u0b7e\u081f\u{1fb9d}\u5c2c\u79bd\uab30\u{1fc06}\u06d6\ua186',
+  size: 943,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView43 = texture10.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 6});
+let computePassEncoder24 = commandEncoder41.beginComputePass();
+let sampler27 = device0.createSampler({
+  label: '\ua9fd\u40b9\u{1fe8c}\ua3f2\u1b0e\u{1f92c}\u033f\u6563\uc4fd',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 2.027,
+  lodMaxClamp: 82.43,
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle2, renderBundle1, renderBundle1, renderBundle2]);
+} catch {}
+try {
+commandEncoder40.clearBuffer(buffer7, 1736, 596);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet0, 754, 103, buffer14, 1536);
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt709', transfer: 'gamma28curve'} });
+let bindGroup24 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView16}]});
+let computePassEncoder25 = commandEncoder40.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(111);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let textureView44 = texture13.createView({arrayLayerCount: 1});
+let texture23 = device0.createTexture({
+  size: [5, 2, 39],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView45 = texture10.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler28 = device0.createSampler({
+  label: '\u41ed\u46ba\u95dc\u03a5',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 70.22,
+  lodMaxClamp: 95.02,
+});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer9, 'uint16', 600, 11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 2},
+  aspect: 'all',
+}, new Uint8Array(273).fill(27), /* required buffer size: 273 */
+{offset: 137, bytesPerRow: 104}, {width: 16, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u0bce\u9eba\u{1fe02}\u{1fb5b}\u{1f7a6}\u1924\u9474\u08be\u0f51',
+  colorFormats: ['rgba16uint'],
+  depthReadOnly: true,
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler29 = device0.createSampler({
+  label: '\ucf84\ue80c\u46b5\udb40',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 35.77,
+  lodMaxClamp: 89.53,
+});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(2166);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer19, 520, buffer20, 192, 212);
+} catch {}
+try {
+renderPassEncoder1.pushDebugGroup('\uab9e');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView46 = texture9.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup24, new Uint32Array(925), 26, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder1.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2136, new Int16Array(114));
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder43 = device0.createCommandEncoder({});
+let textureView47 = texture5.createView({dimension: 'cube', mipLevelCount: 1, arrayLayerCount: 6});
+let renderPassEncoder18 = commandEncoder42.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 20,
+  clearValue: { r: -821.3, g: -240.7, b: -436.7, a: -431.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup22, new Uint32Array(123), 28, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup13, new Uint32Array(3011), 38, 0);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer24 = device0.createBuffer({
+  size: 5981,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder44 = device0.createCommandEncoder();
+let computePassEncoder26 = commandEncoder43.beginComputePass({});
+let renderPassEncoder19 = commandEncoder44.beginRenderPass({colorAttachments: [{view: textureView32, depthSlice: 28, loadOp: 'clear', storeOp: 'store'}]});
+let sampler30 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.99,
+  lodMaxClamp: 86.53,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer24, offset: 256, size: 316}}],
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer20, 456, 298);
+} catch {}
+document.body.prepend(canvas1);
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder45 = device0.createCommandEncoder({});
+let externalTexture8 = device0.importExternalTexture({label: '\u2973\ud81e\u{1f648}', source: videoFrame2});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup1, new Uint32Array(1852), 158, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, undefined, 646_741_848, 849_923_109);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer10, 220, buffer23, 68, 104);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let imageData6 = new ImageData(68, 72);
+let commandEncoder46 = device0.createCommandEncoder();
+let textureView48 = texture0.createView({label: '\ua106\u13ac\u{1fa29}\u001c\u0e58\u76fa\u{1fe88}', baseMipLevel: 0});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup21, new Uint32Array(229), 56, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let promise11 = device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0, constants: {}}});
+try {
+adapter1.label = '\u8ab4\u095d\u47c4\u32eb\u0f99\ue017\u91b5';
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer15, offset: 0, size: 252}}],
+});
+let computePassEncoder27 = commandEncoder45.beginComputePass();
+try {
+computePassEncoder20.setBindGroup(1, bindGroup26, new Uint32Array(4010), 679, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup6);
+} catch {}
+let imageBitmap1 = await createImageBitmap(offscreenCanvas1);
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture25 = device0.createTexture({
+  label: '\u8e73\uf15b\u{1f6f0}\u0f4a\u4aa9\u0b92',
+  size: [40, 23, 135],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer3, 840, 454);
+} catch {}
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+try {
+  await promise7;
+} catch {}
+document.body.append(canvas0);
+let textureView49 = texture25.createView({
+  label: '\u03cd\u0a70\u0201\u08cd',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 63,
+  arrayLayerCount: 3,
+});
+let computePassEncoder28 = commandEncoder46.beginComputePass();
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(3749), 7, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer20, 72, 3);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 608, new Float32Array(1853), 96, 120);
+} catch {}
+let texture26 = device0.createTexture({
+  size: [10, 5, 79],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler31 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.69,
+  maxAnisotropy: 15,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(50).fill(184), /* required buffer size: 50 */
+{offset: 50, bytesPerRow: 43}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let querySet1 = device0.createQuerySet({label: '\u9cee\u{1ff1a}\u0493\u076e\ubd15', type: 'occlusion', count: 336});
+try {
+renderPassEncoder17.executeBundles([renderBundle3, renderBundle1, renderBundle3, renderBundle3]);
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 752 */
+  offset: 752,
+  buffer: buffer5,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet0, 801, 211, buffer5, 0);
+} catch {}
+let imageData7 = new ImageData(40, 12);
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture27 = device0.createTexture({
+  size: [5, 2, 39],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture28 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet1, 296, 4, buffer15, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(216).fill(216), /* required buffer size: 216 */
+{offset: 216, bytesPerRow: 22}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder29 = commandEncoder47.beginComputePass({});
+let renderPassEncoder20 = commandEncoder16.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -468.8, g: 573.9, b: -110.8, a: -932.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer9, 'uint32', 1_828, 157);
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  label: '\u0a87\u894f\u{1fa58}\u433b\uf4f5\ufb8b\u85e3\u40c3\u68cc',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer24, offset: 256, size: 372}}],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture29 = device0.createTexture({
+  size: {width: 5},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup26, new Uint32Array(629), 369, 0);
+} catch {}
+let buffer25 = device0.createBuffer({
+  size: 2237,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup22, []);
+} catch {}
+let buffer26 = device0.createBuffer({size: 16654, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView50 = texture19.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.51,
+  lodMaxClamp: 39.27,
+  maxAnisotropy: 8,
+});
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.23,
+});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle3, renderBundle2]);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let textureView51 = texture9.createView({dimension: '2d', format: 'rgba16uint', mipLevelCount: 1, baseArrayLayer: 3});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup24, new Uint32Array(3304), 369, 0);
+} catch {}
+document.body.append(canvas0);
+let bindGroup28 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView0}]});
+let commandEncoder48 = device0.createCommandEncoder({});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(7909), 1_356, 0);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler11}, {binding: 0, resource: textureView20}],
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let computePassEncoder30 = commandEncoder49.beginComputePass({});
+let renderPassEncoder21 = commandEncoder48.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -465.0, g: -507.5, b: 688.1, a: -810.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 662814513,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup4, new Uint32Array(1262), 39, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup22, new Uint32Array(1086), 245, 0);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let computePassEncoder31 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup17, new Uint32Array(105), 6, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer4, 'uint32', 5_756, 34_763);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer7);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder24.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer1, 'uint32', 1_160, 768);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer18, 1_816, 80);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({});
+let textureView52 = texture16.createView({dimension: 'cube', aspect: 'all'});
+let renderPassEncoder22 = commandEncoder51.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: 164.4, g: -998.6, b: 844.5, a: -157.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup28);
+} catch {}
+let buffer27 = device0.createBuffer({size: 6555, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture30 = device0.createTexture({
+  label: '\ua1ff\ue1ff\u028b\u{1f772}\u{1fc9f}',
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer15, 'uint32', 468, 428);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer3, 380);
+} catch {}
+try {
+computePassEncoder28.insertDebugMarker('\u2fce');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(4_600).fill(32), /* required buffer size: 4_600 */
+{offset: 250, bytesPerRow: 30, rowsPerImage: 29}, {width: 1, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  label: '\u{1fc10}\u0b52\uc3ff\u8abe',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer2, offset: 768, size: 8256}}],
+});
+let textureView53 = texture22.createView({arrayLayerCount: 1});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer17, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer28 = device0.createBuffer({
+  size: 5218,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder52 = device0.createCommandEncoder();
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 122});
+let renderPassEncoder23 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: -844.2, g: -889.6, b: 455.3, a: -390.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup4, new Uint32Array(2621), 325, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer7);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(0, bindGroup12, new Uint32Array(1464), 354, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup16);
+} catch {}
+let gpuCanvasContext3 = canvas0.getContext('webgpu');
+let commandEncoder54 = device0.createCommandEncoder({label: '\u1cc1\u3a8c\u2f6c\u{1ffc7}\ue8ba\u{1fea3}\u07f6\udadd\u{1f724}\ufbbc'});
+let texture31 = device0.createTexture({
+  size: [20, 11, 5],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder32 = commandEncoder54.beginComputePass({});
+try {
+renderPassEncoder20.setIndexBuffer(buffer8, 'uint32', 4_808, 536);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer7, 0, 741);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture32 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer9, 'uint32', 244, 490);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4_294_967_294, undefined, 37_569_144);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer14, 'uint16', 76, 179);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 656 */
+  offset: 656,
+  buffer: buffer28,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1012, new BigUint64Array(1561), 71, 0);
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'smpte240m'} });
+try {
+globalThis.someLabel = commandEncoder37.label;
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({});
+let texture33 = device0.createTexture({
+  size: [20, 11, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let renderBundle4 = renderBundleEncoder5.finish({label: '\uab20\u170f\u0bc4\u00cd'});
+let sampler34 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.20,
+  lodMaxClamp: 84.14,
+  compare: 'greater',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer7, 412, 1_399);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+let textureView54 = texture3.createView({});
+let computePassEncoder33 = commandEncoder53.beginComputePass();
+let renderPassEncoder24 = commandEncoder55.beginRenderPass({
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: 60.57, g: -989.4, b: -447.2, a: -696.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler35 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.71,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup3, new Uint32Array(1814), 32, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup4, new Uint32Array(4081), 491, 0);
+} catch {}
+try {
+renderPassEncoder15.setViewport(3.8882164868567552, 0.4766307498527995, 0.25008245302747556, 1.3446720595756358, 0.5606313611632427, 0.9335914702532144);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer20, 'uint16', 280, 421);
+} catch {}
+let buffer29 = device0.createBuffer({size: 12334, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let textureView55 = texture4.createView({
+  label: '\u5504\u0a78\u4349\u{1ff36}\u2257\udb9f\u6965\u0ffb',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 6,
+});
+let texture34 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView56 = texture10.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 7});
+let renderBundle5 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+let texture35 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler36 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.23,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder15.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer17, 'uint16', 3_114, 183);
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 341});
+let texture36 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 7},
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture37 = gpuCanvasContext1.getCurrentTexture();
+let textureView57 = texture22.createView({dimension: '2d-array', format: 'rgba16uint'});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup4, new Uint32Array(981), 123, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer19, 'uint16', 3_088, 966);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer20);
+} catch {}
+try {
+renderPassEncoder24.insertDebugMarker('\u{1ff87}');
+} catch {}
+let pipeline1 = await promise11;
+let textureView58 = texture17.createView({format: 'rgba16uint'});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+sampler16.label = '\u08df\u{1fd34}\u{1fdf7}\u0263\u0036\u51c0\u{1f614}';
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({label: '\u54b5\ue383\u0346\u0261'});
+let texture38 = device0.createTexture({
+  size: [10, 5, 79],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle4]);
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1584 */
+  offset: 1584,
+  buffer: buffer21,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture39 = device0.createTexture({
+  size: [5, 2, 24],
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView59 = texture35.createView({label: '\u20d8\u{1ffd7}', dimension: '2d-array'});
+let renderPassEncoder25 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -262.3, g: 568.6, b: -785.6, a: -456.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler10}],
+});
+let commandEncoder57 = device0.createCommandEncoder({});
+let texture40 = device0.createTexture({
+  label: '\ufa06\u{1fb0b}\u{1ff0b}\u{1fce3}\u4dd6\udf5a\u0c42\u{1f6cb}\u{1f876}\u13e6\u07b0',
+  size: [64, 64, 13],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture41 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder34 = commandEncoder57.beginComputePass({label: '\u{1faf6}\uf578\u04ea\uc2be\u1a72\uabe6\uc69c\u5cf0'});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle4, renderBundle3, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer4, 'uint32', 8_784, 2_438);
+} catch {}
+let textureView60 = texture3.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler24}],
+});
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture42 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder26 = commandEncoder58.beginRenderPass({colorAttachments: [{view: textureView53, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(715), 235, 0);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(27);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 301.9, g: 560.3, b: -668.2, a: 315.8, });
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer7, 'uint32', 1_760, 1_076);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(2, buffer24);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(10_991).fill(237), /* required buffer size: 10_991 */
+{offset: 123, bytesPerRow: 11, rowsPerImage: 76}, {width: 1, height: 0, depthOrArrayLayers: 14});
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler2}],
+});
+let buffer30 = device0.createBuffer({
+  size: 23596,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.09,
+  lodMaxClamp: 63.63,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup30, new Uint32Array(558), 228, 0);
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u{1fdfd}');
+} catch {}
+let buffer31 = device0.createBuffer({
+  label: '\ucdce\u{1fbb6}',
+  size: 12912,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup16, new Uint32Array(1477), 374, 0);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw8: atomic<u32>;
+
+var<workgroup> vw4: vec4u;
+
+var<workgroup> vw7: array<array<atomic<i32>, 2>, 6>;
+
+var<workgroup> vw9: f32;
+
+var<workgroup> vw5: atomic<u32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw10: array<atomic<i32>, 1>;
+
+@group(0) @binding(0) var tex4: texture_2d<i32>;
+
+@group(0) @binding(27) var sam2: sampler;
+
+var<workgroup> vw6: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(8) f0: array<u32>,
+}
+
+fn fn1() -> array<array<array<vec4<bool>, 4>, 1>, 1> {
+  var out: array<array<array<vec4<bool>, 4>, 1>, 1>;
+  let vf33: vec2f = unpack2x16snorm(u32(unconst_u32(49)));
+  var vf34: vec3u = insertBits(vec3u(unconst_u32(88), unconst_u32(237), unconst_u32(61)), vec3u(bitcast<u32>(reverseBits(i32(unconst_i32(338))))), pack4xU8Clamp(vec4u(unconst_u32(0), unconst_u32(33), unconst_u32(305), unconst_u32(127))), pack4x8snorm(vec4f(unconst_f32(0.3799), unconst_f32(0.02342), unconst_f32(0.06595), unconst_f32(0.08402))));
+  vf34 += vec3u(bitcast<u32>(vf33[0]));
+  var vf35: u32 = pack2x16unorm(vec2f(unconst_f32(0.1157), unconst_f32(0.03663)));
+  let ptr14: ptr<function, u32> = &vf35;
+  vf35 = (*ptr14);
+  vf34 -= bitcast<vec3u>(unpack2x16snorm(u32(unconst_u32(1))).xyx);
+  let vf36: vec2h = faceForward(vec2h(log(f16(unconst_f16(484.9)))), bitcast<vec2h>(dot4U8Packed(pack2x16unorm(vec2f(unconst_f32(0.01942), unconst_f32(-0.5308))), pack4xU8Clamp(vec4u((*ptr14))))), vec2h(cross(vec3f(unconst_f32(0.05698), unconst_f32(-0.06896), unconst_f32(0.1528)), vec3f(bitcast<f32>(pack4x8snorm(vec4f(unconst_f32(0.07184), unconst_f32(0.2568), unconst_f32(0.00473), unconst_f32(0.1939)))))).xy));
+  vf34 = vec3u(faceForward(vec2h(unconst_f16(22231.6), unconst_f16(248.2)), vec2h(unconst_f16(486.2), unconst_f16(7148.6)), bitcast<vec2h>(vf33[0])).xxx);
+  var vf37: u32 = dot4U8Packed(vf34[u32(unconst_u32(393))], bitcast<u32>(log2(vec2h(unconst_f16(7121.3), unconst_f16(787.8)))));
+  let ptr15: ptr<function, u32> = &vf37;
+  return out;
+}
+
+var<workgroup> vw2: f16;
+
+var<workgroup> vw3: mat3x2h;
+
+fn fn0() -> vec2<bool> {
+  var out: vec2<bool>;
+  out = vec2<bool>(insertBits(insertBits(vec3u(unconst_u32(182), unconst_u32(76), unconst_u32(49)), vec3u(unconst_u32(46), unconst_u32(120), unconst_u32(141)), u32(unconst_u32(17)), u32(unconst_u32(39))), vec3u(unconst_u32(14), unconst_u32(486), unconst_u32(327)), u32(unconst_u32(52)), u32(atanh(vec3h(insertBits(vec3u(countTrailingZeros(insertBits(vec3u(unconst_u32(834), unconst_u32(32), unconst_u32(179)), vec3u(log(vec3h(unconst_f16(8395.6), unconst_f16(6260.6), unconst_f16(40415.5)))), vec3u(log(vec3h(unconst_f16(-4832.9), unconst_f16(12688.9), unconst_f16(10877.7))))[1], u32(unconst_u32(15)))[2])), vec3u(unconst_u32(46), unconst_u32(71), unconst_u32(244)), u32(distance(f16(pack4x8snorm(vec4f(unconst_f32(0.08260), unconst_f32(0.1524), unconst_f32(1.000), unconst_f32(0.1502)))), f16(unconst_f16(928.2)))), u32(unconst_u32(69))))).b)).yy);
+  var vf21: vec3f = sin(vec3f(unconst_f32(0.2591), unconst_f32(0.02293), unconst_f32(0.02594)));
+  let vf22: f32 = tan(asin(vec2f(unconst_f32(0.1089), unconst_f32(0.00622)))[1]);
+  var vf23: u32 = pack4x8snorm(vec4f(quantizeToF16(bitcast<f32>(countTrailingZeros(u32(unconst_u32(573)))))));
+  var vf24: f32 = quantizeToF16(f32(unconst_f32(0.02426)));
+  vf21 = vec3f(log(vec3h(f16(vf24))));
+  vf24 = bitcast<f32>(countTrailingZeros(u32(unconst_u32(59))));
+  vf21 = asinh(vec2f(vf21[2])).rrr;
+  let ptr13: ptr<function, vec3f> = &vf21;
+  var vf25: f32 = vf21[countTrailingZeros(u32(unconst_u32(41)))];
+  var vf26: vec3f = sin(vec3f(unconst_f32(0.1174), unconst_f32(0.02339), unconst_f32(0.1332)));
+  vf21 -= vec3f(bitcast<f32>(countTrailingZeros(pack2x16snorm(asinh(vec2f(unconst_f32(0.04116), unconst_f32(0.1390)))))));
+  let vf27: vec3h = atanh(vec3h(unconst_f16(31968.8), unconst_f16(31432.4), unconst_f16(15043.3)));
+  var vf28: f32 = vf21[vec3u(vf21)[1]];
+  var vf29: vec3h = vf27;
+  vf26 = vec3f(bitcast<f32>(vf23));
+  var vf30: f32 = (*ptr13)[bitcast<u32>(sin(vec3f(f32(vf27[u32((*ptr13)[u32(unconst_u32(528))])]))).b)];
+  var vf31: u32 = countTrailingZeros(insertBits(vec3u(unconst_u32(18), unconst_u32(226), unconst_u32(180)), vec3u(u32((*ptr13)[2])), u32(unconst_u32(231)), u32(unconst_u32(150)))[1]);
+  let vf32: f32 = vf26[2];
+  vf31 &= u32(vf21[2]);
+  vf24 = bitcast<f32>(insertBits(vec3u(unconst_u32(21), unconst_u32(229), unconst_u32(148)), vec3u(unconst_u32(168), unconst_u32(290), unconst_u32(125)), u32(vf29[u32(vf27.r)]), u32(unconst_u32(52)))[2]);
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  label: '\u1508\uf9cc\u2384\u0a34\u9657\u{1f82b}\u0040\u{1f72c}\uaf0c\u05b9\u1a99',
+  size: {width: 10, height: 5, depthOrArrayLayers: 26},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder35 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(948);
+} catch {}
+offscreenCanvas0.width = 154;
+let commandEncoder60 = device0.createCommandEncoder({});
+let textureView61 = texture38.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder36 = commandEncoder60.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer25, 'uint32', 52, 493);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer31);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 8, z: 1},
+  aspect: 'all',
+}, new Uint8Array(1_353).fill(129), /* required buffer size: 1_353 */
+{offset: 311, bytesPerRow: 54, rowsPerImage: 19}, {width: 4, height: 4, depthOrArrayLayers: 2});
+} catch {}
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 515});
+let textureView62 = texture4.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 3});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup22, new Uint32Array(1702), 251, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer14, 'uint16', 214, 645);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 164, new BigUint64Array(13893), 396, 0);
+} catch {}
+try {
+adapter1.label = '\uc6a3\u7e57\u{1fa91}\u9d4a\ude55\ucd6c\ue8b3\u{1fc46}';
+} catch {}
+let textureView63 = texture35.createView({dimension: '2d-array'});
+let sampler38 = device0.createSampler({
+  label: '\u923d\u066f\u817b\u0812\ud8a4\u05e5\u0d43\uc6e5\ubd97\u{1f80c}\u{1fc77}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 98.54,
+  lodMaxClamp: 98.61,
+});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup15, new Uint32Array(747), 12, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer17, 'uint32', 64, 7_127);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer2, 0, 11_174);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let bindGroup34 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView41}]});
+let textureView64 = texture13.createView({baseArrayLayer: 0});
+let textureView65 = texture35.createView({dimension: '2d-array', format: 'r16uint', mipLevelCount: 1});
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer7, 'uint32', 3_212, 3_352);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\u83e9\uacc8\u{1f9ac}\u0939\ua70a\u2c0f\u{1f7ed}\u4158\u2809\u371c\ub629',
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct VertexOutput2 {
+  @invariant @builtin(position) f13: vec4f,
+  @location(10) @interpolate(linear, sample) f14: vec2h,
+  @location(3) @interpolate(perspective) f15: f32,
+  @location(12) @interpolate(flat, sample) f16: vec2i,
+}
+
+struct T2 {
+  f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(0) var tex5: texture_2d<i32>;
+
+@id(59627) override override0: u32 = 238;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(27) var sam3: sampler;
+
+var<private> vp10: array<f16, 16> = array<f16, 16>();
+
+fn fn1() -> array<array<T3, 1>, 1> {
+  var out: array<array<T3, 1>, 1>;
+  vp8[u32(unconst_u32(46))] = modf(ldexp(vec4f(f32(mix(f16(unconst_f16(8990.2)), f16(unconst_f16(1632.0)), f16(unconst_f16(2201.8))))), vec4i(textureDimensions(tex5, vp7.exp).ggrg)).z);
+  var vf46 = fn0();
+  var vf47 = fn0();
+  let vf48: u32 = textureNumLevels(tex5);
+  fn0();
+  var vf49 = fn0();
+  vf47[u32(unconst_u32(74))][pack4xI8(textureLoad(tex5, vec2i(unconst_i32(35), unconst_i32(23)), i32(unconst_i32(225))))][u32(unconst_u32(108))] = vf46[33][0][u32(override1)];
+  var vf50 = fn0();
+  vp5 = bool(textureNumLevels(tex5));
+  var vf51 = fn0();
+  let ptr23: ptr<function, array<array<bool, 1>, 1>> = &vf49[33];
+  fn0();
+  var vf52 = fn0();
+  let vf53: vec4u = textureLoad(tex6, vec2i(unconst_i32(144), unconst_i32(386)), i32(vp9.whole));
+  fn0();
+  vp9.whole = f32(vf46[33][0][0]);
+  let vf54: vec4i = textureLoad(tex5, vec2i(unconst_i32(242), unconst_i32(168)), i32(vf46[33][0][0]));
+  return out;
+}
+
+var<private> vp7 = frexp(f32());
+
+var<private> vp9 = modf(f32());
+
+var<private> vp8 = array(modf(f32()), modf(f32()));
+
+var<private> vp6: vec2u = vec2u();
+
+struct T0 {
+  @size(44) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T3 {
+  @size(16) f0: array<vec4h, 1>,
+}
+
+override override1: i32 = 162;
+
+var<private> vp5: bool = bool();
+
+struct T1 {
+  @align(2) @size(8) f0: array<f32, 1>,
+}
+
+fn fn0() -> array<array<array<bool, 1>, 1>, 34> {
+  var out: array<array<array<bool, 1>, 1>, 34>;
+  let vf38: vec2h = trunc(bitcast<vec2h>(vp7.exp));
+  let ptr16 = &vp7;
+  let vf39: i32 = abs(i32(unconst_i32(55)));
+  var vf40: vec4h = exp2(trunc(vec2h(unconst_f16(4125.7), unconst_f16(15471.7))).grrr);
+  var vf41: u32 = pack4xU8Clamp(vec4u(unconst_u32(146), unconst_u32(53), unconst_u32(316), unconst_u32(501)));
+  vp6 -= bitcast<vec2u>(vf40);
+  vf41 += u32((*ptr16).fract);
+  var vf42: f16 = vf38[0];
+  vp9.fract *= vp9.whole;
+  vf42 -= vf40[1];
+  vp6 = vec2u(u32(vp10[15]));
+  let ptr17: ptr<private, f16> = &vp10[15];
+  let ptr18: ptr<private, array<f16, 16>> = &vp10;
+  let ptr19: ptr<private, f32> = &(*ptr16).fract;
+  vp7 = frexp(f32((*ptr18)[15]));
+  let ptr20: ptr<private, f16> = &(*ptr17);
+  let ptr21: ptr<function, vec4h> = &vf40;
+  let ptr22: ptr<private, array<f16, 16>> = &(*ptr18);
+  let vf43: vec2u = max(vec2u(u32((*ptr19))), vec2u(unconst_u32(187), unconst_u32(37)));
+  let vf44: u32 = vf43[u32(vf38[0])];
+  vp10[u32(unconst_u32(252))] = (*ptr21)[override0];
+  vp9.whole = f32(vp10[u32(unconst_u32(182))]);
+  var vf45: u32 = vf43[u32(unconst_u32(291))];
+  return out;
+}
+
+@group(1) @binding(103) var tex6: texture_multisampled_2d<u32>;
+
+@vertex
+fn vertex2(@location(8) a0: vec4h, @location(3) @interpolate(flat, sample) a1: vec2i, @location(2) @interpolate(linear) a2: f16) -> VertexOutput2 {
+  var out: VertexOutput2;
+  fn0();
+  vp7 = frexp(f32(vp10[15]));
+  out.f14 = bitcast<vec2h>(pack4xI8(vec4i(unconst_i32(178), unconst_i32(-840), unconst_i32(185), unconst_i32(-86))));
+  let ptr24: ptr<private, f16> = &vp10[u32(unconst_u32(363))];
+  out.f16 *= vec2i(vp6);
+  out.f14 = bitcast<vec2h>(pack2x16unorm(vec2f(unconst_f32(0.2409), unconst_f32(0.00510))));
+  let ptr25: ptr<private, f16> = &vp10[15];
+  var vf55 = fn0();
+  var vf56 = fn0();
+  fn0();
+  let ptr26 = &vp8[u32(unconst_u32(191))];
+  out.f16 = vec2i(vp7.exp);
+  vp5 = vf55[33][0][0];
+  let vf57: u32 = vp6[pack4x8unorm(select(vec4f(log2(vec4h(unconst_f16(6717.7), unconst_f16(5929.5), unconst_f16(1440.9), unconst_f16(50284.2)))), vec4f(unconst_f32(-0.09137), unconst_f32(0.1335), unconst_f32(0.05091), unconst_f32(0.7282)), bool(unconst_bool(false))))];
+  let vf58: vec4h = a0;
+  let vf59: vec3h = sqrt(vec3h(unconst_f16(2677.3), unconst_f16(17219.0), unconst_f16(1684.3)));
+  let ptr27 = &vp8[u32(unconst_u32(350))];
+  let ptr28: ptr<function, array<array<bool, 1>, 1>> = &vf55[33];
+  return out;
+}
+
+@compute @workgroup_size(5, 1, 1)
+fn compute1() {
+  var vf60 = fn0();
+  let vf61: vec4i = textureGather(2, tex5, sam3, vec2f(unconst_f32(0.5094), unconst_f32(0.07705)));
+  let ptr29: ptr<function, bool> = &vf60[33][0][0];
+  fn1();
+  vp10[u32(unconst_u32(164))] = f16(degrees(f32(unconst_f32(0.7022))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture44 = device0.createTexture({
+  size: [40, 23, 8],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView66 = texture31.createView({dimension: '2d'});
+try {
+computePassEncoder9.insertDebugMarker('\ud53c');
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer3, offset: 512, size: 16}}],
+});
+let buffer32 = device0.createBuffer({
+  size: 7827,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture45 = device0.createTexture({
+  size: [64, 64, 9],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup29, new Uint32Array(251), 17, 0);
+} catch {}
+document.body.prepend(canvas1);
+let texture46 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 2},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(17, 10, 1, 2);
+} catch {}
+try {
+  await promise9;
+} catch {}
+let videoFrame7 = new VideoFrame(videoFrame6, {timestamp: 0});
+let shaderModule4 = device0.createShaderModule({
+  label: '\u8856\u0680\ud993\u63ce\u231a\u84de',
+  code: `
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput3 {
+  @location(11) f17: u32,
+  @builtin(position) f18: vec4f,
+}
+
+@group(0) @binding(0) var tex7: texture_2d<i32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw12: FragmentOutput1;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @align(2) @size(16) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn0() -> array<array<array<u32, 1>, 1>, 1> {
+  var out: array<array<array<u32, 1>, 1>, 1>;
+  var vf62: vec2u = textureDimensions(tex7, i32(unconst_i32(182)));
+  out[u32(unconst_u32(280))][u32(unconst_u32(141))][u32(unconst_u32(17))] >>= pack4xU8Clamp(workgroupUniformLoad(&vw12).f0);
+  vf62 = vec2u(u32((*&vw11)[u32((*&vw11)[(*&vw12).f0[2]])]));
+  out[u32(unconst_u32(158))][u32(unconst_u32(134))][u32(unconst_u32(53))] &= vf62[1];
+  return out;
+}
+
+fn fn1() -> vec2h {
+  var out: vec2h;
+  var vf63: vec2f = unpack2x16snorm(u32(determinant(mat2x2h(f16(pack2x16float(log(vec2f(unconst_f32(0.2709), unconst_f32(0.3139))))), f16(pack2x16float(log(vec2f(unconst_f32(0.2709), unconst_f32(0.3139))))), f16(pack2x16float(log(vec2f(unconst_f32(0.2709), unconst_f32(0.3139))))), f16(pack2x16float(log(vec2f(unconst_f32(0.2709), unconst_f32(0.3139)))))))));
+  vf63 += bitcast<vec2f>(unpack4xI8(u32(unconst_u32(265))).zy);
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput1 {
+  @location(0) @interpolate(flat, sample) f0: vec4u,
+}
+
+var<workgroup> vw11: vec4h;
+
+@vertex
+fn vertex3(@location(12) a0: i32, @location(6) a1: vec4f, @builtin(vertex_index) a2: u32) -> VertexOutput3 {
+  var out: VertexOutput3;
+  fn1();
+  out.f17 += pack4x8unorm(refract(vec4f(unconst_f32(0.1456), unconst_f32(0.3115), unconst_f32(0.06827), unconst_f32(0.06269)), reflect(vec2f(bitcast<f32>(dot4U8Packed(u32(unconst_u32(64)), u32(unconst_u32(23))))), fma(unpack2x16float(pack2x16float(vec2f(a1[3]))), vec2f(f32(asinh(f16(unconst_f16(610.0))))), vec2f(mix(refract(refract(vec4f(exp(bitcast<vec2h>(mix(bitcast<f32>(exp(vec2h(unconst_f16(15350.1), unconst_f16(4573.3)))), f32(unconst_f32(0.1540)), f32(unconst_f32(0.4520))))).rggr), unpack4x8unorm(pack2x16float(vec2f(unconst_f32(0.07878), unconst_f32(0.01744)))), mix(f32(asinh(f16(a1[1]))), f32(unconst_f32(-0.4095)), distance(vec2f(f32(a0)), vec2f(unconst_f32(0.3460), unconst_f32(0.1035))))), inverseSqrt(vec3f(unconst_f32(-0.05013), unconst_f32(0.03353), unconst_f32(0.06041))).zzyz, f32(unconst_f32(0.5887))).y, f32(unconst_f32(0.3576)), f32(unconst_f32(0.1226)))))).rrgr, f32(unconst_f32(0.3419))));
+  out.f18 = vec4f(distance(vec2f(f32(a0)), vec2f(unconst_f32(-0.5433), unconst_f32(0.1291))));
+  var vf64 = fn1();
+  let vf65: u32 = pack2x16float(vec2f(vf64));
+  fn1();
+  out.f17 >>= bitcast<u32>(distance(vec2f(unconst_f32(0.2349), unconst_f32(0.2262)), vec2f(unconst_f32(0.02661), unconst_f32(0.03750))));
+  var vf66 = fn1();
+  var vf67 = fn1();
+  out.f18 += vec4f(mix(bitcast<f32>(vf64), f32(unconst_f32(0.04610)), f32(unconst_f32(0.07982))));
+  out.f17 = dot4U8Packed(u32(unconst_u32(66)), u32(vf67[0]));
+  out.f18 = vec4f(f32(vf64[bitcast<u32>(vf64)]));
+  let vf68: u32 = pack2x16snorm(vec2f(unconst_f32(0.1746), unconst_f32(0.2492)));
+  let vf69: f32 = mix(f32(unconst_f32(0.00723)), f32(unconst_f32(0.1061)), f32(unconst_f32(0.05957)));
+  var vf70: i32 = a0;
+  let vf71: vec3f = inverseSqrt(vec3f(unconst_f32(0.07083), unconst_f32(0.4896), unconst_f32(0.08682)));
+  vf66 *= bitcast<vec2h>(a2);
+  var vf72: f16 = vf64[u32(unconst_u32(455))];
+  vf66 = vec2h(vf64[0]);
+  vf66 = vec2h(inverseSqrt(vec3f(asin(vec4h(f16(mix(cosh(vec4f(vf71[2])).z, f32(unconst_f32(0.1504)), f32(unconst_f32(0.02977)))))).rbr)).zx);
+  vf67 = vec2h(refract(vec4f(unconst_f32(0.05807), unconst_f32(0.1213), unconst_f32(-0.03288), unconst_f32(0.00420)), vec4f(unconst_f32(0.04980), unconst_f32(0.03673), unconst_f32(-0.00616), unconst_f32(0.07129)), f32(unconst_f32(0.1681))).gb);
+  vf72 = vec3h(vf71).b;
+  return out;
+}
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out = FragmentOutput1(bitcast<vec4u>(firstTrailingBit(vec4i(unconst_i32(10), unconst_i32(19), unconst_i32(209), unconst_i32(538)))));
+  out.f0 -= vec4u(asinh(vec2h(unconst_f16(1965.6), unconst_f16(1356.6))).grrr);
+  out.f0 -= vec4u(asinh(vec2h(unconst_f16(31264.9), unconst_f16(14381.3))).grrr);
+  out.f0 |= vec4u(firstTrailingBit(unpack4xI8(pack2x16unorm(vec2f(unconst_f32(0.1696), unconst_f32(-0.06065))))));
+  var vf73: i32 = firstTrailingBit(firstTrailingBit(i32(unconst_i32(32))));
+  vf73 = vf73;
+  var vf74: i32 = firstTrailingBit(i32(unconst_i32(341)));
+  out.f0 = vec4u(degrees(vec4h(inverseSqrt(vec3f(f32(firstTrailingBit(firstTrailingBit(bitcast<vec4i>(unpack2x16unorm(u32(unconst_u32(94))).yyyx)).r)))).zxzx)));
+  out.f0 *= unpack4xU8(u32(firstTrailingBit(textureLoad(tex7, bitcast<vec2i>(degrees(vec4h(f16(vf74)))), i32(unconst_i32(235)))[3])));
+  let vf75: f16 = distance(asinh(vec2h(ldexp(f16(pack2x16unorm(vec2f(unconst_f32(0.01414), unconst_f32(0.2116)))), i32(ldexp(log(vec4h(unconst_f16(168.9), unconst_f16(46.75), unconst_f16(18436.2), unconst_f16(1844.2)))[2], i32(unconst_i32(207))))))), vec2h(unconst_f16(21716.0), unconst_f16(13683.2)));
+  out = FragmentOutput1(vec4u(unpack2x16unorm(u32(unconst_u32(342))).yyyx));
+  vf73 = i32(vf75);
+  var vf76: f16 = distance(vec2h(unconst_f16(7339.9), unconst_f16(18461.9)), vec2h(unconst_f16(1270.4), unconst_f16(8686.7)));
+  out.f0 &= bitcast<vec4u>(textureLoad(tex7, vec2i(unconst_i32(74), unconst_i32(250)), firstTrailingBit(vec4i(firstLeadingBit(vec3u(unconst_u32(392), unconst_u32(428), unconst_u32(48))).rbbb))[0]));
+  out.f0 >>= vec4u(asinh(vec2h(unconst_f16(876.1), unconst_f16(10115.5))).rggg);
+  var vf77: u32 = pack2x16unorm(vec2f(bitcast<f32>(vf74)));
+  let ptr30: ptr<function, f16> = &vf76;
+  let ptr31: ptr<function, i32> = &vf73;
+  out.f0 >>= unpack4xU8(bitcast<u32>((*ptr31)));
+  let vf78: vec2u = textureDimensions(tex7, vec3i(firstLeadingBit(vec3u(pack2x16unorm(vec2f(f32(textureNumLevels(tex7))))))).y);
+  out.f0 |= unpack4xU8(vf78[u32(unconst_u32(528))]);
+  let vf79: vec3u = firstLeadingBit(vec3u(unconst_u32(124), unconst_u32(100), unconst_u32(77)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  vw12.f0 = vec4u(bitcast<u32>(dot(vec4f(unconst_f32(0.04877), unconst_f32(0.1237), unconst_f32(-0.2648), unconst_f32(0.1397)), vec4f(unconst_f32(0.00805), unconst_f32(0.4743), unconst_f32(0.1736), unconst_f32(0.06438)))));
+  vw11 = vec4h((*&vw12).f0);
+  var vf80: u32 = (*&vw12).f0[2];
+  let vf81: f16 = vw11[u32(unconst_u32(216))];
+  let vf82: f16 = tanh(tanh(f16(unconst_f16(2495.6))));
+  vf80 ^= (*&vw12).f0.w;
+  vw11 = vec4h((*&vw11)[vec4u(textureLoad(tex7, vec2i(unconst_i32(157), unconst_i32(16)), i32(unconst_i32(288))))[1]]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder61 = device0.createCommandEncoder();
+let texture47 = device0.createTexture({
+  size: [20, 11, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder37 = commandEncoder61.beginComputePass({});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(3);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer10, 4156, buffer9, 3380, 296);
+} catch {}
+let texture48 = device0.createTexture({
+  size: [40, 23, 319],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder38 = commandEncoder43.beginComputePass({label: '\u09d6\u08df\u0eff\u34a1\u{1ff68}\u02ad\u27c3\uda74'});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer3, 204); };
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer19, 6_584); };
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer14, 'uint32', 1_548, 32);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 532, new BigUint64Array(5818), 1851, 40);
+} catch {}
+await gc();
+let buffer33 = device0.createBuffer({size: 18354, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView67 = texture27.createView({mipLevelCount: 1});
+let computePassEncoder39 = commandEncoder62.beginComputePass();
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.55,
+  lodMaxClamp: 81.02,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup24, new Uint32Array(435), 35, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer32, 'uint16', 324, 547);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer18, 548, 272);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 1552, new DataView(new ArrayBuffer(3194)), 62, 1184);
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler19}, {binding: 0, resource: textureView20}],
+});
+let buffer34 = device0.createBuffer({
+  size: 8205,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView68 = texture30.createView({dimension: '2d-array', baseMipLevel: 0, arrayLayerCount: 1});
+let sampler40 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 81.30,
+  lodMaxClamp: 83.18,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup23, new Uint32Array(115), 8, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+document.body.prepend(canvas0);
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 2954});
+let texture49 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView69 = texture39.createView({baseArrayLayer: 12, arrayLayerCount: 1});
+let sampler41 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.63,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 256, new Float32Array(1027), 560, 84);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler37}, {binding: 0, resource: textureView7}],
+});
+let sampler42 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.10,
+  lodMaxClamp: 78.46,
+  maxAnisotropy: 6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer1, 1_024); };
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 768, new DataView(new ArrayBuffer(12010)), 1651, 872);
+} catch {}
+let sampler43 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.75,
+  lodMaxClamp: 95.10,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer18, 132, 754);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup38 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView48}]});
+let buffer35 = device0.createBuffer({size: 17280, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture50 = device0.createTexture({
+  size: [20, 11, 159],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView70 = texture3.createView({label: '\u581a\u0b31\u4a9e', arrayLayerCount: 1});
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup9, new Uint32Array(77), 15, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+commandEncoder4.clearBuffer(buffer25, 140, 72);
+} catch {}
+let computePassEncoder40 = commandEncoder4.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 93},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView71 = texture6.createView({mipLevelCount: 1});
+let computePassEncoder41 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(173);
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture52 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 26},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup34, new Uint32Array(2072), 461, 0);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup22, new Uint32Array(136), 11, 0);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: -72.88, g: 917.7, b: -257.5, a: -217.3, });
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer7, 'uint16', 340, 551);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer31, 0);
+} catch {}
+document.body.prepend(canvas1);
+let buffer36 = device0.createBuffer({
+  label: '\u04dc\u{1fdb8}\u002f\u084a\u635e\u7c37\u0a9a',
+  size: 4811,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder64 = device0.createCommandEncoder();
+let textureView72 = texture50.createView({mipLevelCount: 1});
+let computePassEncoder42 = commandEncoder64.beginComputePass({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup16, new Uint32Array(525), 73, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer4, 'uint32', 12_544, 11_577);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer33, 'uint32', 2_888, 70);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let buffer37 = device0.createBuffer({size: 1681, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let texture53 = device0.createTexture({
+  label: '\u12a6\uc8e5\u{1f71f}\u017f\u22bc',
+  size: {width: 64, height: 64, depthOrArrayLayers: 55},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16uint'],
+});
+let sampler44 = device0.createSampler({
+  label: '\u167d\u{1f97b}\u{1fb25}\u24f7\ub345',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 96.94,
+});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup4, new Uint32Array(581), 22, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup20, new Uint32Array(1629), 30, 0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup32);
+} catch {}
+document.body.append(canvas0);
+let buffer38 = device0.createBuffer({
+  label: '\uf8b7\u{1fb35}\u0982\u63c7\ub249\u77f8\u{1fc02}\u0123\u7005\ub17f',
+  size: 4473,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture54 = device0.createTexture({
+  size: [5, 2, 1],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture55 = device0.createTexture({
+  label: '\u05ae\u6a53\uc767\u{1f680}\u{1fc31}',
+  size: [40, 23, 319],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer17, 'uint16', 40, 2_366);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer3, offset: 768, size: 992}}],
+});
+let textureView73 = texture21.createView({});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup11, new Uint32Array(427), 22, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer16, 828); };
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer33, 'uint16', 166, 2_462);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer19, 'uint16', 2_338, 225);
+} catch {}
+document.body.append(canvas2);
+try {
+adapter0.label = '\ua97a\ue9a7\ufbb2\u{1f60c}\u{1f7ac}\udc16\u9174';
+} catch {}
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 510});
+let sampler45 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.06,
+  lodMaxClamp: 92.50,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+  await promise13;
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'bt709'} });
+let textureView74 = texture54.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder43 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(0, bindGroup37, new Uint32Array(319), 43, 0);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle4, renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup37, new Uint32Array(254), 223, 0);
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder65 = device0.createCommandEncoder({});
+let renderPassEncoder27 = commandEncoder65.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 3,
+  clearValue: { r: -632.4, g: 276.2, b: -300.5, a: 741.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1456 */
+  offset: 1456,
+  buffer: buffer27,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48_059).fill(146), /* required buffer size: 48_059 */
+{offset: 151, bytesPerRow: 108, rowsPerImage: 43}, {width: 8, height: 14, depthOrArrayLayers: 11});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas1);
+let computePassEncoder44 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(3715), 500, 0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup27, new Uint32Array(1123), 14, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer25, 'uint32', 308, 230);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(111).fill(183), /* required buffer size: 111 */
+{offset: 111, rowsPerImage: 17}, {width: 8, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u0d01\u{1f661}\u{1f8b5}\u07fc\u7cf5\u47ce\u0c5a',
+  entries: [
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 14, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView75 = texture27.createView({
+  label: '\u029f\u0f7e\u0452\u0719\u00b6\u8343\u2740\u86cf\uaa39\u0c34',
+  dimension: '3d',
+  mipLevelCount: 1,
+});
+let sampler46 = device0.createSampler({
+  label: '\u524d\u9239\u7a38\u0753\u05a6\ue638\u{1f748}\u4d05\ufb3e',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 64.98,
+});
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3, renderBundle3, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer30, 1824, buffer38, 104, 368);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer39 = device0.createBuffer({size: 22677, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture56 = device0.createTexture({
+  label: '\u{1fca7}\u0cab\u1a5b\ud61b\u{1f949}\ua7d4\u{1fac4}\u48e8',
+  size: [64, 64, 151],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder45 = commandEncoder58.beginComputePass({});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+let buffer40 = device0.createBuffer({
+  size: 6240,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder66 = device0.createCommandEncoder({});
+let texture57 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder46 = commandEncoder66.beginComputePass({});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.80,
+  lodMaxClamp: 91.98,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup15, new Uint32Array(304), 132, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 256, new DataView(new ArrayBuffer(12954)), 5379, 624);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer41 = device0.createBuffer({size: 21048, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView76 = texture4.createView({dimension: 'cube', mipLevelCount: 1, arrayLayerCount: 6});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 76.92,
+  lodMaxClamp: 84.14,
+});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer17);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame9 = new VideoFrame(videoFrame4, {timestamp: 0});
+let commandEncoder67 = device0.createCommandEncoder({label: '\u599a\ucc5f\u{1fa4f}\uc849\u{1f9fa}\u{1fe27}\u{1fa7a}\u{1f758}'});
+let textureView77 = texture5.createView({
+  label: '\uaecb\u1f9b\u3d1b\u4ba3\uca07\u{1f98e}\u0b98\u2a3d\uef35\u0481',
+  dimension: 'cube-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 6,
+});
+let computePassEncoder47 = commandEncoder67.beginComputePass({});
+let renderPassEncoder28 = commandEncoder47.beginRenderPass({colorAttachments: [{view: textureView9, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u007a\u0fab\ua988\u{1fa4f}\u{1f98e}\u47a0\u{1fc2c}\u070e\u{1fa6b}\u{1fab1}\ufc26',
+  colorFormats: ['rgba16uint'],
+  stencilReadOnly: true,
+});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let sampler49 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 83.98,
+  lodMaxClamp: 96.37,
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup37, new Uint32Array(512), 85, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup37, new Uint32Array(870), 98, 0);
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer3, offset: 2048, size: 4}}],
+});
+let buffer42 = device0.createBuffer({size: 3242, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler50 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.01,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup33, []);
+} catch {}
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+let textureView78 = texture7.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 7});
+try {
+computePassEncoder46.setPipeline(pipeline1);
+} catch {}
+let bindGroup41 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView14}]});
+let buffer43 = device0.createBuffer({
+  label: '\u3549\u6915\u{1fc1e}\u01a1',
+  size: 10741,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView79 = texture14.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup12, new Uint32Array(1725), 227, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(270).fill(220), /* required buffer size: 270 */
+{offset: 56, bytesPerRow: 107}, {width: 0, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let img0 = await imageWithData(26, 17, '#10101010', '#20202020');
+try {
+computePassEncoder11.setBindGroup(0, bindGroup32, new Uint32Array(780), 210, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer39, 0, 7_520);
+} catch {}
+let sampler51 = device0.createSampler({addressModeV: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 50.76});
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer30, 1_324, 372);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt709', transfer: 'gamma28curve'} });
+let bindGroup42 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView16}]});
+let buffer44 = device0.createBuffer({
+  size: 22836,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let computePassEncoder48 = commandEncoder68.beginComputePass({label: '\u019a\u0cb1\u094e'});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup27, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup14, new Uint32Array(1525), 78, 0);
+} catch {}
+let imageData8 = new ImageData(92, 12);
+let commandEncoder69 = device0.createCommandEncoder({});
+let textureView80 = texture12.createView({});
+let sampler52 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.86,
+  lodMaxClamp: 61.76,
+});
+try {
+renderPassEncoder24.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\ub127');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 164, new BigUint64Array(7390), 45, 44);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let buffer45 = device0.createBuffer({
+  size: 6257,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderPassEncoder29 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{view: textureView66, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 48212275,
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(2, buffer3, 440, 241);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(112).fill(212), /* required buffer size: 112 */
+{offset: 38, bytesPerRow: 42, rowsPerImage: 57}, {width: 4, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer23, offset: 0, size: 140}}],
+});
+let commandEncoder70 = device0.createCommandEncoder({});
+let texture58 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 11},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData9 = new ImageData(20, 4);
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler24}, {binding: 0, resource: textureView7}],
+});
+let textureView81 = texture19.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let computePassEncoder49 = commandEncoder70.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer24, 612, 275);
+} catch {}
+try {
+renderBundleEncoder8.insertDebugMarker('\u{1fc05}');
+} catch {}
+document.body.append(img0);
+let textureView82 = texture29.createView({label: '\u{1ffe9}\u4569\ub256\u6a20\u{1fd5f}\u{1fb88}'});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder21.setViewport(47.49820422275323, 46.235364160825185, 6.001161713629962, 9.007727724350705, 0.45373004634660985, 0.4583740067263648);
+} catch {}
+let querySet7 = device0.createQuerySet({label: '\ubbca\u2d95\uceee\u1609\ub123\u0943\u{1fed7}\u991f\u9189', type: 'occlusion', count: 247});
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer7, 3_356); };
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(30.35699817396058, 15.627109162672888, 0.7786865230823956, 14.03313212861452, 0.6448351169939208, 0.9052827203076266);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer38);
+} catch {}
+await gc();
+let textureView83 = texture12.createView({});
+let sampler53 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 96.94,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder48.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 604, new DataView(new ArrayBuffer(6499)), 762, 636);
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView20}, {binding: 27, resource: sampler10}],
+});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 985});
+let texture59 = device0.createTexture({
+  label: '\u{1fed1}\u{1fb44}\u071e\u0130\u0e28\u0776\u0f5e',
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup25, new Uint32Array(1006), 323, 0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView84 = texture34.createView({dimension: '2d-array', aspect: 'all'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup16, new Uint32Array(844), 19, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer38, 0, 830);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let shaderModule5 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+override override3: u32 = 4;
+
+@group(0) @binding(27) var sam4: sampler;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0() -> array<array<array<array<u32, 1>, 4>, 1>, 1> {
+  var out: array<array<array<array<u32, 1>, 4>, 1>, 1>;
+  out[textureDimensions(tex8).x][u32(override2)][u32(unconst_u32(420))][u32(unconst_u32(266))] &= textureDimensions(tex8)[1];
+  out[u32(unconst_u32(98))][vec4u(faceForward(vec4f(unconst_f32(0.00991), unconst_f32(0.06659), unconst_f32(0.00879), unconst_f32(0.03243)), vec4f(unconst_f32(0.02191), unconst_f32(0.2219), unconst_f32(-0.02283), unconst_f32(0.4171)), bitcast<vec4f>(textureDimensions(tex8).yxyy))).z][u32(unconst_u32(90))][u32(unconst_u32(47))] >>= override3;
+  var vf83: vec2u = textureDimensions(tex8);
+  out[0][pack4xI8(textureLoad(tex8, vec2i(i32(ldexp(f32(unconst_f32(0.01203)), i32(unconst_i32(171))))), bitcast<i32>(vf83.x)))][3][u32(unconst_u32(18))] >>= dot4U8Packed(u32(unconst_u32(91)), vf83[0]);
+  out[bitcast<u32>(distance(vec3f(textureDimensions(tex8).grg), vec3f(f32(override3))))][0][u32(unconst_u32(242))][u32(unconst_u32(56))] = dot4U8Packed(u32(unconst_u32(89)), u32(unconst_u32(40)));
+  var vf84: f32 = distance(vec3f(distance(vec3f(unconst_f32(0.1281), unconst_f32(0.06052), unconst_f32(0.2029)), vec3f(ldexp(f32(unconst_f32(0.2888)), i32(dot4U8Packed(u32(unconst_u32(131)), u32(unconst_u32(119)))))))), vec3f(f32(vf83[1])));
+  vf84 = bitcast<f32>(textureDimensions(tex8, i32(vf84)).g);
+  let vf85: u32 = dot4U8Packed(u32(unconst_u32(15)), textureDimensions(tex8, i32(unconst_i32(100))).r);
+  let vf86: u32 = vf83[1];
+  var vf87: u32 = override3;
+  let vf88: u32 = vf86;
+  vf83 >>= vec2u(vf86);
+  let vf89: u32 = dot4U8Packed(u32(unconst_u32(422)), bitcast<u32>(faceForward(vec4f(unconst_f32(0.1893), unconst_f32(0.1182), unconst_f32(0.2784), unconst_f32(0.7065)), vec4f(textureLoad(tex8, vec2i(unconst_i32(97), unconst_i32(123)), i32(unconst_i32(-159)))), vec4f(f32(override2))).b));
+  let ptr32: ptr<function, vec2u> = &vf83;
+  let vf90: f32 = distance(vec3f(unconst_f32(0.02056), unconst_f32(0.00452), unconst_f32(0.1469)), vec3f(f32(dot4U8Packed(textureDimensions(tex8)[0], u32(unconst_u32(1))))));
+  vf87 >>= (*ptr32)[0];
+  let vf91: u32 = override3;
+  vf83 += vec2u(u32(distance(vec3f(bitcast<f32>(textureNumLevels(tex8))), vec3f(bitcast<f32>(vf83[1])))));
+  var vf92: u32 = vf83[vf83[1]];
+  let vf93: u32 = override3;
+  var vf94: u32 = override3;
+  var vf95: vec2u = textureDimensions(tex8, i32(unconst_i32(31)));
+  vf95 += vf95;
+  let ptr33: ptr<function, u32> = &vf92;
+  vf87 = (*ptr32)[0];
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  @size(16) f0: array<array<i32, 1>, 1>,
+  @size(68) f1: array<u32>,
+}
+
+override override2 = true;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(1) @binding(103) var tex9: texture_multisampled_2d<u32>;
+
+@group(0) @binding(0) var tex8: texture_2d<i32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute3() {
+  fn0();
+  let vf96: vec2u = textureDimensions(tex8);
+  var vf97 = fn0();
+  fn0();
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder72 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder26.finish({});
+let textureView85 = texture60.createView({label: '\u7bc6\ubd02\u2432\u01fd\u2467', baseArrayLayer: 6, arrayLayerCount: 2});
+let computePassEncoder50 = commandEncoder71.beginComputePass();
+try {
+computePassEncoder38.setBindGroup(0, bindGroup33, new Uint32Array(4119), 87, 0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 158,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 325,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 78, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 146, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+  ],
+});
+let buffer46 = device0.createBuffer({size: 14176, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder73 = device0.createCommandEncoder({});
+let texture61 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 529},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder51 = commandEncoder72.beginComputePass({label: '\u01e5\u0a13\u20f1\u083f\u22df\u0e16\u0281\u8db0\u0e02'});
+try {
+computePassEncoder51.setPipeline(pipeline0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 1, y: 12, z: 4},
+  aspect: 'all',
+}, new Uint8Array(99).fill(127), /* required buffer size: 99 */
+{offset: 99, bytesPerRow: 25}, {width: 3, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1f959}\u03b6';
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 626,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 82, hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder74 = device0.createCommandEncoder();
+let texture62 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 211},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder73.beginComputePass({});
+let renderPassEncoder30 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView84,
+  clearValue: { r: -593.4, g: 235.7, b: 380.4, a: -254.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+});
+let sampler54 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 27.71,
+  lodMaxClamp: 77.92,
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(29, 3, 7, 3);
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u4192');
+} catch {}
+let texture63 = device0.createTexture({
+  label: '\u9268\uf31e',
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer38);
+} catch {}
+let buffer47 = device0.createBuffer({size: 1773, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder75 = device0.createCommandEncoder({label: '\u0736\ub1b0\u02a2\u6023\u{1feb1}\u04ec\u6c48\u03c7\u051d\u{1fb9f}'});
+let textureView86 = texture63.createView({arrayLayerCount: 1});
+let renderPassEncoder31 = commandEncoder75.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: 223.1, g: -253.8, b: -90.06, a: -930.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 513494543,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u{1fe7e}\u0a5d\u431c',
+  colorFormats: ['rgba16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder17.pushDebugGroup('\u4e61');
+} catch {}
+let textureView87 = texture60.createView({
+  label: '\u{1f848}\u0915\ue23f\u0ee1\u0f71\uf62f\u4e52\u0320\ue6ce\u2108',
+  dimension: '2d-array',
+  aspect: 'all',
+  arrayLayerCount: 2,
+});
+let texture64 = device0.createTexture({size: [5, 2, 21], format: 'rgba16uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let sampler55 = device0.createSampler({
+  label: '\u{1fd9e}\ub0f4\u3b3e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.04,
+  lodMaxClamp: 87.09,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+let querySet9 = device0.createQuerySet({label: '\u96ea\u7716\uc77a\u{1f628}\u0e26\u04f9\uff9d', type: 'occlusion', count: 159});
+let texture65 = device0.createTexture({
+  size: [5, 2, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup24, new Uint32Array(6307), 344, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer35);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture66 = device0.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture67 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder50.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(304);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer18);
+} catch {}
+let buffer48 = device0.createBuffer({size: 7528, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView88 = texture65.createView({dimension: '2d-array', baseMipLevel: 0});
+let textureView89 = texture16.createView({dimension: 'cube'});
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(780);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer7, 'uint32', 636, 67);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer39, 2_836, 5_044);
+} catch {}
+try {
+computePassEncoder30.insertDebugMarker('\u{1f788}');
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture68 = device0.createTexture({
+  size: [10],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture69 = device0.createTexture({
+  size: [5, 2, 2],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView90 = texture52.createView({baseArrayLayer: 2, arrayLayerCount: 6});
+let renderPassEncoder32 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView69,
+  clearValue: { r: 984.7, g: 557.9, b: -550.6, a: -302.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer7, 0, 135);
+} catch {}
+let textureView91 = texture66.createView({label: '\uc156\u{1fb6a}\u5b96\u33dd\uda05\u{1fe60}\u3e07\ua053\u0b55'});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer20, 596); };
+} catch {}
+try {
+renderPassEncoder10.setViewport(17.084889859407028, 5.943415788699635, 8.805462810911326, 4.525288697542893, 0.14362040463276438, 0.5062889753018139);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 328, new Int16Array(5104), 75, 28);
+} catch {}
+document.body.append(canvas2);
+let buffer49 = device0.createBuffer({
+  label: '\u{1f83d}\u{1f6a7}\u164a\uc5af\u280c',
+  size: 17939,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX,
+});
+let commandEncoder77 = device0.createCommandEncoder();
+let texture70 = device0.createTexture({
+  size: [64, 64, 20],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture71 = device0.createTexture({size: {width: 10}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder53 = commandEncoder77.beginComputePass({});
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer20, 'uint32', 12, 665);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(244).fill(166), /* required buffer size: 244 */
+{offset: 244}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise15;
+} catch {}
+document.body.append(img0);
+let textureView92 = texture70.createView({label: '\u020f\u0513\u{1f9c4}'});
+let texture72 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 79},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView93 = texture6.createView({baseMipLevel: 0, mipLevelCount: 1});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer35);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(1539), 150, 0);
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 618});
+let textureView94 = texture65.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+renderPassEncoder19.setBlendConstant({ r: 130.9, g: 291.4, b: 104.9, a: -368.0, });
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(6, 1, 2, 4);
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup46 = device0.createBindGroup({label: '\u0725\u399f', layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView87}]});
+let commandEncoder79 = device0.createCommandEncoder({});
+let textureView95 = texture47.createView({baseMipLevel: 0});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+adapter1.label = '\u{1feaa}\u7323\u79c9\u3645\ubeb0\ue164';
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 188,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let textureView96 = texture63.createView({format: 'rgba16float'});
+let renderPassEncoder33 = commandEncoder79.beginRenderPass({
+  label: '\u04e1\u34ca\ub49a\u6494\u{1fe9f}\u{1fdbd}\u5080\u0bb1\u00b0\u{1f92a}',
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -360.7, g: 275.6, b: -830.7, a: 730.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup39, new Uint32Array(261), 20, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer24, 0);
+} catch {}
+try {
+commandEncoder78.clearBuffer(buffer49, 2732, 1928);
+} catch {}
+try {
+globalThis.someLabel = buffer18.label;
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer34, offset: 3584, size: 132}}],
+});
+let buffer50 = device0.createBuffer({size: 17892, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder80 = device0.createCommandEncoder({label: '\u2547\u074e\u5e3e\u{1fcd0}\u{1ff68}\ucd04\u5e45\u169d\u68c7\u{1fa74}\u0ef8'});
+let texture73 = device0.createTexture({
+  size: {width: 5},
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler56 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.11,
+  lodMaxClamp: 93.33,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer34, 2_520); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup6, new Uint32Array(69), 4, 0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer23, 0, 51);
+} catch {}
+try {
+commandEncoder80.clearBuffer(buffer9, 412, 660);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(17), /* required buffer size: 87 */
+{offset: 87}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let offscreenCanvas2 = new OffscreenCanvas(270, 173);
+let bindGroup48 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 14, resource: externalTexture4},
+    {binding: 134, resource: textureView55},
+    {binding: 56, resource: {buffer: buffer11, offset: 512, size: 296}},
+  ],
+});
+let texture74 = device0.createTexture({
+  size: [10],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle5, renderBundle4, renderBundle10, renderBundle8, renderBundle7, renderBundle7, renderBundle4]);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST, alphaMode: 'opaque'});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let bindGroup49 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView85}]});
+let commandEncoder81 = device0.createCommandEncoder({});
+let textureView97 = texture73.createView({mipLevelCount: 1});
+let texture75 = device0.createTexture({size: {width: 20}, dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.COPY_DST});
+let texture76 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder54 = commandEncoder81.beginComputePass({});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup35, new Uint32Array(905), 47, 0);
+} catch {}
+await gc();
+let commandEncoder82 = device0.createCommandEncoder({});
+let textureView98 = texture64.createView({baseArrayLayer: 3, arrayLayerCount: 1});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer44, 0, 35);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2336 */
+  offset: 2336,
+  buffer: buffer13,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder17.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.append(img0);
+let buffer51 = device0.createBuffer({
+  size: 976,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+try {
+computePassEncoder54.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup48, new Uint32Array(3479), 317, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer30, 'uint32', 1_196, 8_429);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup47, new Uint32Array(915), 116, 0);
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 236});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup41, new Uint32Array(150), 22, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer28, 1_420, 177);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let buffer52 = device0.createBuffer({size: 31267, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView99 = texture63.createView({arrayLayerCount: 1});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup32, new Uint32Array(230), 32, 0);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let textureView100 = texture27.createView({dimension: '3d', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler57 = device0.createSampler({
+  label: '\u03f2\u066e\u2e99\ue0e4\ufebc\uf83f\u61d1\u{1f89f}\u{1f748}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.61,
+  lodMaxClamp: 91.16,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 416 */
+  offset: 416,
+  buffer: buffer25,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder34 = commandEncoder78.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -937.8, g: -520.8, b: 248.1, a: -507.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup27, new Uint32Array(400), 20, 0);
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 78, resource: externalTexture8},
+    {binding: 158, resource: textureView23},
+    {binding: 146, resource: sampler34},
+    {binding: 325, resource: textureView91},
+    {binding: 65, resource: textureView94},
+    {binding: 2, resource: textureView92},
+    {binding: 134, resource: textureView96},
+  ],
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+let textureView101 = texture41.createView({format: 'bgra8unorm'});
+let computePassEncoder55 = commandEncoder84.beginComputePass();
+let renderPassEncoder35 = commandEncoder82.beginRenderPass({colorAttachments: [{view: textureView69, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder24.setBlendConstant({ r: -653.7, g: -831.8, b: -21.02, a: 830.4, });
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer32, 'uint16', 338, 4_785);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 984 */
+  offset: 984,
+  buffer: buffer30,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise16;
+} catch {}
+document.body.prepend(img0);
+try {
+globalThis.someLabel = sampler0.label;
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup2, new Uint32Array(2619), 346, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer0, 176, buffer20, 184, 200);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  label: '\ubddf\u1ec3\u09f6\u0c94\u{1f8fe}\ud5b5\u0918',
+  size: [40, 23, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder56 = commandEncoder83.beginComputePass();
+let renderPassEncoder36 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  depthSlice: 78,
+  clearValue: { r: -532.8, g: 529.6, b: -779.3, a: -350.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup9, new Uint32Array(320), 21, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer40, 'uint32', 3_112, 1_173);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 30, y: 25, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2_367).fill(214), /* required buffer size: 2_367 */
+{offset: 87, bytesPerRow: 24, rowsPerImage: 6}, {width: 6, height: 5, depthOrArrayLayers: 16});
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  label: '\u7817\u022f\ucd9d\ua749\u3c19\u0131\u2369\u09c9\u0cdd\u{1f770}\u02df',
+  layout: bindGroupLayout4,
+  entries: [{binding: 60, resource: textureView87}],
+});
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView102 = texture8.createView({label: '\u{1f649}\u13f7\u0e28\u24ba\u604c', format: 'rgba16uint'});
+let sampler58 = device0.createSampler({
+  label: '\u{1f6fe}\u4d60\u60eb\u09c3\u0e90\ue20d\u0e73\ub2dc',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 61.42,
+  lodMaxClamp: 76.45,
+});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup24, new Uint32Array(176), 39, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(19);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer8, 'uint32', 344, 2_297);
+} catch {}
+try {
+commandEncoder85.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3128 */
+  offset: 3128,
+  bytesPerRow: 256,
+  buffer: buffer7,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet2, 21, 17, buffer7, 3584);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(0, bindGroup12, new Uint32Array(1541), 141, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup22, new Uint32Array(3764), 127, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(34).fill(223), /* required buffer size: 34 */
+{offset: 34}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout5]});
+let commandEncoder88 = device0.createCommandEncoder();
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 2298});
+let texture78 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'etc2-rgb8a1unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture79 = device0.createTexture({
+  label: '\ude65\ud010\u{1f82c}\uc464\u07ee\u{1f6f4}\u0257\u56d3\u085d\u0783',
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let renderPassEncoder37 = commandEncoder85.beginRenderPass({
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: -592.8, g: 835.5, b: 944.5, a: 40.05, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(1, bindGroup5, new Uint32Array(3389), 751, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup31, new Uint32Array(2180), 67, 0);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder89 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({
+  label: '\udbec\u{1fcba}\u037a\u84f4\u0854\ub9ee\uc00e\u1e18\ua660\u7813',
+  type: 'occlusion',
+  count: 945,
+});
+let texture80 = device0.createTexture({
+  size: [5, 2, 14],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer21);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup52 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView97}]});
+let commandEncoder90 = device0.createCommandEncoder({label: '\u1c69\uf13c\u{1f7ee}\u0067\u4ebc\u{1fa59}\ua7ad\u{1f785}\udb5c'});
+let computePassEncoder57 = commandEncoder89.beginComputePass({label: '\u0da8\uf846\u0bdf\ubc46\u4fe4\u0068\u08b8\u6f85\u728c\u484b'});
+let sampler59 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 46.35,
+  lodMaxClamp: 79.29,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle5]);
+} catch {}
+try {
+  await shaderModule5.getCompilationInfo();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3280 */
+  offset: 3280,
+  buffer: buffer52,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(img0);
+let commandEncoder91 = device0.createCommandEncoder();
+let texture81 = device0.createTexture({
+  label: '\ubfe8\udbe5',
+  size: [40],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder58 = commandEncoder88.beginComputePass();
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setStencilReference(433);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer15, 'uint32', 212, 8);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer17, 596, 3_706);
+} catch {}
+let buffer53 = device0.createBuffer({
+  label: '\u4ed5\u7d12\u5d6c\u88ea\u0fbb\u59b7\u0273\u{1fab5}\u558b',
+  size: 14635,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer32, 'uint32', 3_076, 1_584);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer44, 1_228);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer32, 1912, 1136);
+} catch {}
+document.body.prepend(img0);
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup53 = device0.createBindGroup({
+  label: '\u8eb6\u0a4c\u{1fc3f}\ueca4\u0e7b\u71e0',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 146, resource: sampler17},
+    {binding: 78, resource: externalTexture0},
+    {binding: 2, resource: textureView92},
+    {binding: 65, resource: textureView94},
+    {binding: 325, resource: textureView91},
+    {binding: 158, resource: textureView18},
+    {binding: 134, resource: textureView99},
+  ],
+});
+let computePassEncoder59 = commandEncoder87.beginComputePass();
+let sampler60 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.42,
+  lodMaxClamp: 54.86,
+  compare: 'never',
+});
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer14, 'uint32', 428, 200);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 714 */
+  offset: 714,
+  bytesPerRow: 3584,
+  buffer: buffer19,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas2);
+let commandEncoder92 = device0.createCommandEncoder();
+let computePassEncoder60 = commandEncoder90.beginComputePass({});
+let sampler61 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 83.60,
+});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup33, new Uint32Array(4801), 1_130, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer40, 'uint16', 2_416, 358);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2240 */
+  offset: 2240,
+  buffer: buffer19,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 2, y: 22, z: 85},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView103 = texture41.createView({format: 'bgra8unorm'});
+let computePassEncoder61 = commandEncoder86.beginComputePass({label: '\uf255\u02d5\u1bbf\ua8e8\u4666\uf285\u{1fdf0}\u0bfe\uf00e\u6c24\u5f9d'});
+try {
+computePassEncoder61.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup48, new Uint32Array(2724), 1_007, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -952.8, g: 376.2, b: 312.1, a: -807.1, });
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer4, 'uint32', 10_152, 4_183);
+} catch {}
+let sampler62 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 33.89,
+  lodMaxClamp: 74.55,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup4, new Uint32Array(2662), 297, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer30, 2680, buffer3, 740, 240);
+} catch {}
+try {
+commandEncoder91.resolveQuerySet(querySet2, 25, 33, buffer32, 256);
+} catch {}
+document.body.append(canvas2);
+let commandEncoder93 = device0.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder91.beginComputePass({});
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer30, 0);
+} catch {}
+await gc();
+let computePassEncoder63 = commandEncoder93.beginComputePass({});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup45, new Uint32Array(1507), 74, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(517);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer22, 300, buffer6, 1928, 116);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({});
+let textureView104 = texture78.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 4});
+let computePassEncoder64 = commandEncoder13.beginComputePass({label: '\u{1f70e}\u5239\u{1f626}\u{1fd5e}\u7780\uc143\u0e69\u{1f799}\ua55c\u04b9\u0f4b'});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder62.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup40, new Uint32Array(1571), 86, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer19, 'uint32', 4_856, 649);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer40, 0, 330);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(canvas0);
+let computePassEncoder65 = commandEncoder92.beginComputePass({});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup6, new Uint32Array(4104), 583, 0);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(28);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+externalTexture6.label = '\ucffa\ufce7\u64c2\uef90';
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder66 = commandEncoder94.beginComputePass({});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 39.28,
+  lodMaxClamp: 71.44,
+});
+try {
+computePassEncoder64.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup12, new Uint32Array(123), 5, 0);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer8, 'uint16', 3_154, 1_844);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(7, buffer24, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(0).fill(66), /* required buffer size: 0 */
+{offset: 0}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(27) var sam5: sampler;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(8) f0: array<vec2h, 1>,
+}
+
+fn fn1() -> f16 {
+  var out: f16;
+  out += f16(exp2(vec2f(unconst_f32(0.06032), unconst_f32(0.08696))).g);
+  var vf106: vec4f = exp2(vec4f(unconst_f32(-0.4253), unconst_f32(-0.1379), unconst_f32(0.5586), unconst_f32(0.1857)));
+  var vf107: vec2h = cosh(vec2h(insertBits(vec2i(saturate(bitcast<vec2f>(atan2(vec4h(unconst_f16(28426.2), unconst_f16(5680.5), unconst_f16(17090.9), unconst_f16(8167.7)), vec4h(unconst_f16(15648.0), unconst_f16(5924.4), unconst_f16(-7884.6), unconst_f16(7870.1)))))), vec2i(unconst_i32(175), unconst_i32(219)), u32(unconst_u32(622)), u32(unconst_u32(126)))));
+  vf106 -= vec4f(ceil(vec4h(unconst_f16(8628.6), unconst_f16(-5721.1), unconst_f16(6997.8), unconst_f16(4097.8))));
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput4 {
+  @invariant @builtin(position) f19: vec4f,
+}
+
+struct FragmentOutput2 {
+  @location(0) f0: vec4u,
+  @location(4) f1: u32,
+  @location(2) f2: i32,
+}
+
+fn fn0(a0: T0) -> T0 {
+  var out: T0;
+  let vf98: T0 = a0;
+  out.f0[u32(degrees(vec4h(vw14[u32(unconst_u32(30))])).y)] = bitcast<vec2h>(atomicExchange(&(*&vw13)[0], u32(unconst_u32(568))));
+  out.f0[u32(workgroupUniformLoad(&vw14)[2])] = vec2h((*&vw14)[u32((*&vw14)[2])]);
+  var vf99: vec4f = faceForward(vec4f(unconst_f32(0.00688), unconst_f32(0.3049), unconst_f32(0.01458), unconst_f32(0.2408)), vec4f(a0.f0[0].rrgr), vec4f(unconst_f32(0.01432), unconst_f32(0.2449), unconst_f32(-0.2443), unconst_f32(0.6961)));
+  let vf100: vec2f = asin(vec2f(unconst_f32(-0.01412), unconst_f32(0.03003)));
+  var vf101: vec2h = vf98.f0[0];
+  let vf102: f32 = vf99[1];
+  vw14[u32(unconst_u32(91))] = vf98.f0[0][u32(unconst_u32(61))];
+  let ptr34: ptr<workgroup, f16> = &vw14[2];
+  let vf103: f16 = vf98.f0[0][u32(a0.f0[0][bitcast<u32>(vf98.f0[0])])];
+  let ptr35: ptr<workgroup, atomic<u32>> = &vw13[0];
+  var vf104: u32 = atomicLoad(&(*&vw13)[0]);
+  vf99 = vec4f(vf99[1]);
+  vf104 *= bitcast<u32>(trunc(vf98.f0[0]));
+  out.f0[u32(unconst_u32(26))] -= a0.f0[0];
+  let ptr36: ptr<workgroup, f16> = &(*&vw14)[2];
+  var vf105: u32 = atomicExchange(&(*&vw13)[0], u32(unconst_u32(122)));
+  let ptr37: ptr<function, vec2h> = &vf101;
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn2(a0: ptr<private, T0>) -> T0 {
+  var out: T0;
+  out = T0(array<vec2h, 1>((*a0).f0[0]));
+  out.f0[u32(reverseBits(i32(unconst_i32(76))))] = vec2h(saturate(vec2f(unconst_f32(0.4309), unconst_f32(0.1498))));
+  (*a0).f0[u32(max(f32((*a0).f0[0][u32(unconst_u32(99))]), f32(unconst_f32(0.1150))))] = select(vec4h(unconst_f16(-13483.9), unconst_f16(8301.3), unconst_f16(2262.2), unconst_f16(834.9)), pow(vec2h(unconst_f16(-27094.8), unconst_f16(9707.3)), (*a0).f0[0]).yyxx, vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true), unconst_bool(false))).bb;
+  out = T0(array<vec2h, 1>((*a0).f0[0]));
+  var vf108: i32 = dot(vec2i(unconst_i32(25), unconst_i32(-69)), vec2i((*a0).f0[0]));
+  vf108 = i32((*a0).f0[0][u32(unconst_u32(84))]);
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw14: array<f16, 3>;
+
+var<workgroup> vw13: array<atomic<u32>, 1>;
+
+@vertex
+fn vertex4() -> VertexOutput4 {
+  var out: VertexOutput4;
+  let vf109: vec2f = normalize(vec2f(unconst_f32(0.2335), unconst_f32(0.07559)));
+  fn1();
+  var vf110: u32 = pack4x8snorm(vec4f(unconst_f32(0.6815), unconst_f32(0.2018), unconst_f32(-0.03535), unconst_f32(-0.3795)));
+  vf110 -= bitcast<vec2u>(countTrailingZeros(vec2i(unconst_i32(274), unconst_i32(69))))[1];
+  out.f19 += bitcast<vec4f>(countTrailingZeros(vec2i(unconst_i32(192), unconst_i32(20))).grgg);
+  var vf111: vec2f = vf109;
+  let vf112: u32 = pack4x8snorm(normalize(vec2f(vf109[0])).yxyy);
+  var vf113: vec2i = countTrailingZeros(vec2i(unconst_i32(73), unconst_i32(271)));
+  out.f19 = vf111.xyxy;
+  var vf114: u32 = vf112;
+  out = VertexOutput4(normalize(vec2f(unconst_f32(0.04923), unconst_f32(1.000))).grgg);
+  let vf115: vec2f = vf109;
+  vf113 &= vec2i(i32(vf110));
+  var vf116: u32 = pack2x16snorm(vec2f(unconst_f32(0.2506), unconst_f32(0.00357)));
+  vf110 = bitcast<u32>(countTrailingZeros(vec2i(unconst_i32(63), unconst_i32(121)))[0]);
+  return out;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f1 <<= u32(distance(vec3f(unconst_f32(0.01843), unconst_f32(0.2339), unconst_f32(0.3076)), vec3f(unconst_f32(0.02942), unconst_f32(0.05633), unconst_f32(0.08521))));
+  var vf117: f32 = atan2(f32(unconst_f32(0.09473)), distance(vec3f(ldexp(vec2h(unconst_f16(1813.1), unconst_f16(45716.2)), vec2i(unconst_i32(106), unconst_i32(86))).ggr), vec3f(unconst_f32(-0.2244), unconst_f32(0.2302), unconst_f32(0.1081))));
+  var vf118: vec4f = unpack4x8unorm(u32(unconst_u32(56)));
+  out.f1 >>= bitcast<u32>(atan2(f32(unconst_f32(0.5372)), f32(unconst_f32(0.1715))));
+  fn1();
+  fn1();
+  var vf119: u32 = pack4xI8(vec4i(unconst_i32(103), unconst_i32(63), unconst_i32(-54), unconst_i32(364)));
+  let vf120: vec4h = round(vec4h(unconst_f16(16656.9), unconst_f16(52233.3), unconst_f16(6480.1), unconst_f16(11326.0)));
+  out.f0 <<= vec4u(round(vec4h(f16(vf118[u32(unconst_u32(294))]))));
+  fn1();
+  let vf121: vec4h = round(vec4h(unconst_f16(7573.1), unconst_f16(7376.0), unconst_f16(6930.2), unconst_f16(9109.3)));
+  let vf122: vec3f = log2(log2(unpack4x8unorm(u32(unconst_u32(21))).ywy));
+  vf117 = vf118[u32(unconst_u32(212))];
+  vf117 = vf122[1];
+  vf117 = vf122[1];
+  vf118 *= vec4f(f32(vf121[2]));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute4() {
+  atomicOr(&vw13[u32(unpack2x16unorm(u32(unconst_u32(314))).x)], u32(unconst_u32(578)));
+  vw14[u32((*&vw14)[2])] += f16(sin(unpack2x16unorm(u32(unconst_u32(8)))).y);
+  vw14[u32(unconst_u32(17))] -= f16(atomicLoad(&(*&vw13)[0]));
+  vw14[u32(unconst_u32(145))] = (*&vw14)[2];
+  atomicStore(&vw13[u32((*&vw14)[2])], u32(unconst_u32(185)));
+  fn0(T0(array<vec2h, 1>(bitcast<vec2h>(pack4xI8Clamp(vec4i(unconst_i32(367), unconst_i32(611), unconst_i32(173), unconst_i32(357)))))));
+  let ptr38: ptr<workgroup, array<atomic<u32>, 1>> = &vw13;
+  let ptr39: ptr<workgroup, f16> = &(*&vw14)[2];
+  var vf123: vec2f = sin(unpack4x8snorm(u32(unconst_u32(200))).rg);
+  vw14[u32(unconst_u32(13))] = f16(firstLeadingBit(vec3i(unconst_i32(77), unconst_i32(54), unconst_i32(21))).r);
+  vf123 = unpack2x16unorm(atomicLoad(&(*ptr38)[0]));
+  let vf124: f16 = mix(f16(atomicExchange(&(*&vw13)[0], u32(unconst_u32(232)))), sin(vec4h(mix(f16(unconst_f16(15760.0)), f16(unconst_f16(1510.9)), f16(unconst_f16(6841.9)))))[0], f16(unconst_f16(9532.8)));
+  atomicMin(&vw13[u32(unconst_u32(332))], pack4x8snorm(unpack4x8snorm(u32(unconst_u32(32)))));
+  workgroupBarrier();
+  vw14[u32(unconst_u32(126))] *= vf124;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 241,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView105 = texture74.createView({label: '\u06d4\u01f6\u7e5f\u280c\ubb6e\u4327\u{1fd4b}\u{1f7af}\u03cd'});
+let texture82 = device0.createTexture({
+  size: [10, 5, 79],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView106 = texture2.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup34, new Uint32Array(5582), 109, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer36, 300); };
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer7, 7896, 1760);
+} catch {}
+try {
+adapter0.label = '\ue9c7\u0542\u{1ff71}\u8fc9\u0876\u0a2f\u{1ff53}\u{1f903}\u1a7b\u49b5\ubd48';
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({label: '\uf6b0\u{1fc68}\uc3cc\u59c4\ub2c9\ud33a\ubdf5'});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 466});
+let texture83 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 22},
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder67 = commandEncoder95.beginComputePass();
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+let texture84 = device0.createTexture({
+  size: [20, 11, 111],
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder68 = commandEncoder96.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup9, new Uint32Array(409), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer15, 112); };
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer9, 'uint32', 2_840, 114);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer2);
+} catch {}
+let buffer54 = device0.createBuffer({
+  size: 4531,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+let texture85 = device0.createTexture({
+  label: '\u0185\u0d9b\ueeae',
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder69 = commandEncoder97.beginComputePass({label: '\u0587\udb2c\u{1fe1c}\ub8bd'});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer43, 7_888); };
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup0);
+} catch {}
+let bindGroup54 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 15, resource: textureView103}]});
+let commandEncoder98 = device0.createCommandEncoder({});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle10, renderBundle10, renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer31, 0);
+} catch {}
+let computePassEncoder70 = commandEncoder98.beginComputePass({});
+try {
+computePassEncoder70.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setViewport(4.9287547119238475, 0.29477826320098766, 0.0658043075212502, 0.3764055073679614, 0.7081802949823216, 0.8761827028339428);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1104 */
+  offset: 1104,
+  buffer: buffer9,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder99 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder20.finish({label: '\u7edc\u3124\u256c\u5fa6\u029e\u0be8\u{1fef0}'});
+let sampler64 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 32.47,
+  lodMaxClamp: 43.98,
+});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup28, new Uint32Array(1323), 402, 0);
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 100, new DataView(new ArrayBuffer(27328)), 14766, 392);
+} catch {}
+let computePassEncoder71 = commandEncoder32.beginComputePass({});
+let renderPassEncoder38 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 29,
+  clearValue: { r: 748.2, g: 78.53, b: 175.3, a: -348.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(928);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer18, 'uint16', 514, 350);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer20, 0);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1120 */
+  offset: 1120,
+  buffer: buffer0,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 7},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1336 */
+  offset: 1336,
+  buffer: buffer49,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'film', transfer: 'iec61966-2-1'} });
+let commandEncoder100 = device0.createCommandEncoder({});
+try {
+renderPassEncoder2.setScissorRect(5, 0, 0, 2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer33, 'uint16', 764, 6_999);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 676 */
+  offset: 676,
+  rowsPerImage: 87,
+  buffer: buffer21,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder100.clearBuffer(buffer38, 684, 912);
+} catch {}
+try {
+commandEncoder100.insertDebugMarker('\u565b');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 16988, new BigUint64Array(10045), 4226, 392);
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer24, offset: 1536, size: 1208}}],
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture86 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 129},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView107 = texture64.createView({dimension: '2d', baseArrayLayer: 3});
+let computePassEncoder72 = commandEncoder3.beginComputePass({});
+let renderPassEncoder39 = commandEncoder100.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: 348.0, g: 767.1, b: -153.9, a: 740.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler65 = device0.createSampler({
+  label: '\u0b77\ud4b4\u06b2\u0750\u{1f6e9}\u9f0e\u871a\u0eb0\ud163',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 78.39,
+  lodMaxClamp: 84.78,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup32, new Uint32Array(5893), 748, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  label: '\u1bc4\u19cd\u15c3\ucc7b\u4b84\u{1f9ca}\u4566\ud250\ufd00',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 56, resource: {buffer: buffer34, offset: 3328, size: 368}},
+    {binding: 134, resource: textureView55},
+    {binding: 14, resource: externalTexture9},
+  ],
+});
+let commandEncoder102 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: [20, 11, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup53, new Uint32Array(107), 25, 0);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer51);
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'linear'} });
+try {
+globalThis.someLabel = externalTexture11.label;
+} catch {}
+let textureView108 = texture78.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let texture88 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder73 = commandEncoder102.beginComputePass({label: '\u{1fb2d}\u0076\u0871'});
+try {
+computePassEncoder68.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(427).fill(229), /* required buffer size: 427 */
+{offset: 427}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u03a6\u3fc9\ue70f\u016e\u0bb1\ue450\u5890',
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+@group(1) @binding(158) var tex11: texture_cube<i32>;
+
+var<private> vp11: mat4x3h = mat4x3h();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(1) @binding(78) var et0: texture_external;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(103) var tex10: texture_multisampled_2d<u32>;
+
+fn fn0() {
+  vp11 = mat4x3h(vp11[0], vp11[0], vp11[0], vp11[0]);
+  vp11 = mat4x3h(vec3h(unpack2x16unorm(u32(unconst_u32(315))).xyx), vec3h(unpack2x16unorm(u32(unconst_u32(315))).xyx), vec3h(unpack2x16unorm(u32(unconst_u32(315))).xxy), vec3h(unpack2x16unorm(u32(unconst_u32(315))).yxx));
+  textureStore(st2, vec3i(unconst_i32(268), unconst_i32(-104), unconst_i32(248)), vec4f(vec4f(vp11[u32(unconst_u32(230))].xxzx)));
+  textureStore(st0, vec3i(bitcast<i32>(textureNumSamples(tex10))), vec4u(vec4u(unconst_u32(23), unconst_u32(5), unconst_u32(79), unconst_u32(82))));
+  var vf125: vec3f = reflect(vec3f(unconst_f32(0.1093), unconst_f32(0.01255), unconst_f32(0.1566)), ceil(vec4f(unconst_f32(0.09561), unconst_f32(0.03166), unconst_f32(0.07250), unconst_f32(0.2658))).ywz);
+  var vf126: vec4f = ceil(unpack4x8snorm(textureNumSamples(tex10)));
+  var vf127: vec4i = extractBits(vec4i(ceil(bitcast<vec4f>(unpack4xI8(u32(unconst_u32(362)))))), u32(unconst_u32(2)), u32(unconst_u32(46)));
+  let vf128: vec3h = trunc(vec3h(vp11[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.1894), unconst_f32(0.00902), unconst_f32(0.03678)))).z][pack2x16snorm(atanh(vec2f(unconst_f32(0.08982), unconst_f32(0.05562))))]));
+  let vf129: f16 = vf128[0];
+  var vf130: vec4u = textureLoad(st1, vec2i(unconst_i32(-126), unconst_i32(39)), i32(unconst_i32(342)));
+  vf126 += vec4f(bitcast<f32>(textureNumSamples(tex10)));
+  textureStore(st0, vec3i(unconst_i32(17), unconst_i32(115), unconst_i32(2)), vec4u(vec4u(sqrt(vec2h(unconst_f16(-3696.6), unconst_f16(4607.8))).yyyy)));
+  vp11 = mat4x3h(vec3h(vf130.ggg), vec3h(vf130.wxz), vec3h(vf130.zxx), vec3h(vf130.rrg));
+  vp11 += mat4x3h(f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]), f16(vf127[bitcast<vec3u>(asinh(vec3f(unconst_f32(0.03724), unconst_f32(-0.1571), unconst_f32(0.02103)))).b]));
+  storageBarrier();
+  vf127 = vec4i(i32(vp11[u32(unconst_u32(46))][u32(unconst_u32(1))]));
+  let vf131: vec2u = textureDimensions(st1);
+  vf130 |= unpack4xU8(u32(vf126[u32(unconst_u32(91))]));
+  var vf132: vec3h = trunc(vf128);
+  vf125 = ceil(vec4f(vf126[u32(unconst_u32(44))])).bbg;
+  textureStore(st0, vec3i(unconst_i32(75), unconst_i32(89), unconst_i32(111)), vec4u(vec4u(unconst_u32(1), unconst_u32(46), unconst_u32(136), unconst_u32(88))));
+}
+
+struct T0 {
+  f0: array<f16>,
+}
+
+@group(1) @binding(146) var sam6: sampler_comparison;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct VertexOutput5 {
+  @location(6) @interpolate(flat, centroid) f20: vec2u,
+  @builtin(position) f21: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(1) @binding(134) var st2: texture_storage_3d<rgba16float, write>;
+
+@group(1) @binding(65) var st1: texture_storage_2d_array<rgba32uint, read>;
+
+struct T1 {
+  f0: array<u32>,
+}
+
+@group(1) @binding(325) var st3: texture_storage_1d<rg32uint, write>;
+
+@group(1) @binding(2) var st0: texture_storage_3d<rgba8uint, write>;
+
+@vertex
+fn vertex5(@location(6) @interpolate(flat, center) a0: vec4i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  let vf133: vec3f = saturate(vec3f(unconst_f32(0.1057), unconst_f32(0.04497), unconst_f32(0.02129)));
+  out.f20 = vec2u(inverseSqrt(vec2h(unconst_f16(-9439.3), unconst_f16(8014.9))));
+  vp11 += vp11;
+  out.f21 = vec4f(faceForward(vec2h(unconst_f16(7523.8), unconst_f16(12370.1)), vec2h(unconst_f16(20326.6), unconst_f16(3269.3)), vec2h(unconst_f16(517.8), unconst_f16(23840.6))).xxxx);
+  var vf134: vec4i = insertBits(vec4i(unconst_i32(56), unconst_i32(187), unconst_i32(246), unconst_i32(256)), vec4i(unconst_i32(33), unconst_i32(19), unconst_i32(-133), unconst_i32(-101)), u32(unconst_u32(575)), u32(unconst_u32(59)));
+  let vf135: vec2u = textureDimensions(tex11);
+  var vf136: f16 = vp11[pack4xU8(bitcast<vec4u>(vf134))][u32(unconst_u32(244))];
+  let vf137: vec4f = unpack4x8snorm(u32(unconst_u32(657)));
+  out.f21 = vec4f(textureLoad(st1, vec2i(unconst_i32(76), unconst_i32(-225)), insertBits(vec4i(i32(vp11[2][bitcast<u32>(a0[0])])), vec4i(unconst_i32(142), unconst_i32(63), unconst_i32(334), unconst_i32(110)), textureNumLevels(tex11), u32(unconst_u32(132)))[3]));
+  vf134 *= bitcast<vec4i>(textureLoad(st1, vec2i(unconst_i32(34), unconst_i32(446)), i32(unconst_i32(66))));
+  out.f21 *= vf137;
+  vf136 = vec2h(textureDimensions(tex11))[0];
+  var vf138: vec2h = radians(vec2h(unconst_f16(563.2), unconst_f16(18834.7)));
+  out.f21 -= ceil(vec2f(inverseSqrt(vec2h(countTrailingZeros(vec3i(unconst_i32(5), unconst_i32(466), unconst_i32(84))).xy)))).rgrr;
+  var vf139: vec2u = textureDimensions(tex11);
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute5(@builtin(local_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u, @builtin(global_invocation_id) a2: vec3u) {
+  fn0();
+  let vf140: vec2f = unpack2x16float(u32(log2(vec4h(vp11[u32(unconst_u32(216))][u32(unconst_u32(56))]))[3]));
+  let ptr40: ptr<private, vec3h> = &vp11[0];
+  textureStore(st2, vec3i(i32(any(vec2<bool>(bool(reverseBits(vec3i(vp11[u32(unconst_u32(2))])[2])))))), vec4f(vec4f(unconst_f32(-0.03828), unconst_f32(0.1896), unconst_f32(-0.1273), unconst_f32(0.1224))));
+  let vf141: vec4f = unpack4x8unorm(u32(unconst_u32(214)));
+  textureStore(st3, bitcast<i32>(ldexp(bitcast<vec2f>(textureDimensions(st1)), bitcast<vec2i>(vf140)).r), vec4u(vec4u(unconst_u32(348), unconst_u32(55), unconst_u32(51), unconst_u32(69))));
+  vp11 = mat4x3h(round(vec4h(unpack4x8unorm(u32(vf141[2])))).wwx, round(vec4h(unpack4x8unorm(u32(vf141[2])))).bga, round(vec4h(unpack4x8unorm(u32(vf141[2])))).zwy, round(vec4h(unpack4x8unorm(u32(vf141[2])))).zzy);
+  var vf142: vec3u = a0;
+  textureStore(st0, vec3i(unconst_i32(63), unconst_i32(171), unconst_i32(73)), vec4u(vec4u(unconst_u32(96), unconst_u32(179), unconst_u32(16), unconst_u32(16))));
+  fn0();
+  var vf143: f16 = vp11[0][pack2x16float(unpack2x16float(vec4u(log2(bitcast<vec4h>(vf140))).x))];
+  fn0();
+  vp11 = mat4x3h(vf143, vf143, vf143, vf143, vf143, vf143, vf143, vf143, vf143, vf143, vf143, vf143);
+  textureStore(st3, i32(unconst_i32(87)), vec4u(vec4u(faceForward(vec2h(ldexp(vec2f(unconst_f32(-0.1161), unconst_f32(0.1343)), vec2i(bitcast<i32>(vf140[1])))), bitcast<vec2h>(fract(f32(unconst_f32(-0.06382)))), vec2h(unconst_f16(14618.2), unconst_f16(36168.3))).grgg)));
+  fn0();
+  var vf144: f32 = vf140[pack4x8unorm(unpack4x8unorm(u32(unconst_u32(79))))];
+  fn0();
+  fn0();
+  textureStore(st2, bitcast<vec3i>(vf141.gab), vec4f(vec4f(unconst_f32(0.3009), unconst_f32(-0.4379), unconst_f32(0.1350), unconst_f32(0.08851))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer55 = device0.createBuffer({size: 1243, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder103 = device0.createCommandEncoder();
+let texture89 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder74 = commandEncoder103.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer36, 240, buffer38, 1432, 1176);
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer21);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline0);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 626, resource: {buffer: buffer3, offset: 2048, size: 196}},
+    {binding: 13, resource: textureView9},
+  ],
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let textureView109 = texture45.createView({mipLevelCount: 1});
+let computePassEncoder75 = commandEncoder104.beginComputePass({});
+let renderPassEncoder40 = commandEncoder101.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  clearValue: { r: 668.0, g: 101.6, b: -651.9, a: -40.30, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder74.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture90 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler66 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.98,
+  lodMaxClamp: 93.89,
+  maxAnisotropy: 13,
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup9, new Uint32Array(2574), 274, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer7, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u41ca');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 189},
+  aspect: 'all',
+}, new Uint8Array(9_773).fill(21), /* required buffer size: 9_773 */
+{offset: 302, bytesPerRow: 61, rowsPerImage: 11}, {width: 2, height: 2, depthOrArrayLayers: 15});
+} catch {}
+try {
+computePassEncoder41.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+adapter0.label = '\ua63a\u5eae\ubdba\u04a4\ue80d\udc77\u{1f68d}\u{1ff86}\u0345\u{1faf9}\u64e2';
+} catch {}
+let buffer56 = device0.createBuffer({size: 8013, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder105 = device0.createCommandEncoder({});
+let sampler67 = device0.createSampler({
+  label: '\u06c9\u3690\uea2e\ud3e5\u028b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.23,
+  lodMaxClamp: 77.13,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder73.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline1);
+} catch {}
+await gc();
+let bindGroup58 = device0.createBindGroup({
+  label: '\ubd66\udaf9\u{1f711}\u1d89\u{1f7ca}\u{1f947}',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 14, resource: externalTexture3},
+    {binding: 56, resource: {buffer: buffer23, offset: 512, size: 40}},
+    {binding: 134, resource: textureView11},
+  ],
+});
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup44, new Uint32Array(1041), 287, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle1, renderBundle2, renderBundle7]);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer38, 108, buffer40, 2100, 100);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 544, new Float32Array(1900), 102, 96);
+} catch {}
+document.body.prepend(img0);
+let buffer57 = device0.createBuffer({
+  label: '\u{1fbc0}\u{1fe78}\u7ed2\u{1fe20}\ue60a\ufe57\u{1fac5}\ue031\u0806\u5ac6',
+  size: 6077,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder106 = device0.createCommandEncoder();
+let computePassEncoder76 = commandEncoder106.beginComputePass({});
+let sampler68 = device0.createSampler({
+  label: '\u815c\u28ee\u0aad\u{1fbbf}\u71a1',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.97,
+});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1944 */
+  offset: 1944,
+  bytesPerRow: 8448,
+  buffer: buffer31,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder();
+let texture91 = device0.createTexture({
+  size: [5, 2, 39],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup32, new Uint32Array(624), 80, 0);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer30, 880);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let imageBitmap2 = await createImageBitmap(imageData1);
+let texture92 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup26, []);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(0, bindGroup22, new Uint32Array(3204), 1_375, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline1);
+} catch {}
+let buffer58 = device0.createBuffer({
+  size: 791,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup18, new Uint32Array(2077), 745, 0);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({});
+let texture93 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder77 = commandEncoder107.beginComputePass();
+let renderPassEncoder41 = commandEncoder105.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: 754.7, g: 382.4, b: -87.31, a: -652.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 11318807,
+});
+let sampler69 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 96.47,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup45, []);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(170);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer31, 2_548, 312);
+} catch {}
+let buffer59 = device0.createBuffer({size: 14271, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet15 = device0.createQuerySet({label: '\uf7d8\u{1f730}\u0e6d\u3c65\u{1f858}\u6087', type: 'occlusion', count: 584});
+let textureView110 = texture90.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup45, new Uint32Array(3362), 17, 0);
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer50, 'uint16', 1_770, 411);
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 13},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+externalTexture5.label = '\u01f7\u09b0\u04ff\u2941\u2e68\u{1ff0e}';
+} catch {}
+let computePassEncoder78 = commandEncoder108.beginComputePass({label: '\u0d17\ua584\u7b37\ud2a0\ud20d\u{1fb82}\u{1fe3a}\u{1fbfa}'});
+try {
+computePassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup18, new Uint32Array(3561), 252, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer38, 'uint32', 1_504, 1_394);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup43, new Uint32Array(2172), 215, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup12, new Uint32Array(2837), 1_196, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer25, 'uint32', 1_096, 234);
+} catch {}
+try {
+commandEncoder109.resolveQuerySet(querySet2, 0, 16, buffer57, 512);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture94 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 10},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup26, new Uint32Array(629), 229, 0);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: 584.8, g: 631.6, b: -599.6, a: 431.9, });
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture95 = device0.createTexture({
+  size: [5],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder79 = commandEncoder110.beginComputePass();
+try {
+computePassEncoder68.setBindGroup(1, bindGroup17);
+} catch {}
+let bindGroup59 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 241, resource: textureView76}]});
+let texture96 = device0.createTexture({
+  size: [5, 2, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView111 = texture15.createView({label: '\u0a80\u3d82\u{1f815}\u2ac6\u08e3\u0b0b\u83f0\ube37\u82fb\u{1f743}\ue71a'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle12 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer25, 'uint16', 50, 401);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4_294_967_295, undefined, 0, 362_579_640);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+}, new Uint8Array(2_968).fill(13), /* required buffer size: 2_968 */
+{offset: 24, bytesPerRow: 46, rowsPerImage: 4}, {width: 5, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let buffer60 = device0.createBuffer({
+  label: '\u961f\u{1ff4e}\u9f02',
+  size: 2593,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView112 = texture75.createView({baseMipLevel: 0});
+let computePassEncoder80 = commandEncoder111.beginComputePass();
+try {
+computePassEncoder42.setBindGroup(1, bindGroup34, new Uint32Array(4163), 1_611, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup60 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView105}]});
+let texture97 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView113 = texture73.createView({});
+let computePassEncoder81 = commandEncoder109.beginComputePass({label: '\u4822\u77cc\u602c\ufba7\u065a'});
+try {
+renderPassEncoder41.setIndexBuffer(buffer43, 'uint32', 340, 2_110);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder112 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  label: '\u6fcf\u8f69',
+  size: {width: 20, height: 11, depthOrArrayLayers: 159},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup30, new Uint32Array(979), 7, 0);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline1);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2520 */
+  offset: 2520,
+  rowsPerImage: 869,
+  buffer: buffer17,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 6},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder64.pushDebugGroup('\u31f5');
+} catch {}
+document.body.append(canvas0);
+let buffer61 = device0.createBuffer({label: '\u0fd8\u{1fa09}\u6927', size: 5370, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder113 = device0.createCommandEncoder({label: '\ufb58\u4d58\uc63e\u0f11\u2d84\u65e7\u{1fb26}\ua688'});
+let textureView114 = texture6.createView({mipLevelCount: 1});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: -246.9, g: 220.6, b: 12.67, a: -720.8, });
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer7, 1_864, 4_971);
+} catch {}
+try {
+commandEncoder112.copyTextureToBuffer({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1404 */
+  offset: 1404,
+  bytesPerRow: 0,
+  rowsPerImage: 318,
+  buffer: buffer45,
+}, {width: 0, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+await gc();
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4]});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup47, new Uint32Array(796), 28, 0);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let videoFrame13 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let commandEncoder114 = device0.createCommandEncoder({});
+let sampler70 = device0.createSampler({
+  label: '\u{1f659}\u03d4\u{1f86b}\u{1fa81}\u{1f915}\u2c36\u{1fc74}\u44b2\u{1fc6b}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.92,
+  lodMaxClamp: 99.75,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup14, new Uint32Array(174), 68, 0);
+} catch {}
+try {
+computePassEncoder80.pushDebugGroup('\ue167');
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  label: '\u00f8\ufbb9\u{1ff77}\u75ea\u6ac1\u0456\u9e96\u{1f6a7}\u0129',
+  size: [64, 64, 12],
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView115 = texture92.createView({label: '\u7c8b\u0cc9\u7e28\u246d\u97b4\u{1fa3c}', format: 'r32sint'});
+let computePassEncoder82 = commandEncoder112.beginComputePass({label: '\u0d45\u1f70\u{1f953}\u13b0\u6d4e\u265e\ue946\u0528\u0f03\u{1fa0f}\u071f'});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup15, new Uint32Array(1227), 147, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer15, 'uint16', 10, 55);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u0afd');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 328, new Int16Array(20844), 544, 972);
+} catch {}
+let video0 = await videoWithData(128);
+let bindGroup61 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView85}]});
+let commandEncoder116 = device0.createCommandEncoder({});
+let sampler71 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 53.50,
+  lodMaxClamp: 53.50,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup24, new Uint32Array(1742), 36, 0);
+} catch {}
+try {
+renderPassEncoder28.setStencilReference(831);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer50, 'uint16', 2_722, 452);
+} catch {}
+try {
+commandEncoder116.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 72 */
+  offset: 72,
+  bytesPerRow: 22016,
+  buffer: buffer21,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder83 = commandEncoder113.beginComputePass({});
+let renderPassEncoder42 = commandEncoder114.beginRenderPass({
+  label: '\u0203\u0bb4\u9d64\ub410\ud343\u51f5',
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -464.0, g: 853.7, b: -141.5, a: -761.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 385150523,
+});
+try {
+computePassEncoder82.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder116.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1104 */
+  offset: 1104,
+  buffer: buffer9,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 2258});
+let texture100 = device0.createTexture({
+  size: {width: 5},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture15 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder34.setIndexBuffer(buffer32, 'uint16', 196, 1_841);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(0, buffer54);
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler25}],
+});
+let textureView116 = texture50.createView({dimension: '3d', mipLevelCount: 1});
+let renderPassEncoder43 = commandEncoder116.beginRenderPass({
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: 252.9, g: -516.2, b: 580.1, a: 981.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 48695497,
+});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup15, new Uint32Array(920), 54, 0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer39);
+} catch {}
+try {
+commandEncoder115.copyTextureToBuffer({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 384 */
+  offset: 384,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder115.insertDebugMarker('\uae81');
+} catch {}
+document.body.prepend(video0);
+let sampler72 = device0.createSampler({
+  addressModeU: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 47.85,
+  lodMaxClamp: 95.03,
+  compare: 'greater',
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer19, 'uint32', 720, 653);
+} catch {}
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1836 */
+  offset: 1836,
+  buffer: buffer34,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 15, resource: textureView103}]});
+let buffer62 = device0.createBuffer({size: 9252, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder117 = device0.createCommandEncoder({});
+let textureView117 = texture50.createView({mipLevelCount: 1});
+let computePassEncoder84 = commandEncoder115.beginComputePass();
+try {
+computePassEncoder31.setBindGroup(0, bindGroup11, new Uint32Array(1325), 73, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer12, 852); };
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup20, new Uint32Array(1181), 438, 0);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer5, 5312, buffer53, 2360, 0);
+} catch {}
+let texture101 = device0.createTexture({
+  size: [10, 5, 125],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder85 = commandEncoder117.beginComputePass({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u3b9b\uc22c\u7602\u0514\ua048\u68d1\u3d6c\u{1fca4}\u0b89\u27b4\u0f21',
+  colorFormats: ['r32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(321);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer20, 'uint16', 1_766, 127);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer51, 0);
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 13, resource: textureView15},
+    {binding: 626, resource: {buffer: buffer24, offset: 0, size: 1416}},
+  ],
+});
+let commandEncoder118 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView118 = texture32.createView({mipLevelCount: 1});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle9]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 32, new Int16Array(2280), 966, 40);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(1, bindGroup64, new Uint32Array(2398), 81, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup13);
+} catch {}
+let texture103 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder86 = commandEncoder118.beginComputePass({label: '\u{1f6a4}\u001e'});
+try {
+computePassEncoder80.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture104 = device0.createTexture({size: [64, 64, 12], mipLevelCount: 2, format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+buffer10.unmap();
+} catch {}
+let buffer63 = device0.createBuffer({
+  size: 4281,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder119 = device0.createCommandEncoder({});
+let textureView119 = texture61.createView({format: 'rgba8uint'});
+let texture105 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 94},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder119.copyBufferToBuffer(buffer31, 2620, buffer9, 576, 184);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 110,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup65 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 15, resource: textureView108}]});
+let texture106 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView120 = texture35.createView({});
+let computePassEncoder87 = commandEncoder119.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup64, []);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup13, new Uint32Array(621), 78, 0);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(33);
+} catch {}
+try {
+renderPassEncoder39.setViewport(49.378356315770205, 3.31837031820659, 3.5058739095815206, 35.92633019795822, 0.9855527109225056, 0.9938486187283192);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer54);
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+enable f16;
+
+@id(50028) override override7: f16 = 1777.6;
+
+struct T0 {
+  @align(2) @size(56) f0: array<u32>,
+}
+
+struct FragmentOutput3 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) @interpolate(flat) f1: vec4i,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(9976) override override4: u32 = 23;
+
+@id(1150) override override5: f16 = -6876.6;
+
+var<private> vp12: array<f32, 10> = array<f32, 10>(f32(), f32(), f32(), f32(), f32(), f32(), f32(), f32(), f32(), f32());
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(57747) override override6 = 0.1615;
+
+@group(0) @binding(27) var sam7: sampler;
+
+fn fn0() -> vec4h {
+  var out: vec4h;
+  vp12[u32(unconst_u32(6))] = vp12[9];
+  var vf145: i32 = dot4I8Packed(u32(override5), u32(unconst_u32(130)));
+  vp12[9] *= vec3f(cross(vec3h(unconst_f16(26011.2), unconst_f16(2234.2), unconst_f16(19531.2)), vec3h(f16(insertBits(i32(unconst_i32(293)), i32(override5), pack4xU8(vec4u(unconst_u32(180), unconst_u32(59), unconst_u32(463), unconst_u32(199))), u32(unconst_u32(427)))))))[2];
+  let ptr41: ptr<private, vec4h> = &vp13;
+  let vf146: vec3u = countOneBits(vec3u(unpack4x8snorm(bitcast<vec2u>(ldexp(vec2f(unconst_f32(-0.04071), unconst_f32(0.00116)), vec2i(unconst_i32(32), unconst_i32(37))))[0]).gbr));
+  out = vec4h(f16(vp12[u32((*ptr41)[u32(unconst_u32(54))])]));
+  let ptr42: ptr<private, f32> = &vp12[9];
+  var vf147: vec3u = countOneBits(vec3u(insertBits(u32(unconst_u32(123)), u32(unconst_u32(243)), bitcast<u32>((*ptr42)), u32(unconst_u32(149)))));
+  let vf148: u32 = pack4xI8Clamp(vec4i(i32(insertBits(vf146[2], u32(unconst_u32(91)), u32(unconst_u32(119)), vf146[u32(unconst_u32(59))]))));
+  let vf149: u32 = vf146[2];
+  vp13 = vec4h(f16(dot4I8Packed(u32(unconst_u32(47)), bitcast<u32>(insertBits(i32(unconst_i32(425)), vec2i(ldexp(vec2f(unconst_f32(0.2222), unconst_f32(0.1011)), vec2i(bitcast<i32>(vf148)))).y, u32(unconst_u32(59)), vf147[0])))));
+  out = vec4h(f16(vf147[u32(unconst_u32(53))]));
+  let vf150: f32 = override6;
+  let vf151: i32 = insertBits(i32(vf146[u32(unconst_u32(45))]), i32(unconst_i32(262)), vf147.b, u32(ldexp(vec2f(unconst_f32(0.05182), unconst_f32(0.05600)), vec2i(unconst_i32(385), unconst_i32(311)))[1]));
+  return out;
+}
+
+var<private> vp13: vec4h = vec4h();
+
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  out.f1 &= vec4i(dot4I8Packed(u32(unconst_u32(244)), pack4x8snorm(ldexp(vec4f(unconst_f32(0.00402), unconst_f32(0.00939), unconst_f32(0.3879), unconst_f32(0.1381)), vec4i(unconst_i32(157), unconst_i32(380), unconst_i32(50), unconst_i32(795))))));
+  var vf152: f16 = asinh(f16(unconst_f16(-14056.5)));
+  fn0();
+  vp12[u32(override7)] -= vp12[9];
+  var vf153 = fn0();
+  vf153 = vec4h(cross(vec3f(unconst_f32(0.3601), unconst_f32(0.02438), unconst_f32(0.05894)), vec3f(unconst_f32(-0.2479), unconst_f32(-0.3408), unconst_f32(0.07938))).xxyx);
+  vf153 += vec4h(firstLeadingBit(vec3u(u32(override5))).xzzx);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6(@builtin(global_invocation_id) a0: vec3u) {
+  vp12[9] = unpack4x8unorm(u32(unpack4xI8(u32(unconst_u32(55)))[0]))[2];
+  let vf154: u32 = pack4xI8(vec4i(unconst_i32(257), unconst_i32(14), unconst_i32(334), unconst_i32(551)));
+  let vf155: vec3h = log(tanh(vec2h(unconst_f16(2872.2), unconst_f16(5725.6))).grg);
+  vp12[u32(unconst_u32(38))] = f32(log(vec3h(unconst_f16(6099.5), unconst_f16(3385.3), unconst_f16(2654.9)))[1]);
+  let vf156: vec2h = tanh(vec2h(unconst_f16(5993.2), unconst_f16(12217.4)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer64 = device0.createBuffer({size: 7112, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let texture107 = device0.createTexture({
+  label: '\u{1fad7}\u{1f70a}\u55fe\u0f5b\u07fe',
+  size: {width: 20, height: 11, depthOrArrayLayers: 159},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup3, new Uint32Array(103), 1, 0);
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(7), /* required buffer size: 93 */
+{offset: 93}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup66 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView113}]});
+let commandEncoder120 = device0.createCommandEncoder();
+let texture108 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView121 = texture78.createView({label: '\u5914\ucd50\u{1fb9d}\u1ef9\ua2c0\u0bc3', dimension: 'cube', mipLevelCount: 1});
+let computePassEncoder88 = commandEncoder120.beginComputePass({label: '\u0f60\ud0dd\u6902'});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer34, 548); };
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer15, 'uint32', 72, 40);
+} catch {}
+let promise21 = device0.popErrorScope();
+let texture109 = gpuCanvasContext5.getCurrentTexture();
+let sampler73 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 36.25,
+  lodMaxClamp: 77.10,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup27, new Uint32Array(2319), 370, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder({});
+let computePassEncoder89 = commandEncoder121.beginComputePass({});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup40, new Uint32Array(1045), 61, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(0.21984075109262236, 0.9152647024596199, 25.86644354230647, 30.889647729946358, 0.9732141301693271, 0.9980342107754693);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer17, 0);
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+});
+let imageData10 = new ImageData(4, 16);
+let buffer65 = device0.createBuffer({
+  size: 2633,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder64.popDebugGroup();
+} catch {}
+let imageBitmap3 = await createImageBitmap(canvas0);
+let bindGroup67 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView113}]});
+let textureView122 = texture59.createView({arrayLayerCount: 1});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup5, new Uint32Array(39), 7, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+try {
+  await promise21;
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+struct T0 {
+  @align(2) @size(16) f0: array<u32>,
+}
+
+var<private> vp14: array<T1, 9> = array(T1(), T1(array<i32, 1>()), T1(), T1(array(i32())), T1(array<i32, 1>(i32())), T1(array(i32())), T1(array<i32, 1>()), T1(array<i32, 1>()), T1());
+
+var<workgroup> vw17: array<vec2h, 9>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput4 {
+  @location(5) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec4i,
+  @location(2) @interpolate(flat) f3: vec2u,
+}
+
+struct T1 {
+  @size(8) f0: array<i32, 1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(60) var st4: texture_storage_2d_array<r32float, write>;
+
+var<workgroup> vw15: mat3x2h;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw16: array<u32, 10>;
+
+var<workgroup> vw18: FragmentOutput4;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp15: u32 = u32();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let vf157: vec2h = asin(vec2h(unconst_f16(28737.7), unconst_f16(10133.7)));
+  out.f2 *= bitcast<vec4i>(transpose(mat2x2f(unconst_f32(0.1179), unconst_f32(0.1003), unconst_f32(0.01189), unconst_f32(0.01043)))[1].rrgr);
+  let vf158: mat2x2f = transpose(mat2x2f(unconst_f32(0.4903), unconst_f32(0.03900), unconst_f32(0.1271), unconst_f32(0.1410)));
+  vp15 = u32(vf157[u32(unconst_u32(68))]);
+  out.f2 += vec4i(vf157.xxxy);
+  var vf159: f32 = vf158[vec3u(pow(vec3h(fma(vec3f(unconst_f32(0.3012), unconst_f32(0.1726), unconst_f32(0.02404)), vec3f(unconst_f32(0.07313), unconst_f32(0.1131), unconst_f32(0.3247)), vec3f(bitcast<f32>(vp14[8].f0[0])))), vec3h(unconst_f16(1126.6), unconst_f16(6286.1), unconst_f16(268.6)))).x][u32(unconst_u32(13))];
+  out.f3 = vec2u(smoothstep(vec2h(unconst_f16(274.7), unconst_f16(3909.5)), bitcast<vec2h>(vp14[8].f0[0]), vec2h(unconst_f16(971.5), unconst_f16(-46079.2))));
+  var vf160: vec2f = vf158[0];
+  let vf161: f32 = vf158[0][u32(unconst_u32(232))];
+  let ptr43: ptr<private, i32> = &vp14[8].f0[0];
+  let vf162: mat2x2f = vf158;
+  textureStore(st4, vec2i(bitcast<i32>(vf159)), i32(unconst_i32(292)), vec4f(vec4f(bitcast<f32>(vp14[8].f0[0]))));
+  out.f3 |= vec2u(bitcast<u32>(vf162[1][bitcast<u32>(vp14[8].f0[0])]));
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute7() {
+  vp15 = bitcast<u32>(vw18.f2[0]);
+  vw18 = FragmentOutput4(vec4f(bitcast<f32>(vp14[8].f0[0])), u32(vp14[8].f0[0]), vec4i(vp14[8].f0[0]), vec2u(bitcast<u32>(vp14[8].f0[0])));
+}`,
+  hints: {},
+});
+let bindGroup68 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 65, resource: textureView94},
+    {binding: 78, resource: externalTexture14},
+    {binding: 158, resource: textureView76},
+    {binding: 2, resource: textureView119},
+    {binding: 146, resource: sampler67},
+    {binding: 134, resource: textureView96},
+    {binding: 325, resource: textureView91},
+  ],
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder122.beginComputePass({label: '\ua2b0\u{1f653}\u0aa5\uf23a'});
+let sampler74 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.99,
+  lodMaxClamp: 40.29,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup23, new Uint32Array(27), 5, 0);
+} catch {}
+try {
+computePassEncoder48.end();
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView7}, {binding: 27, resource: sampler36}],
+});
+let buffer66 = device0.createBuffer({size: 9928, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder123 = device0.createCommandEncoder();
+let renderPassEncoder44 = commandEncoder123.beginRenderPass({
+  colorAttachments: [{
+  view: textureView116,
+  depthSlice: 151,
+  clearValue: { r: 227.5, g: -931.6, b: 131.8, a: -915.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 6317557,
+});
+let sampler75 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 37.98,
+  lodMaxClamp: 98.17,
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup11, new Uint32Array(1111), 419, 0);
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup59, new Uint32Array(1351), 495, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle1, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(7, buffer63);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+let textureView123 = texture88.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup39, new Uint32Array(246), 53, 0);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer17, 452, 11_034);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 1, y: 9, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 2, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 1},
+  aspect: 'all',
+}, new Uint8Array(941).fill(43), /* required buffer size: 941 */
+{offset: 45, bytesPerRow: 132, rowsPerImage: 4}, {width: 13, height: 3, depthOrArrayLayers: 2});
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'film', transfer: 'unspecified'} });
+try {
+computePassEncoder81.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroupsIndirect(buffer41, 640); };
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(71);
+} catch {}
+document.body.prepend(canvas1);
+let buffer67 = device0.createBuffer({size: 8829, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture110 = device0.createTexture({
+  size: [64, 64, 259],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView124 = texture55.createView({label: '\u0194\uf347\u979a\u2b61\ud7ca\u384b\u062b', mipLevelCount: 1});
+let renderPassEncoder45 = commandEncoder68.beginRenderPass({
+  label: '\u0fbc\u86d9\u0b57\u301a\u0a3f\u0005',
+  colorAttachments: [{
+  view: textureView117,
+  depthSlice: 110,
+  clearValue: { r: 491.8, g: 61.76, b: -203.0, a: -626.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer18, 108);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder39.insertDebugMarker('\u5a04');
+} catch {}
+let canvas3 = document.createElement('canvas');
+let imageData11 = new ImageData(92, 36);
+let textureView125 = texture65.createView({});
+try {
+computePassEncoder85.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(0, bindGroup52, new Uint32Array(5263), 407, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup24, new Uint32Array(2125), 167, 0);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer55, 28, buffer31, 920, 44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 24, y: 4, z: 1},
+  aspect: 'all',
+}, new Uint8Array(59).fill(144), /* required buffer size: 59 */
+{offset: 59, bytesPerRow: 44}, {width: 4, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup70 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 475, resource: {buffer: buffer40, offset: 256}}]});
+let buffer68 = device0.createBuffer({
+  size: 6689,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+let computePassEncoder91 = commandEncoder124.beginComputePass({});
+let renderPassEncoder46 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  clearValue: { r: -127.7, g: 538.2, b: -900.0, a: -546.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer19, 'uint32', 2_456, 838);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer17);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 64 */
+  offset: 64,
+  bytesPerRow: 10496,
+  buffer: buffer21,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 8, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer69 = device0.createBuffer({size: 6430, usage: GPUBufferUsage.VERTEX});
+let textureView126 = texture108.createView({});
+let texture111 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder92 = commandEncoder37.beginComputePass({label: '\u{1fa12}\u06f9\u4d2a'});
+try {
+renderPassEncoder7.executeBundles([renderBundle9, renderBundle9, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup9, new Uint32Array(2749), 34, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(88).fill(123), /* required buffer size: 88 */
+{offset: 88}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u06f1\u{1f8bd}\u0386\u{1f952}\u462e\u2d52',
+  entries: [
+    {
+      binding: 375,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 91,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 65, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let bindGroup71 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 134, resource: textureView86},
+    {binding: 2, resource: textureView119},
+    {binding: 158, resource: textureView23},
+    {binding: 325, resource: textureView91},
+    {binding: 65, resource: textureView88},
+    {binding: 78, resource: externalTexture10},
+    {binding: 146, resource: sampler17},
+  ],
+});
+let commandEncoder125 = device0.createCommandEncoder({});
+let texture112 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView127 = texture36.createView({dimension: '2d-array', arrayLayerCount: 4});
+let computePassEncoder93 = commandEncoder50.beginComputePass({});
+let renderPassEncoder47 = commandEncoder125.beginRenderPass({
+  label: '\u9f46\u2412\u05a4\ub295\u{1ffc6}\u3d38\u1346',
+  colorAttachments: [{
+  view: textureView116,
+  depthSlice: 156,
+  clearValue: { r: -385.2, g: -352.8, b: -914.1, a: -52.65, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder89.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer38, 'uint32', 700, 206);
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView85}]});
+let texture113 = device0.createTexture({
+  size: [10, 5, 1],
+  mipLevelCount: 3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture114 = device0.createTexture({
+  label: '\u{1ff51}\u6ed3\ufaac\ub0a2\ubfee',
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer32, 'uint32', 244, 523);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+let texture115 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(0, bindGroup3, new Uint32Array(1700), 298, 0);
+} catch {}
+await gc();
+let buffer70 = device0.createBuffer({
+  size: 952,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture116 = device0.createTexture({
+  size: [20, 11, 27],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup61, new Uint32Array(2174), 263, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup1, new Uint32Array(3197), 1_799, 0);
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({});
+let texture117 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView128 = texture110.createView({});
+let computePassEncoder94 = commandEncoder126.beginComputePass({});
+let sampler76 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 19.45,
+  lodMaxClamp: 61.63,
+});
+try {
+computePassEncoder94.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup24, new Uint32Array(2511), 239, 0);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer69, 1_440);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup73 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView97}]});
+let textureView129 = texture99.createView({dimension: 'cube', format: 'etc2-rgb8unorm-srgb', baseMipLevel: 0, baseArrayLayer: 0});
+let texture118 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer60, 220, 154);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video0);
+let buffer71 = device0.createBuffer({size: 2071, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder127 = device0.createCommandEncoder({});
+let textureView130 = texture104.createView({dimension: 'cube', mipLevelCount: 1});
+try {
+renderPassEncoder11.executeBundles([renderBundle10, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer4, 'uint32', 7_732, 16_159);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup73, new Uint32Array(1776), 679, 0);
+} catch {}
+try {
+commandEncoder127.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 416 */
+  offset: 416,
+  buffer: buffer23,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup74 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView53}]});
+let commandEncoder128 = device0.createCommandEncoder({label: '\u{1f9c4}\u50ca\u{1fecd}\u0efe\u0d88\uec37\u8eb3'});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 2784});
+let renderPassEncoder48 = commandEncoder128.beginRenderPass({
+  label: '\u0c1d\u3da5',
+  colorAttachments: [{
+  view: textureView102,
+  depthSlice: 28,
+  clearValue: { r: 431.9, g: -947.1, b: 434.6, a: -688.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup54, new Uint32Array(2570), 331, 0);
+} catch {}
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2020 */
+  offset: 2020,
+  bytesPerRow: 18176,
+  buffer: buffer1,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 10, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView20}, {binding: 27, resource: sampler63}],
+});
+let commandEncoder129 = device0.createCommandEncoder({label: '\u{1f92d}\u12c3\u0d2f\u00ac\u89ba\u{1ff89}\u0a2c\uca97\ue225'});
+let computePassEncoder95 = commandEncoder127.beginComputePass({label: '\u2acc\u882a\u{1f6ea}\ua12e\uf820\u0be1\uf924\uc196\u51bc'});
+let sampler77 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+});
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer31, 1_968, 414);
+} catch {}
+try {
+commandEncoder129.copyTextureToTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let commandEncoder130 = device0.createCommandEncoder({label: '\u{1ff5e}\ua79d\u6776\uc71a\u0b93\u7716'});
+let texture119 = device0.createTexture({size: [10, 5, 1], format: 'r32sint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let sampler78 = device0.createSampler({
+  label: '\u0b43\u3dce\ud1e3\u7dee\ufdc0\u9a1a',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.16,
+  lodMaxClamp: 51.65,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer40, 'uint16', 72, 332);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer51);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise22;
+} catch {}
+let bindGroup76 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView85}]});
+let commandEncoder131 = device0.createCommandEncoder({});
+let texture120 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler79 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 85.45,
+  lodMaxClamp: 99.27,
+});
+try {
+computePassEncoder95.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup22, new Uint32Array(3128), 97, 0);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(22);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup18, []);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer65, 'uint32', 884, 113);
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3232 */
+  offset: 3232,
+  bytesPerRow: 8448,
+  buffer: buffer64,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup77 = device0.createBindGroup({
+  label: '\ua428\u0a8b\u028a\u0a85',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView14}],
+});
+let computePassEncoder96 = commandEncoder130.beginComputePass({label: '\u0f9e\uf080'});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(1, bindGroup67, new Uint32Array(119), 10, 0);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup13, new Uint32Array(1946), 596, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer20, 'uint32', 64, 81);
+} catch {}
+let imageData12 = new ImageData(64, 80);
+let shaderModule10 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput5 {
+  @location(0) f0: vec4u,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(27) var sam8: sampler;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(0) var tex12: texture_2d<i32>;
+
+var<workgroup> vw21: FragmentOutput5;
+
+var<workgroup> vw20: mat3x3h;
+
+var<workgroup> vw19: array<array<atomic<i32>, 2>, 3>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp16: array<FragmentOutput5, 3> = array(FragmentOutput5(), FragmentOutput5(), FragmentOutput5(vec4u()));
+
+struct T0 {
+  @align(2) @size(60) f0: array<u32>,
+}
+
+var<private> vp17: bool = bool();
+
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  vp16[u32(unconst_u32(33))].f0 = textureDimensions(tex12).xyxx;
+  var vf163: vec4h = reflect(vec4h(unconst_f16(11206.0), unconst_f16(28.43), unconst_f16(6200.4), unconst_f16(1799.3)), vec4h(unconst_f16(2820.0), unconst_f16(1852.1), unconst_f16(4745.5), unconst_f16(6812.9)));
+  out = FragmentOutput5(textureDimensions(tex12, i32(unconst_i32(374))).yyyx);
+  vp17 = bool(saturate(f32(unconst_f32(0.05456))));
+  let ptr44: ptr<private, FragmentOutput5> = &vp16[2];
+  return out;
+}
+
+@compute @workgroup_size(2, 2, 1)
+fn compute8() {
+  let vf164: f16 = vw20[0][u32(unconst_u32(97))];
+  atomicMin(&vw19[bitcast<u32>(atomicExchange(&(*&vw19)[2][1], i32(unconst_i32(37))))][bitcast<u32>(atomicLoad(&(*&vw19)[2][1]))], i32(vw20[0][0]));
+  let vf165: vec4i = textureLoad(tex12, vec2i(unconst_i32(28), unconst_i32(477)), vec4i(vw21.f0).g);
+  vw20 = mat3x3h(exp(vec2h((*&vw20)[u32(unconst_u32(18))][u32(unconst_u32(88))])).xyx, exp(vec2h((*&vw20)[u32(unconst_u32(18))][u32(unconst_u32(88))])).grr, exp(vec2h((*&vw20)[u32(unconst_u32(18))][u32(unconst_u32(88))])).xxy);
+  let ptr45: ptr<workgroup, atomic<i32>> = &vw19[2][u32(mix(vec4h(unconst_f16(7734.3), unconst_f16(5412.8), unconst_f16(6212.3), unconst_f16(1979.0)), vec4h(f16(vw21.f0[0])), vec4h(unconst_f16(5678.1), unconst_f16(1317.6), unconst_f16(5431.5), unconst_f16(12808.7))).z)];
+  let ptr46: ptr<workgroup, atomic<i32>> = &(*&vw19)[2][1];
+  let vf166: i32 = atomicLoad(&(*ptr45));
+  var vf167: i32 = vf166;
+  vf167 = i32(vw21.f0[1]);
+  vf167 = bitcast<vec4i>(vw21.f0)[1];
+  let ptr47: ptr<workgroup, mat3x3h> = &(*&vw20);
+  atomicOr(&vw19[u32(unconst_u32(571))][1], i32(vp17));
+  vp16[vw21.f0.z].f0 = unpack4xU8(bitcast<u32>(atomicLoad(&vw19[2][1])));
+  let vf168: vec4h = mix(vec4h(unconst_f16(2122.6), unconst_f16(19711.9), unconst_f16(5320.5), unconst_f16(17898.1)), vec4h(f16(atomicExchange(&(*&vw19)[2][1], vf167))), vec4h(unconst_f16(1704.0), unconst_f16(2645.0), unconst_f16(32939.9), unconst_f16(6900.6)));
+  vw20 = mat3x3h(fma(bitcast<vec2h>((*&vw21).f0[0]), vec2h(unconst_f16(479.8), unconst_f16(716.8)), vec2h(unconst_f16(18720.7), unconst_f16(276.1))).rgg, fma(bitcast<vec2h>((*&vw21).f0[0]), vec2h(unconst_f16(479.8), unconst_f16(716.8)), vec2h(unconst_f16(18720.7), unconst_f16(276.1))).grg, fma(bitcast<vec2h>((*&vw21).f0[0]), vec2h(unconst_f16(479.8), unconst_f16(716.8)), vec2h(unconst_f16(18720.7), unconst_f16(276.1))).rrg);
+  vw21 = FragmentOutput5(unpack4xU8(bitcast<u32>(vf167)));
+  var vf169: vec2h = exp(vec2h(unconst_f16(-110.1), unconst_f16(809.7)));
+  var vf170: vec4i = textureGather(3, tex12, sam8, vec2f(bitcast<f32>(atomicLoad(&(*ptr45)))), vec2i());
+  let ptr48: ptr<private, array<FragmentOutput5, 3>> = &vp16;
+  vf169 -= bitcast<vec2h>((*ptr48)[2].f0[u32(unconst_u32(8))]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder132 = device0.createCommandEncoder({});
+let texture121 = device0.createTexture({
+  label: '\ufff7\u1166\u4474\u05e0\u{1fb51}\u0b85\u083b\u{1ffbe}\u{1fcad}\u06ee',
+  size: [20],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder97 = commandEncoder131.beginComputePass({});
+let sampler80 = device0.createSampler({
+  label: '\u{1fc5d}\u5067\u0223\u{1fb3c}\u060b\u60fd\u30b9\u1af2\u0a68',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 32.07,
+  lodMaxClamp: 60.23,
+});
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(5, buffer44, 0, 2_270);
+} catch {}
+try {
+commandEncoder129.clearBuffer(buffer3, 1216, 244);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(142).fill(24), /* required buffer size: 142 */
+{offset: 142}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundle2.label = '\u3173\ue402\u627a\u{1f9ea}\uf103\u0b05\uaf00\u76f8\u523e\u{1feda}\ub892';
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5]});
+let commandEncoder133 = device0.createCommandEncoder({});
+let textureView131 = texture87.createView({dimension: '2d-array'});
+let renderPassEncoder49 = commandEncoder133.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  depthSlice: 4,
+  clearValue: { r: 789.8, g: 973.9, b: 384.9, a: -431.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder97.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline2);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'smpte170m'} });
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 100});
+let sampler81 = device0.createSampler({
+  label: '\u{1fd3a}\u{1f855}\ub510\ua6cb\ua031\u057d\u0021\u0109\u0287',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.30,
+  lodMaxClamp: 98.82,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup66, new Uint32Array(1069), 243, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle9, renderBundle8, renderBundle10, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer43, 'uint32', 1_664, 1_864);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, undefined, 130_099_334, 19_318_612);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer1, 'uint16', 7_018, 1_943);
+} catch {}
+let computePassEncoder98 = commandEncoder132.beginComputePass({label: '\u01fc\u9561\u8938\u0d75\u0e53'});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'display-p3'});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup33, new Uint32Array(36), 18, 0);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer39, 0, 1_299);
+} catch {}
+await gc();
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u357a\u056a\u0141',
+  entries: [
+    {
+      binding: 455,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+let textureView132 = texture79.createView({dimension: '2d'});
+let textureView133 = texture94.createView({dimension: '2d', mipLevelCount: 1});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(1, bindGroup35, new Uint32Array(3168), 252, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer30);
+} catch {}
+try {
+commandEncoder129.insertDebugMarker('\u0f5a');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder135 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer28, 0);
+} catch {}
+let computePassEncoder99 = commandEncoder129.beginComputePass({});
+let sampler82 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.91,
+  lodMaxClamp: 94.76,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup28, new Uint32Array(256), 23, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(1, buffer63, 0, 89);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1720 */
+  offset: 1720,
+  buffer: buffer5,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.append(canvas2);
+let renderPassEncoder50 = commandEncoder134.beginRenderPass({
+  label: '\ubc40\ua7f6\u40f0\u0d40',
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 6,
+  clearValue: { r: -37.91, g: 271.6, b: 529.0, a: 223.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 1028003151,
+});
+try {
+computePassEncoder99.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(3, buffer49, 0, 1_429);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup78 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView87}]});
+let buffer72 = device0.createBuffer({size: 1261, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder100 = commandEncoder135.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup79 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView87}]});
+let textureView134 = texture61.createView({mipLevelCount: 1});
+let texture122 = device0.createTexture({
+  size: [64, 64, 12],
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder100.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder();
+try {
+computePassEncoder60.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(1, bindGroup23, new Uint32Array(1890), 717, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder60); computePassEncoder60.dispatchWorkgroupsIndirect(buffer43, 3_004); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup66, []);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer51);
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 584 */
+  offset: 584,
+  bytesPerRow: 10496,
+  buffer: buffer60,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup80 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView105}]});
+let buffer73 = device0.createBuffer({
+  label: '\u{1ff25}\u{1fdc5}',
+  size: 7276,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let computePassEncoder101 = commandEncoder136.beginComputePass({});
+let sampler83 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.94,
+  lodMaxClamp: 98.37,
+  maxAnisotropy: 11,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(163);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+  await promise23;
+} catch {}
+try {
+sampler8.label = '\u{1f74c}\u4a4c\u29c7\u0deb\u0638\u3916\u4f2c\ucd59\u{1f8bd}\u07e0\u4293';
+} catch {}
+let texture123 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 13},
+  mipLevelCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler84 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 66.56,
+  maxAnisotropy: 17,
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 393,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer74 = device0.createBuffer({size: 15875, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let textureView135 = texture99.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup41, []);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup18, new Uint32Array(637), 0, 0);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(1585);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(1, buffer35, 3_520, 954);
+} catch {}
+let texture124 = device0.createTexture({
+  label: '\ucedb\u{1ffbc}\ueffa\u756a\ufae1\u097e\uafb4\u231e',
+  size: [40],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder101.setPipeline(pipeline1);
+} catch {}
+await gc();
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'bt2020_10bit'} });
+try {
+computePassEncoder65.setBindGroup(1, bindGroup61, new Uint32Array(2453), 847, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer40, 'uint32', 308, 42);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+document.body.append(video0);
+let textureView136 = texture11.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline2);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 120,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let texture125 = device0.createTexture({
+  size: [16, 16, 1],
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder102 = commandEncoder90.beginComputePass({});
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup36, new Uint32Array(380), 86, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let texture126 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer42, 832, buffer73, 336, 288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(239).fill(160), /* required buffer size: 239 */
+{offset: 239}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder137 = device0.createCommandEncoder({});
+let textureView137 = texture125.createView({baseArrayLayer: 0});
+let textureView138 = texture41.createView({dimension: '2d-array'});
+let computePassEncoder103 = commandEncoder89.beginComputePass();
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+commandEncoder137.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1024 */
+  offset: 1024,
+  buffer: buffer42,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let textureView139 = texture75.createView({});
+let computePassEncoder104 = commandEncoder137.beginComputePass({label: '\u0dcc\u8c10\u0e00\uce2d\u05b5\u9c9e\uea9b\u{1f669}\ue4d9\u0157\u13e0'});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup67, []);
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+buffer55.destroy();
+} catch {}
+let buffer75 = device0.createBuffer({size: 758, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture127 = device0.createTexture({
+  size: [5, 2, 76],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView140 = texture17.createView({label: '\u{1fedb}\uff5e\u{1fe3e}\ub471\ua5b9\u3574'});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup14, new Uint32Array(1254), 151, 0);
+} catch {}
+try {
+renderPassEncoder39.beginOcclusionQuery(159);
+} catch {}
+try {
+renderPassEncoder39.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer40, 'uint32', 168, 11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(4_232).fill(54), /* required buffer size: 4_232 */
+{offset: 181, bytesPerRow: 149, rowsPerImage: 13}, {width: 7, height: 2, depthOrArrayLayers: 3});
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler21}, {binding: 0, resource: textureView20}],
+});
+let commandEncoder138 = device0.createCommandEncoder({label: '\u953d\u0511\u0568\ub9f8\udaf7\u{1fde2}'});
+let computePassEncoder105 = commandEncoder138.beginComputePass();
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(22);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint32', 196, 75);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 6204, new Int16Array(668));
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture128 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: 58.23, g: 454.0, b: -314.1, a: -464.2, });
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer40, 'uint16', 560, 1_844);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView141 = texture41.createView({label: '\uf744\u9179\u76a0\u{1fa1e}\u7835'});
+let sampler85 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.49,
+  lodMaxClamp: 99.93,
+});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup22, new Uint32Array(338), 56, 0);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle9, renderBundle7, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer8, 'uint32', 1_456, 190);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder139 = device0.createCommandEncoder({});
+let textureView142 = texture66.createView({label: '\u2ab5\u{1f94d}\u08be'});
+let textureView143 = texture44.createView({dimension: '2d', format: 'rgba16uint'});
+let renderPassEncoder51 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{view: textureView68, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 161763296,
+});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup32, new Uint32Array(5164), 266, 0);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(2, buffer28, 212, 2_266);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let bindGroup82 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 14, resource: externalTexture15},
+    {binding: 56, resource: {buffer: buffer2, offset: 512, size: 540}},
+    {binding: 134, resource: textureView55},
+  ],
+});
+let commandEncoder140 = device0.createCommandEncoder({label: '\u{1f658}\u0f2b\u0148\u0239\u9018\u485f\u51d9\u36ba\u4f1a\u{1f80b}'});
+let renderPassEncoder52 = commandEncoder140.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -781.0, g: 548.2, b: -683.3, a: 439.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup47, new Uint32Array(1704), 127, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup57, new Uint32Array(2475), 69, 0);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(6, buffer53, 0, 7_858);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+computePassEncoder74.setBindGroup(3, bindGroup71, []);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let commandEncoder141 = device0.createCommandEncoder({});
+try {
+computePassEncoder83.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup29, new Uint32Array(637), 91, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer17, 304);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(17_015).fill(75), /* required buffer size: 17_015 */
+{offset: 631, bytesPerRow: 64, rowsPerImage: 32}, {width: 0, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let bindGroup83 = device0.createBindGroup({
+  label: '\uceae\u4488\u9db5\u{1fc60}\u0467\u11a4\ue50f\u02ac\u{1f86f}',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 65, resource: textureView137},
+    {binding: 68, resource: {buffer: buffer30, offset: 256, size: 4708}},
+    {binding: 120, resource: textureView141},
+  ],
+});
+let buffer76 = device0.createBuffer({
+  size: 3226,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder142 = device0.createCommandEncoder();
+let computePassEncoder106 = commandEncoder142.beginComputePass();
+let renderPassEncoder53 = commandEncoder141.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: -291.5, g: -452.1, b: -856.2, a: 258.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup5, new Uint32Array(6293), 1_242, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer45, 'uint32', 336, 608);
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker('\u0e58');
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({label: '\ua15e\u30f5'});
+let textureView144 = texture111.createView({baseMipLevel: 0});
+let textureView145 = texture42.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let renderPassEncoder54 = commandEncoder143.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  depthSlice: 2,
+  clearValue: { r: 889.1, g: -716.9, b: -265.7, a: 23.11, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup20, new Uint32Array(957), 76, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline2);
+} catch {}
+await gc();
+try {
+  await promise25;
+} catch {}
+document.body.append(img0);
+let shaderModule11 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+struct T0 {
+  @align(1) @size(32) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(0) var tex13: texture_2d<i32>;
+
+struct VertexOutput6 {
+  @location(13) f22: vec2i,
+  @location(3) f23: vec4h,
+  @builtin(position) f24: vec4f,
+  @location(7) f25: f32,
+  @location(2) @interpolate(flat, centroid) f26: vec2u,
+  @location(14) f27: vec4h,
+  @location(15) @interpolate(flat, sample) f28: vec2f,
+  @location(5) f29: vec2i,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn2() -> array<VertexOutput6, 1> {
+  var out: array<VertexOutput6, 1>;
+  var vf189: f32 = sign(bitcast<vec4f>(textureGather(1, tex13, sam9, vec2f(unconst_f32(0.04258), unconst_f32(0.2668))))[2]);
+  fn0();
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn0() -> vec2h {
+  var out: vec2h;
+  var vf171: u32 = pack4xI8(vec4i(ceil(vec4f(unconst_f32(0.03995), unconst_f32(0.2877), unconst_f32(0.1206), unconst_f32(0.03462)))));
+  var vf172: vec2f = unpack2x16float(u32(unconst_u32(207)));
+  let vf173: f32 = cosh(f32(unconst_f32(0.6170)));
+  out -= vec2h(step(vec3f(unconst_f32(0.02750), unconst_f32(0.01272), unconst_f32(0.1092)), vec3f(f32(pack4xU8Clamp(vec4u(unconst_u32(649), unconst_u32(75), unconst_u32(186), unconst_u32(55)))))).bb);
+  var vf174: vec3f = step(vec3f(unconst_f32(0.02941), unconst_f32(0.1417), unconst_f32(0.02762)), vec3f(unconst_f32(0.00774), unconst_f32(0.03397), unconst_f32(0.04721)));
+  var vf175: i32 = dot(vec3i(bitcast<i32>(vf173)), vec3i(bitcast<i32>(vf174[1])));
+  vf174 = vec3f(asinh(bitcast<f32>(pack4xU8Clamp(unpack4xU8(bitcast<u32>(vf172[u32(unconst_u32(3))]))))));
+  vf175 |= i32(pack4xI8(vec4i(vf172.xyxy)));
+  let vf176: i32 = dot(vec3i(i32(pack4xU8Clamp(vec4u(ceil(vec4f(unconst_f32(0.4155), unconst_f32(0.2616), unconst_f32(-0.1320), unconst_f32(0.1720))))))), vec3i(cross(vec3h(vf172.xyx), vec3h(unconst_f16(493.1), unconst_f16(261.9), unconst_f16(8835.4)))));
+  let vf177: f16 = inverseSqrt(f16(unconst_f16(19332.4)));
+  var vf178: u32 = pack4xI8(vec4i(unconst_i32(-384), unconst_i32(289), unconst_i32(19), unconst_i32(283)));
+  vf175 *= bitcast<i32>(vf173);
+  let vf179: vec4f = acos(vec4f(unconst_f32(0.1482), unconst_f32(0.05290), unconst_f32(0.01103), unconst_f32(-0.1758)));
+  var vf180: vec3h = cross(vec3h(unconst_f16(10110.5), unconst_f16(3369.7), unconst_f16(2544.8)), vec3h(unconst_f16(4758.2), unconst_f16(3870.2), unconst_f16(9279.3)));
+  return out;
+}
+
+@group(1) @binding(103) var tex14: texture_multisampled_2d<u32>;
+
+fn fn1() -> mat4x2h {
+  var out: mat4x2h;
+  let vf181: vec3h = fma(vec3h(f16(exp2(vec3f(extractBits(vec3u(unconst_u32(41), unconst_u32(425), unconst_u32(41)), u32(unconst_u32(171)), vec3u(fma(vec3h(unconst_f16(9385.8), unconst_f16(-451.2), unconst_f16(5445.2)), vec3h(sin(f16(unconst_f16(-3259.7)))), vec3h(unconst_f16(12291.0), unconst_f16(36862.2), unconst_f16(-2994.8))))[0])).z))), vec3h(unconst_f16(3595.3), unconst_f16(9068.6), unconst_f16(4712.2)), vec3h(fract(bitcast<vec2f>(log(vec4h(f16(pack4xU8Clamp(vec4u(unconst_u32(66), unconst_u32(57), unconst_u32(315), unconst_u32(17)))))))).xyy));
+  var vf182 = fn0();
+  var vf183 = fn0();
+  var vf184: vec4f = atan(vec4f(unconst_f32(-0.9849), unconst_f32(0.02896), unconst_f32(0.1118), unconst_f32(0.00635)));
+  let vf185: vec4h = log(vec4h(f16(determinant(mat3x3f(unconst_f32(0.07320), unconst_f32(0.1359), unconst_f32(0.1111), unconst_f32(0.08278), unconst_f32(0.3891), unconst_f32(0.7483), unconst_f32(0.1088), unconst_f32(0.08075), unconst_f32(0.1133))))));
+  var vf186: u32 = dot4U8Packed(u32(unconst_u32(81)), u32(unconst_u32(185)));
+  vf183 -= vec2h(extractBits(vec3u(unconst_u32(258), unconst_u32(19), unconst_u32(99)), u32(unconst_u32(427)), u32(unconst_u32(204))).zy);
+  var vf187 = fn0();
+  vf183 *= bitcast<vec2h>(exp2(f32(unconst_f32(0.1454))));
+  vf184 = vec4f(f32(sin(vf183[0])));
+  var vf188 = fn0();
+  let ptr49: ptr<function, u32> = &vf186;
+  fn0();
+  return out;
+}
+
+@group(0) @binding(27) var sam9: sampler;
+
+@vertex @must_use
+fn vertex6(@location(12) a0: u32, @builtin(vertex_index) a1: u32, @location(15) a2: f32, @location(3) @interpolate(flat, centroid) a3: u32) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f24 = vec4f(bitcast<f32>(pack2x16unorm(sqrt(vec2f(unconst_f32(0.00552), unconst_f32(0.2421))))));
+  var vf190 = fn0();
+  out.f27 = vec4h(f16(a3));
+  out.f23 *= bitcast<vec4h>(sqrt(vec2f(unconst_f32(1.000), unconst_f32(0.06698))));
+  var vf191 = fn1();
+  out = VertexOutput6(vec2i(i32(a0)), vec4h(f16(a0)), unpack4x8snorm(a0), bitcast<f32>(a0), vec2u(a0), vec4h(f16(a0)), unpack2x16snorm(a0), vec2i(i32(a0)));
+  out.f28 = vec2f(a2);
+  out.f29 ^= vec2i(i32(vf190[u32(unconst_u32(15))]));
+  var vf192: u32 = a3;
+  out.f25 = bitcast<f32>(vf191[u32(unconst_u32(3))]);
+  out.f26 |= vec2u(vf191[3]);
+  out.f22 *= vec2i(i32(vf192));
+  let vf193: u32 = pack2x16unorm(vec2f(unconst_f32(0.00910), unconst_f32(0.03488)));
+  fn1();
+  let ptr50: ptr<function, mat4x2h> = &vf191;
+  out.f24 = unpack4x8unorm(a1);
+  out.f26 |= vec2u((*ptr50)[3]);
+  var vf194: u32 = pack4xU8(vec4u(a1));
+  vf194 -= u32((*ptr50)[1][u32(unconst_u32(76))]);
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute9(@builtin(local_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u) {
+  let vf195: u32 = a1[2];
+  let vf196: vec3u = a1;
+}`,
+  hints: {},
+});
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer77 = device0.createBuffer({
+  size: 856,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture129 = device0.createTexture({
+  size: [40, 23, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder20.setPipeline(pipeline2);
+} catch {}
+await gc();
+let bindGroup84 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView0}]});
+let textureView146 = texture44.createView({dimension: '2d'});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup83);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle6, renderBundle6, renderBundle9, renderBundle0, renderBundle6, renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer8, 'uint32', 3_936, 362);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer23, 36);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup85 = device0.createBindGroup({
+  label: '\ue06a\ub4b8\uc561\u{1ffa6}\u{1f959}\u034e\u0587',
+  layout: bindGroupLayout4,
+  entries: [{binding: 60, resource: textureView85}],
+});
+let pipelineLayout15 = device0.createPipelineLayout({label: '\u596f\u20fc\u0fc1\uc1ed\u{1fc04}\u3e8d\u070b', bindGroupLayouts: []});
+let buffer78 = device0.createBuffer({size: 21797, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let sampler86 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.75,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup58, new Uint32Array(175), 12, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline2);
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'pq'} });
+let commandEncoder144 = device0.createCommandEncoder({label: '\u82c2\u0031\u054c\u0164'});
+let renderPassEncoder55 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{view: textureView84, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet16,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup16, new Uint32Array(1718), 171, 0);
+} catch {}
+try {
+  await buffer66.mapAsync(GPUMapMode.READ, 0, 1084);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({label: '\uc6ee\u026e\u0173\u4afa\uac86\u{1f70a}\uaf99\u6ca2\u0411\uc59d\u468c'});
+let textureView147 = texture44.createView({label: '\ud803\uc511\u{1fea0}\u07ff', dimension: '2d', format: 'rgba16uint', baseArrayLayer: 1});
+let computePassEncoder107 = commandEncoder145.beginComputePass();
+try {
+renderPassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer77, 252);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+  await promise24;
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 78, resource: externalTexture8},
+    {binding: 146, resource: sampler34},
+    {binding: 158, resource: textureView23},
+    {binding: 65, resource: textureView88},
+    {binding: 2, resource: textureView92},
+    {binding: 134, resource: textureView96},
+    {binding: 325, resource: textureView91},
+  ],
+});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(0, bindGroup68, new Uint32Array(1601), 188, 0);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline0);
+} catch {}
+await gc();
+let imageData13 = new ImageData(40, 48);
+try {
+externalTexture1.label = '\u{1fd1b}\u{1f761}';
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 559, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView148 = texture58.createView({dimension: '2d', baseArrayLayer: 1});
+let sampler87 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.45,
+  lodMaxClamp: 92.16,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder69.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer4, 'uint16', 38, 35_530);
+} catch {}
+let bindGroup87 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView147}]});
+let buffer79 = device0.createBuffer({size: 2997, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer54, 0, 2_475);
+} catch {}
+let texture130 = device0.createTexture({
+  label: '\u4d47\u074e\u{1fae7}\u{1fa0a}\u0f36\uf3b9\u{1fc93}\u09f1\u0523\u39e1',
+  size: [64, 64, 12],
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture131 = gpuCanvasContext4.getCurrentTexture();
+let textureView149 = texture14.createView({
+  label: '\u5e08\u8716\u9f03\u6004\u13ef\u12e2\u2728\ue79e\u0900\uc79f',
+  dimension: '3d',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+let sampler88 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 84.30,
+  lodMaxClamp: 90.92,
+});
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup28, new Uint32Array(945), 0, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup13);
+} catch {}
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 561});
+let sampler89 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.35,
+  lodMaxClamp: 92.17,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder101.setBindGroup(3, bindGroup87, new Uint32Array(3308), 607, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup63, new Uint32Array(1070), 127, 0);
+} catch {}
+await gc();
+let imageData14 = new ImageData(76, 32);
+let bindGroup88 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView87}]});
+let commandEncoder146 = device0.createCommandEncoder({label: '\u0ce6\u0975\u0476\uca6d\u889f\u01eb\u1325\u85ba\ud17d\u9a9e\u{1fc3d}'});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup44, new Uint32Array(579), 48, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup27, new Uint32Array(78), 3, 0);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer69, 0);
+} catch {}
+try {
+commandEncoder146.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 14, y: 6, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder();
+let texture132 = device0.createTexture({
+  label: '\uba93\u{1f82f}\u0962\u0b54\ue23c\u9824',
+  size: [20, 11, 1],
+  sampleCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let sampler90 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.04,
+  lodMaxClamp: 87.17,
+});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup76, new Uint32Array(1784), 676, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer40, 'uint32', 148, 538);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 5728, new DataView(new ArrayBuffer(1538)), 405, 84);
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({label: '\u0a24\u0052\u{1fe68}\u{1faad}\u{1faf5}\ub4bf\u0e71'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+try {
+computePassEncoder98.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer33, 'uint32', 2_268, 6_923);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer63, 0, 4_281);
+} catch {}
+let buffer80 = device0.createBuffer({size: 39149, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder108 = commandEncoder146.beginComputePass({label: '\u3afa\u061a\u001b\u804b\u{1fe92}'});
+try {
+computePassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup54, new Uint32Array(2006), 107, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 5476, new Float32Array(64100), 4293, 164);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video1 = await videoWithData(86);
+let shaderModule12 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+@group(0) @binding(65) var st6: texture_storage_2d_array<rgba32uint, read>;
+
+@id(59260) override override11 = false;
+
+@group(0) @binding(134) var st7: texture_storage_3d<rgba16float, write>;
+
+struct FragmentOutput6 {
+  @location(7) f0: vec2u,
+  @location(6) @interpolate(linear, sample) f1: f32,
+  @location(0) @interpolate(flat) f2: vec4u,
+  @builtin(sample_mask) f3: u32,
+  @location(1) f4: vec2f,
+}
+
+@group(0) @binding(158) var tex15: texture_cube<i32>;
+
+override override8: i32 = 87;
+
+@group(0) @binding(146) var sam10: sampler_comparison;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  f0: vec2i,
+}
+
+@group(0) @binding(325) var st8: texture_storage_1d<rg32uint, write>;
+
+@group(0) @binding(2) var st5: texture_storage_3d<rgba8uint, write>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(78) var et1: texture_external;
+
+struct S1 {
+  @location(12) f0: vec2h,
+}
+
+override override9: f32;
+
+fn fn0() -> vec2h {
+  var out: vec2h;
+  out += bitcast<vec2h>(vp18);
+  var vf197: vec4u = textureLoad(st6, vec2i(bitcast<i32>(pack4x8unorm(vec4f(unconst_f32(0.1563), unconst_f32(-0.02283), unconst_f32(0.4326), unconst_f32(0.1226))))), bitcast<vec2i>(sign(vec2f(unconst_f32(0.03194), unconst_f32(0.1216)))).y);
+  let vf198: u32 = pack4x8snorm(sign(vec2f(bitcast<f32>(override8))).xxxy);
+  out = vec2h(sign(vec2f(exp2(f32(unconst_f32(0.4226))))));
+  out = bitcast<vec2h>(vf197[0]);
+  out = bitcast<vec2h>(override9);
+  let vf199: f32 = override9;
+  let vf200: u32 = vf198;
+  var vf201: u32 = pack4x8unorm(vec4f(unconst_f32(0.04895), unconst_f32(0.06724), unconst_f32(0.04970), unconst_f32(0.03802)));
+  let ptr51: ptr<private, u32> = &vp18;
+  out = bitcast<vec2h>(vf197[0]);
+  var vf202: i32 = override8;
+  vf197 &= vec4u(sign(vec2f(unconst_f32(0.09056), unconst_f32(-0.1041))).gggg);
+  vf201 += pack4x8unorm(min(vec4f(unconst_f32(0.1791), unconst_f32(0.5785), unconst_f32(0.03254), unconst_f32(0.00821)), vec4f(unconst_f32(0.01882), unconst_f32(0.1433), unconst_f32(0.04438), unconst_f32(0.09115))));
+  let ptr52: ptr<private, u32> = &vp18;
+  let vf203: u32 = override10;
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  @align(2) f0: array<array<atomic<i32>, 1>, 4>,
+}
+
+struct VertexOutput7 {
+  @location(1) @interpolate(flat, center) f30: u32,
+  @location(12) f31: vec2h,
+  @location(8) @interpolate(linear) f32: vec2h,
+  @location(13) f33: vec4h,
+  @builtin(position) f34: vec4f,
+  @location(4) f35: f32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override10: u32 = 284;
+
+var<workgroup> vw22: mat2x4h;
+
+var<private> vp18: u32 = u32();
+
+struct S0 {
+  @builtin(vertex_index) f0: u32,
+  @location(10) f1: vec2h,
+  @location(12) f2: vec2u,
+  @location(6) f3: vec2i,
+  @location(4) @interpolate(flat) f4: u32,
+  @location(15) f5: vec2f,
+  @location(8) f6: vec4f,
+  @location(9) f7: vec4i,
+  @location(2) f8: u32,
+  @location(13) f9: vec2f,
+  @location(1) @interpolate(flat, center) f10: vec2u,
+  @builtin(instance_index) f11: u32,
+  @location(7) f12: vec4u,
+}
+
+@vertex @must_use
+fn vertex7(@location(11) a0: vec2u, @location(0) @interpolate(linear) a1: vec4h, @location(14) a2: f32, @location(5) @interpolate(flat, center) a3: vec2u, a4: S0) -> VertexOutput7 {
+  var out: VertexOutput7;
+  var vf204: f32 = override9;
+  let vf205: vec2u = a4.f2;
+  fn0();
+  fn0();
+  var vf206: bool = override11;
+  return out;
+}
+
+@fragment
+fn fragment6(@location(1) a0: u32, a1: S1) -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  fn0();
+  var vf207 = fn0();
+  var vf208: vec2h = a1.f0;
+  out.f0 <<= vec2u(bitcast<u32>(atanh(bitcast<f32>(pack2x16float(vec2f(unconst_f32(0.2709), unconst_f32(0.1113)))))));
+  fn0();
+  let ptr53: ptr<function, vec2h> = &vf207;
+  out.f2 |= vec4u(fma(vec4h(unconst_f16(2169.2), unconst_f16(6003.5), unconst_f16(30994.8), unconst_f16(3409.4)), vec4h(unconst_f16(7899.7), unconst_f16(3108.8), unconst_f16(-12060.2), unconst_f16(54924.2)), vec4h(unconst_f16(11955.2), unconst_f16(5007.9), unconst_f16(-15015.5), unconst_f16(2326.2))));
+  var vf209: f32 = distance(textureLoad(et1, vec2u()), vec4f(unconst_f32(0.1143), unconst_f32(-0.02564), unconst_f32(0.1760), unconst_f32(0.01301)));
+  out.f1 -= f32(vf207[bitcast<u32>(vf207)]);
+  out.f2 <<= unpack4xU8(u32((*ptr53)[1]));
+  let vf210: f16 = (*ptr53)[1];
+  vp18 = textureDimensions(st6).y;
+  var vf211: vec2u = textureDimensions(et1);
+  vf207 -= bitcast<vec2h>(atanh(bitcast<f32>(a1.f0)));
+  vp18 &= vp18;
+  fn0();
+  let ptr54: ptr<function, vec2h> = &vf208;
+  fn0();
+  fn0();
+  fn0();
+  vf208 = bitcast<vec2h>(a0);
+  fn0();
+  return out;
+}
+
+@compute @workgroup_size(6, 2, 1)
+fn compute10() {
+  var vf212 = fn0();
+  workgroupBarrier();
+  vw22 = mat2x4h(bitcast<vec4h>(countTrailingZeros(vec2u(vf212))), bitcast<vec4h>(countTrailingZeros(vec2u(vf212))));
+  vw22 = mat2x4h(exp(vf212[0]), exp(vf212[0]), exp(vf212[0]), exp(vf212[0]), exp(vf212[0]), exp(vf212[0]), exp(vf212[0]), exp(vf212[0]));
+  var vf213 = fn0();
+  textureStore(st5, vec3i(bitcast<i32>(pack4xU8Clamp(vec4u(fma(vec3h(unconst_f16(12121.0), unconst_f16(24192.3), unconst_f16(5204.9)), vec3h(atan(f16(unconst_f16(9392.5)))), vec3h(unconst_f16(13255.9), unconst_f16(1291.2), unconst_f16(19097.1))).grgb)))), vec4u(vec4u(unconst_u32(6), unconst_u32(110), unconst_u32(60), unconst_u32(31))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture133 = device0.createTexture({size: [5], dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder109 = commandEncoder148.beginComputePass({});
+let renderPassEncoder56 = commandEncoder147.beginRenderPass({
+  colorAttachments: [{
+  view: textureView30,
+  clearValue: { r: -508.4, g: 799.5, b: -306.2, a: 498.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 59615173,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup79, new Uint32Array(93), 23, 0);
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer21);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 626, resource: {buffer: buffer15, offset: 0, size: 152}},
+    {binding: 13, resource: textureView53},
+  ],
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let computePassEncoder110 = commandEncoder71.beginComputePass({});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup68);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle15, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer8, 'uint16', 560, 993);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer38, 0, 1_093);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  label: '\u678b\u0fb4\u{1f9ae}\u5f98\u4460\ue0d2\u01c2\u2689',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 134, resource: textureView99},
+    {binding: 158, resource: textureView18},
+    {binding: 78, resource: externalTexture4},
+    {binding: 65, resource: textureView94},
+    {binding: 2, resource: textureView119},
+    {binding: 325, resource: textureView142},
+    {binding: 146, resource: sampler67},
+  ],
+});
+let buffer81 = device0.createBuffer({
+  size: 14782,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder150 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  size: [5, 2, 76],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder111 = commandEncoder149.beginComputePass({});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer17, 'uint32', 4_968, 1_536);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer0 = buffer66.getMappedRange(0, 320);
+try {
+commandEncoder150.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 922 */
+  offset: 922,
+  bytesPerRow: 15872,
+  buffer: buffer70,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder({label: '\u846b\uceea\u{1fe67}\u0f83\u5204\u0d08\u03c2\u06e9\u07a9\uf630'});
+let textureView150 = texture94.createView({aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 2});
+let computePassEncoder112 = commandEncoder150.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup69, new Uint32Array(798), 52, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderPassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer1 = buffer66.getMappedRange(440, 16);
+try {
+buffer80.unmap();
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2784 */
+  offset: 2784,
+  buffer: buffer1,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let texture135 = device0.createTexture({
+  label: '\u0133\u{1fae5}\ueaa4\ud2e1\u321f\uc2e4\ua17b\u{1fc42}\u6d2c\u0938\u{1f9e2}',
+  size: [5],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView151 = texture64.createView({label: '\u1955\u05bc\ucea1\u3238\u{1fdea}\u0dc8\u4678\u62ed', dimension: '2d', baseArrayLayer: 1});
+let renderPassEncoder57 = commandEncoder100.beginRenderPass({
+  colorAttachments: [{view: textureView30, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet0,
+});
+let sampler91 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 25.86,
+  lodMaxClamp: 71.06,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup36, new Uint32Array(190), 25, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9]);
+} catch {}
+try {
+commandEncoder151.clearBuffer(buffer37, 476, 4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput8 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec2i,
+}
+
+@group(0) @binding(0) var tex16: texture_2d<i32>;
+
+struct T1 {
+  @align(4) @size(16) f0: vec2f,
+}
+
+struct FragmentOutput7 {
+  @location(5) f0: u32,
+  @location(0) @interpolate(flat, centroid) f1: vec2i,
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @align(1) @size(16) f0: array<u32>,
+}
+
+var<workgroup> vw23: array<atomic<u32>, 36>;
+
+var<private> vp19 = array(array(modf(f16())));
+
+@vertex
+fn vertex8() -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf214: u32 = dot4U8Packed(u32(vp19[u32(unconst_u32(167))][0].whole), u32(unconst_u32(156)));
+  let vf215: u32 = pack4xU8(vec4u(unconst_u32(439), unconst_u32(130), unconst_u32(32), unconst_u32(419)));
+  let vf216: u32 = dot4U8Packed(u32(vp19[0][0].whole), u32(unconst_u32(81)));
+  out = tanh(vec3f(unconst_f32(0.3135), unconst_f32(0.04493), unconst_f32(0.1786))).ggrg;
+  let vf217: vec2h = asinh(vec2h(unconst_f16(20714.1), unconst_f16(6157.9)));
+  var vf218: vec2h = asinh(vec2h(unconst_f16(8822.9), unconst_f16(828.9)));
+  let vf219: f16 = distance(distance(f16(unconst_f16(8805.1)), f16(max(vec3i(i32(vp19[0][0].whole)), vec3i(unconst_i32(202), unconst_i32(-185), unconst_i32(23))).z)), f16(unconst_f16(27712.8)));
+  var vf220: f16 = distance(f16(unconst_f16(14197.0)), f16(unconst_f16(3183.1)));
+  out *= vec4f(bitcast<f32>(pack4xU8(vec4u(unconst_u32(275), unconst_u32(98), unconst_u32(225), unconst_u32(18)))));
+  vp19[u32(unconst_u32(91))][u32(unconst_u32(287))].fract += vp19[0][0].whole;
+  out -= vec4f(f32(dot4U8Packed(u32(vf218[1]), u32(unconst_u32(270)))));
+  vf218 = bitcast<vec2h>(pack4x8snorm(vec4f(unconst_f32(0.2572), unconst_f32(0.1240), unconst_f32(0.2382), unconst_f32(0.1826))));
+  return out;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  out = FragmentOutput7(u32(dot4I8Packed(u32(vp19[0][0].whole), u32(unconst_u32(18)))), vec2i(dot4I8Packed(u32(vp19[0][0].whole), u32(unconst_u32(18)))));
+  var vf221: vec4h = radians(vec4h(unconst_f16(12457.1), unconst_f16(783.7), unconst_f16(2070.5), unconst_f16(-3864.2)));
+  let vf222: vec3h = exp2(tan(vec2h(extractBits(vec2u(unconst_u32(68), unconst_u32(53)), u32(unconst_u32(164)), u32(unconst_u32(188))))).yyy);
+  vf221 = vec4h(vp19[0][0].fract);
+  let vf223: vec3f = sin(vec3f(f32(vf221[1])));
+  let vf224: vec3h = vf222;
+  let ptr55 = &vp19[0][0];
+  let vf225: f32 = vf223[u32(unconst_u32(199))];
+  vp19[u32(unconst_u32(59))][u32(unconst_u32(108))] = modf(vf221.g);
+  let vf226: u32 = pack4xI8Clamp(vec4i(i32(vf222[u32(vp19[bitcast<vec2u>(unpack2x16snorm(u32(unconst_u32(280))))[0]][0].whole)])));
+  out.f0 <<= bitcast<vec3u>(firstTrailingBit(vec3i(unconst_i32(-114), unconst_i32(20), unconst_i32(305))))[2];
+  out.f0 |= pack2x16float(vec2f(log(vec3h(unconst_f16(-8205.0), unconst_f16(-4514.9), unconst_f16(17202.8))).zz));
+  var vf227: f16 = vf222[2];
+  vf221 += bitcast<vec4h>(textureDimensions(tex16, i32(unconst_i32(22))));
+  vf227 = f16(vf226);
+  var vf228: f16 = vf221[u32(unconst_u32(25))];
+  let vf229: vec2u = textureDimensions(tex16);
+  out.f0 = u32(vf227);
+  vf228 *= vf227;
+  let vf230: vec2u = vf229;
+  return out;
+}
+
+@fragment
+fn fragment8() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  out.f1 = vec2i(dot4I8Packed(u32(unconst_u32(172)), u32(unconst_u32(237))));
+  let ptr56 = &vp19[0];
+  out = FragmentOutput8(u32(vp19[0][0].whole), vec2i(i32(vp19[0][0].whole)));
+  let vf231: vec2i = firstTrailingBit(vec2i(unconst_i32(212), unconst_i32(725)));
+  var vf232: vec3f = pow(vec3f(unconst_f32(0.1709), unconst_f32(0.09869), unconst_f32(0.1818)), vec3f(unconst_f32(0.2096), unconst_f32(0.06804), unconst_f32(0.05633)));
+  vp19[u32(unconst_u32(204))][u32(unconst_u32(318))].whole *= f16(countOneBits(i32(unconst_i32(326))));
+  let ptr57: ptr<private, f16> = &(*ptr56)[0].fract;
+  vf232 += vec3f(f32(vp19[0][0].fract));
+  out.f0 = u32(vf232[u32(unconst_u32(281))]);
+  out.f0 -= u32(vp19[0][0].whole);
+  let vf233: f32 = vf232[u32(unconst_u32(134))];
+  let vf234: i32 = vf231[0];
+  out = FragmentOutput8(u32((*ptr56)[0].fract), vec2i(i32((*ptr56)[0].fract)));
+  let vf235: vec4i = textureLoad(tex16, vec2i(unconst_i32(79), unconst_i32(361)), bitcast<vec3i>(vf232)[0]);
+  return out;
+}
+
+@fragment
+fn fragment9(@location(10) a0: vec2h, @location(12) @interpolate(flat, centroid) a1: vec2i) -> @location(200) vec2i {
+  var out: vec2i;
+  let ptr58: ptr<private, f16> = &vp19[0][0].whole;
+  var vf236: mat3x2h = transpose(mat2x3h(vp19[0][0].fract, vp19[0][0].fract, vp19[0][0].fract, vp19[0][0].fract, vp19[0][0].fract, vp19[0][0].fract));
+  out *= vec2i(i32(vf236[u32(unconst_u32(119))][u32(unconst_u32(44))]));
+  var vf237: vec4i = unpack4xI8(u32(unconst_u32(35)));
+  vf237 += vec4i(i32(a0[0]));
+  vp19[u32(vf237[1])][u32(vp19[u32(unconst_u32(171))][0].whole)].whole *= f16(textureNumLevels(tex16));
+  let vf238: u32 = textureNumLevels(tex16);
+  let ptr59 = &vp19;
+  let vf239: vec2u = textureDimensions(tex16);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11(@builtin(num_workgroups) a0: vec3u) {
+  var vf240: i32 = clamp(i32(vp19[0][u32(unconst_u32(32))].fract), min(vec4i(unconst_i32(-273), unconst_i32(40), unconst_i32(59), unconst_i32(1)), vec4i(unconst_i32(93), unconst_i32(143), unconst_i32(43), unconst_i32(18)))[2], i32(atomicLoad(&(*&vw23)[35])));
+  let ptr60: ptr<workgroup, atomic<u32>> = &vw23[35];
+  let ptr61 = &vp19[0][vec4u(min(vec4h(unconst_f16(1816.7), unconst_f16(-6383.9), unconst_f16(18188.2), unconst_f16(7353.1)), vec4h(vp19[u32(unconst_u32(90))][0].whole)))[2]];
+  let vf241: vec3f = sin(vec3f(bitcast<f32>(atomicLoad(&(*ptr60)))));
+  atomicSub(&vw23[u32(unconst_u32(11))], u32(unconst_u32(355)));
+  let vf242: vec4i = min(vec4i(i32(vp19[0][0].whole)), vec4i(unconst_i32(75), unconst_i32(53), unconst_i32(164), unconst_i32(680)));
+  vf240 = bitcast<i32>(atomicLoad(&(*&vw23)[35]));
+  let ptr62 = &vp19[0];
+  vf240 = i32(degrees(sqrt(vec4f(unconst_f32(0.08560), unconst_f32(0.3648), unconst_f32(0.1151), unconst_f32(0.01206))).x));
+  vp19[u32((*ptr62)[0].whole)][u32(unconst_u32(5))] = modf(f16(vf242[0]));
+  atomicAnd(&vw23[35], u32(unconst_u32(97)));
+  let ptr63: ptr<workgroup, array<atomic<u32>, 36>> = &(*&vw23);
+  let ptr64: ptr<workgroup, array<atomic<u32>, 36>> = &vw23;
+  let ptr65 = &vp19[0][0];
+  var vf243: vec3f = fma(vec3f(bitcast<f32>(atomicLoad(&vw23[35]))), vec3f(bitcast<f32>(textureNumLevels(tex16))), vec3f(f32((*ptr62)[0].fract)));
+  let vf244: i32 = vf242[0];
+  var vf245: vec3f = vf241;
+  vp19[u32((*ptr61).whole)][bitcast<u32>(sin(vec3f(bitcast<f32>(atomicExchange(&vw23[35], u32((*ptr62)[0].fract)))))[1])].fract = f16(vf241[u32(unconst_u32(4))]);
+  let ptr66: ptr<private, f16> = &vp19[0][0].whole;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+let computePassEncoder113 = commandEncoder151.beginComputePass();
+let sampler92 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 29.08,
+  lodMaxClamp: 83.51,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup27, new Uint32Array(2654), 220, 0);
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle3, renderBundle4, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(7.877175792437107, 4.315413467014267, 9.422283087077146, 7.7236680605720505, 0.9560456980874596, 0.9732856899870855);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer9, 0, 1_337);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\u0eac');
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'astc-5x4-unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder();
+let textureView152 = texture46.createView({dimension: '2d'});
+let computePassEncoder114 = commandEncoder153.beginComputePass({label: '\ubee9\u8d39\ua971\u7a10\u{1f9be}\u05e4'});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer60, 'uint32', 628, 187);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(5, buffer63, 0, 1_887);
+} catch {}
+let textureView153 = texture60.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup54, new Uint32Array(994), 1, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer15, 'uint16', 78, 681);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer35, 4_888, 483);
+} catch {}
+let arrayBuffer2 = buffer66.getMappedRange(320, 40);
+let buffer82 = device0.createBuffer({size: 4965, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder154 = device0.createCommandEncoder();
+let renderPassEncoder58 = commandEncoder21.beginRenderPass({
+  colorAttachments: [{
+  view: textureView116,
+  depthSlice: 20,
+  clearValue: { r: 828.7, g: -628.4, b: 44.42, a: -886.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+});
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup48, new Uint32Array(567), 43, 0);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline2);
+} catch {}
+let bindGroup91 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView126}]});
+let textureView154 = texture132.createView({dimension: '2d-array', aspect: 'all'});
+let textureView155 = texture110.createView({label: '\u0f02\u0c27\u0df4\u{1f80f}\u61f6\u00eb\u44bd\u{1f607}\u0d18\u0ca1\u0755', baseMipLevel: 0});
+let computePassEncoder115 = commandEncoder152.beginComputePass();
+try {
+computePassEncoder71.setBindGroup(0, bindGroup43, new Uint32Array(1794), 466, 0);
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup90, new Uint32Array(4900), 81, 0);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer45, 'uint32', 252, 594);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer9, 700, 931);
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'pq'} });
+let computePassEncoder116 = commandEncoder154.beginComputePass({label: '\u09e9\u09d3\u3a44\u203c\uca27\u4da2\u7897\u218c'});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(2, bindGroup60, new Uint32Array(1513), 778, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setViewport(8.809252974085084, 19.23677920504546, 2.483149744790089, 2.7219696506405566, 0.9105424143546782, 0.9532710613900026);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 503,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 164,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 360,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4});
+let renderBundle17 = renderBundleEncoder17.finish();
+let sampler93 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.74,
+  lodMaxClamp: 92.43,
+  compare: 'always',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler94 = device0.createSampler({
+  label: '\u9468\u{1f66e}\u163d\u{1f88d}\u5d86\ue288\u{1fca4}\u{1febf}\u0ed9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 97.25,
+});
+try {
+computePassEncoder114.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer25, 'uint16', 314, 545);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline2);
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  label: '\u092d\u05f6\u09fc\u9208\u72f7',
+  layout: bindGroupLayout13,
+  entries: [{binding: 393, resource: textureView143}],
+});
+let buffer83 = device0.createBuffer({
+  size: 25346,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder155 = device0.createCommandEncoder({});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let renderBundle18 = renderBundleEncoder18.finish();
+try {
+computePassEncoder107.setBindGroup(0, bindGroup58, new Uint32Array(5347), 1_118, 0);
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline2);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u57cc\uab16\u{1fe27}\ucbf4\u{1fdb5}\u0a82\u7f5e\u5573\ud9c0\u0ea4',
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder156 = device0.createCommandEncoder({});
+let texture136 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16uint'],
+});
+let computePassEncoder117 = commandEncoder155.beginComputePass({});
+let sampler95 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.38,
+  lodMaxClamp: 95.03,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup33, new Uint32Array(1207), 171, 0);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise26;
+} catch {}
+document.body.prepend(img0);
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture137 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 79},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder113.setBindGroup(0, bindGroup85, new Uint32Array(1360), 388, 0);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(5, buffer49, 1_888);
+} catch {}
+try {
+commandEncoder156.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 412 */
+  offset: 412,
+  buffer: buffer64,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup93 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 56, resource: {buffer: buffer78, offset: 1280, size: 4444}},
+    {binding: 14, resource: externalTexture1},
+    {binding: 134, resource: textureView11},
+  ],
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup16, new Uint32Array(1353), 189, 0);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer58, 'uint32', 164, 242);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+canvas1.height = 806;
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'gamma28curve'} });
+let commandEncoder157 = device0.createCommandEncoder({label: '\u0730\u06a6\uec8a\u{1f99f}\u0fd0\u065b\u1326'});
+let textureView156 = texture18.createView({mipLevelCount: 1});
+let sampler96 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 27.44,
+  lodMaxClamp: 59.73,
+});
+try {
+computePassEncoder117.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer3 = buffer66.getMappedRange(464, 504);
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let sampler97 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.72,
+  lodMaxClamp: 48.88,
+  compare: 'greater',
+});
+try {
+renderPassEncoder51.executeBundles([renderBundle3]);
+} catch {}
+let computePassEncoder118 = commandEncoder157.beginComputePass({});
+try {
+computePassEncoder118.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer83, 'uint32', 4_444, 509);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+sampler11.label = '\u065a\u058f\u{1f652}';
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 3507,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture138 = device0.createTexture({
+  label: '\u9528\u8765\u1a18\u{1ff42}\u3a52\u0656',
+  size: [20, 11, 39],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder119 = commandEncoder156.beginComputePass({});
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(37, 13, 150, 152_069_040, 1_240_104_356);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer1, 3_736);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder109.clearBuffer(buffer70);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(img0);
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 66,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder158 = device0.createCommandEncoder();
+let texture139 = device0.createTexture({
+  label: '\ub453\u09bb\uf55d\u00a9\ucb79',
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder65.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.draw(204, 61, 2_037_630_039, 500_187_606);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(46, 28, 17, -1_880_682_134, 1_836_397_959);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer3, 216);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer43, 'uint16', 1_598, 3_843);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 44},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 4},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 7});
+} catch {}
+document.body.append(img0);
+let textureView157 = texture126.createView({});
+let computePassEncoder120 = commandEncoder158.beginComputePass({});
+try {
+computePassEncoder120.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer19, 92);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture140 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 110},
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder101.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup78, new Uint32Array(2243), 576, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer68, 576);
+} catch {}
+document.body.append(canvas1);
+let buffer85 = device0.createBuffer({
+  size: 48070,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder159 = device0.createCommandEncoder();
+let computePassEncoder121 = commandEncoder159.beginComputePass({});
+let sampler98 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 94.70,
+  compare: 'always',
+});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup47, new Uint32Array(564), 23, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup47, new Uint32Array(3629), 908, 0);
+} catch {}
+try {
+renderPassEncoder15.draw(3, 10, 416_257_470, 1_913_124_249);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(285, 133, 49, 190_242_070, 367_314_490);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer19, 180);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(1, buffer7, 840, 1_688);
+} catch {}
+let video2 = await videoWithData(92);
+let textureView158 = texture125.createView({});
+let textureView159 = texture62.createView({label: '\ud936\u0662\ubf92\u{1fc40}\u070c\u{1f7a0}\u0b85\u041a'});
+let computePassEncoder122 = commandEncoder109.beginComputePass({});
+let sampler99 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 48.35,
+  lodMaxClamp: 56.19,
+  compare: 'greater',
+});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer54, 480);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer58, 'uint16', 8, 329);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let texture141 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 59},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup58, new Uint32Array(333), 23, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer19, 3_956);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer64, 6_520);
+} catch {}
+try {
+computePassEncoder84.insertDebugMarker('\ue0f6');
+} catch {}
+let texture142 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32sint'],
+});
+let texture143 = gpuCanvasContext4.getCurrentTexture();
+try {
+computePassEncoder107.setBindGroup(1, bindGroup26, new Uint32Array(3713), 720, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup42, new Uint32Array(5830), 1_175, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(70, 339, 128, -1_180_311_159, 33_062_358);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let texture144 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 5,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView160 = texture104.createView({
+  label: '\u{1ffea}\u624a\uc93b\uac8d\ue649\u08d4\u2259\ua034\u05d1\u{1f634}',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 6,
+});
+let sampler100 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.72,
+  lodMaxClamp: 77.09,
+  compare: 'always',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder122.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder15.draw(69, 88, 1_502_815_304, 133_508_228);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(38, 67, 27, 57_569_097, 90_296_101);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer53, 184);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer73, 1_120);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer58, 'uint16', 40, 81);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(5, buffer85, 9_628, 1_140);
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let buffer86 = device0.createBuffer({
+  size: 7087,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup87, new Uint32Array(1381), 311, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle16]);
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 11927,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder160 = device0.createCommandEncoder();
+let textureView161 = texture86.createView({arrayLayerCount: 6});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup78, new Uint32Array(511), 70, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(36, 110, 101, -1_039_725_924, 151_469_407);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer1, 6_580);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer40, 'uint32', 748, 471);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder160.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1904 */
+  offset: 1904,
+  buffer: buffer25,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler101 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.68,
+  lodMaxClamp: 79.30,
+});
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup79, new Uint32Array(202), 24, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer1, 3_908);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline2);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise27;
+} catch {}
+let video3 = await videoWithData(118);
+let bindGroup94 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 134, resource: textureView159},
+    {binding: 78, resource: externalTexture1},
+    {binding: 325, resource: textureView142},
+    {binding: 65, resource: textureView88},
+    {binding: 158, resource: textureView23},
+    {binding: 2, resource: textureView119},
+    {binding: 146, resource: sampler40},
+  ],
+});
+let computePassEncoder123 = commandEncoder160.beginComputePass({});
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup28, new Uint32Array(3718), 395, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(168, 38, 217, -2_014_908_277, 961_868_713);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer7, 4_848);
+} catch {}
+await gc();
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 78, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let bindGroup95 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 241, resource: textureView76}]});
+let commandEncoder161 = device0.createCommandEncoder({});
+let texture145 = device0.createTexture({
+  size: [10, 5, 46],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder124 = commandEncoder161.beginComputePass({});
+try {
+computePassEncoder123.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(1, bindGroup56);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup22, new Uint32Array(363), 184, 0);
+} catch {}
+try {
+renderPassEncoder27.setViewport(4.699036646170634, 1.9971452478792735, 0.062414769451329906, 0.0016989981101782892, 0.3289755889994104, 0.9914296659128867);
+} catch {}
+try {
+renderPassEncoder15.draw(282, 208, 550_032_097, 47_373_433);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer85, 8_368);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let sampler102 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 55.30,
+  lodMaxClamp: 57.93,
+});
+try {
+computePassEncoder124.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer83, 'uint16', 4_702, 6);
+} catch {}
+document.body.prepend(img0);
+let textureView162 = texture137.createView({dimension: '3d'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer45, 340);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(166).fill(73), /* required buffer size: 166 */
+{offset: 166}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder162 = device0.createCommandEncoder();
+let computePassEncoder125 = commandEncoder162.beginComputePass();
+let sampler103 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.05,
+  lodMaxClamp: 69.54,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(13, 228, 11, 999_389_025, 278_615_376);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer71, 228);
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame8);
+let bindGroup96 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 13, resource: textureView53},
+    {binding: 626, resource: {buffer: buffer71, offset: 0, size: 328}},
+  ],
+});
+let commandEncoder163 = device0.createCommandEncoder({label: '\u{1f7eb}\u0a7b\u53e6\u{1f732}\ufd89\ub609\ue0e5'});
+let computePassEncoder126 = commandEncoder163.beginComputePass();
+try {
+computePassEncoder121.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup66, new Uint32Array(431), 92, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 15, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer88 = device0.createBuffer({
+  size: 35617,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView163 = texture74.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder15.draw(134, 130, 2_576_720_551, 466_956_242);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(33, 76, 34, 3_745_033, 505_324_433);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer57, 760);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer25, 360);
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer8, offset: 3328, size: 2296}}],
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture146 = device0.createTexture({
+  label: '\u0ea4\ufc9d\u{1fe2f}',
+  size: [5, 2, 13],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView164 = texture118.createView({dimension: '2d-array', aspect: 'all', format: 'r32sint', baseArrayLayer: 0});
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup49, new Uint32Array(171), 2, 0);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer88, 'uint16', 6_272, 9_211);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(5, buffer49, 76);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 3, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(11), /* required buffer size: 21 */
+{offset: 21}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder127 = commandEncoder33.beginComputePass({});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup26, new Uint32Array(1471), 28, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder21.setViewport(21.371517116813386, 54.65731576683201, 5.090090423453277, 8.812267846333382, 0.6897661679411843, 0.8724369896439119);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(50), /* required buffer size: 22 */
+{offset: 22}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView165 = texture75.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler104 = device0.createSampler({
+  label: '\u0dd0\u0723\u{1fb10}\uab9b\ue24d\uc3dc\u{1fa3e}\u1881',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 70.16,
+  compare: 'less',
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup50, new Uint32Array(2265), 0, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup7, new Uint32Array(1274), 22, 0);
+} catch {}
+try {
+renderPassEncoder51.setScissorRect(0, 0, 2, 0);
+} catch {}
+let buffer89 = device0.createBuffer({
+  size: 8597,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder164 = device0.createCommandEncoder({});
+let texture147 = device0.createTexture({
+  size: [5],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder128 = commandEncoder164.beginComputePass();
+let sampler105 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.84,
+  lodMaxClamp: 86.00,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup18, new Uint32Array(7394), 3_153, 0);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer77);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpteSt4281', transfer: 'smpte240m'} });
+let bindGroup98 = device0.createBindGroup({
+  label: '\u0e49\u{1fe89}\u068f\u12e7\u5db9\u{1f6f1}\uf083',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 120, resource: textureView101},
+    {binding: 65, resource: textureView137},
+    {binding: 68, resource: {buffer: buffer60, offset: 0, size: 300}},
+  ],
+});
+let commandEncoder165 = device0.createCommandEncoder({label: '\u037a\u0647\u25c7\u5f41\u{1faae}\u05f5\u0342\ufb9f\uf7d0'});
+let textureView166 = texture121.createView({});
+let computePassEncoder129 = commandEncoder165.beginComputePass({});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup92, new Uint32Array(36), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder112.insertDebugMarker('\ud8b6');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(165).fill(183), /* required buffer size: 165 */
+{offset: 165}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let texture148 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 79},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup42, new Uint32Array(1430), 120, 0);
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer89, 'uint32', 1_136, 260);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+document.body.prepend(canvas0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder166 = device0.createCommandEncoder({label: '\u0838\ub964\u0493'});
+let computePassEncoder130 = commandEncoder166.beginComputePass();
+let sampler106 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 39.13,
+  lodMaxClamp: 90.30,
+});
+let externalTexture18 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(0, buffer35, 0, 4_071);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let buffer90 = device0.createBuffer({size: 3401, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder102.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer73, 456); };
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4, buffer53);
+} catch {}
+let arrayBuffer4 = buffer66.getMappedRange(968, 28);
+let commandEncoder167 = device0.createCommandEncoder({});
+let textureView167 = texture15.createView({dimension: '1d'});
+let computePassEncoder131 = commandEncoder167.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer63, 1_116); };
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup4, new Uint32Array(2254), 216, 0);
+} catch {}
+try {
+renderPassEncoder58.beginOcclusionQuery(72);
+} catch {}
+try {
+renderPassEncoder58.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(3, buffer3, 680);
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+@group(1) @binding(146) var sam11: sampler_comparison;
+
+@group(1) @binding(65) var st10: texture_storage_2d_array<rgba32uint, read>;
+
+var<workgroup> vw30: vec2i;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw26: array<array<i32, 1>, 62>;
+
+fn fn0() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  var vf246: bool = all(bool(unconst_bool(true)));
+  var vf247: vec2i = countLeadingZeros(vec2i(vp21[52][0][0]));
+  textureStore(st9, vec3i(unconst_i32(190), unconst_i32(850), unconst_i32(-246)), vec4u(unpack4xU8(bitcast<u32>(mix(f32(textureNumLayers(st10)), f32(unconst_f32(0.03103)), bitcast<f32>(textureNumLayers(st10)))))));
+  var vf248: mat3x3h = transpose(mat3x3h(unconst_f16(4838.5), unconst_f16(11093.7), unconst_f16(9162.2), unconst_f16(-5306.6), unconst_f16(40.70), unconst_f16(3205.7), unconst_f16(-15730.3), unconst_f16(5675.8), unconst_f16(2365.2)));
+  var vf249: vec2h = atan2(vec2h(unconst_f16(-534.1), unconst_f16(-35356.4)), vec2h(unconst_f16(1450.3), unconst_f16(2039.1)));
+  var vf250: vec3h = vf248[u32(unconst_u32(228))];
+  let ptr67: ptr<private, i32> = &vp21[52][0][0];
+  textureStore(st11, vec3i(i32(vf250[1])), vec4f(vec4f(bitcast<f32>(vp21[bitcast<u32>(ldexp(asinh(vec4f(f32(vf249[u32(unconst_u32(307))])))[1], i32(unconst_i32(2))))][0][0]))));
+  textureStore(st9, vec3i(unconst_i32(-140), unconst_i32(93), unconst_i32(-108)), vec4u(vec4u(unconst_u32(62), unconst_u32(443), unconst_u32(81), unconst_u32(116))));
+  vf249 += bitcast<vec2h>(vf247[0]);
+  var vf251: vec4f = asinh(vec4f(vf249.yxyy));
+  var vf252: vec2h = atan2(vec2h(unpack4xI8(u32(unconst_u32(325))).ab), vec2h(unconst_f16(-1975.3), unconst_f16(16354.9)));
+  var vf253: f32 = vf251[1];
+  vf251 = vec4f(transpose(mat3x3h(f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])]))), f16(countTrailingZeros(u32(vf248[0][u32(vp20[1][0])])))))[0].zyxz);
+  let vf254: f16 = vf252[0];
+  vp21[u32(vf246)][u32(unconst_u32(207))][vec3u(vf248[2]).g] |= bitcast<i32>(vp20[u32(cosh(vec2h(log2(bitcast<vec2f>(countLeadingZeros(vec2i(unconst_i32(-265), unconst_i32(320))))))[1]))]);
+  return out;
+}
+
+var<workgroup> vw32: array<mat3x3h, 1>;
+
+var<workgroup> vw27: FragmentOutput9;
+
+var<workgroup> vw31: array<atomic<u32>, 15>;
+
+struct FragmentOutput9 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+}
+
+var<workgroup> vw25: vec2<bool>;
+
+var<workgroup> vw28: FragmentOutput9;
+
+@group(1) @binding(134) var st11: texture_storage_3d<rgba16float, write>;
+
+@group(1) @binding(78) var et2: texture_external;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw33: mat2x4f;
+
+var<private> vp20: mat4x2h = mat4x2h();
+
+@group(1) @binding(325) var st12: texture_storage_1d<rg32uint, write>;
+
+@group(0) @binding(103) var tex17: texture_multisampled_2d<u32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw24: mat2x3f;
+
+@group(1) @binding(2) var st9: texture_storage_3d<rgba8uint, write>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp21: array<array<array<i32, 1>, 1>, 53> = array<array<array<i32, 1>, 1>, 53>();
+
+var<workgroup> vw29: atomic<u32>;
+
+fn fn1() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  var vf255 = fn0();
+  vw32[u32(unconst_u32(402))] += mat3x3h(vec3h((*&vw33)[bitcast<u32>(vw24[u32(unconst_u32(445))].b)].xwy), vec3h((*&vw33)[bitcast<u32>(vw24[u32(unconst_u32(445))].b)].wzx), vec3h((*&vw33)[bitcast<u32>(vw24[u32(unconst_u32(445))].b)].wxx));
+  vw33 += mat2x4f(bitcast<vec4f>((*&vw28).f0), vec4f((*&vw28).f0));
+  var vf256: u32 = (*&vw28).f0[u32(unconst_u32(18))];
+  out.f0 = bitcast<vec4u>(workgroupUniformLoad(&vw33)[1]);
+  fn0();
+  return out;
+}
+
+struct T0 {
+  @size(36) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(1) @binding(158) var tex18: texture_cube<i32>;
+
+@fragment
+fn fragment10(@location(4) @interpolate(flat, centroid) a0: f32) -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  let vf257: vec4f = floor(vec4f(unconst_f32(-0.08006), unconst_f32(0.03940), unconst_f32(0.1406), unconst_f32(0.2501)));
+  var vf258 = fn0();
+  var vf259: u32 = vf258.f0[1];
+  textureStore(st9, vec3i(unconst_i32(-129), unconst_i32(124), unconst_i32(325)), vec4u(vec4u(unconst_u32(137), unconst_u32(541), unconst_u32(355), unconst_u32(81))));
+  var vf260: vec4f = radians(vec4f(f32(vf259)));
+  fn0();
+  out.f1 -= pack4xU8Clamp(vf258.f0);
+  fn0();
+  textureStore(st11, vec3i(unconst_i32(84), unconst_i32(63), unconst_i32(61)), vec4f(vec4f(unconst_f32(0.2772), unconst_f32(0.01691), unconst_f32(-0.03529), unconst_f32(0.2679))));
+  fn0();
+  var vf261: vec2f = min(vec2f(vf257[0]), vec2f(unconst_f32(0.1736), unconst_f32(0.09505)));
+  vf258 = FragmentOutput9(unpack4xU8(bitcast<u32>(a0)), bitcast<u32>(a0));
+  fn0();
+  var vf262 = fn0();
+  fn0();
+  vf261 = vec2f(vf261[1]);
+  vf261 -= unpack2x16snorm(u32(unconst_u32(14)));
+  out.f1 = vf262.f0[insertBits(vec3u(unconst_u32(343), unconst_u32(390), unconst_u32(125)), vec3u(unconst_u32(249), unconst_u32(106), unconst_u32(260)), u32(unconst_u32(181)), u32(unconst_u32(228))).b];
+  vf261 += bitcast<vec2f>(textureDimensions(et2));
+  fn0();
+  vf262 = FragmentOutput9(unpack4xU8(bitcast<u32>(vp21[52][0][0])), bitcast<u32>(vp21[52][0][0]));
+  out.f1 *= extractBits(u32(vp21[52][0][0]), u32(unconst_u32(320)), u32(unconst_u32(20)));
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture149 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 3},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView168 = texture112.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup89);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle2, renderBundle16, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer57, 'uint16', 1_162, 1_235);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(139).fill(209), /* required buffer size: 139 */
+{offset: 139}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder168.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer19, 'uint32', 2_028, 349);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let bindGroup99 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler15}, {binding: 0, resource: textureView132}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer71, 388); };
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup80, new Uint32Array(866), 3, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer39, 1_032, 2_083);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+}, new Uint8Array(4_232).fill(150), /* required buffer size: 4_232 */
+{offset: 47, bytesPerRow: 15, rowsPerImage: 31}, {width: 1, height: 0, depthOrArrayLayers: 10});
+} catch {}
+let texture150 = device0.createTexture({
+  size: [40, 23, 319],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+computePassEncoder75.setBindGroup(1, bindGroup0, new Uint32Array(354), 9, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView120}]});
+try {
+computePassEncoder130.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise28;
+} catch {}
+document.body.append(canvas2);
+let commandEncoder169 = device0.createCommandEncoder();
+let texture151 = device0.createTexture({
+  label: '\ue5ea\u02a3\u{1fb5f}\u019a\u{1f68d}\u{1fbe8}\u6ba6\u8b30\u{1fc27}\ufda4',
+  size: [40],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder133 = commandEncoder169.beginComputePass({});
+let sampler107 = device0.createSampler({
+  label: '\u{1fb48}\ua8b8\u{1f7d8}\u053e\u0268\u{1f9f2}\u3259\u6416\u04e2\ud550\u9c32',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 28.07,
+  lodMaxClamp: 72.46,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup22, new Uint32Array(4440), 1_832, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder32.pushDebugGroup('\u0997');
+} catch {}
+let imageData15 = new ImageData(24, 24);
+let buffer91 = device0.createBuffer({size: 4967, usage: GPUBufferUsage.STORAGE});
+let texture152 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup19, new Uint32Array(311), 54, 0);
+} catch {}
+let bindGroup101 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 15, resource: textureView141}]});
+let commandEncoder170 = device0.createCommandEncoder({});
+let texture153 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture19 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder133.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder170.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1204 */
+  offset: 1204,
+  buffer: buffer42,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder170.resolveQuerySet(querySet5, 525, 26, buffer18, 256);
+} catch {}
+let buffer92 = device0.createBuffer({
+  label: '\u88a5\u0295\u0959\u{1f849}\u01ba\u36ce\u{1f64f}',
+  size: 2312,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 600});
+let textureView169 = texture139.createView({label: '\u0980\u0035\u5e8f\u07e1\u9f43', format: 'rgba16uint', baseArrayLayer: 3, arrayLayerCount: 1});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup68);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(1, bindGroup4, new Uint32Array(1233), 40, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup18, new Uint32Array(4387), 117, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(5, buffer81, 4_924, 993);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(220), /* required buffer size: 21 */
+{offset: 21}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup102 = device0.createBindGroup({
+  label: '\u02ce\u{1fe81}\u50ce\u0ea3\u{1fcb5}\u5c1e\u{1fe99}\u5be9\u92b2',
+  layout: bindGroupLayout15,
+  entries: [{binding: 559, resource: externalTexture4}, {binding: 50, resource: textureView85}],
+});
+let buffer93 = device0.createBuffer({
+  label: '\u{1f81d}\u0c60\u{1fcdd}\u0279\u23fe\ue4cf\u1dc7\u{1ff51}',
+  size: 384,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView170 = texture110.createView({format: 'rgba16uint'});
+let computePassEncoder134 = commandEncoder170.beginComputePass({label: '\ucb53\u92d0'});
+let sampler108 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 58.89,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup79, []);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup26, new Uint32Array(1020), 328, 0);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(0, buffer93, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 5, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let commandEncoder171 = device0.createCommandEncoder();
+let texture154 = device0.createTexture({
+  label: '\ud0b6\u9924\u0b62\u{1feab}\u0458\u{1fb13}\u76ef',
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler109 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 16.85,
+  lodMaxClamp: 51.03,
+});
+try {
+computePassEncoder128.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(2, bindGroup74, new Uint32Array(499), 5, 0);
+} catch {}
+try {
+renderPassEncoder55.insertDebugMarker('\ue523');
+} catch {}
+let buffer94 = device0.createBuffer({size: 33380, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView171 = texture104.createView({
+  label: '\u11c8\u8a45\u05d5',
+  dimension: 'cube-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  arrayLayerCount: 6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer73, 16); };
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup22, new Uint32Array(2197), 552, 0);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer5 = buffer66.getMappedRange(1000, 20);
+try {
+device0.queue.submit([]);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise29;
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({});
+let texture155 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32sint'],
+});
+let computePassEncoder135 = commandEncoder171.beginComputePass();
+let renderPassEncoder59 = commandEncoder172.beginRenderPass({
+  colorAttachments: [{
+  view: textureView169,
+  clearValue: { r: 655.6, g: 635.8, b: -885.6, a: -353.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 147911408,
+});
+try {
+computePassEncoder131.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle2, renderBundle16, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(24.581912458003604, 10.605523807026263, 6.985669679902943, 5.846177576348153, 0.6707189974503451, 0.6737944589552909);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer9, 272, 79);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+let commandEncoder173 = device0.createCommandEncoder();
+let texture156 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 43},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder60 = commandEncoder173.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  clearValue: { r: 332.3, g: 289.4, b: -524.0, a: -664.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 19938840,
+});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup63, new Uint32Array(2638), 136, 0);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline2);
+} catch {}
+let bindGroup103 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 6, resource: textureView144}]});
+let commandEncoder174 = device0.createCommandEncoder({});
+let textureView172 = texture91.createView({});
+try {
+computePassEncoder134.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(0, buffer84, 1_492, 181);
+} catch {}
+document.body.prepend(img0);
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let texture157 = device0.createTexture({
+  label: '\u2420\ucae0\u0f39\ua6ad\u{1f90b}\uc745\u952e\u{1fd25}',
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView173 = texture155.createView({});
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup33, []);
+} catch {}
+try {
+commandEncoder174.copyTextureToBuffer({
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 954 */
+  offset: 954,
+  bytesPerRow: 48640,
+  buffer: buffer20,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let imageData16 = new ImageData(4, 44);
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 68, resource: {buffer: buffer70, offset: 0}},
+    {binding: 65, resource: textureView157},
+    {binding: 120, resource: textureView101},
+  ],
+});
+let texture158 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let sampler110 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.02,
+  lodMaxClamp: 45.00,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer19, 'uint16', 5_600, 646);
+} catch {}
+try {
+commandEncoder174.copyBufferToBuffer(buffer90, 396, buffer38, 880, 556);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 4, y: 4 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture159 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder136 = commandEncoder174.beginComputePass({});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup63, new Uint32Array(1217), 297, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+let pipeline3 = device0.createComputePipeline({label: '\u854f\ub703', layout: pipelineLayout11, compute: {module: shaderModule7}});
+let texture160 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(2, bindGroup27, new Uint32Array(238), 80, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline2);
+} catch {}
+let texture161 = device0.createTexture({
+  label: '\u{1fa13}\uece7\ufb5b\u66dd',
+  size: [5, 2, 54],
+  mipLevelCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler112 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.77,
+  lodMaxClamp: 94.13,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder132.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer95 = device0.createBuffer({
+  size: 8414,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let textureView174 = texture80.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder137 = commandEncoder175.beginComputePass({});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer7, 'uint16', 4_128, 279);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(7, buffer31, 0, 449);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+await gc();
+let commandEncoder176 = device0.createCommandEncoder({});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder118.setBindGroup(2, bindGroup90, new Uint32Array(3621), 440, 0);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup66, []);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline2);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 193, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup105 = device0.createBindGroup({
+  label: '\u453b\u7a26\u02f6\u74d4\u3c90\u3fe9\ua132',
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 13, resource: textureView143},
+    {binding: 626, resource: {buffer: buffer68, offset: 256, size: 108}},
+  ],
+});
+let computePassEncoder138 = commandEncoder176.beginComputePass({});
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup103);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer73, 'uint16', 996, 112);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(3, buffer85);
+} catch {}
+try {
+renderPassEncoder32.popDebugGroup();
+} catch {}
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 66, resource: textureView123}, {binding: 76, resource: textureView35}],
+});
+let buffer96 = device0.createBuffer({size: 2317, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView175 = texture18.createView({mipLevelCount: 1});
+try {
+computePassEncoder138.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup73, new Uint32Array(229), 9, 0);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle1, renderBundle1, renderBundle2, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer86, 'uint16', 5_262, 149);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(0, buffer31);
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt709', transfer: 'linear'} });
+try {
+adapter1.label = '\u8082\u87fc\u2282\u994d\u06ad\uc902\u0970\u{1ff4a}\u4b54';
+} catch {}
+let bindGroup107 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView9}]});
+let textureView176 = texture91.createView({dimension: '3d', aspect: 'all'});
+let texture162 = device0.createTexture({size: [40, 23, 1], format: 'rgba32float', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let externalTexture20 = device0.importExternalTexture({source: video3});
+try {
+computePassEncoder136.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 102,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 465,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 237,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 81,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 651,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup108 = device0.createBindGroup({
+  label: '\u0dd2\u923d\u5cb0',
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 503, resource: textureView96},
+    {binding: 59, resource: {buffer: buffer58, offset: 0, size: 56}},
+    {binding: 360, resource: sampler73},
+    {binding: 164, resource: {buffer: buffer87, offset: 0, size: 8840}},
+  ],
+});
+let texture163 = device0.createTexture({
+  size: [5],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler113 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.03,
+  lodMaxClamp: 84.16,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer41, 1_364); };
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(818);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 78, resource: {buffer: buffer65, offset: 0, size: 144}}],
+});
+let texture164 = device0.createTexture({
+  label: '\u0058\u{1fddd}\u1e0b\u02d7\u063d\u2e6e',
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView177 = texture160.createView({});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup77, new Uint32Array(688), 1, 0);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer30, 'uint16', 4_182, 603);
+} catch {}
+let textureView178 = texture134.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 10});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup65);
+} catch {}
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView133}]});
+let buffer97 = device0.createBuffer({
+  label: '\ub25b\u62f1\u780a\uc7a4\uad8b\u5e8f\u0a7c\ue104\u26fd',
+  size: 1460,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView179 = texture164.createView({});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], stencilReadOnly: true});
+let renderBundle21 = renderBundleEncoder21.finish();
+try {
+computePassEncoder63.setBindGroup(0, bindGroup105);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(3, bindGroup51, new Uint32Array(594), 91, 0);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let textureView180 = texture163.createView({aspect: 'all'});
+let sampler114 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.22,
+  lodMaxClamp: 91.50,
+  compare: 'equal',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup27, new Uint32Array(1146), 54, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup86, new Uint32Array(2098), 236, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup111 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 50, resource: textureView153}, {binding: 559, resource: externalTexture13}],
+});
+let buffer98 = device0.createBuffer({
+  size: 275,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup19, new Uint32Array(1157), 23, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer57, 'uint16', 784, 204);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(1, buffer44, 3_136);
+} catch {}
+let arrayBuffer6 = buffer66.getMappedRange(1024, 12);
+let textureView181 = texture164.createView({label: '\u484c\ude94\ub7b6\ucd3a', baseArrayLayer: 0});
+let texture165 = device0.createTexture({
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler115 = device0.createSampler({
+  label: '\uc2a1\u{1fe3f}\ud3bf\u07df',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 61.14,
+  lodMaxClamp: 75.41,
+});
+try {
+computePassEncoder127.setBindGroup(3, bindGroup105, new Uint32Array(2588), 146, 0);
+} catch {}
+try {
+renderPassEncoder57.beginOcclusionQuery(1175);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline2);
+} catch {}
+let buffer99 = device0.createBuffer({
+  size: 18309,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView182 = texture158.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup72, new Uint32Array(734), 76, 0);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer7, 'uint32', 468, 752);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let texture166 = device0.createTexture({
+  size: [20, 11, 44],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder139 = commandEncoder177.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer20, 456); };
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer32, 'uint32', 1_184, 1_479);
+} catch {}
+let promise31 = device0.popErrorScope();
+try {
+device0.queue.writeBuffer(buffer49, 828, new Float32Array(1239), 217, 24);
+} catch {}
+try {
+  await promise31;
+} catch {}
+try {
+globalThis.someLabel = sampler13.label;
+} catch {}
+let buffer100 = device0.createBuffer({
+  label: '\u{1fe7e}\u0712\u0654\u{1fbde}\u0f8d',
+  size: 20527,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder178 = device0.createCommandEncoder({label: '\u4ae2\u{1feff}\u0b54\ua0ce\u086a\u2f87\u{1fdc6}'});
+let texture167 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 182},
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler116 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 3.004,
+  lodMaxClamp: 68.26,
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer76, 1_000); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup19, new Uint32Array(1243), 88, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer53, 1_436);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer23, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer4, 'uint32', 580, 41);
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24 */
+  offset: 24,
+  bytesPerRow: 4096,
+  buffer: buffer65,
+}, {
+  texture: texture53,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder178.copyTextureToTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 59, resource: {buffer: buffer85, offset: 512, size: 21786}},
+    {binding: 503, resource: textureView96},
+    {binding: 360, resource: sampler15},
+    {binding: 164, resource: {buffer: buffer86, offset: 1024, size: 612}},
+  ],
+});
+let buffer101 = device0.createBuffer({size: 10245, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView183 = texture74.createView({label: '\uab76\ud74f\u62e2\u0058\u0f83\u65ff\u68fb\u04ad\uefc6'});
+let computePassEncoder140 = commandEncoder178.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(3); };
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder57.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer85, 29_440);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer95, 'uint32', 88, 1_085);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder75.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup43, new Uint32Array(464), 154, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(1, 116, 1_388_203_477, 740_215_399);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 207, 6, 59_764_679, 61_639_663);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer73, 892);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer58, 'uint32', 288, 79);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer49, 1_924);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+let video4 = await videoWithData(54);
+let buffer102 = device0.createBuffer({
+  size: 13421,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder179 = device0.createCommandEncoder({});
+let textureView184 = texture138.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 4});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup45, new Uint32Array(565), 58, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+renderPassEncoder2.draw(282, 51, 820_782_056, 411_688_344);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer32, 'uint16', 184, 69);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer7 = buffer66.getMappedRange(1040, 8);
+try {
+commandEncoder179.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 936 */
+  offset: 936,
+  buffer: buffer92,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder56.insertDebugMarker('\u1ad5');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas4,
+  origin: { x: 203, y: 60 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture168 = device0.createTexture({
+  label: '\uadcd\uaa3c\u12c7\uac58',
+  size: {width: 20, height: 11, depthOrArrayLayers: 5},
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView185 = texture39.createView({dimension: '2d'});
+let computePassEncoder141 = commandEncoder179.beginComputePass({});
+try {
+renderPassEncoder2.draw(42, 13, 3_135_393_659, 537_404_340);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(10, 240, 0, -1_847_383_224, 1_198_729_853);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer32, 'uint32', 700, 407);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer100, 0, 6_267);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise32;
+} catch {}
+document.body.append(video4);
+let buffer103 = device0.createBuffer({size: 15050, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let sampler117 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 27.52,
+  lodMaxClamp: 62.12,
+});
+try {
+renderPassEncoder2.draw(214, 269, 300_590_657, 228_633_404);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(35, 778, 30, 146_659_016, 456_790_491);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer63, 1_864);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer53, 2_252);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'pq'} });
+try {
+adapter1.label = '\ub68e\u0151\u0b6b\u063e\u6618\u00c1\u670e\ue448\uf880';
+} catch {}
+let buffer104 = device0.createBuffer({size: 3742, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView186 = texture33.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup13, new Uint32Array(1640), 643, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup36);
+} catch {}
+let bindGroup113 = device0.createBindGroup({
+  label: '\uc94b\ued4d\u{1f715}\u4533\u59ca\u6d36',
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer101, offset: 1280, size: 1881}}],
+});
+let textureView187 = texture105.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 31});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup69);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle10, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(63, 108, 37, 269_169_317, 408_491_262);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer94, 248);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer103, 2_608);
+} catch {}
+let promise33 = device0.popErrorScope();
+try {
+renderPassEncoder50.pushDebugGroup('\u{1fb25}');
+} catch {}
+try {
+  await promise33;
+} catch {}
+let buffer105 = device0.createBuffer({
+  size: 18764,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler118 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 99.44,
+  lodMaxClamp: 99.69,
+});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup105, new Uint32Array(1199), 35, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup67, new Uint32Array(368), 10, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer76, 28, buffer45, 5444, 352);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup114 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer47, offset: 1024, size: 220}}],
+});
+let buffer106 = device0.createBuffer({size: 3944, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder180 = device0.createCommandEncoder({});
+let textureView188 = texture81.createView({aspect: 'all'});
+let sampler119 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.00,
+});
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup43);
+} catch {}
+document.body.prepend(video0);
+let img1 = await imageWithData(156, 3, '#10101010', '#20202020');
+let buffer107 = device0.createBuffer({size: 11290, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let computePassEncoder142 = commandEncoder8.beginComputePass({label: '\u05bc\u{1f95e}\u0993\u0599\u6251\u0f83\u{1f9a7}\u12f6\u{1fedd}\u7470'});
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder180.copyBufferToBuffer(buffer36, 168, buffer3, 180, 544);
+} catch {}
+let computePassEncoder143 = commandEncoder180.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer1, 1_680); };
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer95, 2452, new Float32Array(5308), 683, 0);
+} catch {}
+let texture169 = device0.createTexture({
+  size: [10, 5, 79],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView189 = texture58.createView({arrayLayerCount: 2});
+let sampler120 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.88,
+  lodMaxClamp: 86.63,
+  maxAnisotropy: 12,
+});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(0, bindGroup71, new Uint32Array(3616), 740, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer85, 1_188, 23_944);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({});
+let textureView190 = texture126.createView({mipLevelCount: 1});
+let texture170 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 3},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder144 = commandEncoder181.beginComputePass();
+try {
+computePassEncoder142.setPipeline(pipeline1);
+} catch {}
+let buffer108 = device0.createBuffer({size: 9463, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let sampler121 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 41.33,
+  lodMaxClamp: 80.66,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer14, 'uint32', 44, 32);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(0, buffer40, 0, 173);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 5},
+  aspect: 'all',
+}, new Uint8Array(241_716).fill(186), /* required buffer size: 241_716 */
+{offset: 12, bytesPerRow: 54, rowsPerImage: 104}, {width: 0, height: 5, depthOrArrayLayers: 44});
+} catch {}
+let buffer109 = device0.createBuffer({size: 8150, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder182 = device0.createCommandEncoder();
+let textureView191 = texture163.createView({baseArrayLayer: 0});
+let computePassEncoder145 = commandEncoder182.beginComputePass({});
+let sampler122 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 88.58,
+});
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer20, 'uint16', 398, 593);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer83);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u026c');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 1740, new DataView(new ArrayBuffer(6981)), 99, 152);
+} catch {}
+try {
+computePassEncoder107.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+computePassEncoder129.setBindGroup(1, bindGroup26, new Uint32Array(345), 10, 0);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(7, buffer89, 1_860, 379);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+let texture171 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 21},
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView192 = texture157.createView({dimension: '2d-array'});
+let sampler123 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.55,
+  lodMaxClamp: 82.94,
+  maxAnisotropy: 15,
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup81, new Uint32Array(4316), 326, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup86);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(1791);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer45, 'uint16', 578, 775);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder50.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 1680, new BigUint64Array(13011), 554, 188);
+} catch {}
+let buffer110 = device0.createBuffer({
+  label: '\u{1f61f}\ucc86\u0806\u0b11\uca25\u{1fa00}\u0a54\u{1f881}\ubc29',
+  size: 12456,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView193 = texture139.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup96, new Uint32Array(3939), 604, 0);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer98, 124, 14);
+} catch {}
+let buffer111 = device0.createBuffer({size: 9754, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder183 = device0.createCommandEncoder();
+let textureView194 = texture65.createView({dimension: '2d-array'});
+let textureView195 = texture36.createView({
+  label: '\u{1ff7c}\u{1f718}\u{1f842}\uad9b\u051a\u03b1\u1f49\u{1fe02}\u4476\u7ebf',
+  format: 'rgba16uint',
+  arrayLayerCount: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+document.body.append(video0);
+let computePassEncoder146 = commandEncoder183.beginComputePass({label: '\u0990\u6041\u6a00\u{1fabc}'});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup11, new Uint32Array(1244), 495, 0);
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpteSt4281', transfer: 'iec61966-2-1'} });
+let commandEncoder184 = device0.createCommandEncoder({label: '\u52ca\udb0b\u05d6\u4552'});
+let texture172 = device0.createTexture({
+  size: [10, 5, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView196 = texture62.createView({label: '\uf445\u0067\u2062\u9e3f\u3756'});
+let computePassEncoder147 = commandEncoder184.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(2, bindGroup87, new Uint32Array(890), 229, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer65, 'uint32', 16, 1_042);
+} catch {}
+try {
+renderPassEncoder60.insertDebugMarker('\ue490');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 58.44,
+  lodMaxClamp: 71.39,
+  maxAnisotropy: 1,
+});
+let externalTexture24 = device0.importExternalTexture({source: video3});
+try {
+computePassEncoder147.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup47, new Uint32Array(2415), 303, 0);
+} catch {}
+try {
+renderPassEncoder45.setScissorRect(2, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer17, 'uint16', 3_562, 7_468);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline2);
+} catch {}
+let textureView197 = texture172.createView({label: '\ua7cb\u0e82\u0e2d', baseMipLevel: 0});
+let sampler125 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 28.20,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(4, buffer89, 628, 448);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(725).fill(217), /* required buffer size: 725 */
+{offset: 725}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler126 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 84.16,
+  lodMaxClamp: 96.89,
+  compare: 'less',
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup35, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer9, 'uint16', 830, 392);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let commandEncoder185 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer65, 376); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer73, 'uint16', 1_306, 398);
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 664 */
+  offset: 664,
+  buffer: buffer70,
+}, {
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video0);
+await gc();
+let bindGroup115 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView126}]});
+let buffer112 = device0.createBuffer({size: 7631, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture173 = device0.createTexture({
+  size: [5, 2, 1],
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView198 = texture82.createView({});
+let computePassEncoder148 = commandEncoder185.beginComputePass({label: '\u{1fd0c}\u9a1e\u{1fcee}'});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder148.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup90);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup90, new Uint32Array(1474), 324, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(4, undefined);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup38, new Uint32Array(950), 259, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 52, new Int16Array(6522), 1664, 80);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer15, 'uint16', 194, 171);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(18).fill(69), /* required buffer size: 18 */
+{offset: 18, bytesPerRow: 18, rowsPerImage: 56}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt709', transfer: 'smpte240m'} });
+let textureView199 = texture82.createView({baseMipLevel: 0});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup96, new Uint32Array(6241), 2_868, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(384);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer1, 'uint32', 532, 10_914);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 408, new BigUint64Array(2688), 1450, 24);
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout11, bindGroupLayout17]});
+let texture174 = device0.createTexture({
+  label: '\u622f\u7726\u6b2a\u08ad\u6941\u4511\u552a\u7e17\ud837',
+  size: [10, 5, 27],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+commandEncoder183.label = '\u024d\u0360\udc46';
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer77, 60, 75);
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let buffer113 = device0.createBuffer({
+  size: 5622,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView200 = texture62.createView({baseMipLevel: 0});
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup16, new Uint32Array(954), 291, 0);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer39);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 3084, new Float32Array(14139), 1247, 664);
+} catch {}
+let textureView201 = texture54.createView({});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame20});
+try {
+renderPassEncoder35.setVertexBuffer(5, buffer95, 3_000, 55);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({label: '\uf41e\u0d28\u046a\u9600\u685d\u08ee\u07d5\ue2c1\u24d6\uf90e', bindGroupLayouts: []});
+let commandEncoder186 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroupsIndirect(buffer12, 1_408); };
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder186.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 800 */
+  offset: 800,
+  bytesPerRow: 12544,
+  rowsPerImage: 356,
+  buffer: buffer45,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 24, new BigUint64Array(3253), 584, 36);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder187 = device0.createCommandEncoder({});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup113);
+} catch {}
+try {
+computePassEncoder147.setBindGroup(2, bindGroup92, new Uint32Array(644), 19, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(3, buffer100, 0);
+} catch {}
+try {
+buffer100.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let pipelineLayout20 = device0.createPipelineLayout({label: '\u7c85\u6ff4\u{1fc81}\u94b0', bindGroupLayouts: []});
+let buffer114 = device0.createBuffer({size: 14710, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let texture175 = device0.createTexture({
+  label: '\u01a7\u011d\u0053\u{1ff04}',
+  size: [10],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder149 = commandEncoder187.beginComputePass({});
+try {
+computePassEncoder135.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder112.setBindGroup(2, bindGroup66, new Uint32Array(735), 72, 0);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup69, new Uint32Array(2516), 329, 0);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(2, buffer81, 2_712);
+} catch {}
+try {
+commandEncoder186.copyBufferToBuffer(buffer89, 2384, buffer112, 652, 856);
+} catch {}
+try {
+commandEncoder186.insertDebugMarker('\uabab');
+} catch {}
+let promise35 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule0, targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.GREEN}]},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+await gc();
+let bindGroup116 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 66, resource: textureView123}, {binding: 76, resource: textureView140}],
+});
+try {
+computePassEncoder142.setBindGroup(0, bindGroup61, new Uint32Array(1107), 38, 0);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer86, 'uint16', 62, 167);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder186.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView202 = texture125.createView({aspect: 'depth-only', baseArrayLayer: 0});
+let computePassEncoder150 = commandEncoder186.beginComputePass({});
+let sampler127 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.48,
+  lodMaxClamp: 81.53,
+  maxAnisotropy: 18,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroupsIndirect(buffer29, 1_820); };
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline2);
+} catch {}
+let imageData17 = new ImageData(24, 4);
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 66, resource: textureView63}, {binding: 76, resource: textureView168}],
+});
+let buffer115 = device0.createBuffer({size: 29030, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder188 = device0.createCommandEncoder({});
+let computePassEncoder151 = commandEncoder188.beginComputePass();
+let externalTexture26 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer94, 0, 2_010);
+} catch {}
+try {
+buffer80.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 0, y: 43 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder189 = device0.createCommandEncoder({});
+let computePassEncoder152 = commandEncoder189.beginComputePass();
+try {
+computePassEncoder87.setBindGroup(0, bindGroup55, new Uint32Array(1122), 11, 0);
+} catch {}
+try {
+computePassEncoder70.end();
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup0, new Uint32Array(1784), 144, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle16, renderBundle4, renderBundle18, renderBundle7, renderBundle16, renderBundle1, renderBundle4, renderBundle18, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer7, 116);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer89, 'uint16', 2_386, 1_483);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder98.resolveQuerySet(querySet4, 509, 0, buffer100, 5632);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler29}, {binding: 0, resource: textureView7}],
+});
+let commandEncoder190 = device0.createCommandEncoder();
+try {
+computePassEncoder148.setBindGroup(3, bindGroup116, []);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup55, new Uint32Array(353), 157, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer102, 'uint16', 2_950, 751);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(0, buffer49);
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler128 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.47,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder16.draw(89, 254, 1_330_806_935, 528_930_247);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(31, 271, 57, 500_004_973, 160_169_665);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer99, 'uint16', 400, 9_180);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 97,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder191 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder9.finish({});
+let textureView203 = texture26.createView({aspect: 'all'});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup37, new Uint32Array(304), 29, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup92, new Uint32Array(4364), 817, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(45, 34, 17, 46_291_631, 597_911_030);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer36, 204);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer50, 'uint32', 484, 8_024);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(1, buffer31, 2_740, 2_131);
+} catch {}
+let arrayBuffer8 = buffer66.getMappedRange(456, 0);
+try {
+commandEncoder98.copyBufferToBuffer(buffer5, 364, buffer34, 4588, 20);
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 72 */
+  offset: 72,
+  buffer: buffer10,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder190.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2928 */
+  offset: 2928,
+  buffer: buffer49,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+await gc();
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder192 = device0.createCommandEncoder({});
+let textureView204 = texture60.createView({dimension: '2d', format: 'r32float', baseArrayLayer: 1});
+let textureView205 = texture99.createView({
+  dimension: 'cube-array',
+  format: 'etc2-rgb8unorm-srgb',
+  baseMipLevel: 0,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder153 = commandEncoder98.beginComputePass({});
+try {
+computePassEncoder153.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup31, new Uint32Array(1376), 1_149, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer53, 4_632);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer77, 0, 49);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 664, new DataView(new ArrayBuffer(9091)), 872, 1012);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(108).fill(117), /* required buffer size: 108 */
+{offset: 108, rowsPerImage: 17}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img2 = await imageWithData(5, 60, '#10101010', '#20202020');
+let imageData18 = new ImageData(140, 32);
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer116 = device0.createBuffer({label: '\u{1f807}\uc5a4', size: 1019, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder193 = device0.createCommandEncoder({});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 18, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise34;
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder();
+let computePassEncoder154 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder154.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(3, 417, 3, 306_984_454, 81_480_790);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer85, 7_924);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(4, buffer98, 0);
+} catch {}
+let promise36 = device0.queue.onSubmittedWorkDone();
+document.body.append(video1);
+try {
+computePassEncoder82.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderPassEncoder16.draw(98, 79, 384_377_468, 288_190_354);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer110, 2_428);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder192.insertDebugMarker('\u05cb');
+} catch {}
+let imageData19 = new ImageData(52, 20);
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'pq'} });
+let buffer117 = device0.createBuffer({
+  size: 13196,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder195 = device0.createCommandEncoder({});
+let textureView206 = texture78.createView({
+  label: '\u{1fbc4}\u0d00\u0ea6\u8c85\u39ac\u0552',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder155 = commandEncoder190.beginComputePass({});
+try {
+computePassEncoder134.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup51, new Uint32Array(251), 129, 0);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(1, 40, 8, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(96, 1, 51, 156_062_000, 1_048_874_247);
+} catch {}
+try {
+commandEncoder193.copyBufferToBuffer(buffer34, 940, buffer67, 1576, 400);
+} catch {}
+try {
+  await promise36;
+} catch {}
+let buffer118 = device0.createBuffer({
+  size: 8273,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+renderPassEncoder16.draw(60, 145, 1_085_129_005, 1_164_700_033);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(7, buffer60, 0);
+} catch {}
+let commandBuffer3 = commandEncoder194.finish();
+let texture176 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder156 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup2, new Uint32Array(466), 78, 0);
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.draw(82, 186, 303_390_545, 528_191_352);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer20);
+} catch {}
+await gc();
+let videoFrame26 = new VideoFrame(videoFrame15, {timestamp: 0});
+let computePassEncoder157 = commandEncoder192.beginComputePass({});
+let renderPassEncoder61 = commandEncoder195.beginRenderPass({
+  colorAttachments: [{
+  view: textureView185,
+  clearValue: { r: 51.86, g: 611.3, b: -225.7, a: 783.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(0, bindGroup97, new Uint32Array(431), 1, 0);
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer114, 7_000);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 78, resource: {buffer: buffer3, offset: 512, size: 628}}],
+});
+let commandEncoder196 = device0.createCommandEncoder({});
+let textureView207 = texture110.createView({});
+let computePassEncoder158 = commandEncoder196.beginComputePass();
+try {
+computePassEncoder158.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(7, 456, 42, 158_540_264, 1_270_502_831);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline2);
+} catch {}
+let commandEncoder197 = device0.createCommandEncoder({label: '\u02ff\u2b5b\u080e\u3830\u09cb\u64e7\u{1f9ea}'});
+let computePassEncoder159 = commandEncoder197.beginComputePass({});
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup114);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup26, new Uint32Array(3176), 63, 0);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(578);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(16, 17, 21, 178_858_720, 1_082_755_249);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 688, new DataView(new ArrayBuffer(32108)), 154, 2468);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'stencil-only',
+}, new Uint8Array(968).fill(27), /* required buffer size: 968 */
+{offset: 263, bytesPerRow: 20, rowsPerImage: 5}, {width: 5, height: 1, depthOrArrayLayers: 8});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup120 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 6, resource: textureView197},
+    {binding: 81, resource: textureView181},
+    {binding: 465, resource: textureView191},
+    {binding: 651, resource: {buffer: buffer47, offset: 512, size: 12}},
+    {binding: 178, resource: {buffer: buffer86, offset: 1792, size: 584}},
+    {binding: 102, resource: {buffer: buffer33, offset: 8192, size: 1442}},
+    {binding: 58, resource: textureView21},
+    {binding: 47, resource: textureView178},
+    {binding: 237, resource: {buffer: buffer101, offset: 1024, size: 3904}},
+  ],
+});
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer119 = device0.createBuffer({
+  size: 3967,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder198 = device0.createCommandEncoder();
+try {
+computePassEncoder140.setBindGroup(0, bindGroup37, new Uint32Array(3338), 544, 0);
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({label: '\u09a5\u169c\u4586\u1a18\ua29d\u{1f962}', bindGroupLayouts: [bindGroupLayout2]});
+let commandEncoder199 = device0.createCommandEncoder({});
+let computePassEncoder160 = commandEncoder198.beginComputePass();
+let sampler129 = device0.createSampler({addressModeV: 'repeat', magFilter: 'nearest', lodMinClamp: 90.18, lodMaxClamp: 92.89});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup58, new Uint32Array(7414), 243, 0);
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer36, 152, buffer26, 672, 2532);
+} catch {}
+try {
+commandEncoder199.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 19, y: 11, z: 4},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder199.resolveQuerySet(querySet0, 288, 114, buffer86, 768);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u70b8\u2703\u9aee\u0465\u{1f7cb}\ub049\ue774\u{1ff49}\u6465';
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({label: '\u20e5\u471d\u0439\u{1f92f}\u739e\u6bc4\u4365\u1a4f\u87eb\u{1ff7c}\u98ce'});
+let texture177 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder161 = commandEncoder200.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer73, 1_312); };
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline3);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer68, 836, 1156);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder();
+let texture178 = device0.createTexture({size: [10], dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.COPY_DST});
+let textureView208 = texture170.createView({arrayLayerCount: 1});
+let computePassEncoder162 = commandEncoder199.beginComputePass({});
+let sampler130 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 49.71});
+try {
+computePassEncoder160.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer64, 116);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer120 = device0.createBuffer({
+  size: 9601,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView209 = texture32.createView({mipLevelCount: 1});
+let renderPassEncoder62 = commandEncoder201.beginRenderPass({
+  label: '\u10ee\uc366\u1c93\u5d09\u0792\uac73\u2c29\ue8a1\u00bd',
+  colorAttachments: [{view: textureView146, loadOp: 'clear', storeOp: 'discard'}],
+});
+try {
+renderPassEncoder16.draw(273, 164, 167_356_831, 327_214_530);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(2, buffer93, 204, 3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 2552, new BigUint64Array(1082), 57, 152);
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+pipelineLayout1.label = '\u0624\u268a\ue470\u{1f72d}\u93c8\u{1f7f9}\ud385\ua291';
+} catch {}
+let sampler131 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.091,
+  compare: 'never',
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder54.setBindGroup(3, bindGroup48, new Uint32Array(916), 31, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(9, 93, 38, 363_829_122, 556_295_310);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder5.pushDebugGroup('\ud3d8');
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+await gc();
+let texture179 = device0.createTexture({
+  label: '\ube1a\u{1fcc1}\uce92\uc6fe\u{1fd48}',
+  size: [20, 11, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView210 = texture100.createView({});
+let sampler132 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.60,
+});
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer3, 1_152);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer103, 48, 615);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(17).fill(60), /* required buffer size: 17 */
+{offset: 17}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer121 = device0.createBuffer({size: 7105, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder202 = device0.createCommandEncoder({});
+let texture180 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 39},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder163 = commandEncoder202.beginComputePass();
+try {
+computePassEncoder161.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup111);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer16, 88);
+} catch {}
+let buffer122 = device0.createBuffer({size: 39392, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder203 = device0.createCommandEncoder({});
+let computePassEncoder164 = commandEncoder203.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer23, 392);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 9, y: 2, z: 8},
+  aspect: 'all',
+}, new Uint8Array(123_181).fill(140), /* required buffer size: 123_181 */
+{offset: 104, bytesPerRow: 195, rowsPerImage: 37}, {width: 4, height: 3, depthOrArrayLayers: 18});
+} catch {}
+try {
+  await promise37;
+} catch {}
+let canvas5 = document.createElement('canvas');
+let buffer123 = device0.createBuffer({size: 10037, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder204 = device0.createCommandEncoder({});
+let textureView211 = texture135.createView({label: '\ud623\u653c\u0994\u8a35\u0385', arrayLayerCount: 1});
+let computePassEncoder165 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder164.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup67);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer89, 'uint32', 1_148, 3);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 160 */
+  offset: 160,
+  bytesPerRow: 31488,
+  buffer: buffer30,
+}, {
+  texture: texture88,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 15, y: 5, z: 28},
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 7},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 10});
+} catch {}
+let video5 = await videoWithData(27);
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'smpteSt4281'} });
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 36,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup121 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 97, resource: textureView178}]});
+let textureView212 = texture111.createView({dimension: '2d-array', format: 'r32sint', baseMipLevel: 0});
+let renderPassEncoder63 = commandEncoder34.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 519.6, g: -243.7, b: -949.5, a: 573.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(1, bindGroup107, new Uint32Array(5144), 361, 0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup105);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(5, buffer31, 2_440, 1_279);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroup122 = device0.createBindGroup({
+  label: '\u9d9f\uefe5\uf077\u{1fcda}\u943e\u{1fee0}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 60, resource: textureView87}],
+});
+let commandEncoder205 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer92, 136); };
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup82);
+} catch {}
+let img3 = await imageWithData(25, 39, '#10101010', '#20202020');
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'logSqrt'} });
+let bindGroup123 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView105}]});
+let renderPassEncoder64 = commandEncoder205.beginRenderPass({
+  label: '\u001b\u0ef4\u1cad\uc910\ua709\u0ac1\u0cba',
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: -716.3, g: 438.4, b: -190.3, a: -177.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 39356878,
+});
+let textureView213 = texture167.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 9});
+let sampler133 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.38,
+  lodMaxClamp: 97.72,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(3); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer53, 816); };
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4_294_967_294, undefined, 1_296_021_520, 38_362_683);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+computePassEncoder129.setBindGroup(3, bindGroup89);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup73, new Uint32Array(668), 135, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 50, resource: textureView87}, {binding: 559, resource: externalTexture6}],
+});
+let externalTexture27 = device0.importExternalTexture({source: video5});
+try {
+computePassEncoder156.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 160, new BigUint64Array(2232), 527, 0);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let textureView214 = texture4.createView({format: 'rgba32sint', mipLevelCount: 1, arrayLayerCount: 5});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], sampleCount: 1});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup84);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(0, bindGroup100, new Uint32Array(1051), 140, 0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle5, renderBundle0, renderBundle4, renderBundle5]);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup117);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup79, new Uint32Array(2692), 74, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer40, 'uint32', 808, 399);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer69, 376, 1_366);
+} catch {}
+try {
+renderPassEncoder5.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'astc-10x10-unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video4);
+await gc();
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  label: '\u10dc\u683d\uecad\u{1f771}\u7fe4\u{1f695}\u0201',
+  entries: [
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 185,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup125 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 15, resource: textureView204}]});
+let commandEncoder206 = device0.createCommandEncoder();
+let texture181 = device0.createTexture({
+  size: [20, 11, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView215 = texture27.createView({mipLevelCount: 1});
+let renderPassEncoder65 = commandEncoder206.beginRenderPass({
+  label: '\u0dcc\u029e\u04e0\u3333',
+  colorAttachments: [{
+  view: textureView117,
+  depthSlice: 9,
+  clearValue: { r: 814.3, g: 615.1, b: -705.1, a: 870.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 23972483,
+});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup29, new Uint32Array(1747), 236, 0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle18, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(1, buffer32);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 15, y: 9, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise38 = device0.queue.onSubmittedWorkDone();
+let texture182 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture183 = device0.createTexture({
+  label: '\u7985\u177d\ua412\u08d3\u69a6\u0b35\u03d6\u8b5d\u2a4b',
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView216 = texture165.createView({mipLevelCount: 1});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder165.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 184 */
+  offset: 184,
+  bytesPerRow: 13056,
+  rowsPerImage: 672,
+  buffer: buffer17,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView217 = texture181.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder166 = commandEncoder1.beginComputePass({label: '\u{1f68f}\u1052\u071b'});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup92, new Uint32Array(1566), 139, 0);
+} catch {}
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer15, 'uint16', 166, 360);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer57, offset: 1024, size: 433}}],
+});
+let textureView218 = texture182.createView({baseArrayLayer: 0, arrayLayerCount: 4});
+let computePassEncoder167 = commandEncoder102.beginComputePass();
+try {
+computePassEncoder151.setBindGroup(3, bindGroup110);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup90, []);
+} catch {}
+try {
+renderPassEncoder57.beginOcclusionQuery(840);
+} catch {}
+try {
+renderPassEncoder57.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(5, buffer30, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroup127 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler14}, {binding: 0, resource: textureView132}],
+});
+let texture184 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 79},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder165.setBindGroup(3, bindGroup78, new Uint32Array(374), 232, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer120, 'uint16', 1_110, 1_214);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer110, 0, 1_821);
+} catch {}
+try {
+buffer107.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 6, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+  await promise38;
+} catch {}
+document.body.append(video3);
+try {
+computePassEncoder148.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer9, 'uint16', 806, 920);
+} catch {}
+let bindGroup128 = device0.createBindGroup({
+  label: '\u0efe\u1262\u04d5\u{1fda0}\u{1f786}\u8744\u2941\u7da1',
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 626, resource: {buffer: buffer20, offset: 256, size: 272}},
+    {binding: 13, resource: textureView213},
+  ],
+});
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup36);
+} catch {}
+let buffer124 = device0.createBuffer({size: 20661, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView219 = texture151.createView({mipLevelCount: 1});
+try {
+renderPassEncoder31.beginOcclusionQuery(75);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle15, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -298.0, g: 367.7, b: -838.9, a: -74.63, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 748, new Int16Array(27710), 1689, 408);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder207 = device0.createCommandEncoder({});
+let texture185 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView220 = texture180.createView({mipLevelCount: 1});
+let computePassEncoder168 = commandEncoder207.beginComputePass();
+try {
+computePassEncoder153.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 20, new Float32Array(25294), 4685, 28);
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let texture186 = gpuCanvasContext4.getCurrentTexture();
+let sampler134 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.48,
+  lodMaxClamp: 93.63,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder115.setBindGroup(2, bindGroup100, new Uint32Array(211), 2, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup107);
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer98, 60);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 134, resource: textureView96},
+    {binding: 78, resource: externalTexture4},
+    {binding: 2, resource: textureView134},
+    {binding: 325, resource: textureView142},
+    {binding: 158, resource: textureView23},
+    {binding: 65, resource: textureView88},
+    {binding: 146, resource: sampler99},
+  ],
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder154.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup53, new Uint32Array(539), 285, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer20, 'uint32', 1_220, 189);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup22);
+} catch {}
+let buffer125 = device0.createBuffer({size: 32267, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let renderBundle24 = renderBundleEncoder24.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer12, 208); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer98, 60, new BigUint64Array(40953), 1549, 0);
+} catch {}
+let buffer126 = device0.createBuffer({
+  size: 2501,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder208 = device0.createCommandEncoder();
+let computePassEncoder169 = commandEncoder208.beginComputePass();
+let sampler135 = device0.createSampler({
+  label: '\uc9e9\u0e9c\u{1fe67}\u{1fa67}\u29af\u01b9\ubafc',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.92,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup97, new Uint32Array(781), 57, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle1, renderBundle8, renderBundle7, renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(3, buffer84);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 9, y: 4 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  label: '\u0ccc\ua432\u0f0a\u{1fb66}\u{1f65d}\u{1fcf1}\u{1ffb7}',
+  entries: [
+    {
+      binding: 808,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 603,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup130 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 78, resource: {buffer: buffer109, offset: 1536, size: 288}}],
+});
+let commandEncoder209 = device0.createCommandEncoder({});
+let renderPassEncoder66 = commandEncoder209.beginRenderPass({
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: 895.5, g: 396.5, b: -410.1, a: 355.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 29741838,
+});
+try {
+renderPassEncoder54.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer4, 'uint16', 11_814, 7_445);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(1, buffer102, 5_196, 320);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+externalTexture17.label = '\u{1fda2}\u6821\u857b\u0322\u{1ff2c}';
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({});
+let renderPassEncoder67 = commandEncoder210.beginRenderPass({
+  colorAttachments: [{view: textureView192, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 15478032,
+});
+try {
+computePassEncoder156.setBindGroup(0, bindGroup62, new Uint32Array(282), 46, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer113, 'uint16', 1_684, 1_734);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 4, y: 20 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer127 = device0.createBuffer({size: 65536, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder211 = device0.createCommandEncoder({label: '\ubb06\u0489\u5e15\u0eb9\uf6d2\u{1f97f}'});
+let textureView221 = texture185.createView({dimension: '2d', baseArrayLayer: 2});
+let computePassEncoder170 = commandEncoder211.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup57, new Uint32Array(381), 34, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup18);
+} catch {}
+let buffer128 = device0.createBuffer({size: 4871, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder212 = device0.createCommandEncoder();
+let renderPassEncoder68 = commandEncoder212.beginRenderPass({
+  label: '\u4bfa\u2646\ufbd2\ud37e\u06fe\u{1f9c1}',
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: -19.58, g: -374.1, b: 427.4, a: -379.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true});
+let renderBundle25 = renderBundleEncoder25.finish({});
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder213 = device0.createCommandEncoder({});
+let renderPassEncoder69 = commandEncoder213.beginRenderPass({colorAttachments: [{view: textureView192, loadOp: 'load', storeOp: 'discard'}]});
+let sampler136 = device0.createSampler({
+  label: '\u04e7\u02ca\u079c\uebef',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.74,
+  lodMaxClamp: 98.99,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder59.executeBundles([renderBundle1, renderBundle1, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(2448);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer38, 'uint32', 264, 64);
+} catch {}
+try {
+renderPassEncoder30.insertDebugMarker('\u{1f6b2}');
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({});
+let texture187 = device0.createTexture({
+  size: {width: 10},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView222 = texture84.createView({baseMipLevel: 0, baseArrayLayer: 3, arrayLayerCount: 8});
+let computePassEncoder171 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder92.setBindGroup(2, bindGroup105, new Uint32Array(1438), 291, 0);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer38, 'uint16', 470, 859);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(143, 93);
+try {
+globalThis.someLabel = computePassEncoder42.label;
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer88, 'uint32', 2_184, 101);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup131 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView178}]});
+let commandEncoder215 = device0.createCommandEncoder();
+let computePassEncoder172 = commandEncoder215.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup103);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer86, 40, new DataView(new ArrayBuffer(25638)), 13575, 368);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture169,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 25},
+  aspect: 'all',
+}, new Uint8Array(7).fill(63), /* required buffer size: 7 */
+{offset: 7}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+document.body.append(img0);
+let texture188 = device0.createTexture({
+  label: '\u0959\ufde6',
+  size: [5, 2, 57],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView223 = texture173.createView({arrayLayerCount: 1});
+let computePassEncoder173 = commandEncoder6.beginComputePass({});
+let sampler137 = device0.createSampler({
+  label: '\u1deb\u{1fe4a}\u{1fa16}\ue1bc\ud5fa\u08b7\u{1ff3d}\u0be4',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.74,
+  lodMaxClamp: 95.41,
+});
+try {
+computePassEncoder172.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup40, new Uint32Array(1467), 457, 0);
+} catch {}
+try {
+renderPassEncoder38.setViewport(2.6403054522440033, 0.2264646996039883, 0.28648967265221836, 0.038166475894891964, 0.934807224742331, 0.989412273089888);
+} catch {}
+try {
+computePassEncoder108.insertDebugMarker('\u{1f932}');
+} catch {}
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup132 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 59, resource: {buffer: buffer70, offset: 0, size: 400}},
+    {binding: 360, resource: sampler119},
+    {binding: 164, resource: {buffer: buffer54, offset: 0, size: 124}},
+    {binding: 503, resource: textureView96},
+  ],
+});
+let pipelineLayout26 = device0.createPipelineLayout({label: '\ufc67\u6cfa\u404a\u{1fbcf}\uebea\u{1fc28}\u{1fac1}\u65cb', bindGroupLayouts: []});
+let buffer129 = device0.createBuffer({
+  size: 1443,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({label: '\u0faa\uf7a7\u9ded', colorFormats: ['rgba32float'], depthReadOnly: true});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup107, []);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer30, 'uint16', 9_096, 156);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+globalThis.someLabel = shaderModule4.label;
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder({});
+let textureView224 = texture124.createView({aspect: 'all'});
+let computePassEncoder174 = commandEncoder216.beginComputePass({});
+try {
+computePassEncoder161.setBindGroup(1, bindGroup124, new Uint32Array(25), 4, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup22, new Uint32Array(128), 15, 0);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(6, buffer49);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup45, new Uint32Array(524), 310, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer76, 'uint16', 138, 486);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+computePassEncoder94.setBindGroup(1, bindGroup13, new Uint32Array(4643), 733, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte240m', transfer: 'bt2020_12bit'} });
+try {
+computePassEncoder58.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+computePassEncoder166.setBindGroup(0, bindGroup26, new Uint32Array(3071), 7, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup31, []);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup5, new Uint32Array(3049), 53, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup30, new Uint32Array(598), 42, 0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(7, buffer102, 124, 484);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let buffer130 = device0.createBuffer({
+  size: 5950,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let renderBundle26 = renderBundleEncoder26.finish({label: '\uf244\u{1f6f4}\u{1f9f9}\ue56f\u{1fe17}\u08dc\ub4c0\u29de'});
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(2, 2, 1); };
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder66.setIndexBuffer(buffer57, 'uint32', 2_092, 348);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 3224, new BigUint64Array(2279), 145, 272);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img1);
+let commandEncoder217 = device0.createCommandEncoder({});
+let computePassEncoder175 = commandEncoder217.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder166.setBindGroup(1, bindGroup71, new Uint32Array(966), 96, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroupsIndirect(buffer36, 1_700); };
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup78, new Uint32Array(2069), 1_121, 0);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(49);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(4, buffer51);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+await gc();
+try {
+offscreenCanvas3.getContext('webgl');
+} catch {}
+let bindGroup133 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler87}, {binding: 0, resource: textureView20}],
+});
+let buffer131 = device0.createBuffer({size: 4571, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder218 = device0.createCommandEncoder();
+let texture189 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'etc2-rgb8a1unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler138 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 38.60,
+  lodMaxClamp: 76.54,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder57.beginOcclusionQuery(430);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer40, 'uint32', 168, 392);
+} catch {}
+await gc();
+let sampler139 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.33,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder69.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer69, 1_024, 209);
+} catch {}
+try {
+commandEncoder218.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 288 */
+  offset: 288,
+  bytesPerRow: 2816,
+  buffer: buffer62,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 9, y: 2, z: 6},
+  aspect: 'all',
+}, {width: 3, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder218.resolveQuerySet(querySet3, 219, 6, buffer29, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup134 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView85}]});
+let buffer132 = device0.createBuffer({
+  size: 12994,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView225 = texture183.createView({
+  label: '\u91c4\u{1fec4}\u3047\u{1f94e}\u0c48\u05a8\u0cb9\u{1ffb5}\u{1f9ba}\u193e',
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder175.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+renderPassEncoder57.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer93, 'uint16', 192, 8);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder218.copyBufferToBuffer(buffer9, 1440, buffer43, 3720, 348);
+} catch {}
+try {
+commandEncoder218.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2184 */
+  offset: 2184,
+  bytesPerRow: 6400,
+  buffer: buffer62,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture190 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder176 = commandEncoder218.beginComputePass({});
+let sampler140 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.04,
+  lodMaxClamp: 75.47,
+  compare: 'never',
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup97, new Uint32Array(7), 1, 0);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup3, new Uint32Array(331), 29, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle4]);
+} catch {}
+let arrayBuffer9 = buffer66.getMappedRange(360, 8);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+offscreenCanvas0.height = 2063;
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'pq'} });
+let texture191 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler141 = device0.createSampler({
+  label: '\u09a9\u0fd2\ud68e\ub762\u0a22\u7f95\u8da7\ud262\u7278',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.46,
+  lodMaxClamp: 80.09,
+  compare: 'less',
+});
+try {
+computePassEncoder103.setBindGroup(2, bindGroup51, new Uint32Array(1664), 7, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer1, 3_664); };
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle6, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer38, 'uint32', 20, 1_553);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer69, 0, 6_430);
+} catch {}
+let bindGroup135 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView178}]});
+let commandEncoder219 = device0.createCommandEncoder({label: '\u473a\u5249'});
+let computePassEncoder177 = commandEncoder219.beginComputePass({});
+try {
+computePassEncoder102.setBindGroup(1, bindGroup129, new Uint32Array(1235), 170, 0);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline3);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 21, y: 3 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView226 = texture92.createView({arrayLayerCount: 1});
+try {
+computePassEncoder126.setBindGroup(1, bindGroup17, new Uint32Array(2108), 191, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer25, 228); };
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup129, new Uint32Array(1344), 126, 0);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer110, 'uint32', 1_824, 2_174);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+let bindGroup136 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 0, resource: textureView201}, {binding: 27, resource: sampler134}],
+});
+let buffer133 = device0.createBuffer({
+  size: 29637,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder42.setVertexBuffer(7, buffer39, 0);
+} catch {}
+try {
+computePassEncoder133.insertDebugMarker('\ueeb0');
+} catch {}
+let commandEncoder220 = device0.createCommandEncoder();
+let computePassEncoder178 = commandEncoder220.beginComputePass({});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup107, new Uint32Array(73), 1, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroupsIndirect(buffer3, 632); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 15},
+  aspect: 'all',
+}, new Uint8Array(1_098_755).fill(122), /* required buffer size: 1_098_755 */
+{offset: 23, bytesPerRow: 107, rowsPerImage: 87}, {width: 7, height: 3, depthOrArrayLayers: 119});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 169, y: 6 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder221 = device0.createCommandEncoder({});
+let textureView227 = texture43.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 8});
+let sampler142 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.72,
+  lodMaxClamp: 80.35,
+  maxAnisotropy: 2,
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+computePassEncoder118.setBindGroup(0, bindGroup132, new Uint32Array(59), 2, 1);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder46.setViewport(4.459530605276759, 0.33629278676107477, 0.5147035260959191, 1.1627141194326969, 0.5524296547993204, 0.9741934550710939);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline2);
+} catch {}
+let renderPassEncoder70 = commandEncoder221.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: -348.5, g: -280.4, b: 943.2, a: 581.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup40, new Uint32Array(1138), 88, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 13, y: 14 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt470m', transfer: 'gamma28curve'} });
+try {
+texture166.label = '\uf665\u11ef\u4ac5\u0c6b\u7a7b\ua40d\uc508\u4439\u0269\u0ab5\u0c7f';
+} catch {}
+let texture192 = device0.createTexture({
+  label: '\u01ea\u{1f6d4}',
+  size: {width: 40, height: 23, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+let textureView228 = texture164.createView({});
+try {
+computePassEncoder144.setBindGroup(3, bindGroup56);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+let arrayBuffer10 = buffer66.getMappedRange(368, 0);
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3240 */
+  offset: 3240,
+  buffer: buffer73,
+}, {
+  texture: texture191,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 2, y: 6 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture193 = device0.createTexture({size: [5, 2, 29], format: 'r32sint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup45, new Uint32Array(1720), 145, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup116);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup59, new Uint32Array(1421), 22, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer50, 'uint16', 5_368, 2_088);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 504 */
+  offset: 504,
+  bytesPerRow: 15616,
+  buffer: buffer21,
+}, {
+  texture: texture146,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder222 = device0.createCommandEncoder({});
+let sampler143 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.97,
+  lodMaxClamp: 82.26,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder160.setBindGroup(0, bindGroup36, new Uint32Array(5), 0, 0);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(326);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer119, 'uint16', 626, 132);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer3, 0, 2_184);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer134 = device0.createBuffer({
+  size: 15906,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let sampler144 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 9.706,
+  lodMaxClamp: 36.72,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer102, 'uint32', 7_744, 1_215);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline2);
+} catch {}
+let bindGroup137 = device0.createBindGroup({
+  label: '\u0570\u{1faf4}\u0a6c\u012f\u04ea\u{1fadb}\u{1f655}\udd65',
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 47, resource: textureView178},
+    {binding: 178, resource: {buffer: buffer84, offset: 1536, size: 164}},
+    {binding: 102, resource: {buffer: buffer44, offset: 3840}},
+    {binding: 237, resource: {buffer: buffer75, offset: 0, size: 28}},
+    {binding: 58, resource: textureView48},
+    {binding: 465, resource: textureView191},
+    {binding: 81, resource: textureView179},
+    {binding: 6, resource: textureView185},
+    {binding: 651, resource: {buffer: buffer8, offset: 768, size: 1260}},
+  ],
+});
+let renderPassEncoder71 = commandEncoder222.beginRenderPass({
+  label: '\u03e8\u{1f775}\u7ba5\u4f98\u051b\u079c\u6077\u8da3\ud211\u5336\u{1f9c6}',
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 731.5, g: -363.1, b: -200.1, a: 994.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 390449887,
+});
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(3, bindGroup96, new Uint32Array(596), 233, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer38, 116, buffer130, 448, 516);
+} catch {}
+let textureView229 = texture17.createView({});
+let renderPassEncoder72 = commandEncoder38.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 343.4, g: 482.7, b: 842.5, a: -855.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup85, new Uint32Array(1034), 106, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer25, 'uint16', 1_038, 31);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer107, 0, 7_805);
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteRp431', transfer: 'iec61966-2-1'} });
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup53, new Uint32Array(1609), 214, 0);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer14, 'uint16', 660, 623);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer132);
+} catch {}
+document.body.append(video2);
+let bindGroup138 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView87}]});
+let texture194 = device0.createTexture({
+  label: '\ud0b3\u{1fcca}\ub566\u0646',
+  size: [64],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder83.setBindGroup(1, bindGroup95, new Uint32Array(836), 59, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup28, new Uint32Array(393), 11, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer50, 'uint32', 2_480, 670);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup139 = device0.createBindGroup({
+  label: '\u0fc3\u{1f9ee}\ud071\ua38d\ueb51\u{1f9f5}\u820e\u2647',
+  layout: bindGroupLayout17,
+  entries: [{binding: 6, resource: textureView144}],
+});
+let commandEncoder223 = device0.createCommandEncoder({});
+let texture195 = device0.createTexture({
+  size: [5, 2, 26],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder179 = commandEncoder223.beginComputePass();
+let sampler145 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.02,
+  lodMaxClamp: 72.11,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder179.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer103);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 1656, new Float32Array(32442), 11607, 668);
+} catch {}
+document.body.prepend(video4);
+let offscreenCanvas4 = new OffscreenCanvas(59, 40);
+try {
+offscreenCanvas4.getContext('webgpu');
+} catch {}
+try {
+computePassEncoder112.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 6, y: 3 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: false, stencilReadOnly: true});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+computePassEncoder125.setBindGroup(3, bindGroup23, new Uint32Array(678), 19, 0);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer57, 'uint16', 760, 2_517);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.append(img0);
+let commandEncoder224 = device0.createCommandEncoder({});
+let texture196 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 32},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder180 = commandEncoder224.beginComputePass();
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle27 = renderBundleEncoder27.finish({label: '\u{1fa8e}\u05ee\ue3cb\u0b41\u9e1c\ubb2f\u7c92\ucf3d\u034c\u462d\u2da3'});
+let externalTexture30 = device0.importExternalTexture({source: video2});
+try {
+computePassEncoder180.setPipeline(pipeline0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder225 = device0.createCommandEncoder({});
+let texture197 = device0.createTexture({
+  size: [10, 5, 10],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle28 = renderBundleEncoder28.finish({});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup47, new Uint32Array(786), 206, 0);
+} catch {}
+try {
+renderPassEncoder56.setViewport(4.220210814743104, 0.5321404639505463, 9.787254066086826, 7.391622762308479, 0.9178439952445197, 0.9344409805069562);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer76, 'uint16', 730);
+} catch {}
+let texture198 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 159},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder73 = commandEncoder225.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 628.6, g: 65.39, b: -656.4, a: -62.57, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler146 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', lodMinClamp: 31.81});
+try {
+computePassEncoder168.setBindGroup(3, bindGroup94);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let bindGroup140 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView120}]});
+let buffer135 = device0.createBuffer({size: 13527, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder226 = device0.createCommandEncoder({});
+let texture199 = device0.createTexture({
+  size: [10],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView230 = texture185.createView({baseArrayLayer: 2, arrayLayerCount: 3});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(528);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer44, 7_692);
+} catch {}
+let arrayBuffer11 = buffer122.getMappedRange(0, 6628);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470m', transfer: 'pq'} });
+let texture200 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView231 = texture26.createView({label: '\u{1f61d}\u{1fa19}\u0e2d\u0a7d', mipLevelCount: 1});
+let computePassEncoder181 = commandEncoder226.beginComputePass({});
+try {
+computePassEncoder181.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle28, renderBundle7, renderBundle7, renderBundle24]);
+} catch {}
+let bindGroup141 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView14}]});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup129, new Uint32Array(1725), 373, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup103);
+} catch {}
+let bindGroup142 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [{binding: 603, resource: textureView141}, {binding: 808, resource: textureView11}],
+});
+let textureView232 = texture83.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(2, bindGroup101, new Uint32Array(849), 53, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1); };
+} catch {}
+let commandEncoder227 = device0.createCommandEncoder({});
+let textureView233 = texture87.createView({label: '\u1713\u96c6\u5ea5\u0158\ue0d5'});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup4, new Uint32Array(1066), 198, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup143 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 110, resource: textureView223}]});
+let commandEncoder228 = device0.createCommandEncoder({});
+let textureView234 = texture170.createView({label: '\u586e\u{1ff7b}\u{1fdcb}\u0413\u{1faf3}', dimension: '2d'});
+let computePassEncoder182 = commandEncoder227.beginComputePass({label: '\u8faa\u6b69\u7677\ufe36\u{1fe0d}\ufb58\u09ad\u0592\u0ea0\u285d'});
+try {
+computePassEncoder182.setPipeline(pipeline3);
+} catch {}
+document.body.append(img1);
+let offscreenCanvas5 = new OffscreenCanvas(127, 260);
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte240m', transfer: 'unspecified'} });
+let commandEncoder229 = device0.createCommandEncoder({});
+let texture201 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 39},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView235 = texture140.createView({
+  label: '\u0114\uc848\u9fdd\u9f08\u6c80\u085f\u{1f614}',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 21,
+});
+let computePassEncoder183 = commandEncoder228.beginComputePass();
+let sampler147 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 60.11,
+});
+try {
+computePassEncoder183.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(2, bindGroup135);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 188.9, g: -441.9, b: -480.7, a: 697.4, });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 65, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(78), /* required buffer size: 59 */
+{offset: 59, bytesPerRow: 334}, {width: 83, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas5.getContext('webgpu');
+video5.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let buffer136 = device0.createBuffer({
+  label: '\u064f\u{1feac}\u032f\u0e11\u5731\ub62f\u{1fe5f}\u6d92',
+  size: 4991,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView236 = texture2.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let sampler148 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.78,
+  lodMaxClamp: 93.88,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup110, []);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup57, new Uint32Array(1330), 206, 0);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer130);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 516, new Float32Array(17952), 1313, 496);
+} catch {}
+let texture202 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder184 = commandEncoder229.beginComputePass({});
+let sampler149 = device0.createSampler({
+  label: '\u{1f964}\u0b79\u0d46\ub7c6\u04fe\ue7ee\u6bfa\u{1f8ae}\u42a0\ub40b\u776b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.75,
+  lodMaxClamp: 95.63,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder184.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder41.setViewport(22.060218845870086, 22.783951650872414, 7.56595646799541, 1.9383367180684021, 0.7771804963078954, 0.9962722518182063);
+} catch {}
+try {
+renderPassEncoder24.insertDebugMarker('\u2d42');
+} catch {}
+let commandEncoder230 = device0.createCommandEncoder({label: '\u0373\u26e5'});
+let computePassEncoder185 = commandEncoder230.beginComputePass({});
+let sampler150 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.494,
+  lodMaxClamp: 77.63,
+  compare: 'less',
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(3, bindGroup53, new Uint32Array(1835), 731, 0);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup78);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup131, new Uint32Array(3382), 485, 0);
+} catch {}
+let commandEncoder231 = device0.createCommandEncoder({});
+let texture203 = device0.createTexture({
+  size: [5, 2, 39],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+try {
+computePassEncoder114.setBindGroup(1, bindGroup71, new Uint32Array(2967), 720, 0);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup11, new Uint32Array(885), 45, 0);
+} catch {}
+try {
+renderPassEncoder44.setViewport(18.802076832779576, 7.656901651093646, 0.8512167785736542, 3.2776352535580546, 0.8784334188732323, 0.9500184175042747);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup129, new Uint32Array(6283), 3_293, 0);
+} catch {}
+try {
+commandEncoder231.copyBufferToBuffer(buffer93, 36, buffer72, 132, 88);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6_412).fill(119), /* required buffer size: 6_412 */
+{offset: 88, bytesPerRow: 17, rowsPerImage: 62}, {width: 1, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let renderPassEncoder74 = commandEncoder231.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 214.1, g: 821.0, b: -760.5, a: 81.41, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 61337494,
+});
+let renderBundle29 = renderBundleEncoder29.finish();
+try {
+computePassEncoder168.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup76, new Uint32Array(2592), 303, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer95, 'uint32', 1_884, 50);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder232 = device0.createCommandEncoder({});
+let texture204 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView237 = texture166.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 25});
+let computePassEncoder186 = commandEncoder232.beginComputePass({});
+try {
+computePassEncoder46.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline2);
+} catch {}
+let commandEncoder233 = device0.createCommandEncoder({label: '\u{1f9b5}\u040b'});
+let texture205 = device0.createTexture({
+  size: [20, 11, 1],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView238 = texture147.createView({});
+let computePassEncoder187 = commandEncoder233.beginComputePass({});
+try {
+computePassEncoder130.setBindGroup(3, bindGroup94, new Uint32Array(2835), 935, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroupsIndirect(buffer15, 112); };
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(1, bindGroup42, new Uint32Array(74), 2, 0);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: video4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 4, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let texture206 = device0.createTexture({
+  size: {width: 5},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler151 = device0.createSampler({
+  label: '\u0503\u60e2\uf44f\uc39c\u{1f7d8}\u0d0f\ub324\u{1fd27}\u0da5\u{1f7f2}\u{1fb17}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.75,
+  lodMaxClamp: 72.70,
+});
+try {
+computePassEncoder159.setBindGroup(2, bindGroup62, []);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(1, bindGroup140, new Uint32Array(332), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder79.end();
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup79, new Uint32Array(5029), 1_577, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer89, 'uint16', 1_476, 693);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer35, 0, 3_722);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 464 */
+  offset: 464,
+  bytesPerRow: 18944,
+  buffer: buffer21,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder234 = device0.createCommandEncoder({});
+let texture207 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 98},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder188 = commandEncoder234.beginComputePass({});
+let sampler152 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 31.28,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder150.setBindGroup(2, bindGroup17, []);
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(5, buffer131, 816);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer135, 4, 5100);
+} catch {}
+try {
+computePassEncoder103.pushDebugGroup('\u7f83');
+} catch {}
+try {
+renderPassEncoder57.insertDebugMarker('\ufc83');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 388, new Int16Array(7938), 336, 120);
+} catch {}
+try {
+  await promise39;
+} catch {}
+try {
+externalTexture2.label = '\u4aa1\u092f\u5ae1';
+} catch {}
+let bindGroup144 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 65, resource: textureView202},
+    {binding: 68, resource: {buffer: buffer70, offset: 256}},
+    {binding: 120, resource: textureView103},
+  ],
+});
+let texture208 = device0.createTexture({
+  size: [10, 5, 93],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup107);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(1, bindGroup57, new Uint32Array(591), 54, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1772 */
+  offset: 1772,
+  buffer: buffer135,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder110.insertDebugMarker('\u0705');
+} catch {}
+let texture209 = device0.createTexture({
+  label: '\ub8fc\u2599\u{1fa2e}\uaceb\u{1fe3f}\uf8df\u45ec\u{1fd15}\u{1fe3f}\ud791\u06ca',
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder189 = commandEncoder110.beginComputePass({});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+  await buffer61.mapAsync(GPUMapMode.READ, 0, 1028);
+} catch {}
+document.body.prepend(canvas1);
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+let bindGroup145 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView113}]});
+let commandEncoder235 = device0.createCommandEncoder({});
+let texture210 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 79},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView239 = texture18.createView({mipLevelCount: 1});
+let computePassEncoder190 = commandEncoder235.beginComputePass({});
+try {
+renderPassEncoder60.setIndexBuffer(buffer17, 'uint16', 1_124, 1_042);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup146 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 360, resource: sampler64},
+    {binding: 59, resource: {buffer: buffer23, offset: 256, size: 56}},
+    {binding: 164, resource: {buffer: buffer2, offset: 2816, size: 6004}},
+    {binding: 503, resource: textureView96},
+  ],
+});
+try {
+computePassEncoder159.setBindGroup(0, bindGroup66, new Uint32Array(1372), 3, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer65, 'uint16', 44, 786);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer31, 1_852);
+} catch {}
+let buffer137 = device0.createBuffer({size: 1844, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder236 = device0.createCommandEncoder({label: '\u4b16\u{1fa93}\u2fd3\u{1f814}\u{1fa33}\u2c0e\ud41d\u{1f6f4}\u05d2\u0433'});
+try {
+computePassEncoder101.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder176.setBindGroup(1, bindGroup126, new Uint32Array(449), 28, 0);
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup111);
+} catch {}
+try {
+renderPassEncoder50.beginOcclusionQuery(77);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle15, renderBundle29]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer85, 'uint16', 25_714, 748);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(5, buffer87);
+} catch {}
+try {
+commandEncoder236.copyTextureToTexture({
+  texture: texture155,
+  mipLevel: 0,
+  origin: {x: 10, y: 5, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture146,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 101,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture211 = device0.createTexture({
+  label: '\u87e9\u4ae1\uadeb\u306b\u60be\u0fc5\u6624\u2b1a\ue264\uee85',
+  size: {width: 20, height: 11, depthOrArrayLayers: 28},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder191 = commandEncoder236.beginComputePass({});
+try {
+renderPassEncoder42.setPipeline(pipeline2);
+} catch {}
+let sampler153 = device0.createSampler({
+  label: '\u05c3\u{1f902}\u7970',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.09,
+});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup82, new Uint32Array(1030), 77, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer130, 'uint16', 60, 577);
+} catch {}
+let arrayBuffer12 = buffer122.getMappedRange(7072, 10072);
+try {
+buffer86.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 2, y: 6, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte240m', transfer: 'smpte240m'} });
+let commandEncoder237 = device0.createCommandEncoder();
+let textureView240 = texture153.createView({label: '\u6ec2\u1ac8\u609f\ud385\u{1fb75}\u{1fb2e}'});
+let computePassEncoder192 = commandEncoder237.beginComputePass();
+try {
+computePassEncoder180.setBindGroup(1, bindGroup24, new Uint32Array(1824), 19, 0);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder50.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder65.setBlendConstant({ r: 686.2, g: 771.1, b: -808.6, a: -354.4, });
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(5, buffer89);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 12, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'bt2020_10bit'} });
+let bindGroup147 = device0.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 129, resource: textureView221}]});
+let sampler154 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.26,
+  lodMaxClamp: 41.25,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup42, new Uint32Array(755), 131, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+computePassEncoder147.setBindGroup(1, bindGroup108, new Uint32Array(262), 49, 1);
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup0, new Uint32Array(598), 59, 0);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -110.9, g: -404.8, b: -234.4, a: 743.3, });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 53 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup148 = device0.createBindGroup({
+  label: '\ude6e\u0565',
+  layout: bindGroupLayout15,
+  entries: [{binding: 50, resource: textureView85}, {binding: 559, resource: externalTexture1}],
+});
+let texture212 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView241 = texture164.createView({});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup108, [0]);
+} catch {}
+try {
+computePassEncoder159.setBindGroup(2, bindGroup44, new Uint32Array(6780), 6_009, 0);
+} catch {}
+try {
+computePassEncoder189.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup127);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer94);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+await gc();
+let texture213 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView242 = texture89.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+computePassEncoder105.setBindGroup(3, bindGroup52, new Uint32Array(1792), 45, 0);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas3);
+let bindGroup149 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 559, resource: externalTexture13}, {binding: 50, resource: textureView153}],
+});
+let buffer138 = device0.createBuffer({
+  label: '\u914e\ud92c\u{1ff1b}\u3d97\u0fe5\u0adb\uea41',
+  size: 16707,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder238 = device0.createCommandEncoder({});
+let texture214 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder193 = commandEncoder238.beginComputePass({});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup133, new Uint32Array(341), 199, 0);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder49.setViewport(58.13489267116336, 56.290937293211556, 4.544231657889136, 7.163446973532586, 0.9235741512009413, 0.9474004029178462);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer99, 'uint16', 492, 2_499);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 844, new BigUint64Array(1903), 180, 208);
+} catch {}
+await gc();
+let textureView243 = texture211.createView({format: 'r16uint', baseArrayLayer: 4, arrayLayerCount: 8});
+let sampler155 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 76.17,
+  lodMaxClamp: 76.63,
+});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup135);
+} catch {}
+try {
+computePassEncoder150.end();
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup14, new Uint32Array(2646), 234, 0);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2314 */
+  offset: 2314,
+  bytesPerRow: 10240,
+  buffer: buffer106,
+}, {
+  texture: texture199,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer139 = device0.createBuffer({
+  label: '\u1a40\u05b3\ud2bd\u0db3\u{1f9ec}\u0f97\u061a\u0d8b\u1e2a\u48ca',
+  size: 9491,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let commandEncoder239 = device0.createCommandEncoder({});
+let texture215 = device0.createTexture({
+  size: [10],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView244 = texture99.createView({label: '\u{1fcd0}\u61c3\u518e\u{1fa6b}\ud1a8\u0be4\uea3f\u05e8', dimension: '2d'});
+let renderPassEncoder75 = commandEncoder186.beginRenderPass({
+  colorAttachments: [{
+  view: textureView147,
+  clearValue: { r: 616.1, g: 115.5, b: -880.0, a: -856.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler156 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 49.64,
+  lodMaxClamp: 51.58,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder143.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+computePassEncoder117.setBindGroup(1, bindGroup77, new Uint32Array(162), 6, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer133, 'uint32', 5_176, 6_897);
+} catch {}
+try {
+computePassEncoder103.popDebugGroup();
+} catch {}
+document.body.append(img0);
+let textureView245 = texture65.createView({label: '\u{1fb53}\u9259', format: 'rgba32uint'});
+let computePassEncoder194 = commandEncoder239.beginComputePass();
+try {
+computePassEncoder171.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+computePassEncoder194.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer40, 'uint16', 6, 2_725);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 150,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 39,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 390,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroup150 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView33}]});
+let buffer140 = device0.createBuffer({
+  size: 35280,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView246 = texture196.createView({arrayLayerCount: 1});
+try {
+computePassEncoder167.setBindGroup(2, bindGroup120, new Uint32Array(2582), 456, 0);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer136, 'uint16', 2_660, 185);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(2, buffer77, 0);
+} catch {}
+document.body.append(video0);
+try {
+buffer30.label = '\u0341\u6a26\u0652\u04f6\u0c9b\uedb0\u04ad\u0265\u{1fca5}';
+} catch {}
+let textureView247 = texture156.createView({dimension: '2d', format: 'rgba32float', baseArrayLayer: 12});
+let sampler157 = device0.createSampler({
+  label: '\u{1fa0b}\u0e1d\u{1f811}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.16,
+  lodMaxClamp: 95.60,
+});
+try {
+computePassEncoder92.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup50, new Uint32Array(1461), 154, 0);
+} catch {}
+try {
+renderPassEncoder75.end();
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder186.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder76 = commandEncoder186.beginRenderPass({
+  colorAttachments: [{
+  view: textureView116,
+  depthSlice: 5,
+  clearValue: { r: -16.55, g: 20.36, b: 208.0, a: 707.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler158 = device0.createSampler({
+  label: '\u1d2f\u7140\u{1fc8d}\u{1f8ee}\u{1fe28}\u0c10',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.09,
+  lodMaxClamp: 83.62,
+  compare: 'always',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder117); computePassEncoder117.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer4, 'uint32', 8_132, 2_822);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture182,
+  mipLevel: 0,
+  origin: {x: 4, y: 5, z: 2},
+  aspect: 'all',
+}, new Uint8Array(193).fill(195), /* required buffer size: 193 */
+{offset: 193}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup151 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 134, resource: textureView11},
+    {binding: 14, resource: externalTexture4},
+    {binding: 56, resource: {buffer: buffer129, offset: 0, size: 480}},
+  ],
+});
+let buffer141 = device0.createBuffer({size: 846, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture216 = device0.createTexture({
+  size: [20, 11, 55],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture217 = gpuCanvasContext5.getCurrentTexture();
+let textureView248 = texture210.createView({label: '\u8be6\u0c2f\u98d8'});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup44, new Uint32Array(2149), 299, 0);
+} catch {}
+try {
+computePassEncoder101.end();
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup12);
+} catch {}
+let buffer142 = device0.createBuffer({
+  size: 1157,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder195 = commandEncoder136.beginComputePass({label: '\u07ca\ube6e\ua7b3\u{1fed7}\u24a2\u{1faed}\u0e16\uae11\u07ae\u{1fc48}'});
+try {
+computePassEncoder117.end();
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder47.beginOcclusionQuery(734);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer40, 'uint16', 80, 335);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer142);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture190,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(40).fill(204), /* required buffer size: 40 */
+{offset: 40}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: imageData1,
+  origin: { x: 20, y: 0 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = bindGroup16.label;
+} catch {}
+let commandBuffer4 = commandEncoder155.finish();
+let sampler159 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.32,
+  lodMaxClamp: 87.84,
+});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup84, new Uint32Array(575), 53, 0);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 157.0, g: -368.0, b: -429.5, a: -609.8, });
+} catch {}
+try {
+renderPassEncoder51.setViewport(8.118340582412074, 0.49616797263548285, 0.9014337318892448, 3.6904906565571522, 0.028515565324528036, 0.9271859551577623);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer7, 1_896);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+struct VertexOutput8 {
+  @location(1) f36: vec2i,
+  @location(14) f37: vec4u,
+  @builtin(position) f38: vec4f,
+}
+
+var<private> vp22 = modf(f16());
+
+@group(0) @binding(27) var sam12: sampler;
+
+fn fn1(a0: ptr<function, FragmentOutput10>) -> array<f16, 12> {
+  var out: array<f16, 12>;
+  vp22.fract = f16(determinant(mat4x4f(unconst_f32(0.2813), unconst_f32(0.2782), unconst_f32(0.01454), unconst_f32(-0.05867), unconst_f32(0.06005), unconst_f32(0.01630), unconst_f32(0.1327), unconst_f32(0.02012), unconst_f32(0.6157), unconst_f32(0.02335), unconst_f32(0.1076), unconst_f32(0.00541), unconst_f32(0.4964), unconst_f32(0.1685), unconst_f32(0.2159), unconst_f32(0.6358))));
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @size(16) f0: array<u32>,
+}
+
+struct FragmentOutput10 {
+  @location(0) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+  @location(6) @interpolate(perspective) f2: f32,
+}
+
+var<private> vp23: VertexOutput8 = VertexOutput8();
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(1) @binding(103) var tex20: texture_multisampled_2d<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  @size(8) f0: array<u32>,
+}
+
+fn fn2() -> array<array<vec2i, 1>, 13> {
+  var out: array<array<vec2i, 1>, 13>;
+  var vf267: vec4i = textureGather(3, tex19, sam12, vec2f(unconst_f32(0.1057), unconst_f32(0.07300)));
+  vp23 = VertexOutput8(vec2i(i32(step(f16(unconst_f16(11522.2)), f16(unconst_f16(1977.8))))), unpack4xU8(u32(step(f16(unconst_f16(11522.2)), f16(unconst_f16(1977.8))))), vec4f(f32(step(f16(unconst_f16(11522.2)), f16(unconst_f16(1977.8))))));
+  out[pack4xI8Clamp(unpack4xI8(u32(unconst_u32(60))))][vec4u(unpack4xI8(u32(unconst_u32(184))))[3]] = vec2i(i32(pack4xU8Clamp(vec4u(unconst_u32(39), unconst_u32(36), unconst_u32(55), unconst_u32(63)))));
+  let vf268: f32 = vp23.f38[3];
+  vp23 = VertexOutput8(textureLoad(tex19, vec2i(vp23.f36[u32(unconst_u32(8))]), i32(unconst_i32(1000))).ba, bitcast<vec4u>(textureLoad(tex19, vec2i(vp23.f36[u32(unconst_u32(8))]), i32(unconst_i32(1000)))), vec4f(textureLoad(tex19, vec2i(vp23.f36[u32(unconst_u32(8))]), i32(unconst_i32(1000)))));
+  vp23 = VertexOutput8(vec2i(textureDimensions(tex20)), textureDimensions(tex20).yyxy, bitcast<vec4f>(textureDimensions(tex20).rggr));
+  var vf269: vec2u = textureDimensions(tex19, bitcast<vec4i>(asin(vec4f(unconst_f32(0.2671), unconst_f32(0.09463), unconst_f32(0.02842), unconst_f32(0.2068)))).w);
+  vf267 *= vf267;
+  var vf270: u32 = vp23.f37[u32(unconst_u32(34))];
+  fn0(array<array<array<array<vec2h, 1>, 1>, 5>, 1>(array<array<array<vec2h, 1>, 1>, 5>(array<array<vec2h, 1>, 1>(array<vec2h, 1>(bitcast<vec2h>(vp23.f37[u32(unconst_u32(19))]))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(bitcast<vec2h>(vp23.f37[u32(unconst_u32(19))]))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(bitcast<vec2h>(vp23.f37[u32(unconst_u32(19))]))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(bitcast<vec2h>(vp23.f37[u32(unconst_u32(19))]))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(bitcast<vec2h>(vp23.f37[u32(unconst_u32(19))]))))), f16(vp23.f38[3]));
+  out[bitcast<u32>(cos(vec2h(unconst_f16(2346.9), unconst_f16(684.6))))][u32(unconst_u32(75))] = vec2i(fma(vec3h(unconst_f16(4868.5), unconst_f16(8566.9), unconst_f16(4568.8)), vec3h(f16(textureNumSamples(tex20))), vec3h(unconst_f16(7540.6), unconst_f16(767.4), unconst_f16(3859.9))).gg);
+  let ptr69: ptr<function, vec4i> = &vf267;
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(0) var tex19: texture_2d<i32>;
+
+fn fn0(a0: array<array<array<array<vec2h, 1>, 1>, 5>, 1>, a1: f16) -> array<f32, 24> {
+  var out: array<f32, 24>;
+  vp23 = VertexOutput8(vec2i(bitcast<i32>(degrees(f32(fma(vec3h(a0[0][4][0][0][bitcast<u32>(a0[u32(unconst_u32(48))][4][0][0])]), vec3h(unconst_f16(5273.1), unconst_f16(963.7), unconst_f16(3494.7)), vec3h(unconst_f16(431.6), unconst_f16(16654.1), unconst_f16(2669.2)))[2])))), vec4u(u32(degrees(f32(fma(vec3h(a0[0][4][0][0][bitcast<u32>(a0[u32(unconst_u32(48))][4][0][0])]), vec3h(unconst_f16(5273.1), unconst_f16(963.7), unconst_f16(3494.7)), vec3h(unconst_f16(431.6), unconst_f16(16654.1), unconst_f16(2669.2)))[2])))), vec4f(degrees(f32(fma(vec3h(a0[0][4][0][0][bitcast<u32>(a0[u32(unconst_u32(48))][4][0][0])]), vec3h(unconst_f16(5273.1), unconst_f16(963.7), unconst_f16(3494.7)), vec3h(unconst_f16(431.6), unconst_f16(16654.1), unconst_f16(2669.2)))[2]))));
+  vp23.f38 = vec4f(vp23.f38[u32(unconst_u32(228))]);
+  let ptr68 = &vp22;
+  vp22 = modf(f16(reverseBits(u32(unconst_u32(119)))));
+  vp22 = modf(vec4h(vp23.f38)[0]);
+  vp22.whole = f16(pack4xI8(vec4i(unconst_i32(62), unconst_i32(86), unconst_i32(11), unconst_i32(282))));
+  out[bitcast<u32>(a0[0][4][0][0])] -= bitcast<f32>(pack4xU8(vec4u(unconst_u32(340), unconst_u32(35), unconst_u32(427), unconst_u32(353))));
+  vp22.fract = f16(cos(f32(unconst_f32(0.3039))));
+  vp22.whole = f16(vp23.f36.x);
+  var vf263: u32 = pack4xU8Clamp(vec4u(a0[0][4][u32(unconst_u32(120))][0].ggrg));
+  out[reverseBits(u32(unconst_u32(28)))] += vp23.f38[vf263];
+  let vf264: i32 = vp23.f36[1];
+  vp22 = modf(f16(radians(f32(unconst_f32(0.02080)))));
+  vp22.whole *= f16(vp23.f36.g);
+  vp22 = modf(f16(vf263));
+  let vf265: array<array<array<vec2h, 1>, 1>, 5> = a0[u32(unconst_u32(139))];
+  vp23.f36 -= vec2i(vf265[4][0][0]);
+  vf263 = bitcast<u32>(a0[0][4][0][0]);
+  var vf266: vec2f = refract(vec2f(unconst_f32(0.8054), unconst_f32(-0.00658)), vec2f(unconst_f32(0.04586), unconst_f32(-0.2079)), f32(vf265[4][0][0][u32(unconst_u32(438))]));
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@vertex
+fn vertex9(@location(15) @interpolate(flat) a0: u32) -> VertexOutput8 {
+  var out: VertexOutput8;
+  out.f36 &= vec2i(bitcast<i32>(pack4xI8Clamp(vec4i(unconst_i32(18), unconst_i32(151), unconst_i32(11), unconst_i32(-102)))));
+  vp22.fract = vp22.fract;
+  var vf271: vec3i = reverseBits(vec3i(unconst_i32(364), unconst_i32(-108), unconst_i32(1)));
+  let vf272: f16 = pow(f16(unconst_f16(26243.6)), f16(unconst_f16(2768.4)));
+  vp22.fract -= f16(vp23.f38[3]);
+  vp22.whole -= f16(vp23.f36[bitcast<u32>(reverseBits(vec3i(degrees(vec2h(unconst_f16(13262.3), unconst_f16(1774.6))).rgr)).r)]);
+  out.f36 = bitcast<vec2i>(vp23.f37.yy);
+  let vf273: i32 = vf271[1];
+  let ptr70: ptr<private, vec4u> = &vp23.f37;
+  vp23 = VertexOutput8(vec2i(i32(vp22.fract)), unpack4xU8(u32(vp22.fract)), vec4f(f32(vp22.fract)));
+  let ptr71: ptr<private, vec4f> = &vp23.f38;
+  return out;
+}
+
+@fragment
+fn fragment11(@location(13) a0: vec2f, @location(14) @interpolate(flat, center) a1: u32, @location(7) @interpolate(linear, centroid) a2: vec4f) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  out.f1 = bitcast<u32>(a0[1]);
+  var vf274: bool = any(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false), unconst_bool(true)));
+  fn0(array<array<array<array<vec2h, 1>, 1>, 5>, 1>(array<array<array<vec2h, 1>, 1>, 5>(array<array<vec2h, 1>, 1>(array<vec2h, 1>(vec2h(mix(vec3f(unconst_f32(-0.00202), unconst_f32(-0.01784), unconst_f32(0.1120)), vec3f(unconst_f32(0.5647), unconst_f32(0.03752), unconst_f32(0.8273)), vec3f(unconst_f32(0.3214), unconst_f32(0.1273), unconst_f32(0.05908))).gr))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(vec2h(mix(vec3f(unconst_f32(-0.00202), unconst_f32(-0.01784), unconst_f32(0.1120)), vec3f(unconst_f32(0.5647), unconst_f32(0.03752), unconst_f32(0.8273)), vec3f(unconst_f32(0.3214), unconst_f32(0.1273), unconst_f32(0.05908))).br))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(vec2h(mix(vec3f(unconst_f32(-0.00202), unconst_f32(-0.01784), unconst_f32(0.1120)), vec3f(unconst_f32(0.5647), unconst_f32(0.03752), unconst_f32(0.8273)), vec3f(unconst_f32(0.3214), unconst_f32(0.1273), unconst_f32(0.05908))).gr))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(vec2h(mix(vec3f(unconst_f32(-0.00202), unconst_f32(-0.01784), unconst_f32(0.1120)), vec3f(unconst_f32(0.5647), unconst_f32(0.03752), unconst_f32(0.8273)), vec3f(unconst_f32(0.3214), unconst_f32(0.1273), unconst_f32(0.05908))).xy))), array<array<vec2h, 1>, 1>(array<vec2h, 1>(vec2h(mix(vec3f(unconst_f32(-0.00202), unconst_f32(-0.01784), unconst_f32(0.1120)), vec3f(unconst_f32(0.5647), unconst_f32(0.03752), unconst_f32(0.8273)), vec3f(unconst_f32(0.3214), unconst_f32(0.1273), unconst_f32(0.05908))).yy))))), f16(a0.x));
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView249 = texture42.createView({dimension: '2d', baseArrayLayer: 10, arrayLayerCount: 1});
+let externalTexture31 = device0.importExternalTexture({label: '\ua501\u52f1\u{1fb41}\u606c\u0474\u02c9\uca5f', source: video0});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup64, new Uint32Array(725), 75, 0);
+} catch {}
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer25, 'uint16', 84, 286);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+var<workgroup> vw38: array<FragmentOutput11, 1>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(27) var sam13: sampler;
+
+override override14: i32 = 36;
+
+struct T0 {
+  @align(1) f0: array<atomic<i32>, 4>,
+}
+
+var<workgroup> vw34: i32;
+
+var<workgroup> vw35: mat2x3h;
+
+@id(38046) override override15: u32 = 294;
+
+@group(0) @binding(0) var tex21: texture_2d<i32>;
+
+override override13 = 0.2088;
+
+var<workgroup> vw37: array<mat2x3h, 7>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw36: FragmentOutput11;
+
+override override17: i32 = 146;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct FragmentOutput11 {
+  @location(0) @interpolate(flat) f0: vec4u,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw39: bool;
+
+override override12 = true;
+
+override override16: u32 = 12;
+
+var<workgroup> vw40: mat4x4f;
+
+@vertex
+fn vertex10(@location(12) a0: vec2h, @location(10) @interpolate(flat, centroid) a1: vec4u, @location(13) a2: f32, @location(2) a3: vec2u, @builtin(vertex_index) a4: u32, @location(1) @interpolate(perspective, center) a5: vec4f, @location(0) @interpolate(flat, centroid) a6: i32, @builtin(instance_index) a7: u32, @location(7) @interpolate(flat, centroid) a8: vec2u, @location(6) @interpolate(flat) a9: i32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf275: vec4f = a5;
+  out -= vec4f(bitcast<f32>(a8[bitcast<u32>(a2)]));
+  let vf276: vec2f = fma(vec2f(unconst_f32(0.01658), unconst_f32(0.00591)), vec2f(unconst_f32(0.2661), unconst_f32(0.4256)), vec2f(unconst_f32(0.05770), unconst_f32(0.01131)));
+  out = vec4f(f32(a0[a3[u32(unconst_u32(433))]]));
+  let vf277: f16 = length(vec3h(unconst_f16(12235.9), unconst_f16(2486.8), unconst_f16(48154.7)));
+  out = bitcast<vec4f>(a1);
+  out = unpack4x8snorm(a1[1]);
+  out = vec4f(f32(vf277));
+  let vf278: f32 = vf275[0];
+  let vf279: u32 = pack2x16unorm(unpack4x8snorm(bitcast<u32>(override14)).ab);
+  let vf280: vec2u = a3;
+  out = unpack4x8snorm(a8[pack4xU8(vec4u(unconst_u32(177), unconst_u32(344), unconst_u32(38), unconst_u32(33)))]);
+  out += unpack4x8snorm(a1[u32(unconst_u32(127))]);
+  var vf281: vec3u = firstLeadingBit(vec3u(unconst_u32(250), unconst_u32(219), unconst_u32(61)));
+  vf281 -= vec3u(u32(vf275[0]));
+  let vf282: vec2f = unpack2x16float(u32(unconst_u32(317)));
+  var vf283: u32 = vf280[1];
+  vf281 <<= vec3u(u32(vf282[u32(unconst_u32(93))]));
+  return out;
+}
+
+@vertex
+fn vertex11(@location(6) @interpolate(flat) a0: vec4f, @location(1) a1: f32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf284: vec2f = unpack2x16unorm(pack4xU8(bitcast<vec4u>(cos(a0))));
+  let vf285: vec2h = refract(bitcast<vec2h>(a0[bitcast<u32>(refract(vec2h(acos(vec2f(f32(override17)))), vec2h(smoothstep(vec4f(unconst_f32(-0.03906), unconst_f32(0.4898), unconst_f32(0.2369), unconst_f32(0.02122)), bitcast<vec4f>(extractBits(vec3i(unconst_i32(147), unconst_i32(145), unconst_i32(29)), u32(unconst_u32(149)), override15).brbb), vec4f(unconst_f32(0.1193), unconst_f32(0.2958), unconst_f32(0.1831), unconst_f32(0.04871))).xz), f16(unconst_f16(1790.3))))]), vec2h(unconst_f16(10040.3), unconst_f16(23772.3)), f16(unconst_f16(7193.7)));
+  out = vec4f(refract(vec2h(unconst_f16(30646.3), unconst_f16(8732.6)), vec2h(unconst_f16(23499.6), unconst_f16(1245.2)), f16(unconst_f16(22874.5))).xyyx);
+  var vf286: f32 = override13;
+  var vf287: f32 = override13;
+  let vf288: i32 = override17;
+  let vf289: vec2f = unpack2x16unorm(bitcast<u32>(override17));
+  let vf290: vec3u = countOneBits(vec3u(unconst_u32(57), unconst_u32(65), unconst_u32(52)));
+  vf286 = bitcast<vec3f>(countOneBits(vec3u(trunc(vec2h(unconst_f16(15330.2), unconst_f16(6089.6))).yxx))).z;
+  var vf291: vec2h = vf285;
+  let vf292: vec2f = unpack2x16unorm(u32(unconst_u32(127)));
+  let vf293: vec4f = a0;
+  let vf294: vec2f = vf292;
+  let vf295: f16 = vf285[u32(unconst_u32(67))];
+  let vf296: f16 = vf291[0];
+  var vf297: vec4f = vf293;
+  out += vec4f(vf284[u32(unconst_u32(105))]);
+  let vf298: vec2h = atan2(vec2h(unconst_f16(2553.6), unconst_f16(3703.6)), vec2h(unconst_f16(21121.1), unconst_f16(8598.5)));
+  let vf299: f32 = a0[u32(unconst_u32(28))];
+  let vf300: f32 = vf284[0];
+  vf291 += bitcast<vec2h>(vf289[u32(unconst_u32(472))]);
+  return out;
+}
+
+@fragment
+fn fragment12(@location(8) @interpolate(perspective, center) a0: vec2h) -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  let vf301: f32 = override13;
+  out = FragmentOutput11(vec4u(bitcast<u32>(length(f32(unconst_f32(1.000))))));
+  let vf302: f32 = quantizeToF16(f32(unconst_f32(0.09842)));
+  var vf303: vec4i = textureLoad(tex21, vec2i(unconst_i32(283), unconst_i32(217)), i32(unconst_i32(139)));
+  var vf304: vec2u = textureDimensions(tex21, i32(unconst_i32(158)));
+  let vf305: i32 = override14;
+  var vf306: u32 = textureNumLevels(tex21);
+  var vf307: i32 = vf303[3];
+  let vf308: i32 = vf303[u32(a0[1])];
+  let vf309: u32 = pack4x8snorm(vec4f(unconst_f32(0.05525), unconst_f32(0.04140), unconst_f32(0.09945), unconst_f32(0.00767)));
+  var vf310: u32 = vf304[0];
+  vf304 |= vec2u(vf309);
+  let vf311: f16 = a0[u32(unconst_u32(12))];
+  let vf312: f32 = vf301;
+  let vf313: u32 = vf304[0];
+  let vf314: vec4h = inverseSqrt(vec4h(unconst_f16(4877.2), unconst_f16(8245.9), unconst_f16(7168.4), unconst_f16(18326.0)));
+  let vf315: vec4i = unpack4xI8(u32(unconst_u32(242)));
+  vf306 = u32(override12);
+  let vf316: f16 = vf314[1];
+  var vf317: f16 = a0[1];
+  let vf318: f16 = vf311;
+  out.f0 = bitcast<vec4u>(textureLoad(tex21, vec2i(unconst_i32(101), unconst_i32(17)), i32(inverseSqrt(vec4h(f16(vf315[1])))[0])));
+  var vf319: f16 = vf314[1];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute12(@builtin(local_invocation_index) a0: u32) {
+  vw37[u32(unconst_u32(15))] = mat2x3h(f16(workgroupUniformLoad(&vw39)), f16(workgroupUniformLoad(&vw39)), f16(workgroupUniformLoad(&vw39)), f16(workgroupUniformLoad(&vw39)), f16(workgroupUniformLoad(&vw39)), f16(workgroupUniformLoad(&vw39)));
+  let ptr72: ptr<workgroup, mat2x3h> = &(*&vw37)[u32((*&vw37)[u32(vw40[2][u32(unconst_u32(188))])][1].g)];
+  let vf320: f16 = vw37[6][0][u32(unconst_u32(181))];
+  storageBarrier();
+  vw39 = bool((*&vw40)[1][u32(unconst_u32(128))]);
+  vw34 = i32(workgroupUniformLoad(&vw39));
+  let ptr73: ptr<workgroup, array<FragmentOutput11, 1>> = &(*&vw38);
+  vw40 = mat4x4f(f32((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), f32((*ptr73)[0].f0[u32(unconst_u32(150))]), f32((*ptr73)[0].f0[u32(unconst_u32(150))]), f32((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), f32((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), f32((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), f32((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]), bitcast<f32>((*ptr73)[0].f0[u32(unconst_u32(150))]));
+  vw36.f0 = vec4u((*&vw37)[6][0].rgrg);
+  let vf321: FragmentOutput11 = workgroupUniformLoad(&vw36);
+  let ptr74: ptr<workgroup, mat2x3h> = &vw37[6];
+  let vf322: vec4f = vw40[u32(unconst_u32(2))];
+  vw38[u32(vw37[u32(unconst_u32(88))][0][1])].f0 *= vec4u((*ptr74)[1].zxzx);
+  var vf323: f32 = vf322[bitcast<u32>(vw34)];
+  let vf324: bool = override12;
+  vw40 = mat4x4f(bitcast<f32>(vw36.f0[1]), f32(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), f32(vw36.f0[1]), f32(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), f32(vw36.f0[1]), f32(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), f32(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), bitcast<f32>(vw36.f0[1]), f32(vw36.f0[1]));
+  let ptr75: ptr<workgroup, array<FragmentOutput11, 1>> = &(*ptr73);
+  let ptr76: ptr<workgroup, mat2x3h> = &vw37[u32((*&vw37)[6][u32(unconst_u32(376))][u32(unconst_u32(220))])];
+  vw38[u32(unconst_u32(49))].f0 += unpack4xU8(vw36.f0[1]);
+  vf323 -= f32((*ptr74)[1][u32(unconst_u32(29))]);
+  let vf325: f16 = vw35[u32(unconst_u32(52))][u32(unconst_u32(105))];
+}`,
+  sourceMap: {},
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup59, new Uint32Array(1335), 744, 0);
+} catch {}
+try {
+computePassEncoder166.insertDebugMarker('\u918f');
+} catch {}
+let bindGroup152 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 58, resource: textureView137},
+    {binding: 6, resource: textureView146},
+    {binding: 47, resource: textureView178},
+    {binding: 465, resource: textureView180},
+    {binding: 178, resource: {buffer: buffer3, offset: 1792, size: 208}},
+    {binding: 102, resource: {buffer: buffer9, offset: 1024, size: 2558}},
+    {binding: 651, resource: {buffer: buffer39, offset: 1536, size: 1572}},
+    {binding: 81, resource: textureView241},
+    {binding: 237, resource: {buffer: buffer30, offset: 1536}},
+  ],
+});
+let externalTexture32 = device0.importExternalTexture({source: videoFrame16});
+try {
+computePassEncoder103.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+  await buffer48.mapAsync(GPUMapMode.WRITE, 3096);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(9_262).fill(241), /* required buffer size: 9_262 */
+{offset: 62, bytesPerRow: 40, rowsPerImage: 23}, {width: 0, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup153 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 58, resource: textureView48},
+    {binding: 47, resource: textureView178},
+    {binding: 237, resource: {buffer: buffer47, offset: 512, size: 60}},
+    {binding: 178, resource: {buffer: buffer63, offset: 256, size: 52}},
+    {binding: 6, resource: textureView233},
+    {binding: 651, resource: {buffer: buffer91, offset: 256, size: 120}},
+    {binding: 102, resource: {buffer: buffer98, offset: 0, size: 31}},
+    {binding: 81, resource: textureView241},
+    {binding: 465, resource: textureView180},
+  ],
+});
+let buffer143 = device0.createBuffer({
+  label: '\u{1f636}\u5757\u{1ff0b}\u{1fdbd}\uc09e\u0556',
+  size: 2165,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder240 = device0.createCommandEncoder({});
+let computePassEncoder196 = commandEncoder240.beginComputePass({label: '\u{1fda9}\u{1fff9}\u080e\u{1feb2}\u{1fbb9}\u0a42\ubcdb\u{1f666}\ue30f'});
+let externalTexture33 = device0.importExternalTexture({source: video5});
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup120, new Uint32Array(6086), 1_575, 0);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+}, new Uint8Array(62).fill(211), /* required buffer size: 62 */
+{offset: 62, rowsPerImage: 141}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'gamma22curve'} });
+let commandEncoder241 = device0.createCommandEncoder({label: '\u8e72\u{1f9e4}\u{1f61a}\u{1f78b}\u0653\u08fb\u{1f804}\ua2b4\u{1f6e6}'});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 543});
+let texture218 = device0.createTexture({size: {width: 40}, dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder197 = commandEncoder241.beginComputePass({});
+try {
+computePassEncoder173.setBindGroup(0, bindGroup53, new Uint32Array(433), 30, 0);
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline2);
+} catch {}
+let commandEncoder242 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1002});
+let renderPassEncoder77 = commandEncoder242.beginRenderPass({
+  colorAttachments: [{view: textureView247, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 223906486,
+});
+let sampler160 = device0.createSampler({
+  label: '\u3add\u1ba5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  lodMinClamp: 31.35,
+  lodMaxClamp: 44.34,
+  compare: 'never',
+});
+try {
+computePassEncoder197.setPipeline(pipeline3);
+} catch {}
+let buffer144 = device0.createBuffer({
+  size: 997,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView250 = texture201.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroupsIndirect(buffer120, 276); };
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup25, new Uint32Array(918), 127, 0);
+} catch {}
+try {
+renderPassEncoder76.executeBundles([renderBundle5, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer69);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 824 */
+  offset: 824,
+  buffer: buffer111,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1034 */
+  offset: 1034,
+  buffer: buffer82,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture190,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer129, 84, new Float32Array(4305), 84, 24);
+} catch {}
+let computePassEncoder198 = commandEncoder63.beginComputePass({});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup93, new Uint32Array(1952), 330, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(3, buffer18, 324);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(1, buffer83, 5_960, 1_178);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(275).fill(81), /* required buffer size: 275 */
+{offset: 149, bytesPerRow: 7, rowsPerImage: 9}, {width: 3, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+computePassEncoder19.label = '\u{1f7e4}\uc10a\u09e1';
+} catch {}
+let renderBundle30 = renderBundleEncoder30.finish();
+try {
+renderPassEncoder50.setIndexBuffer(buffer58, 'uint16', 56, 70);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(1, buffer83, 6_168, 547);
+} catch {}
+let bindGroup154 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 237, resource: {buffer: buffer23, offset: 0, size: 232}},
+    {binding: 102, resource: {buffer: buffer17, offset: 6400, size: 3865}},
+    {binding: 6, resource: textureView235},
+    {binding: 81, resource: textureView228},
+    {binding: 651, resource: {buffer: buffer68, offset: 2304, size: 4}},
+    {binding: 58, resource: textureView41},
+    {binding: 178, resource: {buffer: buffer39, offset: 3072, size: 452}},
+    {binding: 465, resource: textureView180},
+    {binding: 47, resource: textureView197},
+  ],
+});
+try {
+buffer23.unmap();
+} catch {}
+try {
+  await buffer62.mapAsync(GPUMapMode.WRITE);
+} catch {}
+let buffer145 = device0.createBuffer({
+  size: 9715,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder243 = device0.createCommandEncoder();
+try {
+computePassEncoder89.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder198.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+commandEncoder243.copyTextureToTexture({
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 10, y: 6, z: 23},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup155 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 559, resource: externalTexture23}, {binding: 50, resource: textureView87}],
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup40, []);
+} catch {}
+try {
+computePassEncoder72.setBindGroup(3, bindGroup108, new Uint32Array(591), 12, 1);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(4, buffer63);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup117, new Uint32Array(1754), 314, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer99, 'uint32', 748, 1_602);
+} catch {}
+let texture219 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture34 = device0.importExternalTexture({source: videoFrame15});
+try {
+computePassEncoder185.setBindGroup(0, bindGroup100, new Uint32Array(1287), 606, 0);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer17, 'uint32', 6_272, 2_059);
+} catch {}
+let arrayBuffer13 = buffer62.getMappedRange(0, 72);
+try {
+device0.queue.writeBuffer(buffer79, 452, new Float32Array(24529), 3290, 24);
+} catch {}
+offscreenCanvas0.width = 407;
+let buffer146 = device0.createBuffer({size: 12046, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 799});
+let texture220 = device0.createTexture({
+  size: [20],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView251 = texture174.createView({dimension: '2d'});
+let computePassEncoder199 = commandEncoder243.beginComputePass({});
+try {
+computePassEncoder199.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+renderPassEncoder43.setViewport(30.297200915218802, 6.280494402560807, 5.628562958647194, 8.132906330068451, 0.0940027390245276, 0.16778503678047973);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer145, 'uint16', 2_530, 1_137);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(1, buffer118, 0, 2_007);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup96, new Uint32Array(894), 163, 0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, undefined, 148_970_366, 1_296_622_816);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer145, 112, new Int16Array(17168), 289, 108);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: img3,
+  origin: { x: 0, y: 19 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let buffer147 = device0.createBuffer({
+  size: 4696,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle10, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer30, 0, 7_527);
+} catch {}
+let buffer148 = device0.createBuffer({
+  size: 4989,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView252 = texture168.createView({dimension: '2d'});
+let sampler161 = device0.createSampler({
+  label: '\u9c68\u{1fa5e}\u036c\u5348\u{1f637}',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.91,
+  lodMaxClamp: 73.19,
+  compare: 'always',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer25, 104); };
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'astc-10x10-unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+} catch {}
+let promise41 = device0.queue.onSubmittedWorkDone();
+let bindGroup156 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [{binding: 603, resource: textureView103}, {binding: 808, resource: textureView11}],
+});
+let commandEncoder244 = device0.createCommandEncoder({label: '\u04ff\u02a8\ud1dd\u6183\ufbc9\u{1f672}\u{1fdac}'});
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer54, 388); };
+} catch {}
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup135);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer51, 68);
+} catch {}
+try {
+commandEncoder244.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1080 */
+  offset: 1080,
+  buffer: buffer5,
+}, {
+  texture: texture211,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup157 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [{binding: 603, resource: textureView103}, {binding: 808, resource: textureView11}],
+});
+let commandEncoder245 = device0.createCommandEncoder({});
+let computePassEncoder200 = commandEncoder245.beginComputePass();
+try {
+computePassEncoder200.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer102, 'uint16', 1_196, 190);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup60);
+} catch {}
+let arrayBuffer14 = buffer122.getMappedRange(6632, 56);
+try {
+commandEncoder244.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1032 */
+  offset: 1032,
+  bytesPerRow: 3328,
+  buffer: buffer95,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture167,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 107},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+let bindGroup158 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 76, resource: textureView35}, {binding: 66, resource: textureView237}],
+});
+let commandEncoder246 = device0.createCommandEncoder();
+try {
+renderPassEncoder43.setIndexBuffer(buffer120, 'uint16', 434, 727);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer129, 'uint16', 192, 626);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(2, buffer143);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture177,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer86, 572, new Float32Array(26431), 78, 336);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder247 = device0.createCommandEncoder({});
+let texture221 = device0.createTexture({
+  label: '\u0c6b\u{1f87c}\ufe90\u{1fc99}\u{1fa84}\u{1fa8c}\u076d\u{1fc0b}\u0f90\u0c87\u0046',
+  size: [5, 2, 39],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle31 = renderBundleEncoder31.finish({});
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup158, new Uint32Array(1300), 226, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer19, 'uint32', 568, 4_921);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(1, buffer40, 912);
+} catch {}
+let computePassEncoder201 = commandEncoder246.beginComputePass();
+let externalTexture35 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup91, new Uint32Array(423), 33, 0);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 912 */
+  offset: 912,
+  rowsPerImage: 6,
+  buffer: buffer20,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter0.label = '\u{1f82d}\u{1f84c}\u11c0\uae3b\uf1cc\u0073\ua842\u046a\u{1fffb}\u2d96';
+} catch {}
+let buffer149 = device0.createBuffer({
+  size: 11969,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder202 = commandEncoder72.beginComputePass({});
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup88, []);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer81, 1_108, 3_368);
+} catch {}
+try {
+buffer119.unmap();
+} catch {}
+try {
+commandEncoder247.copyBufferToBuffer(buffer42, 64, buffer78, 1096, 536);
+} catch {}
+try {
+commandEncoder247.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 544 */
+  offset: 544,
+  buffer: buffer142,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder247.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 104 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1168 */
+  offset: 1168,
+  bytesPerRow: 6144,
+  buffer: buffer34,
+}, {width: 13, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder247.clearBuffer(buffer122);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData20 = new ImageData(4, 96);
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpteRp431', transfer: 'iec6196624'} });
+let querySet24 = device0.createQuerySet({label: '\u3743\u{1f9a7}\u07ba\u{1faf8}', type: 'occlusion', count: 863});
+let textureView253 = texture80.createView({label: '\ua3f0\u{1fb00}', dimension: '2d-array', baseArrayLayer: 2, arrayLayerCount: 4});
+let computePassEncoder203 = commandEncoder244.beginComputePass({label: '\u7129\ue2e4\u4e36\u{1f889}\ueb04\u{1ff62}\udea1\u841e\uaca3\u51bd\u{1f6ab}'});
+try {
+renderPassEncoder44.setIndexBuffer(buffer119, 'uint32', 568, 53);
+} catch {}
+try {
+buffer81.unmap();
+} catch {}
+document.body.prepend(video5);
+let commandEncoder248 = device0.createCommandEncoder({});
+let texture222 = device0.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder204 = commandEncoder248.beginComputePass({});
+let renderPassEncoder78 = commandEncoder247.beginRenderPass({
+  colorAttachments: [{
+  view: textureView225,
+  clearValue: { r: 465.2, g: -434.3, b: -43.69, a: 112.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+computePassEncoder203.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup109);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle10, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+buffer145.unmap();
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 223,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder249 = device0.createCommandEncoder();
+let textureView254 = texture11.createView({mipLevelCount: 1, baseArrayLayer: 11, arrayLayerCount: 7});
+let computePassEncoder205 = commandEncoder249.beginComputePass({label: '\u7886\u{1fc0e}\u05fe'});
+try {
+computePassEncoder182.setBindGroup(2, bindGroup101);
+} catch {}
+try {
+computePassEncoder74.setBindGroup(3, bindGroup53, new Uint32Array(1442), 85, 0);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder205.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer43, 'uint16', 1_008, 3_290);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer132, 364, new BigUint64Array(9175), 1806, 112);
+} catch {}
+let commandEncoder250 = device0.createCommandEncoder({});
+let computePassEncoder206 = commandEncoder250.beginComputePass({});
+let externalTexture36 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder206.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(1, bindGroup135);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup155, new Uint32Array(5300), 660, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer89, 'uint16', 536);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(23).fill(63), /* required buffer size: 23 */
+{offset: 23, rowsPerImage: 91}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame40 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'gamma22curve'} });
+let buffer150 = device0.createBuffer({size: 5074, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView255 = texture144.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder192.setBindGroup(1, bindGroup128);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup82, new Uint32Array(2179), 578, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 80, new Int16Array(425), 71, 100);
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageBitmap0);
+let bindGroup159 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 626, resource: {buffer: buffer147, offset: 2816, size: 636}},
+    {binding: 13, resource: textureView233},
+  ],
+});
+let texture223 = device0.createTexture({
+  size: {width: 3276, height: 24, depthOrArrayLayers: 1},
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder155.setBindGroup(1, bindGroup19, new Uint32Array(10000), 694, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup85, new Uint32Array(5959), 129, 0);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer126, 124, 34);
+} catch {}
+let buffer151 = device0.createBuffer({
+  size: 24371,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder251 = device0.createCommandEncoder();
+let texture224 = device0.createTexture({
+  label: '\u{1f87f}\u{1fb23}',
+  size: [10, 5, 79],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder207 = commandEncoder251.beginComputePass({});
+let externalTexture37 = device0.importExternalTexture({
+  label: '\ue921\u85ff\u{1fe14}\ufacf\u{1f8b3}\u14cf\u{1f6d7}',
+  source: videoFrame32,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder207.setPipeline(pipeline1);
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  label: '\u047d\u08ec\u{1fc66}\u539e\u0653\u{1fa90}\udfcd',
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer151, offset: 8192, size: 9064}}],
+});
+try {
+computePassEncoder201.setBindGroup(1, bindGroup143);
+} catch {}
+try {
+computePassEncoder202.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup151);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup35, new Uint32Array(258), 104, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(227), /* required buffer size: 59 */
+{offset: 59}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'hlg'} });
+let buffer152 = device0.createBuffer({
+  size: 6198,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder252 = device0.createCommandEncoder({label: '\u0f09\u24e6\u{1f8f7}\ueaed\u{1fcba}'});
+let computePassEncoder208 = commandEncoder252.beginComputePass({});
+try {
+computePassEncoder123.setBindGroup(1, bindGroup19, new Uint32Array(3793), 75, 0);
+} catch {}
+try {
+computePassEncoder207.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup150, new Uint32Array(1401), 177, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer95, 'uint32', 140, 118);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame31,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 7, y: 32, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 206});
+let texture225 = device0.createTexture({
+  size: [10, 5, 79],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView256 = texture70.createView({aspect: 'all'});
+try {
+computePassEncoder169.setBindGroup(1, bindGroup38, []);
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup87, new Uint32Array(1728), 131, 0);
+} catch {}
+let video6 = await videoWithData(123);
+let shaderModule17 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+struct FragmentOutput12 {
+  @location(0) f0: vec4f,
+  @location(1) @interpolate(perspective) f1: vec2f,
+}
+
+@group(0) @binding(60) var st13: texture_storage_2d_array<r32float, write>;
+
+var<workgroup> vw42: mat3x3f;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw41: mat2x2f;
+
+var<workgroup> vw45: T0;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw43: array<atomic<i32>, 40>;
+
+var<workgroup> vw47: mat4x4h;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn0() -> vec2i {
+  var out: vec2i;
+  var vf326: vec2f = unpack2x16unorm(u32(length(vec4h(unconst_f16(-4767.5), unconst_f16(-21706.5), unconst_f16(991.9), unconst_f16(1790.3)))));
+  var vf327: vec4f = unpack4x8unorm(u32(unconst_u32(83)));
+  vf326 = unpack2x16unorm(u32(unconst_u32(87)));
+  let vf328: f32 = vf327[2];
+  out = bitcast<vec2i>(vf326);
+  let vf329: f32 = vf326[u32(unconst_u32(66))];
+  let vf330: f16 = length(vec4h(vf327));
+  var vf331: f16 = length(vec4h(unconst_f16(-3124.3), unconst_f16(7743.4), unconst_f16(10551.8), unconst_f16(2805.9)));
+  let vf332: f16 = length(vec4h(unconst_f16(-4512.0), unconst_f16(5453.5), unconst_f16(9662.1), unconst_f16(2065.2)));
+  let vf333: vec2f = ceil(vec2f(f32(atan2(f16(unconst_f16(4618.4)), f16(unconst_f16(31968.1))))));
+  vf327 += vec4f(vf329);
+  let vf334: f16 = vf332;
+  var vf335: u32 = pack4xI8(vec4i(unconst_i32(22), unconst_i32(32), unconst_i32(12), unconst_i32(-308)));
+  var vf336: f32 = vf333[0];
+  let vf337: vec4f = unpack4x8unorm(u32(unconst_u32(111)));
+  var vf338: vec3u = firstTrailingBit(vec3u(unconst_u32(161), unconst_u32(369), unconst_u32(205)));
+  let vf339: vec2f = unpack2x16unorm(bitcast<u32>(vf328));
+  var vf340: f32 = vf333[0];
+  var vf341: vec2f = vf339;
+  let vf342: f32 = vf337[1];
+  let vf343: vec4f = unpack4x8unorm(pack2x16float(vf339));
+  vf338 |= vec3u(pack4xI8(vec4i(unconst_i32(134), unconst_i32(71), unconst_i32(155), unconst_i32(138))));
+  vf335 &= u32(vf326[0]);
+  let ptr77: ptr<function, vec4f> = &vf327;
+  return out;
+}
+
+var<workgroup> vw46: T0;
+
+struct T0 {
+  f0: array<atomic<u32>, 1>,
+}
+
+var<workgroup> vw44: atomic<i32>;
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw48: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn1() -> f16 {
+  var out: f16;
+  var vf344 = fn0();
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw49: atomic<i32>;
+
+@vertex
+fn vertex12(@location(10) a0: vec4f, @location(14) @interpolate(flat, centroid) a1: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  fn1();
+  out = atan2(vec4f(unconst_f32(-0.4024), unconst_f32(0.4486), unconst_f32(-0.08647), unconst_f32(0.2169)), unpack2x16float(u32(unconst_u32(42))).rrrr);
+  var vf345 = fn1();
+  var vf346 = fn1();
+  var vf347: i32 = a1[1];
+  var vf348: vec2i = extractBits(vec2i(unconst_i32(40), unconst_i32(437)), u32(sinh(vec3h(unconst_f16(10181.2), unconst_f16(8370.3), unconst_f16(44159.4))).b), u32(unconst_u32(403)));
+  fn1();
+  let vf349: u32 = pack4xU8Clamp(vec4u(unconst_u32(101), unconst_u32(85), unconst_u32(148), unconst_u32(12)));
+  out += acos(vec4f(unconst_f32(0.2663), unconst_f32(0.02606), unconst_f32(0.07063), unconst_f32(0.07515)));
+  fn0();
+  var vf350 = fn0();
+  fn1();
+  let vf351: vec2i = a1;
+  return out;
+}
+
+@fragment
+fn fragment13(@location(10) @interpolate(linear) a0: vec2h) -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  let vf352: vec4h = acosh(vec4h(unconst_f16(18185.4), unconst_f16(17454.3), unconst_f16(11940.5), unconst_f16(13906.1)));
+  var vf353 = fn0();
+  out.f1 = vec2f(step(asin(vec3f(unconst_f32(0.1772), unconst_f32(0.1982), unconst_f32(0.2805))).y, vec2f(vf353)[0]));
+  var vf354: vec2f = unpack2x16unorm(u32(unconst_u32(45)));
+  vf353 |= vec2i(i32(a0[u32(unconst_u32(103))]));
+  var vf355: vec3f = cross(vec3f(f32(a0[bitcast<u32>(tanh(vec3f(unconst_f32(0.00382), unconst_f32(0.04727), unconst_f32(0.04776)))[0])])), tan(vec2f(unconst_f32(0.01555), unconst_f32(0.05561))).rrg);
+  vf353 = vec2i(i32(a0[0]));
+  out.f0 = vec4f(vf354[1]);
+  vf355 = vec3f(cosh(vec4h(unconst_f16(7098.1), unconst_f16(4073.3), unconst_f16(23363.0), unconst_f16(3570.8))).zwx);
+  fn0();
+  var vf356: f16 = vf352[vec3u(sin(vf352.aba)).y];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute13() {
+  var vf357: f16 = vw47[0][pack2x16unorm(vw41[0])];
+  workgroupBarrier();
+  var vf358: vec3f = (*&vw42)[u32(unconst_u32(333))];
+  let ptr78: ptr<workgroup, array<atomic<i32>, 40>> = &vw43;
+  let ptr79: ptr<workgroup, atomic<i32>> = &(*ptr78)[39];
+  let ptr80: ptr<function, vec3f> = &vf358;
+  let ptr81: ptr<workgroup, T0> = &(*&vw46);
+  atomicCompareExchangeWeak(&vw48, unconst_i32(48), unconst_i32(356));
+  let vf359: f32 = vw42[1][1];
+  let vf360: u32 = atomicLoad(&(*&vw46).f0[0]);
+  vw42 = mat3x3f(f32(atomicLoad(&(*ptr81).f0[0])), f32(atomicLoad(&(*ptr81).f0[0])), bitcast<f32>(atomicLoad(&(*ptr81).f0[0])), bitcast<f32>(atomicLoad(&(*ptr81).f0[0])), f32(atomicLoad(&(*ptr81).f0[0])), f32(atomicLoad(&(*ptr81).f0[0])), bitcast<f32>(atomicLoad(&(*ptr81).f0[0])), bitcast<f32>(atomicLoad(&(*ptr81).f0[0])), f32(atomicLoad(&(*ptr81).f0[0])));
+  let ptr82: ptr<workgroup, atomic<i32>> = &vw44;
+  atomicAdd(&vw49, i32(unconst_i32(539)));
+  let vf361: i32 = atomicExchange(&(*ptr79), i32(unconst_i32(32)));
+  let ptr83: ptr<workgroup, atomic<i32>> = &vw44;
+  var vf362: u32 = atomicLoad(&(*&vw46).f0[0]);
+  let ptr84: ptr<workgroup, T0> = &vw46;
+  let ptr85: ptr<workgroup, atomic<u32>> = &(*&vw46).f0[0];
+  vw47 -= mat4x4h(f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))), f16(atomicLoad(&(*ptr79))));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture226 = device0.createTexture({
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder108.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+computePassEncoder201.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(7, undefined);
+} catch {}
+let bindGroup161 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 56, resource: {buffer: buffer117, offset: 0}}]});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 7});
+try {
+renderPassEncoder13.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 1, y: 6, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder253 = device0.createCommandEncoder({});
+let textureView257 = texture160.createView({});
+let renderPassEncoder79 = commandEncoder253.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 78.96, g: 597.9, b: 330.2, a: -3.496, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+});
+try {
+computePassEncoder122.setBindGroup(0, bindGroup118);
+} catch {}
+try {
+computePassEncoder208.insertDebugMarker('\u{1fbe8}');
+} catch {}
+let promise43 = device0.queue.onSubmittedWorkDone();
+let imageData21 = new ImageData(16, 16);
+let bindGroup162 = device0.createBindGroup({
+  label: '\u4381\u830e\u4a8f\u016e\ud8eb\u0274\u3553\ub7f9\ufbf1\u0631\u1142',
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 360, resource: sampler62},
+    {binding: 59, resource: {buffer: buffer15, offset: 256, size: 55}},
+    {binding: 503, resource: textureView220},
+    {binding: 164, resource: {buffer: buffer68, offset: 768, size: 120}},
+  ],
+});
+let commandEncoder254 = device0.createCommandEncoder({});
+let computePassEncoder209 = commandEncoder254.beginComputePass();
+try {
+computePassEncoder158.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder69.end();
+} catch {}
+let imageData22 = new ImageData(8, 4);
+let texture227 = device0.createTexture({size: [20], dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup27, new Uint32Array(137), 7, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer134, 'uint16', 1_098, 540);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder213.insertDebugMarker('\u96f4');
+} catch {}
+let textureView258 = texture117.createView({dimension: 'cube-array', format: 'rgba16uint', baseMipLevel: 0, arrayLayerCount: 6});
+let computePassEncoder210 = commandEncoder213.beginComputePass();
+try {
+computePassEncoder149.setBindGroup(0, bindGroup119, new Uint32Array(102), 0, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(5, buffer40, 0);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let texture228 = device0.createTexture({
+  label: '\u66ba\ue67d\u4701\ue202\u093a\u5b9f\ud191\u549b\u868b\u{1fffe}\u{1fc24}',
+  size: [64],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler162 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 94.59,
+  lodMaxClamp: 97.84,
+});
+try {
+computePassEncoder140.setBindGroup(2, bindGroup52, new Uint32Array(485), 15, 0);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer15, 'uint32', 12, 323);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer117, 2772, new Int16Array(12288), 3128, 1372);
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  label: '\u69a5\u8a8f\u7b83',
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView259 = texture4.createView({
+  label: '\u371b\u0dbb\ue390\uf58d\u{1feea}\u{1ff01}\u0310\u2bc2\uab83\u{1f7a8}',
+  dimension: 'cube',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle7, renderBundle24, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer152, 'uint32', 408, 2_112);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(2, buffer44, 4_096);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 308, new DataView(new ArrayBuffer(1324)));
+} catch {}
+let buffer153 = device0.createBuffer({size: 58360, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let texture229 = device0.createTexture({
+  size: [20, 11, 139],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler163 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 16.91,
+  lodMaxClamp: 26.15,
+});
+try {
+computePassEncoder74.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder204.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder206.pushDebugGroup('\u{1ff09}');
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let bindGroup163 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 241, resource: textureView62}]});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup150, []);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(1, bindGroup163, new Uint32Array(1547), 647, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer86, 'uint16', 1_448, 360);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup164 = device0.createBindGroup({label: '\u0476\u29e0', layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView9}]});
+let gpuCanvasContext10 = canvas6.getContext('webgpu');
+let bindGroup165 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 8, resource: textureView76},
+    {binding: 66, resource: {buffer: buffer119, offset: 1280, size: 108}},
+  ],
+});
+try {
+renderPassEncoder24.setStencilReference(83);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer43, 'uint32', 212, 652);
+} catch {}
+let arrayBuffer15 = buffer61.getMappedRange(136, 208);
+let imageData23 = new ImageData(4, 232);
+let bindGroup166 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView105}]});
+let commandEncoder255 = device0.createCommandEncoder();
+let textureView260 = texture26.createView({});
+let sampler164 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.60,
+  lodMaxClamp: 81.39,
+});
+try {
+renderPassEncoder52.setIndexBuffer(buffer15, 'uint32', 44, 266);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer28, 444, 1);
+} catch {}
+let arrayBuffer16 = buffer61.getMappedRange(344, 192);
+let computePassEncoder211 = commandEncoder255.beginComputePass({});
+let sampler165 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.55,
+  lodMaxClamp: 89.60,
+  compare: 'always',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder211.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup156);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer71, 392, new Int16Array(7946), 147, 284);
+} catch {}
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'linear'} });
+let sampler166 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.32,
+  lodMaxClamp: 86.21,
+  compare: 'equal',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder147.setBindGroup(3, bindGroup158);
+} catch {}
+try {
+computePassEncoder180.setBindGroup(0, bindGroup97, new Uint32Array(368), 22, 0);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(2);
+} catch {}
+try {
+buffer126.unmap();
+} catch {}
+try {
+  await promise43;
+} catch {}
+let buffer154 = device0.createBuffer({size: 6372, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder256 = device0.createCommandEncoder();
+let computePassEncoder212 = commandEncoder256.beginComputePass({});
+try {
+computePassEncoder212.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup141, new Uint32Array(1610), 508, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer85);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture146,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9_456).fill(214), /* required buffer size: 9_456 */
+{offset: 26, bytesPerRow: 82, rowsPerImage: 115}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule11,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 720,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 8, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 256,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 8, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+document.body.prepend(video0);
+let bindGroup167 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView133}]});
+let buffer155 = device0.createBuffer({size: 35942, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+try {
+renderPassEncoder76.setBindGroup(0, bindGroup65, new Uint32Array(780), 187, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 3, y: 16 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise42;
+} catch {}
+await gc();
+let bindGroup168 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 97, resource: textureView178}]});
+try {
+device0.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(303).fill(29), /* required buffer size: 303 */
+{offset: 303, bytesPerRow: 9}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device0.queue.onSubmittedWorkDone();
+let buffer156 = device0.createBuffer({
+  size: 57674,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder257 = device0.createCommandEncoder({});
+let texture230 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+computePassEncoder192.setBindGroup(0, bindGroup3, new Uint32Array(225), 55, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle18, renderBundle23, renderBundle7, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder71.setViewport(3.3127153800755944, 1.385065188454358, 0.3693594021678892, 0.5954784364936271, 0.7206966241625016, 0.7538557641975625);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 78, resource: {buffer: buffer121, offset: 2048, size: 204}}],
+});
+let pipelineLayout27 = device0.createPipelineLayout({label: '\ucde0\u7813\u367f\u5e2d\u5482\u0797\u0489\u98fe\u2bd0', bindGroupLayouts: []});
+let buffer157 = device0.createBuffer({size: 6968, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder258 = device0.createCommandEncoder();
+let computePassEncoder213 = commandEncoder257.beginComputePass({label: '\u04ba\u507f\u0b9c\u55ed\u003c\u8f10\u1d13\ue584'});
+let sampler167 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.53,
+  lodMaxClamp: 70.67,
+});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup99, new Uint32Array(1131), 118, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, undefined, 490_941_649, 1_233_215_594);
+} catch {}
+try {
+  await promise41;
+} catch {}
+document.body.append(video2);
+let bindGroup170 = device0.createBindGroup({
+  label: '\ubb69\u1242\uc917\u{1fa97}\u{1fcc0}\u{1fe94}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer15, offset: 256, size: 308}}],
+});
+try {
+renderPassEncoder68.setIndexBuffer(buffer73, 'uint32', 1_296, 2_132);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer53);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer155, 860, new BigUint64Array(14460), 868, 56);
+} catch {}
+let textureView261 = texture49.createView({label: '\u72fc\u28c5'});
+let computePassEncoder214 = commandEncoder258.beginComputePass({});
+let sampler168 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 37.54});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup94, new Uint32Array(3545), 174, 0);
+} catch {}
+try {
+computePassEncoder214.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup169);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer153, 'uint16', 10_418, 8_029);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+renderPassEncoder48.insertDebugMarker('\udb19');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView262 = texture167.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 29});
+try {
+computePassEncoder213.setPipeline(pipeline3);
+} catch {}
+let commandEncoder259 = device0.createCommandEncoder({});
+let computePassEncoder215 = commandEncoder259.beginComputePass({label: '\u8f65\u0084\u725b\ud114\u5d88\u7c99\u{1fefb}\u1169\u0dc1'});
+try {
+computePassEncoder144.setBindGroup(1, bindGroup58, new Uint32Array(1714), 403, 0);
+} catch {}
+try {
+computePassEncoder215.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder110.setBindGroup(0, bindGroup134, new Uint32Array(1655), 550, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup122);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder70.setStencilReference(431);
+} catch {}
+try {
+renderPassEncoder66.setViewport(3.4705033624629023, 8.70092180262209, 13.350537273749143, 0.9966777706789619, 0.9593082647739721, 0.9774583726611167);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+buffer145.unmap();
+} catch {}
+document.body.prepend(img1);
+let buffer158 = device0.createBuffer({
+  size: 4358,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture231 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler169 = device0.createSampler({
+  label: '\u0c94\u0449\u{1fc57}\ua172\u88a8\u0287\u6873\u0536\u7d98\u0b7b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.31,
+  lodMaxClamp: 55.59,
+});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup120, []);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer18, 'uint16', 196, 98);
+} catch {}
+try {
+computePassEncoder206.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas4);
+let texture232 = device0.createTexture({
+  size: [40, 23, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder122.setBindGroup(1, bindGroup115, new Uint32Array(1436), 122, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup31, new Uint32Array(1652), 366, 0);
+} catch {}
+try {
+renderPassEncoder36.drawIndexedIndirect(buffer53, 4_460);
+} catch {}
+let commandEncoder260 = device0.createCommandEncoder({label: '\u{1f947}\u056b\u07fe\u6431\u0b1a\u7ca0\ucbfa\u0aa9\u00b1\uf555'});
+let sampler170 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.09,
+  lodMaxClamp: 98.88,
+  compare: 'not-equal',
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder78.beginOcclusionQuery(63);
+} catch {}
+try {
+renderPassEncoder36.drawIndirect(buffer25, 52);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(7, buffer2, 0, 119);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData24 = new ImageData(4, 32);
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer159 = device0.createBuffer({
+  label: '\u1c9e\u44cd\u5c18',
+  size: 30506,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let texture233 = device0.createTexture({
+  size: [10, 5, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle29, renderBundle7, renderBundle4, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -395.8, g: 541.0, b: -58.12, a: 901.6, });
+} catch {}
+try {
+renderPassEncoder36.draw(109, 18, 1_673_217_167, 751_974_176);
+} catch {}
+try {
+renderPassEncoder36.drawIndexedIndirect(buffer120, 3_244);
+} catch {}
+try {
+commandEncoder260.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 272 */
+  offset: 272,
+  buffer: buffer77,
+}, {
+  texture: texture167,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let promise45 = device0.queue.onSubmittedWorkDone();
+let texture234 = device0.createTexture({
+  size: {width: 20},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder216 = commandEncoder260.beginComputePass({});
+try {
+renderPassEncoder78.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder36.draw(524, 180, 185_544_792, 122_199_483);
+} catch {}
+try {
+renderPassEncoder36.drawIndexedIndirect(buffer1, 11_400);
+} catch {}
+try {
+renderPassEncoder36.drawIndirect(buffer12, 1_652);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer105, 192);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let buffer160 = device0.createBuffer({
+  label: '\u0aad\u7c8e\uea9a\u0d7c\u0bfd\u{1f652}\u{1fecf}\uf502\u187c\u{1fdbe}\u4d88',
+  size: 3995,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+computePassEncoder216.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup134);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup54, new Uint32Array(4777), 33, 0);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder36.drawIndexed(0, 548, 2, 50_367_893, 641_667_869);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(7, buffer138, 2_064, 6_723);
+} catch {}
+let texture235 = device0.createTexture({
+  size: [5, 2, 39],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder138.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline2);
+} catch {}
+document.body.prepend(video5);
+let imageData25 = new ImageData(20, 60);
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup118, new Uint32Array(1722), 524, 0);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer161 = device0.createBuffer({
+  label: '\u005c\u029a\u{1f6c8}\u{1f629}',
+  size: 12430,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+});
+let texture236 = device0.createTexture({
+  label: '\u9b8a\u7636\ue547\u01bd\ua9d9\u0f5f\u74e1\u{1f9aa}\u{1fb3e}',
+  size: {width: 40, height: 23, depthOrArrayLayers: 319},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32sint'],
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let renderBundle32 = renderBundleEncoder32.finish({});
+try {
+renderPassEncoder36.drawIndexedIndirect(buffer45, 4);
+} catch {}
+try {
+renderPassEncoder36.drawIndirect(buffer12, 3_956);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(6, buffer76);
+} catch {}
+let promise46 = shaderModule2.getCompilationInfo();
+let buffer162 = device0.createBuffer({size: 10886, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let texture237 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 80},
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture238 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 53},
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup47, new Uint32Array(660), 16, 0);
+} catch {}
+try {
+renderPassEncoder36.drawIndirect(buffer35, 4_628);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let pipeline5 = await promise35;
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup171 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [
+    {binding: 13, resource: textureView125},
+    {binding: 626, resource: {buffer: buffer105, offset: 1792, size: 1800}},
+  ],
+});
+let texture239 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup118, new Uint32Array(2232), 342, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(17.01194771527592, 9.205897277446546, 14.64985350264736, 13.13190705730564, 0.22899113720971287, 0.8993766103747486);
+} catch {}
+try {
+renderPassEncoder36.draw(85, 254, 194_760_420, 774_124_806);
+} catch {}
+try {
+renderPassEncoder36.drawIndexedIndirect(buffer41, 3_788);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(5, undefined, 226_711_489);
+} catch {}
+let pipelineLayout28 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture240 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder138.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup76, new Uint32Array(2192), 296, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer33, 'uint16', 132, 4_253);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer17 = buffer62.getMappedRange(72, 4);
+let bindGroup172 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 503, resource: textureView99},
+    {binding: 164, resource: {buffer: buffer65, offset: 1792, size: 192}},
+    {binding: 360, resource: sampler18},
+    {binding: 59, resource: {buffer: buffer148, offset: 512, size: 154}},
+  ],
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup33, new Uint32Array(1753), 395, 0);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup146, new Uint32Array(119), 19, 1);
+} catch {}
+try {
+renderPassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(4, buffer129, 268, 81);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame37,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 1, y: 6, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData26 = new ImageData(24, 60);
+let bindGroup173 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 455, resource: textureView144}]});
+let buffer163 = device0.createBuffer({
+  size: 7849,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder217 = commandEncoder80.beginComputePass({});
+let sampler171 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.90,
+  lodMaxClamp: 28.91,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup128, new Uint32Array(3550), 132, 0);
+} catch {}
+try {
+computePassEncoder217.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer99, 'uint32', 10_228, 645);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 48, new BigUint64Array(6941), 2731, 160);
+} catch {}
+let bindGroup174 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 164, resource: {buffer: buffer92, offset: 0}},
+    {binding: 503, resource: textureView86},
+    {binding: 360, resource: sampler18},
+    {binding: 59, resource: {buffer: buffer84, offset: 512, size: 593}},
+  ],
+});
+let sampler172 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 22.79,
+});
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup166, []);
+} catch {}
+let bindGroup175 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView97}]});
+try {
+renderPassEncoder55.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer156, 0);
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 155,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 235,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 585,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 172,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 494,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout29 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout14]});
+let buffer164 = device0.createBuffer({
+  size: 17828,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture241 = device0.createTexture({
+  label: '\u04f2\u0182\u79f9',
+  size: [20, 11, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView263 = texture233.createView({
+  label: '\u658d\u07d1\u11af\u09b6\u{1f6c6}\u06ca\u046d\u{1f813}',
+  baseMipLevel: 0,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder68.setBindGroup(2, bindGroup71);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 681.3, g: 841.4, b: -715.6, a: -853.1, });
+} catch {}
+let arrayBuffer18 = buffer61.getMappedRange(536, 28);
+document.body.append(video3);
+let bindGroup176 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer15, offset: 0, size: 204}}],
+});
+let textureView264 = texture241.createView({dimension: '2d-array'});
+try {
+renderPassEncoder24.setIndexBuffer(buffer93, 'uint16', 360, 3);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder24.insertDebugMarker('\u99ae');
+} catch {}
+await gc();
+try {
+computePassEncoder203.setBindGroup(1, bindGroup168);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer126, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'smpteSt4281'} });
+let texture242 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup106, new Uint32Array(2432), 354, 0);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: 370.5, g: 960.6, b: 384.6, a: -756.4, });
+} catch {}
+try {
+renderPassEncoder33.setViewport(6.887030333578807, 18.379849083835857, 23.54090716113243, 18.05729140300891, 0.6720520791510629, 0.7577271822668573);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer57, 'uint16', 1_444, 991);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'astc-10x6-unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer165 = device0.createBuffer({
+  size: 22921,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let sampler173 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.75,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup172, new Uint32Array(284), 59, 1);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder180.pushDebugGroup('\u02ec');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer164, 8008, new Float32Array(7184), 1247, 144);
+} catch {}
+let bindGroup177 = device0.createBindGroup({
+  label: '\u562b\u048e\u0edd\u{1f7b5}\u0dd2\u2857\u3ec2\u6e30\u707c\ube77\u9220',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView14}],
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup101, new Uint32Array(0), 0, 0);
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer98, 'uint32', 8, 33);
+} catch {}
+let imageData27 = new ImageData(20, 24);
+let shaderModule18 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+struct S2 {
+  @location(0) @interpolate(flat) f0: u32,
+}
+
+fn fn0(a0: f32, a1: ptr<storage, array<u32>, read>) -> array<array<mat2x2f, 1>, 4> {
+  var out: array<array<mat2x2f, 1>, 4>;
+  let ptr86: ptr<storage, u32, read> = &(*a1)[bitcast<vec2u>(unpack2x16unorm(u32(unconst_u32(68)))).g];
+  out[u32(a0)][(*a1)[arrayLength(&(*a1))]] = mat2x2f(bitcast<vec2f>(tan(vec4h(unconst_f16(6804.6), unconst_f16(6811.4), unconst_f16(38439.9), unconst_f16(20985.1)))), bitcast<vec2f>(tan(vec4h(unconst_f16(6804.6), unconst_f16(6811.4), unconst_f16(38439.9), unconst_f16(20985.1)))));
+  out[u32(unconst_u32(330))][u32(all(vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(true))))] += mat2x2f(bitcast<vec2f>(unpack4xU8(u32(unconst_u32(12))).wz), vec2f(unpack4xU8(u32(unconst_u32(12))).ab));
+  out[u32(all(vec4<bool>(bool(arrayLength(&(*a1))))))][u32(unconst_u32(115))] -= mat2x2f(bitcast<f32>((*a1)[arrayLength(&(*a1))]), f32((*a1)[arrayLength(&(*a1))]), bitcast<f32>((*a1)[arrayLength(&(*a1))]), bitcast<f32>((*a1)[arrayLength(&(*a1))]));
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  @size(76) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(60) var st14: texture_storage_2d_array<r32float, write>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw50: mat3x3h;
+
+@vertex
+fn vertex13(@location(3) a0: vec2i, a1: S2, @location(7) a2: vec4h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vec4f(bitcast<f32>(a0[bitcast<u32>(a0[1])]));
+  var vf363: f16 = a2[u32(unconst_u32(560))];
+  var vf364: f16 = a2[2];
+  let vf365: vec3h = cross(vec3h(unconst_f16(5074.1), unconst_f16(3471.0), unconst_f16(4004.9)), vec3h(unconst_f16(89.95), unconst_f16(3695.0), unconst_f16(14634.0)));
+  let ptr87: ptr<function, f16> = &vf364;
+  vf363 = vf364;
+  var vf366: u32 = a1.f0;
+  out = vec4f(f32(a0[u32(unconst_u32(1))]));
+  out = vec4f(cross(vec3h(f16(a1.f0)), vec3h(f16(a1.f0))).gbbg);
+  out += vec4f(a2);
+  let vf367: u32 = a1.f0;
+  var vf368: u32 = vf367;
+  vf363 = vec2h(log2(vec2f(f32(vf365[u32(a2[u32(unconst_u32(263))])]))))[0];
+  let vf369: i32 = a0[u32(unconst_u32(251))];
+  var vf370: i32 = a0[1];
+  vf366 += u32((*ptr87));
+  var vf371: vec3f = refract(vec3f(unconst_f32(0.2144), unconst_f32(0.2047), unconst_f32(0.1754)), vec3f(unconst_f32(-0.2737), unconst_f32(0.03589), unconst_f32(0.1500)), vec3f(saturate(vec3h(refract(vec3f(unconst_f32(0.1153), unconst_f32(0.04463), unconst_f32(0.03359)), vec3f(unconst_f32(0.2485), unconst_f32(0.00173), unconst_f32(0.04919)), f32(a0[u32(unconst_u32(232))]))))).y);
+  vf366 = u32((*ptr87));
+  let vf372: i32 = vf369;
+  var vf373: vec4h = a2;
+  let vf374: f16 = vf373[3];
+  var vf375: vec3h = cross(vec3h(unconst_f16(1027.9), unconst_f16(7548.0), unconst_f16(14785.6)), vec3h(vf371));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute14() {
+  vw50 = (*&vw50);
+  vw50 = mat3x3h(vw50[0][1], vw50[0][1], vw50[0][1], vw50[0][1], vw50[0][1], vw50[0][1], vw50[0][1], vw50[0][1], vw50[0][1]);
+  vw50 += (*&vw50);
+  let vf376: f16 = (*&vw50)[1][0];
+  vw50 += (*&vw50);
+  let ptr88: ptr<workgroup, mat3x3h> = &vw50;
+  vw50 = mat3x3h(length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))), length(vec4h(unconst_f16(12932.4), unconst_f16(12609.2), unconst_f16(52916.4), unconst_f16(3869.4))));
+  let ptr89: ptr<workgroup, mat3x3h> = &vw50;
+  vw50 = (*ptr88);
+  vw50 -= mat3x3h((*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z], (*ptr88)[2][vec3u((*&vw50)[1]).z]);
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute15() {
+  var vf377: f32 = cos(f32(unconst_f32(0.1245)));
+  var vf378: bool = all(vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+  var vf379: vec3h = asinh((*&vw50)[0]);
+  vf379 = vec3h(f16(vf377));
+  var vf380: f16 = length(vec3h(f16(cos(f32(unconst_f32(0.03616))))));
+  let vf381: vec2u = firstLeadingBit(vec2u(unconst_u32(275), unconst_u32(96)));
+  vw50 = mat3x3h(f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))), f16(dot4U8Packed(u32(unconst_u32(201)), bitcast<u32>(insertBits(vec2i(i32((*&vw50)[1][0])), vec2i(unconst_i32(35), unconst_i32(478)), u32(unconst_u32(47)), u32(unconst_u32(258))).g))));
+  vf377 = vec3f((*&vw50)[u32(unconst_u32(367))])[2];
+  let ptr90: ptr<workgroup, vec3h> = &(*&vw50)[1];
+  vf379 = vec3h(vw50[0][u32(vw50[0][u32(unconst_u32(292))])]);
+  vf379 = vec3h(vw50[0][1]);
+}`,
+  sourceMap: {},
+});
+let buffer166 = device0.createBuffer({
+  label: '\u{1f734}\u0421\u8c25\u06de\u0a34\u00e5\u0494\u{1f97c}',
+  size: 4787,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+computePassEncoder211.setBindGroup(1, bindGroup32, new Uint32Array(230), 67, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup171);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(917);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer84, 144);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 12}
+*/
+{
+  source: video2,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], stencilReadOnly: true});
+let renderBundle33 = renderBundleEncoder33.finish();
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup84, new Uint32Array(3036), 831, 0);
+} catch {}
+try {
+  await promise46;
+} catch {}
+let buffer167 = device0.createBuffer({
+  size: 4598,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture243 = device0.createTexture({
+  size: [20, 11, 1],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder193.insertDebugMarker('\u3c3f');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer77, 392, new BigUint64Array(8400), 2171, 0);
+} catch {}
+let buffer168 = device0.createBuffer({
+  size: 14541,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture244 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 79},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let sampler174 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.52,
+  maxAnisotropy: 5,
+});
+try {
+  await promise44;
+} catch {}
+let canvas7 = document.createElement('canvas');
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  label: '\u18b9\u5b55\u29e6\u131c\ue128\u7dbe\ue64f\u9c52\u{1fcc2}',
+  entries: [
+    {
+      binding: 264,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 194, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup178 = device0.createBindGroup({
+  layout: bindGroupLayout29,
+  entries: [{binding: 223, resource: {buffer: buffer109, offset: 1280, size: 548}}],
+});
+let texture245 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView265 = texture39.createView({aspect: 'all', baseMipLevel: 0, baseArrayLayer: 8, arrayLayerCount: 3});
+let sampler175 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.31,
+  lodMaxClamp: 61.34,
+  compare: 'less-equal',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup170);
+} catch {}
+let texture246 = gpuCanvasContext7.getCurrentTexture();
+let textureView266 = texture226.createView({});
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder73.setBlendConstant({ r: 743.2, g: 712.7, b: 410.5, a: -546.3, });
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+buffer142.unmap();
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let buffer169 = device0.createBuffer({size: 30404, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let texture247 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 159},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView267 = texture38.createView({aspect: 'all', mipLevelCount: 1});
+let sampler176 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 65.02,
+  lodMaxClamp: 69.09,
+});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup147);
+} catch {}
+try {
+renderPassEncoder46.setBlendConstant({ r: -921.9, g: 318.2, b: -86.97, a: -231.7, });
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer144, 'uint16', 0, 662);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(42, 47);
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 522,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup179 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 241, resource: textureView62}]});
+let texture248 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder30.setIndexBuffer(buffer130, 'uint16', 412, 518);
+} catch {}
+let textureView268 = texture248.createView({});
+try {
+  await shaderModule12.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer164, 7560, new BigUint64Array(16733), 7015, 296);
+} catch {}
+document.body.append(canvas0);
+let canvas8 = document.createElement('canvas');
+try {
+globalThis.someLabel = externalTexture20.label;
+} catch {}
+let pipelineLayout30 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer170 = device0.createBuffer({
+  size: 27380,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet27 = device0.createQuerySet({label: '\u5c0b\u37e1\u5bd9\ub29c\u{1fa0f}\u0711\u079b\u6937\u0e6a', type: 'occlusion', count: 1678});
+let textureView269 = texture46.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup73, new Uint32Array(574), 80, 0);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle22, renderBundle22, renderBundle33, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer150, 268, 1_131);
+} catch {}
+try {
+buffer118.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(160).fill(42), /* required buffer size: 160 */
+{offset: 160}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let texture249 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView270 = texture174.createView({label: '\u2083\u0e7b\u{1fceb}\ub34f\u{1f820}', baseArrayLayer: 1, arrayLayerCount: 7});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup79);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup126);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline2);
+} catch {}
+let sampler177 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.78,
+  lodMaxClamp: 92.09,
+  compare: 'always',
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup129, new Uint32Array(676), 58, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(4, 3, 3, 1);
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup175);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup122, new Uint32Array(47), 11, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer3, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(158).fill(13), /* required buffer size: 158 */
+{offset: 81, bytesPerRow: 45}, {width: 4, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let texture250 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler178 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.56,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup168, new Uint32Array(3749), 737, 0);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle21]);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let buffer171 = device0.createBuffer({
+  size: 4568,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture251 = device0.createTexture({size: [40, 23, 1], mipLevelCount: 2, format: 'rgba32float', usage: GPUTextureUsage.COPY_SRC});
+let textureView271 = texture133.createView({});
+try {
+computePassEncoder180.popDebugGroup();
+} catch {}
+let buffer172 = device0.createBuffer({size: 9527, usage: GPUBufferUsage.INDEX});
+let textureView272 = texture184.createView({});
+try {
+renderPassEncoder72.setBindGroup(2, bindGroup23, new Uint32Array(1461), 144, 0);
+} catch {}
+let arrayBuffer19 = buffer122.getMappedRange(20424, 9248);
+try {
+buffer92.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView273 = texture90.createView({dimension: '1d', aspect: 'all', arrayLayerCount: 1});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup122, new Uint32Array(1366), 12, 0);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle9, renderBundle6, renderBundle28, renderBundle9, renderBundle15, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer93);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+await gc();
+let sampler179 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.23,
+  lodMaxClamp: 99.64,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup155);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 321.9, g: 955.1, b: -268.0, a: -382.4, });
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder76.insertDebugMarker('\uabd3');
+} catch {}
+try {
+  await promise40;
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpteSt4281', transfer: 'bt2020_12bit'} });
+try {
+computePassEncoder109.setBindGroup(1, bindGroup177);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(0, bindGroup50, new Uint32Array(5748), 744, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup101, new Uint32Array(2280), 780, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle3, renderBundle5, renderBundle29]);
+} catch {}
+try {
+renderPassEncoder78.setIndexBuffer(buffer43, 'uint32', 316, 2_956);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(3, buffer17, 0, 1_992);
+} catch {}
+let sampler180 = device0.createSampler({
+  label: '\u5849\u7480',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 89.64,
+  lodMaxClamp: 92.12,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+buffer128.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise45;
+} catch {}
+document.body.prepend(img1);
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 207});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({label: '\u088e\u98d8\u7fed\u0646\u8f27', colorFormats: ['rgba16uint']});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer25, 'uint32', 748, 336);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer164, 'uint16', 3_610, 2_797);
+} catch {}
+let texture252 = device0.createTexture({
+  size: [10, 5, 79],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView274 = texture163.createView({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup131);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup35, new Uint32Array(67), 28, 0);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([renderBundle21, renderBundle21, renderBundle21, renderBundle22, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer170, 4_312, 4_320);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer152, 'uint16', 694, 1_282);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(4, buffer145, 2_180);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture253 = device0.createTexture({
+  size: [20, 11, 1],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder24.executeBundles([renderBundle7, renderBundle5]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 96, new Int16Array(6559), 1269, 128);
+} catch {}
+let buffer173 = device0.createBuffer({
+  size: 11499,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle34 = renderBundleEncoder34.finish({});
+try {
+renderPassEncoder45.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer137, 24, new DataView(new ArrayBuffer(3577)), 667, 212);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(397).fill(184), /* required buffer size: 397 */
+{offset: 397}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView275 = texture241.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer159, 'uint32', 9_452, 1_348);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+buffer140.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext11 = canvas7.getContext('webgpu');
+let textureView276 = texture194.createView({});
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup143);
+} catch {}
+try {
+renderPassEncoder58.beginOcclusionQuery(32);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 795, hasDynamicOffset: false },
+    },
+    {
+      binding: 173,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer174 = device0.createBuffer({size: 13234, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup118, new Uint32Array(1741), 143, 0);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer32, 'uint32', 912, 273);
+} catch {}
+try {
+buffer150.unmap();
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+offscreenCanvas0.width = 456;
+let texture254 = device0.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView277 = texture104.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup5, new Uint32Array(1140), 163, 0);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer4, 'uint16', 17_700, 2_106);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer49);
+} catch {}
+let gpuCanvasContext12 = canvas8.getContext('webgpu');
+let videoFrame45 = new VideoFrame(videoFrame36, {timestamp: 0});
+let commandBuffer5 = commandEncoder10.finish({});
+let textureView278 = texture191.createView({aspect: 'all', baseArrayLayer: 0});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], sampleCount: 1, stencilReadOnly: true});
+try {
+renderPassEncoder12.setViewport(22.793880246070497, 16.04132058601893, 5.472011217663266, 8.762049595501562, 0.013348022273360738, 0.7445514063308016);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer132, 'uint16', 1_218, 2_957);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(6, buffer49, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup23, new Uint32Array(475), 4, 0);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(1, undefined, 0);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let commandEncoder261 = device0.createCommandEncoder({});
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup174, new Uint32Array(129), 22, 1);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer158, 'uint32', 88, 1_197);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(6, buffer76);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+commandEncoder261.clearBuffer(buffer89, 1260, 960);
+} catch {}
+let bindGroup180 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 56, resource: {buffer: buffer75, offset: 0, size: 60}},
+    {binding: 134, resource: textureView55},
+    {binding: 14, resource: externalTexture29},
+  ],
+});
+let textureView279 = texture181.createView({dimension: '2d-array'});
+let sampler181 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 48.80,
+  lodMaxClamp: 97.53,
+  compare: 'never',
+});
+try {
+computePassEncoder147.setBindGroup(0, bindGroup81, []);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+renderPassEncoder58.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder59.setViewport(62.670538900218304, 57.8889136260294, 0.1248610077751552, 2.3479075158750575, 0.9569432091416258, 0.957550707994564);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer144, 'uint16', 114, 30);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer90, 'uint16', 488, 466);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(1, buffer105, 1_168);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48).fill(243), /* required buffer size: 48 */
+{offset: 48, bytesPerRow: 0}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer175 = device0.createBuffer({
+  label: '\u9dc0\u204b\ue9f6\u{1fb9c}',
+  size: 2337,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView280 = texture248.createView({aspect: 'all', baseArrayLayer: 0});
+try {
+renderPassEncoder55.setIndexBuffer(buffer33, 'uint32', 812, 8_590);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer18, 'uint16', 634, 491);
+} catch {}
+try {
+commandEncoder261.clearBuffer(buffer169);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let texture255 = device0.createTexture({
+  size: [64],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder80 = commandEncoder261.beginRenderPass({
+  colorAttachments: [{
+  view: textureView146,
+  clearValue: { r: -142.4, g: 212.4, b: 666.8, a: -627.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup120);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer158, 'uint16', 1_128, 28);
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas6.getContext('webgpu');
+let renderBundle35 = renderBundleEncoder35.finish({});
+let sampler182 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.37,
+  lodMaxClamp: 66.65,
+});
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup119, new Uint32Array(2550), 5, 0);
+} catch {}
+let promise47 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder175.setBindGroup(2, bindGroup168);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer132, 0, 530);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 952, new DataView(new ArrayBuffer(2528)), 69, 108);
+} catch {}
+let externalTexture38 = device0.importExternalTexture({
+  label: '\u2955\u0ac2\u06b4\u0c4e\u{1ffb2}\u4724\u3bac\u{1ff95}\u{1f973}\uda74\uef59',
+  source: videoFrame28,
+});
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup169, new Uint32Array(2650), 57, 0);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture256 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 12},
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder169.setBindGroup(2, bindGroup40, new Uint32Array(277), 50, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup55, new Uint32Array(64), 7, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer40, 'uint16', 58, 1_473);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+  await promise47;
+} catch {}
+let bindGroup181 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 66, resource: {buffer: buffer89, offset: 512, size: 1176}},
+    {binding: 8, resource: textureView62},
+  ],
+});
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup91, new Uint32Array(1262), 87, 0);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+let bindGroup182 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 97, resource: textureView197}]});
+let buffer176 = device0.createBuffer({
+  label: '\ucd2a\uf918\u96d6\u{1fdb8}\u0c5f\ubd72',
+  size: 2801,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+renderPassEncoder76.setBindGroup(0, bindGroup25, new Uint32Array(33), 5, 0);
+} catch {}
+try {
+renderPassEncoder59.draw(46, 62, 481_215_824, 2_820_301_505);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer84, 0, 33);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(img2);
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 349});
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup54, new Uint32Array(1277), 79, 0);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle32]);
+} catch {}
+try {
+renderPassEncoder59.draw(198, 499, 22_568_185, 176_288_049);
+} catch {}
+try {
+renderPassEncoder59.drawIndirect(buffer150, 616);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 45, y: 24 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 1, y: 4, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup183 = device0.createBindGroup({
+  label: '\u09c2\u1dfa\u60f5\udf86\u02b0\u035f',
+  layout: bindGroupLayout2,
+  entries: [{binding: 27, resource: sampler108}, {binding: 0, resource: textureView201}],
+});
+let textureView281 = texture1.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup15, new Uint32Array(96), 19, 0);
+} catch {}
+try {
+renderPassEncoder65.setScissorRect(10, 1, 1, 0);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame46 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'gamma28curve'} });
+try {
+globalThis.someLabel = renderPassEncoder52.label;
+} catch {}
+let bindGroup184 = device0.createBindGroup({
+  layout: bindGroupLayout33,
+  entries: [
+    {binding: 40, resource: textureView176},
+    {binding: 494, resource: textureView275},
+    {binding: 585, resource: sampler107},
+    {binding: 155, resource: sampler13},
+    {binding: 172, resource: textureView86},
+    {binding: 235, resource: {buffer: buffer105, offset: 256, size: 4157}},
+    {binding: 45, resource: textureView39},
+    {binding: 7, resource: {buffer: buffer20, offset: 0, size: 200}},
+  ],
+});
+let buffer177 = device0.createBuffer({size: 22398, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let sampler183 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.72,
+  lodMaxClamp: 76.27,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder179.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+computePassEncoder85.setBindGroup(1, bindGroup167, new Uint32Array(6574), 483, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+commandEncoder165.label = '\ub4e6\u{1f80c}\u0a85\uae33\uacf4\u06c2\u1486\u966b\ue51f\u7264\u{1f837}';
+} catch {}
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 397,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let textureView282 = texture248.createView({arrayLayerCount: 1});
+let texture257 = gpuCanvasContext13.getCurrentTexture();
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true});
+let sampler184 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.90,
+  lodMaxClamp: 64.29,
+  compare: 'equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup66, new Uint32Array(633), 14, 0);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer136, 'uint16', 1_382, 609);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(3, buffer118);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet30 = device0.createQuerySet({label: '\u{1f99c}\u6be0\u7ad5\u1106\u2f66\udd09\ud320\ufd90', type: 'occlusion', count: 933});
+let texture258 = device0.createTexture({
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView283 = texture65.createView({dimension: '2d-array'});
+try {
+computePassEncoder203.setBindGroup(1, bindGroup122, []);
+} catch {}
+try {
+renderPassEncoder59.draw(525, 34, 552_180_157, 2_827_154_613);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer85, 'uint16', 6_444, 17_113);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup62);
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 262,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 226,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let textureView284 = texture258.createView({arrayLayerCount: 1});
+let renderBundle36 = renderBundleEncoder36.finish({});
+try {
+renderPassEncoder53.end();
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: -44.43, g: -571.2, b: -27.36, a: 920.8, });
+} catch {}
+try {
+commandEncoder141.copyTextureToTexture({
+  texture: texture244,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let buffer178 = device0.createBuffer({size: 21447, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture259 = device0.createTexture({
+  size: [40, 23, 60],
+  mipLevelCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder59.drawIndirect(buffer127, 1_044);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer93, 'uint16', 64, 34);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder41.insertDebugMarker('\u2263');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData28 = new ImageData(76, 104);
+let bindGroup185 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 68, resource: {buffer: buffer88, offset: 11008, size: 1176}},
+    {binding: 120, resource: textureView204},
+    {binding: 65, resource: textureView137},
+  ],
+});
+let texture260 = device0.createTexture({
+  size: [20, 11, 25],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler185 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', minFilter: 'nearest', mipmapFilter: 'nearest'});
+let externalTexture39 = device0.importExternalTexture({source: video2});
+try {
+renderPassEncoder59.end();
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+commandEncoder141.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3296 */
+  offset: 3296,
+  bytesPerRow: 23040,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder172.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 5, y: 19, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture163,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video6);
+let buffer179 = device0.createBuffer({
+  label: '\u0d60\u05d0\u0bf4\u{1f9ea}',
+  size: 15941,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let textureView285 = texture260.createView({arrayLayerCount: 2});
+let texture261 = device0.createTexture({
+  label: '\u0825\u1305\u37ed\ua308\uc29a\u387e\u{1f8a5}',
+  size: [5],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder218 = commandEncoder172.beginComputePass({});
+try {
+renderPassEncoder48.setIndexBuffer(buffer132, 'uint16', 1_388, 203);
+} catch {}
+try {
+commandEncoder141.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1232 */
+  offset: 1232,
+  bytesPerRow: 5376,
+  buffer: buffer19,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder116.setBindGroup(3, bindGroup88, []);
+} catch {}
+try {
+computePassEncoder218.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder141.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 4, y: 4, z: 63},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 28},
+  aspect: 'all',
+},
+{width: 11, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+computePassEncoder109.setBindGroup(3, bindGroup86, []);
+} catch {}
+try {
+computePassEncoder120.setBindGroup(2, bindGroup134, new Uint32Array(1271), 304, 0);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle22, renderBundle35, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder73.setScissorRect(1, 0, 0, 0);
+} catch {}
+await gc();
+let arrayBuffer20 = buffer48.getMappedRange(3096, 64);
+let bindGroup186 = device0.createBindGroup({
+  label: '\u0aea\u{1fe64}\u047d\u{1fa8d}\u09b5',
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer88, offset: 2816, size: 5953}}],
+});
+let texture262 = device0.createTexture({size: [10, 5, 10], format: 'r32sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder219 = commandEncoder141.beginComputePass({});
+let sampler186 = device0.createSampler({addressModeV: 'repeat', magFilter: 'nearest', minFilter: 'nearest', lodMaxClamp: 80.62});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup127);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer89, 'uint16', 4_558, 597);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder169.setBindGroup(3, bindGroup88, []);
+} catch {}
+try {
+computePassEncoder219.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer153, 'uint16', 6_434, 5_809);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer39, 0, 7_334);
+} catch {}
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55); };
+} catch {}
+let texture263 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 31},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer162, 528);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture249,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(504).fill(86), /* required buffer size: 504 */
+{offset: 504, bytesPerRow: 147}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas9 = document.createElement('canvas');
+try {
+adapter0.label = '\u{1f6ad}\u109c\u203a\u74ae\u0cc6\u0ea9\u5586\ub0bb\u03bc';
+} catch {}
+let texture264 = device0.createTexture({
+  size: [64],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView286 = texture45.createView({mipLevelCount: 1});
+try {
+computePassEncoder98.setBindGroup(2, bindGroup61);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup150);
+} catch {}
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 523});
+let textureView287 = texture168.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+renderPassEncoder79.setScissorRect(0, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+buffer109.unmap();
+} catch {}
+try {
+renderPassEncoder20.pushDebugGroup('\u0f35');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let buffer180 = device0.createBuffer({
+  size: 20186,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture265 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 39},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup109);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer120, 'uint32', 1_624, 2_507);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer51, 68, 482);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 12}
+*/
+{
+  source: canvas3,
+  origin: { x: 96, y: 23 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup187 = device0.createBindGroup({
+  layout: bindGroupLayout24,
+  entries: [{binding: 0, resource: textureView138}, {binding: 36, resource: externalTexture26}],
+});
+let texture266 = device0.createTexture({
+  size: [8, 6, 1],
+  mipLevelCount: 3,
+  format: 'astc-8x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView288 = texture42.createView({label: '\u7f4d\u54d7\ufd0a\u{1f9cc}\u0a62\u0795\ued17', dimension: '2d', baseArrayLayer: 1});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup69);
+} catch {}
+try {
+buffer174.unmap();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+try {
+externalTexture37.label = '\u6b73\ud2d7';
+} catch {}
+let texture267 = device0.createTexture({
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture268 = device0.createTexture({
+  size: [5, 2, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler187 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.82,
+  compare: 'never',
+  maxAnisotropy: 5,
+});
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder178.insertDebugMarker('\u05da');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture269 = device0.createTexture({
+  size: [40, 23, 319],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup140, []);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer167, 'uint16', 262, 879);
+} catch {}
+let bindGroup188 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 68, resource: {buffer: buffer60, offset: 0, size: 108}},
+    {binding: 65, resource: textureView157},
+    {binding: 120, resource: textureView103},
+  ],
+});
+try {
+renderPassEncoder40.setVertexBuffer(0, buffer120, 2_492, 1_541);
+} catch {}
+try {
+buffer127.unmap();
+} catch {}
+let gpuCanvasContext14 = canvas9.getContext('webgpu');
+try {
+renderPassEncoder49.setIndexBuffer(buffer15, 'uint16', 296, 4);
+} catch {}
+let bindGroup189 = device0.createBindGroup({layout: bindGroupLayout4, entries: [{binding: 60, resource: textureView85}]});
+let texture270 = device0.createTexture({
+  label: '\u403f\u0a97\u0648\u06bd\ub2bc\u4344',
+  size: {width: 64},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView289 = texture190.createView({mipLevelCount: 1});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup105, new Uint32Array(1579), 164, 0);
+} catch {}
+try {
+renderPassEncoder76.setBlendConstant({ r: 48.66, g: 493.2, b: -373.4, a: -753.1, });
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video6.height = 6;
+await gc();
+let imageData29 = new ImageData(44, 60);
+let textureView290 = texture254.createView({});
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 20, new Int16Array(1743), 100, 32);
+} catch {}
+let textureView291 = texture81.createView({label: '\u9c08\u3dc9\u63fb\u{1fd66}\uaa8f\u06be'});
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle2]);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(39, 64);
+let sampler188 = device0.createSampler({
+  label: '\ufbe8\ub0f6\ub199\u8da0\u0713\u{1fd31}\u3a41',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.24,
+  lodMaxClamp: 98.35,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup121, new Uint32Array(2049), 345, 0);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle23, renderBundle15, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer38, 'uint16', 870, 1_892);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture218,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(57).fill(65), /* required buffer size: 57 */
+{offset: 57}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas7.getContext('webgpu');
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+struct FragmentOutput13 {
+  @location(0) f0: u32,
+}
+
+struct VertexOutput9 {
+  @builtin(position) f39: vec4f,
+  @location(12) f40: i32,
+  @location(10) @interpolate(flat, centroid) f41: i32,
+  @location(7) @interpolate(linear, center) f42: f32,
+  @location(6) @interpolate(flat, center) f43: vec2u,
+  @location(11) @interpolate(perspective, centroid) f44: vec2f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(65) var tex22: texture_depth_multisampled_2d;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw53: VertexOutput9;
+
+struct T1 {
+  @size(16) f0: i32,
+  @align(4) @size(48) f1: vec2i,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(68) var<storage, read> buffer181: array<array<f16, 13>, 3>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp24 = array(modf(vec4f()), modf(vec4f()), modf(vec4f()));
+
+fn fn0() -> array<FragmentOutput13, 1> {
+  var out: array<FragmentOutput13, 1>;
+  var vf382: vec2u = textureDimensions(tex23, i32(unconst_i32(40)));
+  vp24[u32(unconst_u32(196))] = modf(vec4f(f32(sqrt(f16(vp24[u32(unconst_u32(328))].fract.w)))));
+  vf382 -= bitcast<vec2u>(unpack4x8unorm(u32(unconst_u32(18))).bb);
+  out[u32(unconst_u32(168))].f0 *= u32(textureLoad(tex22, vec2i(unconst_i32(-339), unconst_i32(59)), select(i32(unconst_i32(440)), i32(unconst_i32(3)), bool(unconst_bool(false)))));
+  let ptr91 = &vp24[2];
+  vp24[u32(unconst_u32(126))] = modf(unpack4x8unorm(textureNumSamples(tex22)));
+  out[u32(unconst_u32(3))] = FragmentOutput13(u32(vp24[2].whole.z));
+  vf382 >>= bitcast<vec2u>(textureLoad(tex23, vec2i(i32(textureLoad(tex22, vec2i(unconst_i32(13), unconst_i32(-134)), i32(unconst_i32(13))))), i32(unconst_i32(493))).yz);
+  let ptr92: ptr<function, vec2u> = &vf382;
+  let vf383: vec3f = sqrt(vec3f(unconst_f32(-0.01901), unconst_f32(0.01533), unconst_f32(0.1799)));
+  vp24[2] = modf(bitcast<vec4f>(textureDimensions(tex23, i32(unconst_i32(224))).grgr));
+  var vf384: u32 = textureNumLevels(tex23);
+  vf382 >>= textureDimensions(tex23, i32(vf383[u32(unconst_u32(216))]));
+  let ptr93 = &vp24[pack4x8snorm(unpack4x8unorm(vf382[0]))];
+  let vf385: vec3i = countLeadingZeros(bitcast<vec3i>((*ptr91).whole.bgr));
+  var vf386: vec3i = vf385;
+  let vf387: f32 = vf383[1];
+  vp24[textureNumLevels(tex23)].whole -= (*ptr93).fract;
+  let ptr94 = &(*ptr93);
+  vf384 >>= u32(vf386[u32(unconst_u32(51))]);
+  let vf388: f16 = sqrt(f16(vf385[1]));
+  return out;
+}
+
+var<workgroup> vw51: atomic<u32>;
+
+fn fn1() -> array<array<FragmentOutput13, 1>, 16> {
+  var out: array<array<FragmentOutput13, 1>, 16>;
+  vp24[u32(unconst_u32(50))] = modf(vp24[2].whole);
+  vp24[u32(unconst_u32(34))].whole += vp24[2].whole;
+  var vf389: f32 = textureLoad(tex22, vec2i(tan(vec3f(unconst_f32(0.04193), unconst_f32(0.4955), unconst_f32(0.02200))).yz), i32(unconst_i32(20)));
+  let ptr95 = &vp24;
+  vf389 = atan((*ptr95)[2].whole.yw)[1];
+  var vf390: vec2f = atan((*ptr95)[2].fract.ba);
+  let ptr96 = &(*ptr95)[2];
+  vp24[u32(unconst_u32(192))].whole *= (*ptr95)[2].whole;
+  return out;
+}
+
+var<workgroup> vw52: VertexOutput9;
+
+struct T0 {
+  @align(2) f0: atomic<u32>,
+  @align(2) @size(76) f1: array<u32>,
+}
+
+@group(0) @binding(120) var tex23: texture_2d<f32>;
+
+@vertex
+fn vertex14(@location(9) a0: u32, @location(8) @interpolate(perspective) a1: vec2f) -> VertexOutput9 {
+  var out: VertexOutput9;
+  var vf391 = fn0();
+  let vf392: vec2u = textureDimensions(tex23);
+  out.f40 |= i32(length(vec3h(f16(dot4I8Packed(pack4x8snorm(vp24[2].fract), pack4x8unorm(unpack4x8unorm(u32(unconst_u32(79)))))))));
+  vf391[u32(unconst_u32(81))] = FragmentOutput13(u32(distance(f16(unconst_f16(21767.5)), f16(unconst_f16(-6254.6)))));
+  fn0();
+  out.f44 = unpack2x16unorm(vf391[0].f0);
+  out.f40 = i32(pack4xU8Clamp(vec4u(u32(dot4I8Packed(u32(unconst_u32(65)), bitcast<u32>(a1[u32(unconst_u32(166))]))))));
+  vp24[u32(unconst_u32(284))] = vp24[2];
+  let ptr97: ptr<function, array<FragmentOutput13, 1>> = &vf391;
+  out.f40 -= bitcast<vec2i>(acosh(vec2f(acos(vec3h(unconst_f16(7554.5), unconst_f16(5038.5), unconst_f16(23759.5))).bb)))[0];
+  return out;
+}
+
+@fragment
+fn fragment14() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  out.f0 *= pack4xU8(vec4u(vp24[2].whole));
+  vp24[u32(unconst_u32(148))] = modf(unpack4x8snorm(u32(unconst_u32(52))));
+  out.f0 &= u32(determinant(mat4x4f(f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))), f32(any(bool(unconst_bool(true)))))));
+  var vf393: vec4u = max(vec4u(unconst_u32(50), unconst_u32(186), unconst_u32(4), unconst_u32(230)), vec4u(u32(any(bool(unconst_bool(false))))));
+  vp24[u32(unconst_u32(419))].whole = vec4f(f32(distance(vec4h(unconst_f16(-3973.5), unconst_f16(7564.3), unconst_f16(60000.0), unconst_f16(7752.0)), vec4h(max(vec4u(round(vec2f(f32(sin(f16(pack4xI8(vec4i(unconst_i32(92), unconst_i32(288), unconst_i32(296), unconst_i32(305)))))))).yyxy), vec4u(unconst_u32(10), unconst_u32(12), unconst_u32(140), unconst_u32(61)))))));
+  let ptr98: ptr<private, vec4f> = &vp24[2].fract;
+  var vf394: f16 = distance(vec4h(unconst_f16(2313.7), unconst_f16(25479.9), unconst_f16(4633.7), unconst_f16(6675.6)), tan(vec2h(clamp(vec2f(unconst_f32(0.1343), unconst_f32(0.00006)), unpack4x8snorm(textureNumSamples(tex22)).wy, vp24[2].fract.ba))).ggrg);
+  var vf395 = fn1();
+  vf394 *= f16(vf395[15][0].f0);
+  let ptr99: ptr<function, array<FragmentOutput13, 1>> = &vf395[15];
+  vf393 = vec4u(u32(distance(vec4h(unconst_f16(956.1), unconst_f16(37817.7), unconst_f16(4573.6), unconst_f16(-5732.8)), vec4h(f16((*ptr98)[1])))));
+  vf395[vf395[15][u32(unconst_u32(107))].f0][u32(any(bool(unconst_bool(false))))].f0 -= pack4x8snorm(vp24[2].fract);
+  var vf396: f32 = (*ptr98)[textureNumSamples(tex22)];
+  fn1();
+  var vf397 = fn1();
+  var vf398 = fn1();
+  let ptr100: ptr<function, u32> = &vf395[15][0].f0;
+  let ptr101: ptr<function, u32> = &vf398[15][0].f0;
+  vf395[vf398[15][0].f0][u32(unconst_u32(66))].f0 = (*ptr100);
+  var vf399: vec4f = unpack4x8snorm((*ptr101));
+  var vf400 = fn1();
+  fn1();
+  fn1();
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute16() {
+  vw52 = VertexOutput9(vec4f(bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.3196), unconst_f32(0.04834))))), i32(pack2x16snorm(vec2f(unconst_f32(0.3196), unconst_f32(0.04834)))), bitcast<i32>(pack2x16snorm(vec2f(unconst_f32(0.3196), unconst_f32(0.04834)))), bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.3196), unconst_f32(0.04834)))), vec2u(pack2x16snorm(vec2f(unconst_f32(0.3196), unconst_f32(0.04834)))), vec2f(f32(pack2x16snorm(vec2f(unconst_f32(0.3196), unconst_f32(0.04834))))));
+  vp24[pack4x8unorm(vw52.f39)] = modf(vp24[2].fract);
+  vw53 = VertexOutput9(vec4f(vw53.f39[3]), i32(vw53.f39[3]), bitcast<i32>(vw53.f39[3]), vw53.f39[3], vec2u(bitcast<u32>(vw53.f39[3])), vec2f(vw53.f39[3]));
+  vw53 = VertexOutput9((*&vw52).f39, i32((*&vw52).f39.y), i32((*&vw52).f39.r), (*&vw52).f39.r, vec2u((*&vw52).f39.aa), (*&vw52).f39.zz);
+  let ptr102: ptr<storage, array<array<f16, 13>, 3>, read> = &(*&buffer181);
+  let ptr103: ptr<workgroup, i32> = &(*&vw52).f41;
+  vw52.f43 -= vec2u(vw53.f44);
+  let ptr104: ptr<workgroup, i32> = &(*ptr103);
+  let vf401: VertexOutput9 = workgroupUniformLoad(&vw53);
+  let ptr105: ptr<workgroup, f32> = &(*&vw52).f42;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder48.end();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer90, 'uint16', 228, 461);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder220 = commandEncoder128.beginComputePass({});
+let sampler189 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 63.02,
+  lodMaxClamp: 63.34,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup142, new Uint32Array(177), 2, 0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle18, renderBundle3, renderBundle5]);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55); };
+} catch {}
+let pipelineLayout31 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout34]});
+let texture271 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup190 = device0.createBindGroup({
+  layout: bindGroupLayout36,
+  entries: [
+    {binding: 105, resource: textureView101},
+    {binding: 116, resource: {buffer: buffer89, offset: 512, size: 2348}},
+    {binding: 173, resource: textureView178},
+    {binding: 157, resource: {buffer: buffer143, offset: 256, size: 404}},
+  ],
+});
+let buffer182 = device0.createBuffer({
+  size: 3128,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView292 = texture171.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 2});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup121, new Uint32Array(2371), 26, 0);
+} catch {}
+try {
+computePassEncoder220.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer171, 364, new BigUint64Array(12169), 1296, 136);
+} catch {}
+let bindGroup191 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 188, resource: textureView105}]});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer33, 'uint32', 364, 1_253);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+document.body.append(canvas6);
+try {
+computePassEncoder198.setBindGroup(0, bindGroup84, new Uint32Array(44), 4, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup1, new Uint32Array(448), 54, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer171, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u0f25');
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  label: '\u030c\u5762\u{1fae3}\u0e0d\u62ec\u0dc8\u22ae',
+  layout: bindGroupLayout4,
+  entries: [{binding: 60, resource: textureView87}],
+});
+let buffer183 = device0.createBuffer({size: 10444, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let externalTexture40 = device0.importExternalTexture({source: videoFrame28, colorSpace: 'srgb'});
+try {
+computePassEncoder75.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext12.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+adapter1.label = '\u{1f9e6}\u693a\ud7cf\u6b18\u6e43';
+} catch {}
+let bindGroup193 = device0.createBindGroup({
+  label: '\u1ffb\u{1fbbc}\u{1fe03}\u8605',
+  layout: bindGroupLayout38,
+  entries: [
+    {binding: 226, resource: textureView264},
+    {binding: 56, resource: {buffer: buffer151, offset: 8192, size: 268}},
+    {binding: 57, resource: {buffer: buffer6, offset: 256}},
+    {binding: 262, resource: textureView284},
+    {binding: 41, resource: textureView285},
+  ],
+});
+let buffer184 = device0.createBuffer({
+  size: 32936,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture272 = device0.createTexture({
+  label: '\u0df7\u{1fab6}\u{1f6dd}\u07e9\u{1fa16}\ua24f\u0258\u08e5',
+  size: [40, 23, 319],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView293 = texture118.createView({dimension: '2d-array', baseMipLevel: 0});
+let sampler190 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 76.06});
+try {
+computePassEncoder194.setBindGroup(3, bindGroup155);
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle21, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer17, 'uint32', 2_080, 775);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer99);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(3, bindGroup54, new Uint32Array(534), 90, 0);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup123);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer162, 'uint32', 8_040, 397);
+} catch {}
+let querySet32 = device0.createQuerySet({label: '\u0365\u0201\u09cb\u43f3\ue5cc\u{1fa90}\u4561\u{1ff33}\u4589', type: 'occlusion', count: 436});
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup179, new Uint32Array(679), 199, 0);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(83);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer167, 'uint16', 1_380, 305);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(2, buffer54, 0, 1_295);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup194 = device0.createBindGroup({
+  layout: bindGroupLayout29,
+  entries: [{binding: 223, resource: {buffer: buffer24, offset: 512, size: 88}}],
+});
+let texture273 = device0.createTexture({
+  size: [5, 2, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler191 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 59.23,
+});
+try {
+computePassEncoder173.setBindGroup(1, bindGroup117);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer33, 'uint32', 92, 1_525);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T1 {
+  @size(20) f0: array<u32>,
+}
+
+struct T0 {
+  f0: array<u32>,
+}
+
+@id(17967) override override18 = false;
+
+var<workgroup> vw55: atomic<i32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw57: atomic<u32>;
+
+var<workgroup> vw58: atomic<i32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw54: atomic<i32>;
+
+@group(0) @binding(65) var tex24: texture_depth_multisampled_2d;
+
+@group(0) @binding(68) var<storage, read> buffer185: array<array<f16, 39>>;
+
+@id(26796) override override19: i32;
+
+struct FragmentOutput14 {
+  @location(4) @interpolate(flat, sample) f0: vec2u,
+  @location(6) f1: vec4f,
+  @location(0) f2: u32,
+}
+
+struct T2 {
+  @align(2) @size(80) f0: array<u32>,
+}
+
+var<workgroup> vw56: atomic<i32>;
+
+@group(0) @binding(120) var tex25: texture_2d<f32>;
+
+@fragment
+fn fragment15(@location(14) a0: vec4h, @location(15) @interpolate(linear) a1: vec2f) -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  let vf402: vec3f = min(vec3f(unconst_f32(0.05622), unconst_f32(0.01937), unconst_f32(0.2038)), vec3f(unconst_f32(0.01750), unconst_f32(0.4577), unconst_f32(0.07307)));
+  out.f1 -= vec4f(bitcast<f32>(override19));
+  out.f2 = bitcast<u32>(atan2(vec4f(bitcast<f32>(textureNumSamples(tex24))), vec4f(unconst_f32(0.00053), unconst_f32(0.01906), unconst_f32(0.07908), unconst_f32(-0.02071)))[3]);
+  var vf403: vec2f = fract(vec2f(f32(a0[u32(unconst_u32(194))])));
+  out.f0 += vec2u(countOneBits(vec3i(unconst_i32(20), unconst_i32(169), unconst_i32(111))).xz);
+  var vf404: f32 = a1[0];
+  out.f0 += vec2u(atan2(vf403.xxyx, vec4f(vf403[u32(override19)])).ba);
+  let vf405: f16 = a0[2];
+  var vf406: vec2f = step(vec2f(unconst_f32(0.2576), unconst_f32(0.00038)), vec2f(f32(a0[u32(unconst_u32(79))])));
+  out.f0 *= bitcast<vec2u>(refract(vec4h(unconst_f16(6665.6), unconst_f16(8477.8), unconst_f16(340.0), unconst_f16(9268.8)), vec4h(unconst_f16(18249.0), unconst_f16(2259.4), unconst_f16(22258.2), unconst_f16(7306.2)), f16(unconst_f16(4803.4))));
+  vf404 += vf406[0];
+  let vf407: vec3f = min(vec3f(unconst_f32(0.08391), unconst_f32(0.2159), unconst_f32(0.1212)), min(vec3f(f32(a0[2])), vec3f(unconst_f32(-0.1904), unconst_f32(0.1184), unconst_f32(0.09812))));
+  let vf408: f16 = vf405;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute17() {
+  let vf409: f16 = cos((*&buffer185)[arrayLength(&(*&buffer185))][38]);
+  atomicAdd(&vw56, atomicLoad(&vw54));
+  var vf410: bool = override18;
+  let vf411: i32 = atomicLoad(&(*&vw54));
+  let vf412: i32 = atomicExchange(&vw58, i32(buffer185[arrayLength(&buffer185)][38]));
+  let vf413: f16 = cos(buffer185[arrayLength(&buffer185)][38]);
+  let ptr106: ptr<storage, f16, read> = &buffer185[arrayLength(&buffer185)][38];
+  atomicAnd(&vw56, i32(unconst_i32(-229)));
+  let ptr107: ptr<storage, array<f16, 39>, read> = &(*&buffer185)[arrayLength(&(*&buffer185))];
+  var vf414: i32 = atomicLoad(&(*&vw55));
+  atomicMin(&vw58, i32(unconst_i32(225)));
+  let vf415: u32 = atomicExchange(&vw57, u32(unconst_u32(182)));
+  atomicMin(&vw55, i32(unconst_i32(62)));
+  vf410 = bool(buffer185[arrayLength(&buffer185) - 1][38]);
+  atomicXor(&vw57, u32(vf409));
+  atomicMax(&vw57, bitcast<u32>(atomicExchange(&vw58, i32(unconst_i32(109)))));
+  let ptr108: ptr<storage, array<array<f16, 39>>, read> = &buffer185;
+  let vf416: u32 = atomicExchange(&vw57, u32(unconst_u32(166)));
+  atomicExchange(&vw57, u32(cosh(vec2f(unconst_f32(0.00432), unconst_f32(0.00045)))[1]));
+}`,
+  hints: {},
+});
+let buffer186 = device0.createBuffer({size: 7110, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let sampler192 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 72.86,
+});
+try {
+computePassEncoder171.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup175, new Uint32Array(831), 135, 0);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(2, buffer7);
+} catch {}
+let canvas10 = document.createElement('canvas');
+try {
+canvas10.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout39 = device0.createBindGroupLayout({entries: [{binding: 160, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }}]});
+let bindGroup195 = device0.createBindGroup({
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 61, resource: textureView86},
+    {binding: 47, resource: {buffer: buffer82, offset: 0, size: 1632}},
+  ],
+});
+let texture274 = device0.createTexture({
+  size: [40, 23, 319],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView294 = texture21.createView({dimension: '3d', aspect: 'all'});
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup174, new Uint32Array(403), 116, 1);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(3, buffer118, 0, 695);
+} catch {}
+document.body.prepend(canvas0);
+try {
+pipelineLayout0.label = '\u9b8c\u608c\u{1f721}\u874c\ub8e6\ueda2\u3b1f\uc90e\u{1fa1a}\uf527\ud96c';
+} catch {}
+let bindGroup196 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [
+    {binding: 65, resource: {buffer: buffer123, offset: 512, size: 2380}},
+    {binding: 3, resource: textureView141},
+    {binding: 91, resource: {buffer: buffer101, offset: 5120, size: 60}},
+    {binding: 375, resource: textureView15},
+  ],
+});
+let texture275 = device0.createTexture({size: {width: 20}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView295 = texture16.createView({
+  label: '\u4f72\ubf8d\uc355\u{1faf5}\u{1fdac}\u{1fee7}\u9c1e\u32f5',
+  dimension: 'cube',
+  aspect: 'all',
+  baseArrayLayer: 2,
+});
+try {
+renderPassEncoder40.setIndexBuffer(buffer172, 'uint16', 532, 261);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let bindGroup197 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 103, resource: textureView14}]});
+let textureView296 = texture184.createView({label: '\ub4a5\u3f92\ud895\u{1febe}\uf886\u{1f864}\ue43a', arrayLayerCount: 1});
+try {
+computePassEncoder202.setBindGroup(1, bindGroup57);
+} catch {}
+let bindGroup198 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 393, resource: textureView223}]});
+let buffer187 = device0.createBuffer({size: 1256, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView297 = texture260.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+let sampler193 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.17,
+  lodMaxClamp: 74.97,
+  compare: 'less',
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup45, []);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(1, bindGroup92, new Uint32Array(5304), 555, 0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer18, 468, 264);
+} catch {}
+try {
+computePassEncoder133.insertDebugMarker('\u6277');
+} catch {}
+let textureView298 = texture68.createView({aspect: 'all'});
+try {
+computePassEncoder129.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+computePassEncoder208.setBindGroup(2, bindGroup181, new Uint32Array(1523), 142, 0);
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle35, renderBundle35]);
+} catch {}
+document.body.prepend(canvas6);
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 400});
+let sampler194 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 86.37,
+  lodMaxClamp: 95.08,
+});
+try {
+computePassEncoder128.setBindGroup(1, bindGroup110, new Uint32Array(3369), 1_973, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup176, new Uint32Array(2441), 685, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle23]);
+} catch {}
+try {
+renderPassEncoder29.drawIndexed(0, 9, 1, 48_466_179, 580_824_564);
+} catch {}
+try {
+renderPassEncoder29.drawIndexedIndirect(buffer71, 332);
+} catch {}
+try {
+renderPassEncoder29.drawIndirect(buffer35, 1_476);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 672, new Int16Array(10174), 2468, 604);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer188 = device0.createBuffer({
+  size: 8964,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture276 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture277 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler195 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.81,
+  lodMaxClamp: 65.23,
+});
+try {
+computePassEncoder122.setBindGroup(3, bindGroup80, new Uint32Array(1144), 21, 0);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(0, buffer87, 0, 4_112);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+await gc();
+let pipelineLayout32 = device0.createPipelineLayout({bindGroupLayouts: []});
+let querySet34 = device0.createQuerySet({label: '\u{1fed3}\u0488', type: 'occlusion', count: 1027});
+let sampler196 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge', maxAnisotropy: 1});
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup95);
+} catch {}
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+let bindGroup199 = device0.createBindGroup({
+  label: '\u55cf\u{1f908}\uca49',
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 61, resource: textureView220},
+    {binding: 47, resource: {buffer: buffer93, offset: 0, size: 152}},
+  ],
+});
+let computePassEncoder221 = commandEncoder69.beginComputePass({label: '\ubf81\u0380\u33e8\u0de0\uf338\u7c1c\u0220'});
+try {
+renderPassEncoder5.setViewport(2.0289786660182116, 31.81579797743095, 16.1433070272571, 0.05021187062350718, 0.5391775509591593, 0.5823487559636447);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(5, buffer188, 0, 80);
+} catch {}
+let sampler197 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.31,
+  lodMaxClamp: 79.78,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder221.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setViewport(23.954214771537867, 10.684379943177582, 1.2803932785958234, 0.3844290927335515, 0.8562419869116815, 0.9549194758258431);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(6, buffer30, 0);
+} catch {}
+let textureView299 = texture256.createView({dimension: '2d'});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup38, new Uint32Array(1552), 122, 0);
+} catch {}
+try {
+renderPassEncoder76.setScissorRect(0, 1, 0, 1);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer129, 'uint32', 368, 152);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer77, 0, 86);
+} catch {}
+let promise48 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas0);
+let bindGroup200 = device0.createBindGroup({
+  label: '\u{1fad7}\u0208\uaf6e\u004e\u{1fbd7}\u981e',
+  layout: bindGroupLayout23,
+  entries: [{binding: 129, resource: textureView204}],
+});
+let texture278 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder205.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle28, renderBundle4, renderBundle24, renderBundle0, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer38, 'uint32', 504, 464);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(0, buffer77, 144, 230);
+} catch {}
+try {
+buffer69.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise48;
+} catch {}
+let buffer189 = device0.createBuffer({
+  size: 13930,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup178);
+} catch {}
+try {
+computePassEncoder149.setBindGroup(2, bindGroup183, new Uint32Array(4758), 867, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer89, 'uint32', 648, 81);
+} catch {}
+let texture279 = device0.createTexture({
+  size: [10, 5, 79],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture280 = gpuCanvasContext1.getCurrentTexture();
+let textureView300 = texture218.createView({});
+let sampler198 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.56,
+  lodMaxClamp: 86.08,
+});
+try {
+computePassEncoder157.setBindGroup(3, bindGroup170, new Uint32Array(1051), 248, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle10, renderBundle16, renderBundle28, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer85, 3_300);
+} catch {}
+let imageData30 = new ImageData(24, 20);
+try {
+globalThis.someLabel = bindGroup77.label;
+} catch {}
+let textureView301 = texture267.createView({});
+try {
+computePassEncoder212.setBindGroup(0, bindGroup156);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup136, new Uint32Array(1991), 314, 0);
+} catch {}
+let arrayBuffer21 = buffer48.getMappedRange(3248, 64);
+try {
+device0.queue.writeTexture({
+  texture: texture267,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(21_902).fill(142), /* required buffer size: 21_902 */
+{offset: 302, bytesPerRow: 45, rowsPerImage: 8}, {width: 0, height: 1, depthOrArrayLayers: 61});
+} catch {}
+let buffer190 = device0.createBuffer({
+  label: '\u0f07\u9384\u036e\u9c62\u02f7\u0ec6\ued50',
+  size: 3113,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView302 = texture245.createView({label: '\ufe57\ued94\u0041', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 4});
+let sampler199 = device0.createSampler({
+  label: '\u5a1c\u78bf\uafff\u9a44\u2884\u18ad\u1a9a\uff15\u06f3',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 92.96,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder84.setBindGroup(1, bindGroup180, new Uint32Array(1476), 170, 0);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -719.3, g: -194.4, b: 430.9, a: -410.4, });
+} catch {}
+let bindGroup201 = device0.createBindGroup({
+  label: '\u2ffe\u3e88\u83cd\ua672\u0b76\ue699\u0457\uafa0\u0d6d',
+  layout: bindGroupLayout26,
+  entries: [{binding: 808, resource: textureView55}, {binding: 603, resource: textureView197}],
+});
+let texture281 = device0.createTexture({
+  label: '\uefda\u548a',
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture282 = device0.createTexture({
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup96);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer173, 'uint32', 6_636, 340);
+} catch {}
+let sampler200 = device0.createSampler({
+  label: '\ufab7\u0e30\u00f7\u3145\u{1f69b}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 79.66,
+  lodMaxClamp: 90.30,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup101);
+} catch {}
+document.body.append(img2);
+video5.width = 75;
+let shaderModule21 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+struct T1 {
+  @align(2) @size(8) f0: array<u32>,
+}
+
+struct T0 {
+  @align(2) @size(80) f0: array<array<atomic<u32>, 1>>,
+}
+
+fn fn1() -> array<array<array<array<vec2u, 1>, 1>, 1>, 11> {
+  var out: array<array<array<array<vec2u, 1>, 1>, 1>, 11>;
+  out[10][arrayLength(&(*&buffer191))][u32(unconst_u32(41))][u32(unconst_u32(48))] = vec2u(unpack4xI8(bitcast<u32>(tanh(vec2h(unconst_f16(16419.6), unconst_f16(12727.1))))).ag);
+  var vf420 = fn0(FragmentOutput15(u32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12]), vec4i(i32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12])), vec2u(u32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12]))), S3(vec3u(bitcast<u32>(round(f32(unconst_f32(0.07251)))))));
+  let ptr110: ptr<private, array<array<i32, 1>, 1>> = &vp25[2][u32(unconst_u32(49))];
+  let ptr111: ptr<private, array<i32, 1>> = &vp25[2][0][0];
+  fn0(FragmentOutput15(bitcast<u32>(vp25[2][0][u32(unconst_u32(165))][0]), vec4i(vp25[2][0][u32(unconst_u32(165))][0]), vec2u(u32(vp25[2][0][u32(unconst_u32(165))][0]))), S3(vec3u(u32(buffer191[arrayLength(&buffer191)][2][0][0][12]))));
+  var vf421 = fn0(FragmentOutput15(pack4x8snorm(tanh(vec4f(unconst_f32(0.1169), unconst_f32(0.01720), unconst_f32(0.2952), unconst_f32(0.01688)))), bitcast<vec4i>(tanh(vec4f(unconst_f32(0.1169), unconst_f32(0.01720), unconst_f32(0.2952), unconst_f32(0.01688)))), vec2u(tanh(vec4f(unconst_f32(0.1169), unconst_f32(0.01720), unconst_f32(0.2952), unconst_f32(0.01688))).rg)), S3(vec3u(bitcast<u32>(vp25[2][0][0][0]))));
+  vf421[u32(unconst_u32(110))][u32(unconst_u32(558))][u32(unconst_u32(199))][u32(unconst_u32(287))] = bool(buffer191[arrayLength(&buffer191) - 1][2][0][0][12]);
+  var vf422 = fn0(FragmentOutput15(u32(vf420[26][0][0][0]), vec4i(i32(vf420[26][0][0][0])), vec2u(u32(vf420[26][0][0][0]))), S3(vec3u(bitcast<u32>(vp25[2][0][0][0]))));
+  return out;
+}
+
+@group(0) @binding(65) var tex26: texture_depth_multisampled_2d;
+
+fn fn0(a0: FragmentOutput15, a1: S3) -> array<array<array<array<bool, 1>, 1>, 1>, 27> {
+  var out: array<array<array<array<bool, 1>, 1>, 1>, 27>;
+  var vf417: vec4i = a0.f1;
+  let ptr109: ptr<private, array<array<array<i32, 1>, 1>, 1>> = &vp25[2];
+  out[bitcast<u32>(a0.f1.w)][u32((*ptr109)[0][0][0])][bitcast<u32>((*ptr109)[0][0][0])][bitcast<u32>((*ptr109)[0][0][0])] = bool((*ptr109)[0][0][0]);
+  var vf418: u32 = a1.f0[u32(unconst_u32(597))];
+  vf418 &= a0.f2[0];
+  vf418 ^= u32((*ptr109)[0][u32(vp25[2][u32(unconst_u32(82))][0][0])][0]);
+  vp25[pack4xI8(a0.f1)][u32(unconst_u32(44))][u32(unconst_u32(96))][0] |= vp25[2][0][0][0];
+  var vf419: vec3u = a1.f0;
+  vp25[2][u32(unconst_u32(65))][0][u32(unconst_u32(561))] = bitcast<i32>(a0.f2[u32(unconst_u32(331))]);
+  return out;
+}
+
+fn fn2() -> vec2<bool> {
+  var out: vec2<bool>;
+  var vf423: f16 = inverseSqrt(f16(unconst_f16(2352.4)));
+  let ptr112: ptr<private, array<array<array<i32, 1>, 1>, 1>> = &vp25[2];
+  let ptr113: ptr<private, array<array<array<i32, 1>, 1>, 1>> = &(*ptr112);
+  let vf424: vec4h = fma(vec4h(unconst_f16(2429.6), unconst_f16(5859.7), unconst_f16(2524.3), unconst_f16(2405.6)), vec4h(f16(vp25[2][0][0][0])), vec4h(exp2(f16(unconst_f16(644.3)))));
+  let ptr114: ptr<private, array<i32, 1>> = &(*ptr112)[0][0];
+  vf423 = f16(pack4xI8(vec4i(vp25[2][0][0][u32(unconst_u32(62))])));
+  vp25[u32(unconst_u32(54))][u32(unconst_u32(289))][0][u32(unconst_u32(190))] ^= (*ptr112)[0][0][0];
+  vf423 *= f16((*ptr113)[0][0][u32(vp25[2][0][0][u32(unconst_u32(130))])]);
+  let ptr115: ptr<private, array<array<i32, 1>, 1>> = &(*ptr112)[0];
+  let ptr116: ptr<private, i32> = &(*ptr115)[0][0];
+  var vf425: f16 = exp2(f16((*ptr112)[0][0][0]));
+  vf423 = vec3h(log2(vec3f(unconst_f32(0.3816), unconst_f32(0.00455), unconst_f32(0.05660))))[2];
+  vf425 -= f16((*ptr113)[0][0][0]);
+  let vf426: vec4h = fma(vec4h(unconst_f16(5967.1), unconst_f16(14453.9), unconst_f16(2572.8), unconst_f16(1276.3)), vec4h(f16(vp25[2][0][u32(unconst_u32(309))][0])), vec4h(unconst_f16(1760.5), unconst_f16(5645.2), unconst_f16(-8010.3), unconst_f16(4992.7)));
+  vp25[u32(unconst_u32(73))][u32(unconst_u32(224))][bitcast<u32>(textureLoad(tex26, vec2i(unconst_i32(18), unconst_i32(381)), (*ptr112)[0][0][0]))][u32(vp25[2][0][0][u32(unconst_u32(335))])] = (*ptr112)[0][0][0];
+  vf423 -= f16(cosh(length(f32(unconst_f32(0.2549)))));
+  return out;
+}
+
+struct S3 {
+  @builtin(workgroup_id) @size(16) f0: vec3u,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput15 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) @interpolate(flat, center) f1: vec4i,
+  @location(0) f2: vec2u,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(68) var<storage, read> buffer191: array<array<array<array<array<f16, 13>, 1>, 1>, 3>>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp25: array<array<array<array<i32, 1>, 1>, 1>, 3> = array<array<array<array<i32, 1>, 1>, 1>, 3>(array(array(array<i32, 1>(i32()))), array(array(array<i32, 1>())), array<array<array<i32, 1>, 1>, 1>(array(array<i32, 1>(i32()))));
+
+@group(0) @binding(120) var tex27: texture_2d<f32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@fragment
+fn fragment16() -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  out = FragmentOutput15(pack2x16unorm(vec2f(unconst_f32(0.1285), unconst_f32(0.1734))), unpack4xI8(pack2x16unorm(vec2f(unconst_f32(0.1285), unconst_f32(0.1734)))), vec2u(pack2x16unorm(vec2f(unconst_f32(0.1285), unconst_f32(0.1734)))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute18(@builtin(local_invocation_id) a0: vec3u, a1: S3) {
+  fn0(FragmentOutput15(u32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12]), vec4i(i32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12])), vec2u(u32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12]))), S3(vec3u(u32(buffer191[arrayLength(&buffer191)][2][0][0][12]))));
+  let ptr117: ptr<storage, f16, read> = &buffer191[arrayLength(&buffer191)][2][0][0][12];
+  fn1();
+  vp25[2][u32(unconst_u32(86))][a0[u32(unconst_u32(119))]][u32(unconst_u32(20))] = vec3i(a1.f0).b;
+  vp25[u32(unconst_u32(65))][u32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12])][u32(unconst_u32(59))][u32(unconst_u32(134))] &= vec3i(faceForward(vec3h(unconst_f16(6620.9), unconst_f16(5958.8), unconst_f16(3142.4)), vec3h(unconst_f16(17982.5), unconst_f16(13692.9), unconst_f16(14158.3)), refract(vec2h(unconst_f16(9317.7), unconst_f16(11003.2)), vec2h(unconst_f16(4301.4), unconst_f16(8192.8)), f16(vp25[2][0][0][0])).xxx)).x;
+  vp25[u32(unpack2x16float(bitcast<u32>(asin(f32(unconst_f32(-0.3747))))).y)][u32(unconst_u32(274))][u32(unconst_u32(116))][pack2x16float(vec2f(f32(buffer191[i32(unconst_i32(203))][2][0][0][12])))] += i32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12]);
+  fn0(FragmentOutput15(u32((*ptr117)), vec4i(i32((*ptr117))), vec2u(u32((*ptr117)))), S3(vec3u(u32(buffer191[arrayLength(&buffer191)][2][0][0][12]))));
+  fn0(FragmentOutput15(bitcast<u32>(vp25[2][0][0][0]), vec4i(vp25[2][0][0][0]), vec2u(u32(vp25[2][0][0][0]))), S3(vec3u(u32(buffer191[arrayLength(&buffer191)][2][0][0][12]))));
+  fn1();
+  vp25[2][u32(unconst_u32(282))][u32(unconst_u32(100))][u32((*&buffer191)[arrayLength(&(*&buffer191))][2][0][0][12])] *= i32(buffer191[arrayLength(&buffer191)][2][0][0][bitcast<u32>(vp25[2][0][0][0])]);
+  vp25[u32(unconst_u32(39))][u32(unconst_u32(372))][u32(unconst_u32(54))][vec3u(faceForward(vec3h(unconst_f16(8935.4), unconst_f16(64.09), unconst_f16(23599.1)), vec3h(unconst_f16(24014.4), unconst_f16(-17030.6), unconst_f16(-11423.0)), vec3h(f16(vp25[2][0][0][0]))))[0]] |= i32(buffer191[arrayLength(&buffer191)][2][0][0][12]);
+}`,
+  sourceMap: {},
+});
+let bindGroup202 = device0.createBindGroup({
+  label: '\ubbd1\u{1f993}\u0373\udb45\u062c\u0965',
+  layout: bindGroupLayout24,
+  entries: [{binding: 36, resource: externalTexture26}, {binding: 0, resource: textureView104}],
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle1, renderBundle34]);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline2);
+} catch {}
+let texture283 = device0.createTexture({
+  label: '\u0e0b\u02e7\u765d\ub598\ud170\u{1f830}\ua3cd\u630d\uaa1d\u34df\u0ecc',
+  size: [64],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler201 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 51.55,
+  lodMaxClamp: 55.95,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup100, new Uint32Array(246), 9, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup94, new Uint32Array(37), 7, 0);
+} catch {}
+try {
+renderPassEncoder42.setBlendConstant({ r: -558.5, g: 225.1, b: 231.1, a: 845.2, });
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer149, 'uint16', 2_546, 2_719);
+} catch {}
+let arrayBuffer22 = buffer62.getMappedRange(80, 0);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let videoFrame47 = new VideoFrame(canvas0, {timestamp: 0});
+let textureView303 = texture276.createView({dimension: '2d-array', format: 'rgba32float', baseArrayLayer: 6, arrayLayerCount: 1});
+let sampler202 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.12,
+  lodMaxClamp: 76.73,
+});
+let externalTexture41 = device0.importExternalTexture({label: '\u8ac0\uaa7a\u4156\ua04e\u{1f639}\ub1f8', source: videoFrame18});
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup21, new Uint32Array(1842), 417, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 168, new Float32Array(15951), 3831, 40);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame48 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let sampler203 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 10,
+});
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+let textureView304 = texture90.createView({});
+try {
+computePassEncoder155.setBindGroup(2, bindGroup119);
+} catch {}
+try {
+computePassEncoder138.setBindGroup(1, bindGroup123, new Uint32Array(26), 4, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline4);
+} catch {}
+let buffer192 = device0.createBuffer({
+  label: '\u82f4\u97d1',
+  size: 8706,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView305 = texture185.createView({
+  label: '\u4d1a\u3de0\u6f63\u{1ff39}\u0bcd\u0d11\uf62c\u{1fbea}\u0958',
+  dimension: 'cube-array',
+  aspect: 'all',
+  arrayLayerCount: 6,
+});
+let sampler204 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 94.96,
+});
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer136);
+} catch {}
+let texture284 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler205 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.43,
+  lodMaxClamp: 96.64,
+  maxAnisotropy: 5,
+});
+let externalTexture42 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder208.setBindGroup(0, bindGroup159, []);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer168, 'uint32', 3_044, 706);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(435).fill(223), /* required buffer size: 435 */
+{offset: 435}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas8.height = 127;
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 179});
+let textureView306 = texture185.createView({label: '\ud61c\u4ee6', dimension: 'cube-array', arrayLayerCount: 6});
+let externalTexture43 = device0.importExternalTexture({
+  label: '\u65bd\u{1f80f}\u7a28\u07e2\u0bf3\u402e\u1414\u087f\u{1fb50}\u{1fc57}',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder130.setBindGroup(0, bindGroup108, [0]);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle32, renderBundle0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(6_580).fill(104), /* required buffer size: 6_580 */
+{offset: 12, bytesPerRow: 104, rowsPerImage: 7}, {width: 2, height: 1, depthOrArrayLayers: 10});
+} catch {}
+let texture285 = device0.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let sampler206 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.897,
+  lodMaxClamp: 36.11,
+});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup139);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle7, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(12.313637255892608, 31.574514483877884, 47.94351071820423, 21.14700138125078, 0.11888404069318048, 0.39287054975089936);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup194);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup199, new Uint32Array(224), 6, 0);
+} catch {}
+try {
+buffer187.unmap();
+} catch {}
+let bindGroup203 = device0.createBindGroup({layout: bindGroupLayout37, entries: [{binding: 397, resource: textureView284}]});
+let texture286 = device0.createTexture({
+  size: [10],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder191.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder149.setBindGroup(2, bindGroup26, new Uint32Array(196), 9, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle23, renderBundle24]);
+} catch {}
+await gc();
+let texture287 = device0.createTexture({
+  size: [10, 5, 79],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView307 = texture97.createView({dimension: 'cube', baseArrayLayer: 1});
+try {
+computePassEncoder175.setBindGroup(0, bindGroup97);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer76);
+} catch {}
+let imageData31 = new ImageData(20, 40);
+let buffer193 = device0.createBuffer({
+  label: '\u02ff\u3bf2\u58df\u{1f7d0}\u0422\u6116\u9157\u78fe',
+  size: 14904,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView308 = texture115.createView({dimension: 'cube', mipLevelCount: 1});
+try {
+renderPassEncoder45.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(2, buffer85, 0, 9_025);
+} catch {}
+document.body.prepend(video2);
+let bindGroup204 = device0.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 129, resource: textureView204}]});
+try {
+computePassEncoder177.setBindGroup(0, bindGroup203, new Uint32Array(1483), 167, 0);
+} catch {}
+try {
+renderPassEncoder50.beginOcclusionQuery(1942);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer144, 'uint16', 204, 121);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 276, new BigUint64Array(11294), 927, 136);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(186).fill(188), /* required buffer size: 186 */
+{offset: 186, bytesPerRow: 62}, {width: 12, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let img4 = await imageWithData(26, 4, '#10101010', '#20202020');
+try {
+renderBundleEncoder37.setIndexBuffer(buffer40, 'uint16', 296, 310);
+} catch {}
+let texture288 = device0.createTexture({
+  size: [20, 11, 159],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView309 = texture278.createView({dimension: 'cube', baseMipLevel: 0, baseArrayLayer: 3});
+let sampler207 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 42.06,
+  compare: 'greater',
+});
+try {
+computePassEncoder123.setBindGroup(2, bindGroup139, new Uint32Array(2374), 381, 0);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup149);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup65, new Uint32Array(4514), 180, 0);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer85, 'uint32', 48_068, 0);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline2);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+computePassEncoder109.setBindGroup(2, bindGroup140);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup185, new Uint32Array(251), 6, 0);
+} catch {}
+try {
+renderPassEncoder50.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder80.setScissorRect(2, 1, 10, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer83, 2_380, 18_384);
+} catch {}
+try {
+buffer178.unmap();
+} catch {}
+let sampler208 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 53.27,
+  lodMaxClamp: 89.75,
+  compare: 'equal',
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup106, new Uint32Array(444), 19, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle2, renderBundle1, renderBundle9, renderBundle9, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer8, 'uint16', 62, 974);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(0, buffer60);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer32, 'uint32', 648, 3_292);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(6, buffer20, 332);
+} catch {}
+let imageData32 = new ImageData(24, 40);
+try {
+computePassEncoder152.setBindGroup(2, bindGroup142);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer162, 'uint16', 5_700, 41);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(2, buffer173, 76);
+} catch {}
+let bindGroup205 = device0.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 129, resource: textureView204}]});
+let textureView310 = texture88.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup60);
+} catch {}
+let texture289 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView311 = texture71.createView({});
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let img5 = await imageWithData(51, 21, '#10101010', '#20202020');
+let buffer194 = device0.createBuffer({
+  size: 6094,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let texture290 = device0.createTexture({
+  label: '\ucfff\u2ffd\u{1fa40}\u{1fbd7}\u7fe4',
+  size: [40, 23, 5],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle37 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup182, []);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(171);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer30, 'uint32', 4_636, 534);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle0]);
+} catch {}
+let texture291 = device0.createTexture({
+  label: '\u9b90\u50c3',
+  size: {width: 40, height: 23, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView312 = texture53.createView({label: '\u29ff\u4974\ued6c\u0477\u0844', format: 'rgba16uint', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder180.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let canvas11 = document.createElement('canvas');
+let buffer195 = device0.createBuffer({size: 13895, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 465});
+let texture292 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView313 = texture47.createView({dimension: '2d-array'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup13, new Uint32Array(1089), 427, 0);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext16 = canvas11.getContext('webgpu');
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup206 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [
+    {binding: 164, resource: {buffer: buffer23, offset: 0, size: 8}},
+    {binding: 360, resource: sampler121},
+    {binding: 59, resource: {buffer: buffer180, offset: 2560, size: 14497}},
+    {binding: 503, resource: textureView96},
+  ],
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(6, buffer170);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 2, y: 17, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas12 = document.createElement('canvas');
+let bindGroup207 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 475, resource: {buffer: buffer23, offset: 0, size: 28}}],
+});
+let texture293 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 4},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder56.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(1, buffer118);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 296,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 240,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture294 = device0.createTexture({size: [10], mipLevelCount: 1, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView314 = texture6.createView({mipLevelCount: 1});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup131);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup159);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(6, buffer156, 0);
+} catch {}
+canvas9.width = 27;
+let videoFrame49 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'smpte240m'} });
+try {
+adapter1.label = '\u282c\u04b8\u7d57\u59fc';
+} catch {}
+let texture295 = device0.createTexture({
+  label: '\ud801\u{1fe27}\u85e6\ua564\u0c22\u9762\ucf83',
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer28, 0);
+} catch {}
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 137,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup208 = device0.createBindGroup({
+  layout: bindGroupLayout40,
+  entries: [
+    {binding: 240, resource: {buffer: buffer91, offset: 1024, size: 196}},
+    {binding: 296, resource: sampler204},
+  ],
+});
+try {
+computePassEncoder113.setBindGroup(0, bindGroup201);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup208);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle8, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(6, buffer184, 5_220, 8_958);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+externalTexture11.label = '\uc61a\udde0\ubb30\u{1f8b5}\u0734\u0655\u3144\u0818';
+} catch {}
+let buffer196 = device0.createBuffer({size: 6591, usage: GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder80.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer173, 'uint16', 3_302, 1_128);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, buffer69);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let buffer197 = device0.createBuffer({
+  size: 11731,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder44.setVertexBuffer(1, buffer23);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder212.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+computePassEncoder141.setBindGroup(2, bindGroup199, new Uint32Array(778), 89, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer86, 'uint16', 28, 1_852);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let bindGroup209 = device0.createBindGroup({layout: bindGroupLayout39, entries: [{binding: 160, resource: sampler92}]});
+let buffer198 = device0.createBuffer({
+  size: 1148,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture296 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView315 = texture55.createView({mipLevelCount: 1});
+let sampler209 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.93,
+  lodMaxClamp: 99.08,
+  maxAnisotropy: 5,
+});
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 277});
+let externalTexture44 = device0.importExternalTexture({
+  label: '\u{1faa7}\u17ed\u2997\ub5c0\ua0e2\u8903\ub43f',
+  source: videoFrame31,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder65.setIndexBuffer(buffer93, 'uint32', 28, 2);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(7, buffer100);
+} catch {}
+let externalTexture45 = device0.importExternalTexture({source: videoFrame41, colorSpace: 'srgb'});
+try {
+computePassEncoder176.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup131, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(38).fill(23), /* required buffer size: 38 */
+{offset: 38, rowsPerImage: 73}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup210 = device0.createBindGroup({layout: bindGroupLayout35, entries: [{binding: 522, resource: textureView280}]});
+try {
+renderPassEncoder40.setIndexBuffer(buffer159, 'uint32', 2_076, 1_128);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(3, buffer30, 1_692);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 504, new Int16Array(28688), 449, 160);
+} catch {}
+try {
+computePassEncoder96.setBindGroup(2, bindGroup106, new Uint32Array(5370), 1_485, 0);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture170,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(660).fill(148), /* required buffer size: 660 */
+{offset: 660}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler210 = device0.createSampler({
+  label: '\ufd53\uea7c\u4f89\u{1fe23}\u{1fb19}\ubb68\u{1fc82}\u0334\u0bb2\u{1f705}\u606f',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 49.17,
+  lodMaxClamp: 59.18,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup163);
+} catch {}
+try {
+computePassEncoder115.setBindGroup(0, bindGroup59, new Uint32Array(2267), 843, 0);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup200, new Uint32Array(660), 17, 0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer120, 180, 350);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture277,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(115).fill(169), /* required buffer size: 115 */
+{offset: 115, rowsPerImage: 9}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+document.body.append(img5);
+let videoFrame50 = new VideoFrame(canvas10, {timestamp: 0});
+let buffer199 = device0.createBuffer({
+  size: 15348,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup58, new Uint32Array(239), 55, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle2, renderBundle34]);
+} catch {}
+try {
+renderPassEncoder66.pushDebugGroup('\u{1fecd}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView316 = texture130.createView({dimension: 'cube-array', aspect: 'all', baseMipLevel: 0, arrayLayerCount: 6});
+try {
+computePassEncoder132.setBindGroup(2, bindGroup205);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer50, 'uint32', 10_340, 279);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(3, buffer35);
+} catch {}
+try {
+canvas12.getContext('webgpu');
+} catch {}
+let buffer200 = device0.createBuffer({size: 8522, usage: GPUBufferUsage.MAP_READ});
+let sampler211 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 46.26,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+document.body.append(img0);
+let videoFrame51 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'film', transfer: 'smpteSt4281'} });
+try {
+computePassEncoder196.setBindGroup(2, bindGroup64, new Uint32Array(403), 44, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer163, 4396, new DataView(new ArrayBuffer(14904)), 957, 1320);
+} catch {}
+let imageData33 = new ImageData(20, 4);
+try {
+computePassEncoder114.setBindGroup(0, bindGroup95, []);
+} catch {}
+try {
+computePassEncoder216.setBindGroup(0, bindGroup2, new Uint32Array(365), 2, 0);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(6, buffer98, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture249,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(202).fill(171), /* required buffer size: 202 */
+{offset: 202, rowsPerImage: 169}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup211 = device0.createBindGroup({
+  label: '\ud269\ua4c2\u4177\u3899\u0730\u0a7d\u0588\u9a27\u49e7',
+  layout: bindGroupLayout24,
+  entries: [{binding: 36, resource: externalTexture30}, {binding: 0, resource: textureView138}],
+});
+let buffer201 = device0.createBuffer({size: 20940, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let textureView317 = texture39.createView({dimension: '2d', baseArrayLayer: 9});
+try {
+computePassEncoder157.setBindGroup(0, bindGroup78, new Uint32Array(473), 87, 0);
+} catch {}
+try {
+computePassEncoder220.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup167, new Uint32Array(274), 19, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(2, bindGroup88, new Uint32Array(7435), 496, 0);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(5, undefined);
+} catch {}
+let promise49 = shaderModule1.getCompilationInfo();
+try {
+computePassEncoder199.insertDebugMarker('\u{1fb27}');
+} catch {}
+let bindGroup212 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 475, resource: {buffer: buffer184, offset: 1792}}]});
+let buffer202 = device0.createBuffer({size: 17299, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let textureView318 = texture254.createView({dimension: '1d', baseMipLevel: 0, arrayLayerCount: 1});
+let sampler212 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 13.41,
+  lodMaxClamp: 30.88,
+});
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup73);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer45, 'uint16', 488, 265);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup52, new Uint32Array(2756), 916, 0);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer168, 'uint32', 1_848, 97);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture232,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(83).fill(220), /* required buffer size: 83 */
+{offset: 83, bytesPerRow: 86}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder110.setBindGroup(0, bindGroup195);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer182, 'uint16', 736, 34);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4_294_967_295, undefined, 2_051_283_621, 242_054_034);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+  await promise49;
+} catch {}
+await gc();
+let img6 = await imageWithData(3, 188, '#10101010', '#20202020');
+try {
+computePassEncoder44.setBindGroup(0, bindGroup136, new Uint32Array(1539), 46, 0);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder66.popDebugGroup();
+} catch {}
+let querySet38 = device0.createQuerySet({type: 'occlusion', count: 2133});
+let sampler213 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMinClamp: 73.18, lodMaxClamp: 84.11});
+try {
+computePassEncoder108.setBindGroup(2, bindGroup86, new Uint32Array(783), 64, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer7, 2_984); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer40, 360, new Float32Array(9816), 72, 40);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer83, 'uint32', 1_228, 5_154);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer93, 0, 28);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3530 */
+  offset: 3530,
+  bytesPerRow: 256,
+  buffer: buffer197,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+textureView58.label = '\u53b3\u04fb\u{1f62f}\u0631\u8049\u4435\uf78d\u027d\ue958\u065a\u68e3';
+} catch {}
+let computePassEncoder222 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder222.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(3, bindGroup131, new Uint32Array(84), 17, 0);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle28, renderBundle16, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer113);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(7_479).fill(201), /* required buffer size: 7_479 */
+{offset: 751, bytesPerRow: 29, rowsPerImage: 29}, {width: 0, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let textureView319 = texture63.createView({mipLevelCount: 1});
+let sampler214 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.96,
+  lodMaxClamp: 68.15,
+  compare: 'equal',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup107);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup117, new Uint32Array(1318), 178, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(128, 26, 365_135_212, 460_122_036);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(21, 98, 26, 1_479_790_233, 53_356_649);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer162, 452);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer201, 'uint16', 4_146, 1_183);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(1, buffer130, 0, 1_951);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame37,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule0}});
+let textureView320 = texture254.createView({label: '\u{1fa0d}\u{1fe5e}\u{1ff71}\u409e\ue404\u019e\u0e83\uf683\u144e', mipLevelCount: 1});
+let computePassEncoder223 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder190.setBindGroup(0, bindGroup35, new Uint32Array(248), 248, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(84, 408, 168_071_033, 70_574_560);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer149, 1_324);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer60, 'uint32', 300, 803);
+} catch {}
+try {
+globalThis.someLabel = externalTexture14.label;
+} catch {}
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 483,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let textureView321 = texture102.createView({label: '\u36e9\u{1fd2a}\u8ffd\u0f7d\uff17'});
+let externalTexture46 = device0.importExternalTexture({label: '\u2d34\u8321', source: video2});
+try {
+computePassEncoder223.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer199, 164);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(6, buffer170, 0, 4_922);
+} catch {}
+let arrayBuffer23 = buffer62.getMappedRange(88, 12);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: canvas8,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let imageData34 = new ImageData(36, 36);
+let bindGroupLayout43 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 52, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 589, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let texture297 = device0.createTexture({
+  size: {width: 10, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView322 = texture33.createView({dimension: '2d-array', baseMipLevel: 0});
+let sampler215 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.73,
+  lodMaxClamp: 96.35,
+});
+try {
+computePassEncoder200.setBindGroup(0, bindGroup118, new Uint32Array(412), 22, 0);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup129);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer182, 304);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(4, buffer20);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 11, depthOrArrayLayers: 159}
+*/
+{
+  source: imageData12,
+  origin: { x: 1, y: 10 },
+  flipY: true,
+}, {
+  texture: texture288,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout12,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule9,
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule18,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 168,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 16, shaderLocation: 0}, {format: 'sint32x3', offset: 4, shaderLocation: 3}],
+      },
+      {arrayStride: 44, attributes: [{format: 'snorm16x2', offset: 12, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = externalTexture28.label;
+} catch {}
+let bindGroup213 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer89, offset: 2304, size: 608}}],
+});
+let textureView323 = texture113.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup23, new Uint32Array(780), 86, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(164, 0, 104, 78_191_689, 1_950_387_572);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer19, 1_208);
+} catch {}
+let bindGroup214 = device0.createBindGroup({
+  label: '\u932e\u{1f77a}\uc6b2\u0860\u18bd',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 134, resource: textureView55},
+    {binding: 14, resource: externalTexture0},
+    {binding: 56, resource: {buffer: buffer126, offset: 0, size: 4}},
+  ],
+});
+let texture298 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler216 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 72.71,
+  lodMaxClamp: 87.69,
+  compare: 'equal',
+});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup197);
+} catch {}
+try {
+renderPassEncoder51.setBlendConstant({ r: 359.5, g: 935.0, b: -553.8, a: -824.1, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer114, 1_272);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer114, 2_564);
+} catch {}
+let arrayBuffer24 = buffer61.getMappedRange(568, 40);
+try {
+gpuCanvasContext14.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture182,
+  mipLevel: 0,
+  origin: {x: 15, y: 26, z: 1},
+  aspect: 'all',
+}, new Uint8Array(3_208).fill(68), /* required buffer size: 3_208 */
+{offset: 167, bytesPerRow: 127}, {width: 15, height: 24, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter1.label = '\u317c\u0ebf\u0dc0\u262e\u{1f78c}\u038f\u992f\u{1f882}\u0558';
+} catch {}
+let texture299 = device0.createTexture({
+  size: {width: 20, height: 11, depthOrArrayLayers: 159},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroupsIndirect(buffer35, 3_456); };
+} catch {}
+try {
+renderPassEncoder35.setViewport(0.6341552773642406, 0.20587156393235717, 4.138169859132198, 1.1433071018884382, 0.06990357192339258, 0.08256149797630491);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(18, 141, 17, 541_047_113, 1_141_165_355);
+} catch {}
+let arrayBuffer25 = buffer66.getMappedRange(1048, 8);
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(255).fill(44), /* required buffer size: 255 */
+{offset: 255, bytesPerRow: 140}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+renderPassEncoder7.draw(191, 574, 323_992_725, 212_287_141);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer65, 156);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup183);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer50, 'uint16', 80, 1_754);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(5, buffer197, 7_624, 1_012);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer158, 380, new BigUint64Array(7754), 815, 28);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle22, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder7.draw(262, 80, 376_225_418, 876_996_333);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer179, 'uint32', 1_644, 4_155);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder172.setBindGroup(0, bindGroup185, new Uint32Array(132), 10, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup28, new Uint32Array(1506), 464, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(71, 104, 14, 677_957_567, 313_485_656);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer119, 4);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(3, buffer138, 0, 874);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer135, 3568, new Int16Array(2612), 135, 624);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let bindGroup215 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 68, resource: {buffer: buffer136, offset: 256, size: 936}},
+    {binding: 120, resource: textureView141},
+    {binding: 65, resource: textureView158},
+  ],
+});
+let textureView324 = texture113.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup130, new Uint32Array(766), 99, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder7.draw(24, 520, 1_826_023_272, 149_488_886);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer93, 'uint16', 0, 10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 196, new BigUint64Array(12868), 10585, 96);
+} catch {}
+let videoFrame52 = videoFrame13.clone();
+let sampler217 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 53.10,
+});
+try {
+renderPassEncoder76.setBindGroup(1, bindGroup42, new Uint32Array(3708), 591, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(84, 532, 218_070_197, 395_761_302);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(8, 104, 84, 239_006_053, 889_689_772);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer161, 3_692);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer152, 0);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup36, new Uint32Array(11), 0, 0);
+} catch {}
+let imageData35 = new ImageData(20, 64);
+let textureView325 = texture154.createView({dimension: '2d', baseArrayLayer: 2});
+try {
+computePassEncoder138.setBindGroup(2, bindGroup68);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup148, new Uint32Array(1337), 43, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(89, 105, 1_370_467_528, 286_794_453);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer140, 3_132, 11_937);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture282,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 2},
+  aspect: 'all',
+}, new Uint8Array(5_280).fill(104), /* required buffer size: 5_280 */
+{offset: 76, bytesPerRow: 249, rowsPerImage: 4}, {width: 14, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55); };
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let buffer203 = device0.createBuffer({
+  size: 575,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView326 = texture242.createView({label: '\u{1f8c7}\ub92b\ue3d0'});
+let sampler218 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 47.27,
+  lodMaxClamp: 90.21,
+});
+try {
+computePassEncoder127.setBindGroup(1, bindGroup85, new Uint32Array(1042), 120, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(59, 183, 50, 562_679_766, 1_997_418_529);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer162, 'uint32', 3_120, 5_330);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer142, 0);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup114, new Uint32Array(23), 0, 0);
+} catch {}
+document.body.prepend(canvas7);
+let renderBundle38 = renderBundleEncoder38.finish({});
+try {
+computePassEncoder158.setBindGroup(3, bindGroup196);
+} catch {}
+try {
+computePassEncoder156.setBindGroup(2, bindGroup88, new Uint32Array(2799), 393, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(69, 45, 38, -1_880_607_094, 1_071_745_799);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer16, 2_072);
+} catch {}
+try {
+buffer197.unmap();
+} catch {}
+let promise50 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+renderPassEncoder73.setViewport(4.465555253859785, 0.3121185931301529, 0.28403332168031714, 0.9899147016966015, 0.3367085336061091, 0.38110872807690266);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(51, 114, 0, 29_954_480, 1_811_163_372);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer57, 'uint32', 1_616, 815);
+} catch {}
+try {
+  await shaderModule6.getCompilationInfo();
+} catch {}
+let texture300 = device0.createTexture({
+  size: {width: 2376, height: 78, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup110, new Uint32Array(352), 18, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup166, new Uint32Array(1193), 94, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(16, 42, 2, 115_983_924, 92_231_495);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer20, 252);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline4);
+} catch {}
+let videoFrame53 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'gamma22curve'} });
+let bindGroup216 = device0.createBindGroup({
+  layout: bindGroupLayout20,
+  entries: [{binding: 56, resource: {buffer: buffer70, offset: 0, size: 326}}],
+});
+try {
+computePassEncoder147.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup206, [1536]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(5, 1, 8, 3);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(50, 330, 2, 458_983_376, 906_617_333);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer20, 136);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer16, 1_800);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer149, 'uint16', 542, 911);
+} catch {}
+document.body.append(img5);
+let textureView327 = texture226.createView({});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 12}
+*/
+{
+  source: imageData21,
+  origin: { x: 2, y: 2 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 0,
+  origin: {x: 6, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let buffer204 = device0.createBuffer({size: 7520, usage: GPUBufferUsage.MAP_READ});
+let texture301 = device0.createTexture({
+  size: {width: 64},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder104.setBindGroup(1, bindGroup185);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup171);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle3, renderBundle34]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(79, 3, 32, -1_333_943_822, 1_192_653_190);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer145, 2_552);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline5);
+} catch {}
+document.body.append(img3);
+let pipelineLayout33 = device0.createPipelineLayout({label: '\u{1f866}\u21f6\u0d70\u35e4\u04b9\u9493\uc9c2', bindGroupLayouts: []});
+let texture302 = gpuCanvasContext7.getCurrentTexture();
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(51, 26, 137, 164_926_063, 919_672_362);
+} catch {}
+try {
+renderPassEncoder80.setIndexBuffer(buffer57, 'uint32', 1_932, 607);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline5);
+} catch {}
+let promise51 = shaderModule19.getCompilationInfo();
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 896 */
+  offset: 896,
+  bytesPerRow: 22784,
+  rowsPerImage: 56,
+  buffer: buffer60,
+}, {
+  texture: texture239,
+  mipLevel: 1,
+  origin: {x: 6, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let textureView328 = texture136.createView({dimension: '2d-array'});
+let computePassEncoder224 = commandEncoder108.beginComputePass();
+let sampler219 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.58,
+  lodMaxClamp: 77.77,
+  compare: 'always',
+});
+try {
+computePassEncoder224.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer82, 352);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData36 = new ImageData(84, 4);
+let textureView329 = texture11.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderPassEncoder7.draw(91, 350, 750_250_694, 919_170_654);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer123, 104);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer150, 228);
+} catch {}
+let arrayBuffer26 = buffer61.getMappedRange(608, 28);
+let offscreenCanvas8 = new OffscreenCanvas(181, 12);
+let pipelineLayout34 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout34, bindGroupLayout13]});
+let buffer205 = device0.createBuffer({
+  label: '\ua0be\ua624\u3c45\u{1f7af}\u1b45\u0d8f\u{1fd98}\u072e',
+  size: 13036,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler220 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 97.11,
+  lodMaxClamp: 99.66,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder104.setBindGroup(2, bindGroup54, []);
+} catch {}
+try {
+computePassEncoder169.setBindGroup(0, bindGroup75, new Uint32Array(1810), 574, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroupsIndirect(buffer1, 10_496); };
+} catch {}
+try {
+renderPassEncoder47.beginOcclusionQuery(371);
+} catch {}
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer12, 504);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(6, buffer54, 0, 445);
+} catch {}
+let texture303 = device0.createTexture({
+  label: '\u1b2d\u0f1c\u4488\udb95\u6248\u0024\u4171\u{1f614}',
+  size: {width: 20, height: 11, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView330 = texture18.createView({mipLevelCount: 1});
+let sampler221 = device0.createSampler({
+  label: '\u064a\u0534\u0765\u{1f9cc}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.61,
+  lodMaxClamp: 81.06,
+  compare: 'equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder32.setViewport(0.01570983456205155, 0.7584799731128906, 4.072138609462069, 0.8286256991280306, 0.5555175470286509, 0.7063530647453826);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer150, 556);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer65, 72);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer145, 'uint16', 250, 2_345);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer170, 0, 1_761);
+} catch {}
+let textureView331 = texture195.createView({baseArrayLayer: 6, arrayLayerCount: 1});
+let externalTexture47 = device0.importExternalTexture({source: videoFrame43});
+try {
+renderPassEncoder7.draw(15, 48, 337_550_488, 2_039_243_040);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer57, 1_840);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer158, 'uint32', 112, 1_260);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 196, new DataView(new ArrayBuffer(8157)), 1477, 352);
+} catch {}
+let imageData37 = new ImageData(28, 12);
+let videoFrame54 = videoFrame36.clone();
+try {
+adapter1.label = '\u0169\u09d7\u{1fd05}\uf51b\uf12f\u{1f8b4}\u{1fec4}\u{1ff32}\u0019\u56c6\u57c6';
+} catch {}
+let bindGroup217 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 56, resource: {buffer: buffer105, offset: 1536}}]});
+let texture304 = device0.createTexture({size: [10], dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler222 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 93.85,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder151.setBindGroup(2, bindGroup114, new Uint32Array(1981), 447, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder7.draw(111, 16, 536_067_180, 910_035_461);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer64, 428);
+} catch {}
+let arrayBuffer27 = buffer61.getMappedRange(0, 20);
+let imageData38 = new ImageData(168, 48);
+try {
+computePassEncoder75.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder7.draw(27, 470, 87_350_734, 470_339_389);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer163, 348);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 32, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame37,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture204,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup218 = device0.createBindGroup({
+  label: '\u0443\u35f6\u782f\u{1f7b3}\udc59\u0551\u10e0\uf86e',
+  layout: bindGroupLayout12,
+  entries: [{binding: 455, resource: textureView232}],
+});
+let renderPassEncoder81 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView321,
+  depthSlice: 110,
+  clearValue: { r: -581.0, g: -108.8, b: -995.2, a: 326.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet38,
+});
+try {
+computePassEncoder160.setBindGroup(1, bindGroup194);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder7.draw(157, 269, 804_193_404, 124_053_620);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer20, 1_220);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer108, 904);
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({layout: pipelineLayout29, compute: {module: shaderModule19, constants: {}}});
+let textureView332 = texture48.createView({label: '\ud7f8\u{1f7d2}\u06d7\u{1fd06}\u7c24\u067b'});
+let sampler223 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.69,
+  lodMaxClamp: 79.86,
+  compare: 'greater',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder169.setBindGroup(2, bindGroup169);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(96, 74, 53, 84_777_467, 418_553_232);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer85, 7_964);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(6, buffer35, 3_500, 135);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer167, 1004, new DataView(new ArrayBuffer(15802)), 92, 96);
+} catch {}
+let pipelineLayout35 = device0.createPipelineLayout({bindGroupLayouts: []});
+let externalTexture48 = device0.importExternalTexture({label: '\u0d57\u69a2\u{1fd0b}\u57b0', source: video4});
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup22, new Uint32Array(2290), 301, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder7.draw(122, 95, 1_047_041_781, 1_269_559_034);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer188, 896);
+} catch {}
+try {
+  await buffer72.mapAsync(GPUMapMode.READ, 0, 4);
+} catch {}
+try {
+adapter0.label = '\u{1fd9a}\ud8f8\u2861';
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup139, new Uint32Array(3566), 613, 0);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(5, 23, 3, 1);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(9, 25, 16, 43_893_477, 681_281_383);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer82, 136);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer184, 9_472);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer113, 'uint32', 420, 16);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder20.insertDebugMarker('\u9d32');
+} catch {}
+await gc();
+videoFrame1.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame52.close();
+videoFrame54.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -568,7 +568,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
     NSUInteger bytesPerRow = dataLayout.bytesPerRow;
     if (bytesPerRow == WGPU_COPY_STRIDE_UNDEFINED)
-        bytesPerRow = size.height ? (data.size() / size.height) : data.size();
+        bytesPerRow = std::max<uint32_t>(size.height ? (data.size() / size.height) : data.size(), Texture::bytesPerRow(textureFormat, widthForMetal, texture.sampleCount()));
 
     switch (texture.dimension()) {
     case WGPUTextureDimension_1D:


### PR DESCRIPTION
#### 5e69533350052ad8208c73f6aa58ffe729b3a102
<pre>
[WebGPU] ASTC textures have wrong bytesPerRow when computed automatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=281271">https://bugs.webkit.org/show_bug.cgi?id=281271</a>
<a href="https://rdar.apple.com/137684504">rdar://137684504</a>

Reviewed by Tadeu Zagallo.

We were not factoring in the blockSize when automatically computing
the bytesPerRow for ASTC block compressed textures.

* LayoutTests/fast/webgpu/nocrash/fuzz-281271-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-281271.html: Added.
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):

Canonical link: <a href="https://commits.webkit.org/285027@main">https://commits.webkit.org/285027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6d37d889a842c3b851c568720dfbc1d3cb372ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56279 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14743 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36714 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/70704 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77027 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15430 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63976 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5748 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46409 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->