### PR TITLE
[WebGPU] instance_id should be limited to 2^32 - 1

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281272-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281272-expected.txt
@@ -1,0 +1,153 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 785x991
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x991
+  RenderBlock {HTML} at (0,0) size 785x991 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x975
+      RenderText {#text} at (0,137) size 97x17
+        text run at (0,137) width 97: "\x{4468}\x{113C}\x{14DE}\x{BF15}\x{D83E}\x{DFB3}\x{C112}\x{DF8}"
+      RenderText {#text} at (396,137) size 45x17
+        text run at (396,137) width 45: "\x{B75F}\x{4B1}\x{D06}"
+      RenderText {#text} at (440,137) size 86x17
+        text run at (440,137) width 86: "\x{16EC}\x{AC93}\x{BEDA}\x{4339}\x{D83D}\x{DE86}\x{9CDE}"
+      RenderText {#text} at (525,137) size 92x17
+        text run at (525,137) width 12: "\x{ADB}"
+        text run at (536,137) width 14 RTL: "\x{8B8}"
+        text run at (549,137) width 68: "\x{8EDA}\x{5396}\x{F773}\x{D83F}\x{DC1C}\x{6C53}"
+      RenderText {#text} at (616,137) size 31x17
+        text run at (616,137) width 31: "\x{CC21}\x{4064}"
+      RenderText {#text} at (646,137) size 113x17
+        text run at (646,137) width 61: "\x{1F12}\x{9F14}\x{C770}\x{D83D}\x{DF00}\x{D83F}\x{DD8A}"
+        text run at (706,137) width 12 RTL: "\x{5ED}"
+        text run at (717,137) width 42: "\x{3705}\x{D83E}\x{DDA9}\x{3F2}"
+      RenderText {#text} at (0,354) size 79x17
+        text run at (0,354) width 79: "\x{D83F}\x{DF4F}\x{B89E}\x{8FA3}\x{D83D}\x{DF1A}\x{B8DB}\x{19}"
+      RenderText {#text} at (78,354) size 97x17
+        text run at (78,354) width 97: "\x{3947}\x{6B59}\x{3A5C}\x{5FFF}\x{C380}\x{194}\x{D83F}\x{DF33}"
+      RenderText {#text} at (385,354) size 127x17
+        text run at (385,354) width 18 RTL: "\x{7D3}\x{FAA}"
+        text run at (402,354) width 110: "\x{54F7}\x{1CA}\x{105}\x{C0AA}\x{D382}\x{1B32}\x{D83D}\x{DE9C}\x{E02}"
+      RenderText {#text} at (511,354) size 135x17
+        text run at (511,354) width 135: "\x{150}\x{D83E}\x{DCBB}\x{E1F2}\x{666D}\x{D83F}\x{DD69}\x{A783}\x{7767}\x{D83D}\x{DE44}\x{E4F2}\x{513}\x{D83F}\x{DEF9}"
+      RenderText {#text} at (645,354) size 47x17
+        text run at (645,354) width 47: "\x{40C9}\x{E09}\x{D83D}\x{DFEE}\x{D83F}\x{DF65}"
+      RenderText {#text} at (691,354) size 67x17
+        text run at (691,354) width 67: "\x{3CAC}\x{8D6}\x{5FCF}\x{6D1B}\x{F10F}\x{D83F}\x{DCD2}"
+      RenderText {#text} at (0,354) size 769x47
+        text run at (757,354) width 12: "\x{A7F}"
+        text run at (0,384) width 130: "\x{BA1D}\x{B87}\x{B54E}\x{C02D}\x{2209}\x{62FB}\x{D83F}\x{DC0D}\x{D83E}\x{DF1C}\x{CEF}\x{4B2B}"
+      RenderText {#text} at (129,384) size 43x17
+        text run at (129,384) width 43: "\x{6126}\x{1079}\x{D83D}\x{DFF2}"
+      RenderText {#text} at (171,384) size 62x17
+        text run at (171,384) width 21: "\x{D83E}\x{DDE3}"
+        text run at (191,384) width 12 RTL: "\x{FB22}"
+        text run at (202,384) width 31: "\x{8406}\x{B45E}"
+      RenderText {#text} at (232,384) size 128x17
+        text run at (232,384) width 112: "\x{AE5F}\x{AC04}\x{C898}\x{B488}\x{4068}\x{D83F}\x{DD7D}\x{D83D}\x{DFF6}\x{AE22}"
+        text run at (343,384) width 6 RTL: "\x{5D5}"
+        text run at (348,384) width 12: "\x{230}"
+      RenderText {#text} at (359,384) size 41x17
+        text run at (359,384) width 41: "\x{D83D}\x{DF24}\x{F31F}\x{9ABB}"
+      RenderText {#text} at (399,384) size 91x17
+        text run at (399,384) width 91: "\x{BDD0}\x{4A2}\x{67E3}\x{191}\x{C565}\x{DC8B}\x{15AA}\x{9E8}"
+      RenderText {#text} at (300,553) size 108x17
+        text run at (300,553) width 108: "\x{8D1}\x{E1C7}\x{46C0}\x{4C8C}\x{477}\x{F189}\x{D83E}\x{DE0E}\x{D83D}\x{DF8A}\x{32A3}"
+      RenderText {#text} at (407,553) size 119x17
+        text run at (407,553) width 82: "\x{42D}\x{9AB}\x{89E}\x{B6B4}\x{7894}\x{D83F}\x{DFDE}\x{DAF}"
+        text run at (488,553) width 5 RTL: "\x{673}"
+        text run at (492,553) width 34: "\x{3F2B}\x{F85}\x{EAF5}"
+      RenderText {#text} at (525,553) size 138x17
+        text run at (525,553) width 10: "\x{F8F}"
+        text run at (534,553) width 14 RTL: "\x{806}"
+        text run at (547,553) width 98: "\x{D83E}\x{DD91}\x{C8D2}\x{C11E}\x{D83F}\x{DEBE}\x{D83D}\x{DE69}\x{C50}\x{9423}"
+        text run at (644,553) width 8 RTL: "\x{8AE}"
+        text run at (651,553) width 12: "\x{EAC}"
+      RenderText {#text} at (662,553) size 76x17
+        text run at (662,553) width 76: "\x{4993}\x{6CC2}\x{D83F}\x{DE51}\x{387}\x{BDA8}\x{8F95}"
+      RenderText {#text} at (0,553) size 753x108
+        text run at (737,553) width 16: "\x{BC30}"
+        text run at (0,644) width 64: "\x{158A}\x{D83D}\x{DF82}\x{3F35}\x{347F}\x{D83E}\x{DC05}"
+      RenderText {#text} at (63,644) size 56x17
+        text run at (63,644) width 56: "\x{5F23}\x{B049}\x{289C}\x{B379}"
+      RenderText {#text} at (118,644) size 89x17
+        text run at (118,644) width 83: "\x{6295}\x{249F}\x{9746}\x{D83E}\x{DC8D}\x{D83F}\x{DD62}\x{D415}"
+        text run at (200,644) width 7 RTL: "\x{7D4}"
+      RenderText {#text} at (206,644) size 82x17
+        text run at (206,644) width 82: "\x{E0A}\x{4DDA}\x{D83D}\x{DE0F}\x{1376}\x{768D}\x{CC3F}\x{F19}\x{5AE}"
+      RenderImage {IMG} at (0,666) size 196x248
+      RenderText {#text} at (237,901) size 86x17
+        text run at (237,901) width 86: "\x{1F6}\x{D83E}\x{DDBA}\x{CDA5}\x{2B5}\x{7CB4}\x{8930}"
+      RenderText {#text} at (322,901) size 34x17
+        text run at (322,901) width 16: "\x{FE69}"
+        text run at (337,901) width 14 RTL: "\x{FEB6}"
+        text run at (350,901) width 6: "\x{A1}"
+      RenderText {#text} at (355,901) size 77x17
+        text run at (355,901) width 21: "\x{DE39}\x{E22}"
+        text run at (375,901) width 16 RTL: "\x{60B}\x{66D}"
+        text run at (390,901) width 42: "\x{65AD}\x{6F5E}\x{D83F}\x{DE54}"
+      RenderText {#text} at (431,901) size 71x17
+        text run at (431,901) width 29: "\x{4AC}\x{2B1E}\x{93A9}"
+        text run at (459,901) width 1 RTL: "\x{61C}"
+        text run at (459,901) width 43: "\x{D83D}\x{DE15}\x{F86B}\x{A5E4}"
+      RenderText {#text} at (501,901) size 127x17
+        text run at (501,901) width 127: "\x{94CE}\x{96F6}\x{9504}\x{1887}\x{3AFB}\x{C9C0}\x{804C}\x{6D89}\x{CDAD}"
+      RenderText {#text} at (627,901) size 47x17
+        text run at (627,901) width 47: "\x{FF79}\x{D83F}\x{DE7B}\x{1D07}\x{D83E}\x{DDEB}"
+      RenderText {#text} at (673,901) size 52x17
+        text run at (673,901) width 11: "\x{DA9}"
+        text run at (683,901) width 10 RTL: "\x{70A}"
+        text run at (692,901) width 33: "\x{B9E5}\x{9F1}\x{B5}"
+      RenderText {#text} at (0,901) size 762x41
+        text run at (724,901) width 38: "\x{F9C2}\x{D83F}\x{DFFE}\x{E975}"
+        text run at (0,925) width 56: "\x{4A71}\x{C68F}\x{9EE0}\x{FB1B}"
+      RenderText {#text} at (55,925) size 26x17
+        text run at (55,925) width 15 RTL: "\x{8A1}"
+        text run at (69,925) width 12: "\x{F6D}"
+      RenderText {#text} at (80,925) size 138x17
+        text run at (80,925) width 138: "\x{2F97}\x{AE1}\x{ADD3}\x{184E}\x{4E1D}\x{5EE2}\x{981}\x{A12F}\x{D83E}\x{DCFA}\x{CB22}\x{93FC}"
+      RenderText {#text} at (217,925) size 120x17
+        text run at (217,925) width 95: "\x{D83F}\x{DEAD}\x{67B9}\x{D83E}\x{DFD0}\x{3AFF}\x{19C}\x{2A5D}\x{4178}"
+        text run at (311,925) width 15 RTL: "\x{725}"
+        text run at (325,925) width 12: "\x{D83F}\x{DD92}"
+      RenderText {#text} at (336,925) size 102x17
+        text run at (336,925) width 65: "\x{815D}\x{6CFD}\x{D83D}\x{DF5E}\x{1B80}\x{3A5}"
+        text run at (400,925) width 14 RTL: "\x{84F}"
+        text run at (413,925) width 25: "\x{D2A}\x{386}"
+      RenderText {#text} at (437,925) size 22x17
+        text run at (437,925) width 22: "\x{DDF9}\x{E182}"
+      RenderText {#text} at (458,925) size 138x17
+        text run at (458,925) width 138: "\x{10D0}\x{9C26}\x{92E8}\x{C6DD}\x{84BB}\x{9D2C}\x{D83F}\x{DD9B}\x{D83F}\x{DFC8}\x{D83F}\x{DFF1}\x{31F}\x{E74A}"
+      RenderText {#text} at (595,925) size 129x17
+        text run at (595,925) width 129: "\x{5C6E}\x{828C}\x{F7A}\x{7C56}\x{F84E}\x{B2DF}\x{9FA6}\x{ED6}\x{5A13}\x{D83E}\x{DF47}"
+      RenderText {#text} at (0,925) size 766x45
+        text run at (723,925) width 17 RTL: "\x{790}"
+        text run at (739,925) width 27: "\x{F692}\x{C57F}"
+        text run at (0,953) width 48: "\x{EA76}\x{E30}\x{8FEC}\x{FF1B}"
+        text run at (47,953) width 12 RTL: "\x{8C6}"
+        text run at (58,953) width 27: "\x{D83E}\x{DE41}\x{AD46}"
+      RenderText {#text} at (84,953) size 86x17
+        text run at (84,953) width 86: "\x{55D9}\x{24D6}\x{3488}\x{B653}\x{FAA}\x{526D}"
+      RenderText {#text} at (169,953) size 55x17
+        text run at (169,953) width 55: "\x{D83E}\x{DE67}\x{D83E}\x{DEB0}\x{D256}\x{241}"
+      RenderText {#text} at (223,953) size 53x17
+        text run at (223,953) width 53: "\x{B836}\x{543D}\x{D83F}\x{DCE8}\x{D83F}\x{DE2B}"
+      RenderText {#text} at (275,953) size 130x17
+        text run at (275,953) width 16: "\x{6616}"
+        text run at (290,953) width 16 RTL: "\x{851}"
+        text run at (305,953) width 100: "\x{74F0}\x{D83F}\x{DC0E}\x{58E}\x{5EBD}\x{4BEC}\x{8C06}\x{3AEA}"
+      RenderText {#text} at (404,953) size 71x17
+        text run at (404,953) width 71: "\x{EEB3}\x{EEA}\x{E123}\x{48D}\x{974A}\x{CF66}\x{20EB}"
+      RenderText {#text} at (474,953) size 118x17
+        text run at (474,953) width 118: "\x{248}\x{D83D}\x{DEDF}\x{337C}\x{4CAB}\x{D83D}\x{DFB7}\x{D83F}\x{DE66}\x{93AA}\x{FF75}\x{7AFB}"
+layer at (104,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (96,0) size 301x150
+layer at (182,164) size 211x211
+  RenderVideo {VIDEO} at (174,156) size 212x211
+layer at (8,424) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,416) size 300x150
+layer at (295,583) size 481x82
+  RenderHTMLCanvas {CANVAS} at (287,575) size 482x82
+layer at (204,881) size 41x41
+  RenderVideo {VIDEO} at (196,873) size 41x41

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-281272.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-281272.html
@@ -1,0 +1,22583 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAoFtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAABUKAGvMILFBzOKWOiF6G++u4q25iLQf/vD2XlioJF5Qbq9Jo5ooAL4SbAZpEZABEf7iWARcABdv//syjoCwF0gmvRazgrxX10RsAABXqjcgAAEvOnYAAAAH04JBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAABLKAmT4gmy7srQ+f3f/hrRdtzCUzy2A5UNrJhn9PTJut4gAW7GyDrPKy0COxn31wCJgAP864AAVMAFwAAACWgAAAMAAKmAAAADAAdEAAAAOAIB0HgoHi+QQ5H7ZPd0KgUMk3gAzYAAABUwABYi7vKBOjQAUJj5e4AC030dWdAFZA7k9gn4KoZIAAAAKgIJpB4KB4vxDkbSUPIlgAR8WAAATUAAAAW8AAA4IAABmQAHLAAZMABJQAAAADECAeDwkDyDy+kENJetwJKE9AAKSAAb8ALbxqgA7NaABJb1r4BqDxtgIhY2R3AbY//gAAAAJQIJqDwkDyDy+xC6qoCTgJiAAAHvAAdMABRwAC7gAFXAAK2AAWEAAAA1AgHgeJh6HoPD6YQ0lrZAkgf4AA24ACPgA5urXsWTqgKllrz3OhIrPNN28Bb2RLqIHSQBJ3AAAAAmAgmoHiYeh6Dw+xC6qoCTgJiAAAHvAAdMABRwAC7gAFXAAK2AAWEAAAAzAgHhaNB6DwHr6YQ0lu3Akgf4AA24ACPgA5urXsWTqgwkQ4dq2wZwEifi+Bb1y7AdI3QgAAAAJgIJqFo0HoPAevsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAElW1vb3YAAABsbXZoZAAAAADi56x84uesfQAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAQhdHJhawAAAFx0a2hkAAAAD+LnrHzi56x9AAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAANVbWRpYQAAACBtZGhkAAAAAOLnrHzi56x9AAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAvxtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAoRzdGJsAAABQnN0c2QAAAAAAAAAAQAAATJodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAumh2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALBKAAAQAnQAEMEf//AWAAAAMAsAAAAwAAAwBaFcC/WggACDAoUoCAAIBQBhXpoQACACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUBDQEAgACJCCQEBYAAAAwCwAAADAAADAFpIAgIBAWIFe5FlU3AQ0BAIogACAAdEAcAsvBTJAAhECUgCixgpkicAAQAJTgGlBBAAf5CAAAAAEmNvbHJuY2xjAAEADQABAAAADGFsbW8AAAECAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAO0AAABqAAAAXgAAAGMAAABhAAAAJHN0Y28AAAAAAAAABQAAACQAAAERAAABewAAAdkAAAI8`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAsZtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAAC/KAGvMIM0QO98cZDqaxN33yTgv9Uw/wbMiBKSmf/rknVodFa0gFSRB+YtKr4Up74CNkjcM+SYMCp7ziSu8Bg3w4ASXfadLta3BfYFlGTZo+WXcRL7BDRMXe+W8a7ndExzm+AqyeF/HDTmTdCX4xD6u/RLi1MTxf/hWeD76QW8VuPqEK/yBa0b+zFH1AfCBEOPQXAkV9AAAdvXqOMcXnAW1HLDDNgAA3+PPoshT6AwdRBQAAmb4iVshT7Y1rXmtJwAAAAfTgkFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA1//gAAAAEsoCZPiCbLuytD5/d/+GtF23MJTPLYDlQ2smGf09Mm63iABbsbIOs8rLQI7GffXAImAA/zrgABUwAXAAAAJaAAAAwAAqYAAAAMAB0QAAAAvAgHQeCgeL5BDnrSU93QqBQyTfA7uDPSBgAAfH8SF/gAAc8AAA/YAEvAAOqAAoYAAAAAqAgmkHgoHi/EORtJQ8iWABHxYAABNQAAABbwAADggAAGZAAcsABkwAElAAAAAKQIB4PCQPIPL6QQ1akTAkoT0AokIsrQsBG2mfNWAAC/gAJWAAQsB+wMuAAAAJQIJqDwkDyDy+xC6qoCTgJiAAAHvAAdMABRwAC7gAFXAAK2AAWEAAAApAgHgeJh6HoPD6YQ1YkTAkgf4AwTI6918BUD17GEASEAAsIABXQJGA6oAAAAmAgmoHiYeh6Dw+xC6qoCTgJiAAAHvAAdMABRwAC7gAFXAAK2AAWEAAAAqAgHhaNB6DwHr6YQ1YkjAkgf4AwTI6918BUD17GEASEAF4zYAu4ACRgOqAAAAJgIJqFo0HoPAevsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAElW1vb3YAAABsbXZoZAAAAADi56lB4uepQgAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAQhdHJhawAAAFx0a2hkAAAAD+LnqUHi56lCAAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAANVbWRpYQAAACBtZGhkAAAAAOLnqUHi56lCAAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAvxtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAoRzdGJsAAABQnN0c2QAAAAAAAAAAQAAATJodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAumh2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALBKAAAQAnQAEMEf//AWAAAAMAsAAAAwAAAwBaFcC/WggACDAoUoCAAIBQBhXpoQACACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUJAQcAgACJCCQEBYAAAAwCwAAADAAADAFpIAgIBAWIFe5FlU3CQEHAIogACAAdEAcAsvBTJAAhECUgCixgpkicAAQAJTgGlBBAAf5CAAAAAEmNvbHJuY2xjAAkAAQAHAAAADGFsbW8AAAECAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAVgAAABhAAAAVgAAAFcAAABYAAAAJHN0Y28AAAAAAAAABQAAACQAAAF8AAAB3QAAAjMAAAKK`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAfhtZGF0AAAAHgYFGkdWStxcTEM/lO/FETzRQ6gB/8zM/wIABr//gAAAAJ4luCAfgCzoj/dHlBRGWsK+O8ypQVe5jrfqctszBB6qYbMrWK2GtwD2wFhXMY0ATsi60z9nqyJbUOAdjYh9PVxL4wHv9V00oZG/4wgveOp/3/zN2R/i3An4gfCjMXb2OcpD7gWgkwpNLmI+c0cLfVdM7cr0lfErk702IRZLDFFc3zbVpZHfFFY59IdU3aOc7ZXQk6zToYQMb/UoKy1F6AAAAEsh4QhfCZc5129nAmiF/F+tGqS/U7WBunZ4gvVnot4aXrqLve8EyPFoCQrNUMBUotDRc9+5kIo+UypDxsqPNSqccc+UZbPRmJhpNCYAAAA5AaiBib/0nMMwDG458AFHAB1iAgymTcPBeIj0e7jqqAv2ICI+5mXuM8owyZAEVA7ghoWILkIMFknwAAAAZSHiEEv/B7/guvjdqhNVxyVNJxrOv7dBHkwG4f0irD+VhFYN2TdL0RuEeTGvR9TdEB+nEGDldyedCjFHgyywYVepRGa1IrNOamOEb2JW0iqxXsv+NiipNsxi8PXGAiLP/aLh0nE+AAAAMwGow4k/88JpIAnK9uAACAAAGYZBFwgjlCS+XS8AY36rnhmqtb8SslAAAAMAAAMAAAMBBwAAA7xtb292AAAAbG12aGQAAAAA4ueqMeLnqjEAAAJYAAALuAABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAADSHRyYWsAAABcdGtoZAAAAA/i56ox4ueqMQAAAAEAAAAAAAALuAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAABAAAAAQAAAAAAAER0YXB0AAAAFGNsZWYAAAAAAQAAAAEAAAAAAAAUcHJvZgAAAAABAAAAAQAAAAAAABRlbm9mAAAAAAEAAAABAAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAALuAAAAAAAAQAAAAACfG1kaWEAAAAgbWRoZAAAAADi56ox4ueqMQAAAlgAAAu4VcQAAAAAADFoZGxyAAAAAG1obHJ2aWRlYXBwbAAAAAAAAAAAEENvcmUgTWVkaWEgVmlkZW8AAAIjbWluZgAAABR2bWhkAAAAAQBAgACAAIAAAAAAOGhkbHIAAAAAZGhscmFsaXNhcHBsAAAAAAAAAAAXQ29yZSBNZWRpYSBEYXRhIEhhbmRsZXIAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMYWxpcwAAAAEAAAGrc3RibAAAAKZzdHNkAAAAAAAAAAEAAACWYXZjMQAAAAAAAAABAAAAAAAAAAAAAAIAAAACAAEAAQAASAAAAEgAAAAAAAAAAQVILjI2NAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAACphdmNDAWQADf/hAA8nZAANrFYoEAhpqDBoMBABAAQo7jyw/fj4AAAAABJjb2xybmNsYwAGAA0ABgAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAACWAAAAAH///2oAAAAAQAAAlgAAAAB///9qAAAACBjc2xnAAAAAAAAAlj///2oAAACWAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBgQGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAMQAAABPAAAAPQAAAGkAAAA3AAAAJHN0Y28AAAAAAAAABQAAACQAAADoAAABNwAAAXQAAAHd`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAwhtZGF0AAAAH04BBRpHVkrcXExDP5TvxRE80UOoA+4AAO4CAANf/4AAAACsKAGvMIM4QO9+SJDqaxN33jPq/30Q/8YyyIEpKZ//xcCbAk0vyq0gFZEH5i0qvhSnvgI2SNwz5JgwKnvOJK8nUg33CIlYARdxSH3S7XnmI4Wuv6P7UPcDkkijI7N7PcL5FLLMqQA5ke7u35vA6wYJQ/0g2nx3fvk1fiYSZNqRiJEbGj6n80VXROrbbckIotEWLKur1+elzaAAARNRyeqd4FDAAAGNgU8ABaYOyAAAAB9OCQUaR1ZK3FxMQz+U78URPNFDqAPuAADuAgADX/+AAAAASygJk+IJsu7K0Pn93/4a0XbcwlM8tgOVDayYZ/T0ybreIAFuxsg6zystAjsZ99cAiYAD/OuAAFTABcAAAAloAAADAACpgAAAAwAHRAAAAFYCAdB4KB4vkEFIcp/CFPd0KgUMk3wO7g70gYAAHx/Ehf4AVkDFU3CVHA6uGZjvY615FlFgDgg5kNKYSHALIydugatrkdDW/FAACQgAJmADGcYHOs4VhgAAACoCCaQeCgeL8Q5G0lDyJYAEfFgAAE1AAAAFvAAAOCAAAZkABywAGTAASUAAAAA4AgHg8JA8g8vpBBCVWshgkoT0AokItOQsBG2mfNWABrqQ4/Ij9gmT+AF3eAsxUB1sEACsgAH7Ay4AAAAlAgmoPCQPIPL7ELqqgJOAmIAAAe8AB0wAFHAALuAAVcAArYABYQAAADkCAeB4mHoeg8PphBCVGoigkgf4AwTI7hd8BUD17GEIe5G58YQMDhBd0h8wTvcPD2QWRL4b/WwRw0AAAAAmAgmoHiYeh6Dw+xC6qoCTgJiAAAHvAAdMABRwAC7gAFXAAK2AAWEAAAA5AgHhaNB6DwHr6YQQlRqIoJIH+AMEyO4XfAVA9exhCHuRufGEDA4TrukPmCd7h4eyFkS+G/1sEcNAAAAAJgIJqFo0HoPAevsQuqqAk4CYgAAB7wAHTAAUcAAu4ABVwACtgAFhAAAElW1vb3YAAABsbXZoZAAAAADi56o94ueqPQAAAlgAAAu4AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAQhdHJhawAAAFx0a2hkAAAAD+Lnqj3i56o9AAAAAQAAAAAAAAu4AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAEAAAABAAAAAAAARHRhcHQAAAAUY2xlZgAAAAABAAAAAQAAAAAAABRwcm9mAAAAAAEAAAABAAAAAAAAFGVub2YAAAAAAQAAAAEAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAu4AAAAAAABAAAAAANVbWRpYQAAACBtZGhkAAAAAOLnqj3i56o9AAACWAAAC7hVxAAAAAAAMWhkbHIAAAAAbWhscnZpZGVhcHBsAAAAAAAAAAAQQ29yZSBNZWRpYSBWaWRlbwAAAvxtaW5mAAAAFHZtaGQAAAABAECAAIAAgAAAAAA4aGRscgAAAABkaGxyYWxpc2FwcGwAAAAAAAAAABdDb3JlIE1lZGlhIERhdGEgSGFuZGxlcgAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAxhbGlzAAAAAQAAAoRzdGJsAAABQnN0c2QAAAAAAAAAAQAAATJodmMxAAAAAAAAAAEAAAAAAAAAAAAAAgAAAAIAAQABAABIAAAASAAAAAAAAAABBEhFVkMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAumh2Y0MBAWAAAACwAAAAAABa8AD8/fj4AAALBKAAAQAnQAEMEf//AWAAAAMAsAAAAwAAAwBaFcC/WggACDAoUoCAAIBQBhXpoQACACJCAQEBYAAAAwCwAAADAAADAFqgCAgEBYgV7kWVTUBAQkAgACJCCQEBYAAAAwCwAAADAAADAFpIAgIBAWIFe5FlU3AQEJAIogACAAdEAcAsvBTJAAhECUgCixgpkicAAQAJTgGlBBAAf5CAAAAAEmNvbHJuY2xjAAEAAQAJAAAADGFsbW8AAAECAAAAAAAAABlzZ3BkAQAAAHN5bmMAAAABAAAAARQAAAAkc2JncAAAAABzeW5jAAAAAgAAAAEAAAABAAAABAAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAAHCAAAAAEAAAAAAAAAAf//+1AAAAAB///9qAAAACBjc2xnAAAAAAAABLD///tQAAAHCAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBAYGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAUUAAACIAAAAZQAAAGcAAABnAAAAJHN0Y28AAAAAAAAABQAAACQAAAFpAAAB8QAAAlYAAAK9`,
+`data:video/mp4;base64,AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAAAWttZGF0AAAAHgYFGkdWStxcTEM/lO/FETzRQ6gB/8zM/wIABr//gAAAAHUluCAfgCzoj//8Hk+jASILFi8d5lSgq9zHnvBhxX/NkovPF2/g9VMNmVrFbDW4B7YCwrmMaAJ2RdaZ+z1ZEwEiI47D6ngetC3f26N6kMRH3uXs70tozPe/lUNs3SVnYHFUG0toeZsyZ65Iwhk3Lgda0LdXRcgAAAAnIeEIXwEKJIE1guCbPQfAA22HyhawyVdfkp6Qm7/YquaBl0w6UCk4AAAALAGogYm/9JzDMAAAAwAaUAAATMBTihrk6Y2pX1/aAAnKAFIBxw2AgIT4M3BgAAAAOCHiEET/AC4tCCa6jC5Uux0Wpuwxsp4wj8Hhf7UBeKsL/k52df+ulktOIBGuupFGjkkz2GJbMHH0AAAALQGow4//9JdwIAAAAwABBwAAAwLwAnIyzNPpqoPLdkBeQcEKWEjBww6oiYVQ5AAAA7xtb292AAAAbG12aGQAAAAA4uesdeLnrHUAAAJYAAALuAABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAADSHRyYWsAAABcdGtoZAAAAA/i56x14uesdQAAAAEAAAAAAAALuAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAABAAAAAQAAAAAAAER0YXB0AAAAFGNsZWYAAAAAAQAAAAEAAAAAAAAUcHJvZgAAAAABAAAAAQAAAAAAABRlbm9mAAAAAAEAAAABAAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAALuAAAAAAAAQAAAAACfG1kaWEAAAAgbWRoZAAAAADi56x14uesdQAAAlgAAAu4VcQAAAAAADFoZGxyAAAAAG1obHJ2aWRlYXBwbAAAAAAAAAAAEENvcmUgTWVkaWEgVmlkZW8AAAIjbWluZgAAABR2bWhkAAAAAQBAgACAAIAAAAAAOGhkbHIAAAAAZGhscmFsaXNhcHBsAAAAAAAAAAAXQ29yZSBNZWRpYSBEYXRhIEhhbmRsZXIAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMYWxpcwAAAAEAAAGrc3RibAAAAKZzdHNkAAAAAAAAAAEAAACWYXZjMQAAAAAAAAABAAAAAAAAAAAAAAIAAAACAAEAAQAASAAAAEgAAAAAAAAAAQVILjI2NAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAACphdmNDAWQADf/hAA8nZAANrFYoEAhpqAhASBABAAQo7jyw/fj4AAAAABJjb2xybmNsYwABAAgACQAAAAAAAAAYc3R0cwAAAAAAAAABAAAABQAAAlgAAAA4Y3R0cwAAAAAAAAAFAAAAAQAAAAAAAAABAAACWAAAAAH///2oAAAAAQAAAlgAAAAB///9qAAAACBjc2xnAAAAAAAAAlj///2oAAACWAAAAAAAAAu4AAAAFHN0c3MAAAAAAAAAAQAAAAEAAAARc2R0cAAAAAAgEBgQGAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAoc3RzegAAAAAAAAAAAAAABQAAAJsAAAArAAAAMAAAADwAAAAxAAAAJHN0Y28AAAAAAAAABQAAACQAAAC/AAAA6gAAARoAAAFW`,
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxBindingsPerBindGroup: 1000,
+    maxTextureArrayLayers: 256,
+    maxVertexBuffers: 8,
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 186777991,
+    maxStorageBufferBindingSize: 142275561,
+  },
+});
+let imageData0 = new ImageData(12, 84);
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\ufd17\u00d0\u8e01\ua161\uf342\u{1ff82}',
+  entries: [
+    {
+      binding: 275,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 234, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {binding: 37, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 354,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 348,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler0 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.635,
+  lodMaxClamp: 93.29,
+  maxAnisotropy: 13,
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u{1fc05}\u0ce3\u92fd\u89e8\u3680\u{1fc52}\u8113\u{1f8eb}\uec87\u{1f959}\u42c9',
+  bindGroupLayouts: [],
+});
+let texture0 = device0.createTexture({
+  label: '\u0567\u{1ff7d}\u652a\uba4c\u1b4c',
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture0.createView({label: '\u707a\u9097\u66c3\u0f28\u{1f9a7}\u44e4\u0e28\u{1fab6}\ude1f'});
+let sampler1 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 8.351});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture1 = device0.createTexture({
+  size: [320],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let imageBitmap0 = await createImageBitmap(imageData0);
+let commandEncoder1 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 123});
+let textureView1 = texture1.createView({});
+let computePassEncoder1 = commandEncoder1.beginComputePass({label: '\u{1f664}\u3e8d\u2dbf\u01cb\ue1cd\ud1fe\u0f2c\u{1f91b}'});
+let sampler2 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.85,
+  lodMaxClamp: 88.36,
+  maxAnisotropy: 20,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(145), /* required buffer size: 19 */
+{offset: 19}, {width: 63, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise0;
+} catch {}
+let textureView2 = texture1.createView({label: '\u1f27\uf41b\u0873\u1412\udc29\u091c', baseArrayLayer: 0});
+try {
+computePassEncoder0.insertDebugMarker('\u6b93');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer0 = device0.createBuffer({size: 825, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let sampler3 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.59,
+  lodMaxClamp: 71.22,
+});
+let buffer1 = device0.createBuffer({size: 112, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let texture2 = device0.createTexture({
+  size: [320, 300, 74],
+  format: 'etc2-rgb8a1unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+struct T2 {
+  f0: array<atomic<i32>>,
+}
+
+alias vec3b = vec3<bool>;
+
+var<private> vp1 = modf(vec4h());
+
+struct T1 {
+  f0: array<u32>,
+}
+
+@group(0) @binding(47) var<uniform> buffer2: array<array<vec2h, 1>, 1>;
+
+fn fn0() -> array<array<array<f32, 1>, 1>, 3> {
+  var out: array<array<array<f32, 1>, 1>, 3>;
+  let ptr0 = &vp0[12][0];
+  vp1.fract = vec4h(vp0[12][0].fract);
+  let ptr1 = &vp0[12][0];
+  let vf0: i32 = insertBits(i32((*ptr0).whole), i32(extractBits(u32(vp0[12][0].whole), u32(unconst_u32(266)), u32(unconst_u32(213)))), u32(unconst_u32(56)), u32(unconst_u32(46)));
+  var vf1: vec3f = acosh(vec3f(unconst_f32(0.01842), unconst_f32(0.3334), unconst_f32(0.3983)));
+  vf1 -= acosh(acosh(vec3f(f32((*ptr0).fract))));
+  let vf2: vec3u = countOneBits(vec3u(max(vec2f(unconst_f32(0.1921), unconst_f32(0.4306)), vec2f(unconst_f32(0.1703), unconst_f32(0.1378))).rrr));
+  vp1.whole += vp1.whole;
+  let vf3: u32 = pack2x16float(vec2f(extractBits(vec4i(unconst_i32(117), unconst_i32(766), unconst_i32(93), unconst_i32(19)), u32(unconst_u32(16)), u32(unconst_u32(227))).ab));
+  out[2][0][vf3] = f32((*ptr0).whole);
+  let vf4: f16 = distance(f16(unconst_f16(-907.3)), vp0[u32(unconst_u32(128))][0].fract);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4i,
+  @location(0) @interpolate(flat, centroid) f1: vec4u,
+  @location(1) @interpolate(linear) f2: vec4f,
+}
+
+var<private> vp0 = array(array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())), array(modf(f16())));
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+@group(0) @binding(44) var tex0: texture_1d<i32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf5: f32 = fma(f32(unconst_f32(0.1008)), f32(unconst_f32(0.02896)), f32(unconst_f32(0.00101)));
+  let ptr2: ptr<private, vec4h> = &vp1.whole;
+  var vf6: vec3h = cosh(vec3h(unconst_f16(4798.9), unconst_f16(9729.1), unconst_f16(856.8)));
+  let ptr3 = &vp0[12][u32(unconst_u32(392))];
+  return out;
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let ptr4: ptr<uniform, array<vec2h, 1>> = &(*&buffer2)[0];
+  vp1.whole -= vec4h(vp0[12][0].fract);
+  out.f2 = vec4f(buffer2[0][0].yyxx);
+  let vf7: vec2h = atan(vec2h((*&buffer2)[0][0][0]));
+  let ptr5: ptr<private, vec4h> = &vp1.fract;
+  let vf8: vec4i = countTrailingZeros(vec4i(i32(vp0[12][0].fract)));
+  var vf9: vec4i = vf8;
+  discard;
+  let ptr6: ptr<uniform, array<vec2h, 1>> = &buffer2[0];
+  out.f2 *= vec4f(f32(buffer2[0][0][1]));
+  out.f1 += vec4u((*ptr6)[0].gggg);
+  let ptr7: ptr<uniform, vec2h> = &buffer2[0][0];
+  out.f2 += vec4f((*ptr7).rrgg);
+  out.f0 *= vec4i((*&buffer2)[bitcast<u32>((*&buffer2)[0][u32(unconst_u32(93))])][0].xyyy);
+  let ptr8: ptr<uniform, vec2h> = &(*ptr6)[0];
+  out.f1 = unpack4xU8(u32((*ptr5)[0]));
+  let ptr9: ptr<uniform, vec2h> = &(*ptr4)[0];
+  out.f1 |= vec4u(u32(vp0[12][0].fract));
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0() {
+  vp1 = modf(buffer2[pack4xI8(vec4i(unconst_i32(0), unconst_i32(-4), unconst_i32(101), unconst_i32(-208)))][0].ggrg);
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  let vf10: u32 = pack4xU8Clamp(vec4u(unconst_u32(10), unconst_u32(526), unconst_u32(31), unconst_u32(32)));
+  var vf11: vec4f = smoothstep(vec4f(unconst_f32(0.02602), unconst_f32(0.05421), unconst_f32(0.03250), unconst_f32(0.2374)), vec4f(f32(vp0[12][0].whole)), unpack4x8snorm(pack4xU8Clamp(vec4u(unconst_u32(64), unconst_u32(45), unconst_u32(405), unconst_u32(31)))));
+  vf11 = vec4f(pow(f32(vp1.fract[0]), bitcast<f32>((*&buffer2)[0][0])));
+  let vf12: f16 = buffer2[0][0][0];
+  var vf13 = fn0();
+  var vf14: f32 = vf11[1];
+  vf13[u32(unconst_u32(213))][bitcast<vec2u>(reverseBits(vec2i(i32(vp0[12][0].fract)))).r][u32(unconst_u32(71))] = bitcast<f32>(buffer2[0][0]);
+  vp0[u32(unconst_u32(74))][vec4u(cosh(vec4h(unconst_f16(10110.1), unconst_f16(278.7), unconst_f16(1596.6), unconst_f16(5125.9))))[0]] = modf(buffer2[0][0][1]);
+  vp0[u32(unconst_u32(207))][u32(fma(f16(unconst_f16(6619.1)), vf12, f16(unconst_f16(1897.2))))].whole = fma(vec2h(unconst_f16(3402.2), unconst_f16(7288.0)), vec2h(unconst_f16(8327.0), unconst_f16(2203.7)), bitcast<vec2h>(vf13[2][0][0]))[0];
+  let ptr10 = &vp0[12][0];
+  var vf15 = fn0();
+  vf14 += vec3f(inverseSqrt(vec3h(unconst_f16(21394.6), unconst_f16(12734.5), unconst_f16(22953.0)))).g;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute2(@builtin(global_invocation_id) a0: vec3u) {
+  storageBarrier();
+  vp0[pack4xU8Clamp(vec4u(unpack4xI8(u32(unconst_u32(174)))))][u32(unconst_u32(164))].whole = buffer2[0][0].g;
+  vp0[u32(vp0[12][0].fract)][u32(unconst_u32(326))].whole = faceForward(vec2h(unconst_f16(4094.2), unconst_f16(28687.8)), vec2h(unconst_f16(12040.2), unconst_f16(3305.3)), vec2h(unconst_f16(1726.8), unconst_f16(2814.0)))[1];
+  let vf16: vec3f = sinh(vec3f(buffer2[0][0].xyy));
+  vp1.fract -= (*&buffer2)[0][u32(unconst_u32(193))].ggrg;
+  let ptr11 = &vp0[u32(unconst_u32(602))];
+  let ptr12: ptr<uniform, vec2h> = &(*&buffer2)[0][u32(unconst_u32(354))];
+  var vf17: f16 = (*ptr12)[0];
+  var vf18: vec2u = firstLeadingBit(a0.gb);
+  fn0();
+  vf17 *= atan2(f16(unconst_f16(22425.0)), buffer2[0][0].y);
+  fn0();
+  vp1.whole += vec4h(vp0[12][0].fract);
+  vp1 = modf((*&buffer2)[0][u32(unconst_u32(0))].yxxx);
+  var vf19: vec4i = unpack4xI8(u32(vp0[12][0].whole));
+  vf19 = bitcast<vec4i>(extractBits(vec4u(u32((*ptr11)[0].whole)), bitcast<u32>(buffer2[0][0]), u32(unconst_u32(86))));
+  vf18 |= vec2u((*&buffer2)[vec4u(vp1.whole).g][0]);
+  let vf20: vec2h = atan(vec2h(unconst_f16(-16163.5), unconst_f16(-8730.6)));
+  let vf21: u32 = dot(vec3u(unconst_u32(144), unconst_u32(196), unconst_u32(26)), vec3u(u32(vp0[12][0].fract)));
+  fn0();
+  vf17 = vp0[12][0].fract;
+  let vf22: u32 = vf18[1];
+  var vf23: f32 = vf16[1];
+  vp1 = modf((*&buffer2)[0][0].yxxx);
+  vf17 = f16(textureDimensions(tex0, 0i));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer3 = device0.createBuffer({
+  size: 13106,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u051e\ubb31\udf17\u45f8\u39a3\u{1f641}\u0447\udd72\u0579\u0e52\uc0ca'});
+let textureView3 = texture1.createView({format: 'rgba32sint', baseMipLevel: 0});
+let commandEncoder3 = device0.createCommandEncoder();
+let textureView4 = texture2.createView({dimension: '2d', baseArrayLayer: 25});
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 256 */
+  offset: 256,
+  buffer: buffer3,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder0.pushDebugGroup('\u{1f6ba}');
+} catch {}
+let textureView5 = texture2.createView({baseArrayLayer: 7, arrayLayerCount: 15});
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 6152, new BigUint64Array(24524), 7850, 60);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(175), /* required buffer size: 59 */
+{offset: 59}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 123,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u3af5\u08aa\u{1f6b2}\ud4f2\ue4bc\u{1f964}\uce7d\ub4ac\u9fa5\u05f2'});
+let computePassEncoder2 = commandEncoder3.beginComputePass();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({size: [256, 256, 24], mipLevelCount: 6, format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder3 = commandEncoder5.beginComputePass({label: '\u5e3e\u720f\u07b5\u71a8'});
+let commandEncoder6 = device0.createCommandEncoder({});
+try {
+device0.queue.writeBuffer(buffer3, 760, new Float32Array(497), 118, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(85).fill(230), /* required buffer size: 85 */
+{offset: 85}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u454d\u53e5\ua689'});
+let textureView6 = texture4.createView({label: '\u6032\u{1f97a}\uc4c8\u06be\u0f6c\u{1fc74}', aspect: 'all'});
+let sampler4 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 47.82,
+  lodMaxClamp: 97.60,
+});
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3120 */
+  offset: 3120,
+  bytesPerRow: 55296,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 84, y: 200, z: 37},
+  aspect: 'all',
+}, {width: 20, height: 40, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView7 = texture4.createView({label: '\u2b16\ubcd8\u6995\u00a7\u{1ffa3}\ub8c8\ua5bd\u8e1e\u8abc\u0ade'});
+let computePassEncoder5 = commandEncoder4.beginComputePass({});
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3760 */
+  offset: 3760,
+  buffer: buffer3,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 10, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet0, 1, 9, buffer3, 256);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput1 {
+  @location(1) f0: f32,
+  @location(0) f1: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  @align(1) @size(4) f0: array<f16>,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw1: atomic<i32>;
+
+struct T1 {
+  @align(2) f0: array<array<array<vec2f, 2>, 1>, 1>,
+  @align(1) f1: array<array<array<u32, 1>, 2>, 2>,
+  f2: mat2x4h,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(47) var<uniform> buffer4: array<array<vec2h, 1>, 1>;
+
+var<workgroup> vw0: vec2i;
+
+@vertex
+fn vertex1() -> VertexOutput0 {
+  var out: VertexOutput0;
+  var vf24: vec2u = reverseBits(vec2u(min(pack4x8unorm(unpack4x8snorm(reverseBits(vec2u(unconst_u32(199), unconst_u32(19))).g)), u32(unconst_u32(77)))));
+  let vf25: u32 = vf24[1];
+  vf24 &= vec2u(floor(vec4f(unconst_f32(0.1046), unconst_f32(0.5872), unconst_f32(0.07790), unconst_f32(0.06954))).rb);
+  let vf26: u32 = vf24[1];
+  let vf27: bool = all(bool(unconst_bool(true)));
+  let vf28: u32 = countOneBits(u32(unconst_u32(334)));
+  var vf29: vec4f = unpack4x8snorm(u32(unconst_u32(69)));
+  vf24 *= bitcast<vec2u>(vf29.rb);
+  return out;
+}
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let ptr13: ptr<uniform, vec2h> = &buffer4[0][0];
+  let ptr14: ptr<uniform, array<vec2h, 1>> = &buffer4[0];
+  out.f0 -= bitcast<f32>(buffer4[0][bitcast<u32>((*&buffer4)[u32(unconst_u32(156))][0])]);
+  var vf30: vec3f = cross(vec3f(unconst_f32(-0.02265), unconst_f32(0.00974), unconst_f32(-0.08132)), vec3f((*ptr14)[0].yxy));
+  out = FragmentOutput1(bitcast<f32>(buffer4[0][0]), vec4u(buffer4[0][0].rrgg));
+  let vf31: vec3f = cross(vec3f(unconst_f32(0.4381), unconst_f32(0.1922), unconst_f32(0.01937)), vec3f(unconst_f32(-0.6876), unconst_f32(0.2777), unconst_f32(0.1717)));
+  var vf32: vec4f = refract(vec4f((*ptr14)[0].yxxx), vec4f(unconst_f32(0.00236), unconst_f32(0.01060), unconst_f32(0.01061), unconst_f32(0.3250)), bitcast<f32>(buffer4[0][0]));
+  vf30 = vec3f((*ptr14)[0].rrg);
+  vf32 *= vec4f(f32(buffer4[0][0][1]));
+  vf30 = vec3f(max(f32(unconst_f32(-0.05271)), f32(unconst_f32(0.08709))));
+  let ptr15: ptr<uniform, array<vec2h, 1>> = &buffer4[u32(unconst_u32(459))];
+  let ptr16: ptr<uniform, vec2h> = &(*ptr15)[0];
+  var vf33: f16 = buffer4[0][0][1];
+  vf30 = bitcast<vec3f>(unpack4xU8(u32(unconst_u32(223))).yxz);
+  let ptr17: ptr<uniform, vec2h> = &(*&buffer4)[0][0];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute3() {
+  vw0 = vec2i(buffer4[0][0]);
+  atomicCompareExchangeWeak(&vw1, unconst_i32(3), unconst_i32(-507));
+  atomicCompareExchangeWeak(&vw1, unconst_i32(15), unconst_i32(2));
+  var vf34: vec2f = log2(vec2f(buffer4[0][0]));
+  vf34 = vec2f(f32((*&buffer4)[0][0][0]));
+  vw0 = vec2i((*&buffer4)[0][u32(unconst_u32(335))]);
+  vf34 = vec2f(f32(select(f16(unconst_f16(15940.4)), f16(unconst_f16(11894.3)), bool(unconst_bool(true)))));
+  atomicMax(&vw1, i32(unconst_i32(6)));
+  vf34 = vec2f(f32(atomicLoad(&(*&vw1))));
+  let vf35: vec4i = unpack4xI8(bitcast<u32>(fma(vec4f(f32(pack2x16float(vec2f(unconst_f32(0.07586), unconst_f32(0.09311))))), bitcast<vec4f>(workgroupUniformLoad(&vw0).grgg), vec4f(unconst_f32(0.4283), unconst_f32(-0.09054), unconst_f32(0.4442), unconst_f32(0.00203))).g));
+  vf34 -= vec2f(bitcast<f32>(vf35[2]));
+  var vf36: vec3f = cos(vec3f(bitcast<f32>(atomicExchange(&(*&vw1), bitcast<i32>((*&buffer4)[0][0])))));
+  var vf37: vec2f = unpack2x16snorm(u32(unconst_u32(679)));
+  var vf38: vec4i = max(vec4i(unconst_i32(-66), unconst_i32(868), unconst_i32(4), unconst_i32(-205)), vec4i(vf35[2]));
+  vw0 = vec2i(i32(buffer4[0][0][1]));
+  let ptr18: ptr<uniform, array<array<vec2h, 1>, 1>> = &(*&buffer4);
+  let vf39: vec2f = unpack2x16snorm(u32((*ptr18)[0][0][0]));
+  vf37 = bitcast<vec2f>(max(vec4i(unconst_i32(97), unconst_i32(59), unconst_i32(-212), unconst_i32(101)), vec4i((*ptr18)[0][u32(unconst_u32(7))].yyyx)).xz);
+}`,
+  sourceMap: {},
+});
+let commandEncoder9 = device0.createCommandEncoder();
+let textureView8 = texture1.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4720 */
+  offset: 4720,
+  bytesPerRow: 6656,
+  buffer: buffer3,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let computePassEncoder6 = commandEncoder2.beginComputePass({});
+let texture6 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView9 = texture5.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let buffer5 = device0.createBuffer({
+  size: 1013,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  size: [256, 256, 38],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder7 = commandEncoder9.beginComputePass({});
+try {
+commandEncoder6.copyBufferToBuffer(buffer5, 184, buffer3, 1596, 60);
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({label: '\u0d15\u4cc0\u{1faf7}\u0a4a\u{1fa53}\u956a\ufe13\u0e53\u8ea3\u0355'});
+let texture8 = device0.createTexture({
+  size: [80, 75, 2],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder8 = commandEncoder8.beginComputePass({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 45.49,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  label: '\u{1fb05}\u0621\u{1fed3}\u{1fbe1}\u02a7',
+  layout: bindGroupLayout0,
+  entries: [{binding: 275, resource: {buffer: buffer0, offset: 256, size: 28}}],
+});
+let buffer6 = device0.createBuffer({
+  label: '\ua422\u{1f8f7}\ue2ef\u{1feae}\ubaa6\u0dd0',
+  size: 8373,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.81,
+  lodMaxClamp: 86.18,
+});
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 44, resource: textureView8},
+    {binding: 47, resource: {buffer: buffer3, offset: 7680, size: 883}},
+  ],
+});
+let textureView10 = texture2.createView({
+  label: '\ue568\u0bf7\u114a\u890c\u2acd\u9e49\u0c5b',
+  dimension: '2d',
+  format: 'etc2-rgb8a1unorm-srgb',
+  baseArrayLayer: 2,
+});
+let sampler7 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.30,
+});
+let buffer7 = device0.createBuffer({
+  size: 7415,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture9 = device0.createTexture({size: [40], dimension: '1d', format: 'rgba32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let computePassEncoder9 = commandEncoder6.beginComputePass({});
+let sampler8 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.34,
+  lodMaxClamp: 96.55,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(313), 46, 0);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\ua6b9');
+} catch {}
+let buffer8 = device0.createBuffer({size: 26769, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 15, y: 12, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1696 */
+  offset: 1696,
+  bytesPerRow: 25600,
+  buffer: buffer6,
+}, {width: 1, height: 26, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer3, offset: 2304, size: 3136}},
+    {binding: 123, resource: textureView4},
+  ],
+});
+let commandEncoder14 = device0.createCommandEncoder();
+let textureView11 = texture2.createView({baseMipLevel: 0, baseArrayLayer: 22, arrayLayerCount: 2});
+let computePassEncoder10 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+let commandBuffer0 = commandEncoder0.finish({});
+let computePassEncoder11 = commandEncoder11.beginComputePass();
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.95,
+});
+let bindGroup3 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer3, offset: 2304, size: 860}},
+    {binding: 123, resource: textureView4},
+  ],
+});
+let texture10 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView12 = texture8.createView({mipLevelCount: 1});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+try {
+buffer5.unmap();
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer1, offset: 0, size: 12}},
+    {binding: 123, resource: textureView4},
+  ],
+});
+let textureView13 = texture10.createView({});
+let computePassEncoder13 = commandEncoder14.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 10, y: 13, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3296 */
+  offset: 3296,
+  bytesPerRow: 17152,
+  buffer: buffer8,
+}, {width: 14, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 123, resource: textureView4},
+    {binding: 67, resource: {buffer: buffer1, offset: 0, size: 28}},
+  ],
+});
+let buffer9 = device0.createBuffer({
+  size: 20715,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder14 = commandEncoder13.beginComputePass({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.72,
+  lodMaxClamp: 64.59,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup3, new Uint32Array(319), 45, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 512, new Float32Array(5486), 273, 2080);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1f987}\u{1f8b1}\u{1f73e}\ubb51\u03dd\u9e8e\ubff2',
+  colorFormats: ['rgba32uint', 'r8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer6, 'uint32', 1_744, 389);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 88, y: 20, z: 4},
+  aspect: 'all',
+}, new Uint8Array(72_622).fill(90), /* required buffer size: 72_622 */
+{offset: 82, bytesPerRow: 222, rowsPerImage: 63}, {width: 84, height: 48, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 47, resource: {buffer: buffer5, offset: 0, size: 378}},
+    {binding: 44, resource: textureView1},
+  ],
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture11 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 19},
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture12 = device0.createTexture({
+  size: [320, 300, 42],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder15 = commandEncoder15.beginComputePass({});
+try {
+buffer9.unmap();
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 5, y: 49 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer10 = device0.createBuffer({size: 8044, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let computePassEncoder16 = commandEncoder16.beginComputePass({});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u0295\u360f\ub5e7\u0bd2'});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0, new Uint32Array(1130), 158, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgba32uint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule1, buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: false},
+});
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 133, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 144,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer11 = device0.createBuffer({size: 8407, usage: GPUBufferUsage.UNIFORM});
+let texture14 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture15 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 46},
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView14 = texture12.createView({
+  label: '\u0cfe\u0378\u3129\u9e4d\ub12e\u849a\u0876\u9ef1\u09ab\uf4a3\u01a4',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 4,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup6, new Uint32Array(81), 8, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\ub70c\u{1fe26}\u{1f84a}\u8974\udcb4\u874b\uf823',
+  size: 25605,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder17 = device0.createCommandEncoder();
+let texture16 = device0.createTexture({
+  label: '\u{1fd79}\uc924\u{1f692}\udb31\u0c81',
+  size: [40, 37, 1],
+  sampleCount: 4,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup5, new Uint32Array(1275), 12, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup6, new Uint32Array(2088), 112, 0);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipeline1 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1}});
+let textureView15 = texture14.createView({mipLevelCount: 1});
+let texture17 = device0.createTexture({
+  label: '\u027d\u14b5\u6893\u1cb9\uf043\u{1f84d}\u00f3\u464e',
+  size: [40, 37, 69],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder17.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 15 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView16 = texture16.createView({});
+let textureView17 = texture3.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+await gc();
+let textureView18 = texture3.createView({dimension: 'cube', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder18 = commandEncoder18.beginComputePass({});
+let sampler11 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', magFilter: 'nearest', mipmapFilter: 'nearest'});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer6, 'uint32', 2_892, 795);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer9, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer6, 2820, buffer8, 448, 2448);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 51, resource: {buffer: buffer7, offset: 256, size: 975}},
+    {binding: 34, resource: textureView15},
+    {binding: 144, resource: textureView15},
+    {binding: 133, resource: {buffer: buffer7, offset: 1792, size: 540}},
+    {binding: 43, resource: sampler1},
+    {binding: 10, resource: textureView16},
+    {binding: 134, resource: {buffer: buffer3, offset: 512, size: 7444}},
+  ],
+});
+let buffer13 = device0.createBuffer({size: 7661, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], stencilReadOnly: true});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer9, 'uint32', 3_320, 426);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(2, buffer5, 0, 141);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 416 */
+  offset: 416,
+  bytesPerRow: 14336,
+  buffer: buffer6,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData1 = new ImageData(68, 12);
+let querySet1 = device0.createQuerySet({label: '\u86ff\u8535\u631f', type: 'occlusion', count: 338});
+let computePassEncoder19 = commandEncoder19.beginComputePass({});
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.45,
+  lodMaxClamp: 37.07,
+  maxAnisotropy: 4,
+});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer5, 'uint16', 108, 441);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint16', 18, 0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(3, buffer9, 0);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let commandEncoder20 = device0.createCommandEncoder({label: '\u253e\u{1fcc0}\u{1fceb}\u86b7\u{1f745}\u{1f943}'});
+let texture18 = device0.createTexture({
+  size: [160, 150, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup6, new Uint32Array(1927), 301, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer5, 'uint16', 68, 446);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 71, y: 44, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder();
+let computePassEncoder20 = commandEncoder20.beginComputePass({label: '\udb55\u9964\u{1fac1}\u1ebb\u0538\u{1ff4e}\u0ca3\uadb1\u93a3\uee30\ub312'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup7, new Uint32Array(307), 10, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer13, 1220, buffer9, 1276, 236);
+} catch {}
+let computePassEncoder21 = commandEncoder21.beginComputePass({});
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(0, buffer9);
+} catch {}
+let imageData2 = new ImageData(4, 36);
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 123, resource: textureView15},
+    {binding: 67, resource: {buffer: buffer7, offset: 3072, size: 588}},
+  ],
+});
+let buffer14 = device0.createBuffer({
+  size: 2215,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture19 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler13 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.14,
+  lodMaxClamp: 85.90,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup6, new Uint32Array(1574), 121, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(1, buffer12, 2_356, 693);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 1064});
+let computePassEncoder22 = commandEncoder22.beginComputePass({});
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder2.drawIndexed(24, 147, 1, 863_819_034, 173_146_577);
+} catch {}
+try {
+renderBundleEncoder2.drawIndirect(buffer14, 184);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData2);
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer7, offset: 0, size: 444}},
+    {binding: 123, resource: textureView15},
+  ],
+});
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder2.drawIndexed(30, 127, 1, 286_510_548, 420_208_577);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer12, 0, 9_099);
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u3148\u0456\u0e50\uc2e5',
+  size: 6047,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup0, new Uint32Array(2189), 168, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.drawIndirect(buffer0, 52);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 282,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer16 = device0.createBuffer({size: 987, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder23 = device0.createCommandEncoder({});
+let computePassEncoder23 = commandEncoder23.beginComputePass();
+try {
+computePassEncoder20.setBindGroup(1, bindGroup7, new Uint32Array(1714), 95, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.draw(616, 279, 557_382_162, 4_294_967_295);
+} catch {}
+try {
+renderBundleEncoder2.drawIndexedIndirect(buffer6, 816);
+} catch {}
+try {
+renderBundleEncoder2.drawIndirect(buffer7, 1_620);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 3260, new DataView(new ArrayBuffer(4213)), 135, 264);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView19 = texture14.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup5, new Uint32Array(373), 31, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup6, new Uint32Array(4205), 579, 0);
+} catch {}
+try {
+renderBundleEncoder2.draw(71, 12, 10_642_164, 96_660_066);
+} catch {}
+try {
+renderBundleEncoder2.drawIndexedIndirect(buffer5, 112);
+} catch {}
+try {
+renderBundleEncoder2.drawIndirect(buffer0, 100);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer6, 492, buffer14, 208, 548);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 36, y: 8, z: 33},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 12, y: 12, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(1_586).fill(69), /* required buffer size: 1_586 */
+{offset: 90, bytesPerRow: 186}, {width: 2, height: 9, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 47, resource: {buffer: buffer5, offset: 0, size: 117}},
+    {binding: 44, resource: textureView1},
+  ],
+});
+let commandEncoder25 = device0.createCommandEncoder();
+let texture20 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder24 = commandEncoder24.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(3, bindGroup10, new Uint32Array(2701), 765, 0);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.drawIndexed(12, 107, 61, 196_047_633, 506_943_779);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet0, 8, 19, buffer3, 3840);
+} catch {}
+let buffer17 = device0.createBuffer({
+  size: 21540,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture21 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder2.draw(78, 24, 475_354_225, 77_748_092);
+} catch {}
+try {
+renderBundleEncoder2.drawIndexed(19, 297, 33, 1_606_460_107, 371_574_269);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(4, buffer14, 332, 211);
+} catch {}
+let computePassEncoder25 = commandEncoder13.beginComputePass();
+let renderBundle1 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup10, new Uint32Array(534), 72, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer9, 'uint32', 1_984, 3_121);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(2, buffer12, 5_852, 1_675);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let imageData3 = new ImageData(48, 24);
+let buffer18 = device0.createBuffer({
+  size: 22139,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u3b99\u14ee\u087b\ua3c9\u{1fc8e}\u1dfb\u4b01\ue4d9'});
+let texture22 = device0.createTexture({
+  size: [256, 256, 24],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder26 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder18.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer5, 32, buffer3, 168, 56);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 7, y: 5, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 16, y: 40, z: 1},
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData3,
+  origin: { x: 5, y: 2 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u0fe0\u944c\u070e\u5439\u{1fa48}\u{1f72b}\u60e2\u403f\u0d94\u0e39\u017c';
+} catch {}
+let buffer19 = device0.createBuffer({size: 6432, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder27 = device0.createCommandEncoder({});
+let textureView20 = texture8.createView({mipLevelCount: 1});
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.76,
+  lodMaxClamp: 77.54,
+  compare: 'greater-equal',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup8, new Uint32Array(777), 26, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer17, 'uint32', 1_372, 343);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder();
+let computePassEncoder27 = commandEncoder28.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup7, new Uint32Array(1289), 104, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer9, 3_660); };
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+await gc();
+let computePassEncoder28 = commandEncoder25.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 12.09,
+  lodMaxClamp: 55.34,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup4, new Uint32Array(39), 1, 0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(7, buffer17, 1_216, 3_291);
+} catch {}
+try {
+renderBundleEncoder1.insertDebugMarker('\uc1f5');
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({label: '\u{1fd96}\u9fbe\uad73\u{1fd1d}\u02c3\u{1fc0c}'});
+let texture23 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView21 = texture15.createView({dimension: '2d', baseArrayLayer: 3});
+let renderBundle2 = renderBundleEncoder1.finish({label: '\u074e\u331f\uf785\u1bb9\u0004\ub44b\u8e78\u8457\u9778\u07d3\u757b'});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup0, new Uint32Array(93), 3, 0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer8, 17172, buffer3, 132, 1904);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 11372, new Int16Array(1733), 124, 144);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  label: '\u{1fa91}\u{1fade}\u6df9\ubd99\u084a\udba4',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 134, resource: {buffer: buffer18, offset: 2304, size: 4048}},
+    {binding: 133, resource: {buffer: buffer14, offset: 512, size: 445}},
+    {binding: 34, resource: textureView15},
+    {binding: 144, resource: textureView15},
+    {binding: 51, resource: {buffer: buffer11, offset: 2560, size: 1559}},
+    {binding: 43, resource: sampler4},
+    {binding: 10, resource: textureView16},
+  ],
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.68,
+  lodMaxClamp: 99.24,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer15, 700, buffer8, 6720, 3064);
+} catch {}
+let buffer20 = device0.createBuffer({size: 39913, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({
+  label: '\u{1f790}\ud1d9\ua215\u{1fcda}\u804b\u2595\u3286',
+  size: [40, 48, 69],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView22 = texture9.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 8, y: 1 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 67, resource: {buffer: buffer1, offset: 0}}, {binding: 123, resource: textureView10}],
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let computePassEncoder29 = commandEncoder27.beginComputePass({label: '\u{1fd4e}\u8f97\u{1fa69}\u1970\u{1fcbf}\u{1faeb}\u2b18\u9a26\u48c9'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup2, new Uint32Array(120), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer18, 3464, buffer8, 1684, 208);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 19, y: 2, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+@group(0) @binding(47) var<uniform> buffer21: array<array<f16, 1>, 2>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw6: array<array<array<vec2<bool>, 1>, 1>, 8>;
+
+var<private> vp2: mat3x3f = mat3x3f();
+
+@group(0) @binding(44) var tex1: texture_1d<i32>;
+
+fn fn2() -> mat2x3f {
+  var out: mat2x3f;
+  out += mat2x3f(vp2[0], vp2[1]);
+  vp2 = mat3x3f(f32(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), bitcast<f32>(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), f32(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), bitcast<f32>(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), bitcast<f32>(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), f32(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), f32(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), f32(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))), bitcast<f32>(pack2x16float(bitcast<vec2f>(textureLoad(tex1, i32(unconst_i32(33)), i32(all(bool(unconst_bool(true))))).xz))));
+  vp2 = mat3x3f(f32(override0), f32(override0), f32(override0), f32(override0), f32(override0), f32(override0), f32(override0), f32(override0), f32(override0));
+  return out;
+}
+
+var<workgroup> vw2: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct S0 {
+  @location(11) f0: vec4u,
+  @location(4) f1: vec2i,
+}
+
+var<workgroup> vw5: S0;
+
+var<workgroup> vw4: array<atomic<u32>, 4>;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+struct FragmentOutput2 {
+  @location(0) f0: vec4u,
+  @location(3) @interpolate(flat, sample) f1: vec2u,
+  @builtin(sample_mask) f2: u32,
+}
+
+@id(9865) override override1: i32 = 135;
+
+var<workgroup> vw3: array<i32, 61>;
+
+var<workgroup> vw7: array<vec2<bool>, 10>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+override override0 = false;
+
+fn fn0(a0: mat3x4f) -> array<array<array<array<f32, 1>, 1>, 1>, 18> {
+  var out: array<array<array<array<f32, 1>, 1>, 1>, 18>;
+  var vf40: bool = override0;
+  let vf41: vec4f = smoothstep(smoothstep(vec4f(unconst_f32(0.07364), unconst_f32(-0.2779), unconst_f32(0.5402), unconst_f32(0.1558)), vec4f(unconst_f32(0.04045), unconst_f32(0.02907), unconst_f32(0.4130), unconst_f32(0.2256)), vec4f(unconst_f32(0.1299), unconst_f32(0.1362), unconst_f32(0.2918), unconst_f32(0.08899))), a0[0], vec4f(unconst_f32(0.01330), unconst_f32(0.3561), unconst_f32(0.03559), unconst_f32(0.1860)));
+  var vf42: vec4f = vf41;
+  let vf43: f32 = vf42[0];
+  var vf44: vec4f = a0[1];
+  vp2 = mat3x3f(vf43, vf43, vf43, vf43, vf43, vf43, vf43, vf43, vf43);
+  vf42 += vec4f(f32(vf40));
+  let ptr19: ptr<function, vec4f> = &vf44;
+  vf42 *= a0[1];
+  vp2 = mat3x3f(vf42.xxz, vf42.zwx, vf42.xzz);
+  var vf45: f32 = (*ptr19)[2];
+  var vf46: f32 = (*ptr19)[2];
+  vf42 = vec4f(vf46);
+  let ptr20: ptr<function, f32> = &vf45;
+  let ptr21: ptr<function, f32> = &vf46;
+  let vf47: vec2f = faceForward(vec2f(unconst_f32(0.2548), unconst_f32(0.5735)), vec2f(unconst_f32(-0.02527), unconst_f32(0.1552)), vec2f(bitcast<f32>(override1)));
+  let vf48: f32 = vf41[3];
+  var vf49: vec4f = smoothstep(vec4f(bitcast<f32>(override1)), vec4f(unconst_f32(0.03822), unconst_f32(0.1043), unconst_f32(0.6802), unconst_f32(0.00605)), vec4f(unconst_f32(0.03090), unconst_f32(0.04391), unconst_f32(0.08392), unconst_f32(0.00379)));
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1(a0: ptr<storage, array<S0, 1>, read>) -> array<array<f16, 1>, 58> {
+  var out: array<array<f16, 1>, 58>;
+  vp2 += mat3x3f(f32(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), f32(textureDimensions(tex1)), f32(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), f32(textureDimensions(tex1)), f32(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)));
+  let vf50: vec3i = insertBits(vec3i(unconst_i32(71), unconst_i32(32), unconst_i32(45)), vec3i(unconst_i32(16), unconst_i32(83), unconst_i32(161)), bitcast<u32>((*a0)[0].f1.g), u32(unconst_u32(115)));
+  let vf51: u32 = textureDimensions(tex1, 0i);
+  let vf52: u32 = vf51;
+  vp2 = mat3x3f(vec3f((*a0)[0].f0.ara), vec3f((*a0)[0].f0.gar), bitcast<vec3f>((*a0)[0].f0.zxx));
+  vp2 = mat3x3f(vec3f((*a0)[0].f1.yxy), vec3f((*a0)[0].f1.rgg), vec3f((*a0)[0].f1.grr));
+  vp2 = mat3x3f(bitcast<vec3f>(vf50), vec3f(vf50), bitcast<vec3f>(vf50));
+  let ptr22: ptr<private, vec3f> = &vp2[1];
+  let vf53: i32 = (*a0)[0].f1[1];
+  let vf54: vec4i = textureLoad(tex1, i32(unconst_i32(102)), i32(unconst_i32(364)));
+  vp2 += mat3x3f(f32(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), f32(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)), f32(textureDimensions(tex1)), f32(textureDimensions(tex1)), bitcast<f32>(textureDimensions(tex1)));
+  var vf55: i32 = (*a0)[0].f1[1];
+  let ptr23: ptr<storage, vec2i, read> = &(*a0)[0].f1;
+  vp2 = mat3x3f(vec3f((*a0)[0].f0.arb), vec3f((*a0)[0].f0.wxx), vec3f((*a0)[0].f0.grg));
+  let vf56: u32 = textureDimensions(tex1);
+  let ptr24: ptr<storage, vec4u, read> = &(*a0)[0].f0;
+  var vf57: vec3i = vf50;
+  let ptr25: ptr<storage, vec2i, read> = &(*a0)[0].f1;
+  vf55 += (*ptr23).y;
+  vf55 = i32((*ptr22)[0]);
+  vf57 = vec3i((*a0)[0].f0.zxz);
+  let vf58: vec4i = textureLoad(tex1, vf57[0], (*a0)[u32(vp2[1].x)].f1[0]);
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex2(@location(7) a0: vec2i, @location(9) a1: vec2i, a2: S0, @location(12) a3: vec2i, @location(0) a4: f32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  vp2 = mat3x3f(bitcast<f32>(textureNumLevels(tex1)), bitcast<f32>(textureNumLevels(tex1)), bitcast<f32>(textureNumLevels(tex1)), bitcast<f32>(textureNumLevels(tex1)), f32(textureNumLevels(tex1)), f32(textureNumLevels(tex1)), bitcast<f32>(textureNumLevels(tex1)), bitcast<f32>(textureNumLevels(tex1)), bitcast<f32>(textureNumLevels(tex1)));
+  out += bitcast<vec4f>(a2.f0);
+  fn2();
+  fn0(mat3x4f(vec4f(sin(vec3h(floor(vec2f(unconst_f32(0.3375), unconst_f32(0.1091))).grg)).grgb), vec4f(sin(vec3h(floor(vec2f(unconst_f32(0.3375), unconst_f32(0.1091))).grg)).xyzz), vec4f(sin(vec3h(floor(vec2f(unconst_f32(0.3375), unconst_f32(0.1091))).grg)).xzzy)));
+  vp2 += mat3x3f(bitcast<f32>(override1), bitcast<f32>(override1), bitcast<f32>(override1), bitcast<f32>(override1), f32(override1), f32(override1), bitcast<f32>(override1), f32(override1), f32(override1));
+  var vf59 = fn2();
+  var vf60: vec3h = sin(vec3h(f16(override0)));
+  fn2();
+  out -= unpack4x8snorm(pack2x16snorm(vec2f(unconst_f32(-0.6820), unconst_f32(0.1116))));
+  vf59 = mat2x3f(bitcast<f32>(pack2x16snorm(vec2f(f32(override1)))), bitcast<f32>(pack2x16snorm(vec2f(f32(override1)))), bitcast<f32>(pack2x16snorm(vec2f(f32(override1)))), f32(pack2x16snorm(vec2f(f32(override1)))), bitcast<f32>(pack2x16snorm(vec2f(f32(override1)))), f32(pack2x16snorm(vec2f(f32(override1)))));
+  fn2();
+  var vf61: vec2i = a2.f1;
+  return out;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  var vf62: vec2h = sinh(vec2h(unconst_f16(13161.1), unconst_f16(30753.5)));
+  vf62 *= vec2h(reflect(vec4f(unconst_f32(0.05385), unconst_f32(0.05011), unconst_f32(-0.07552), unconst_f32(0.1819)), vec4f(vf62.yxyy)).ab);
+  vp2 = mat3x3f(f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]), f32((*&buffer21)[1][bitcast<u32>(override1)]));
+  let ptr26: ptr<uniform, f16> = &buffer21[1][0];
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute4() {
+  vw7[u32((*&buffer21)[1][0])] = vec2<bool>(bool(atomicLoad(&vw2)));
+  atomicSub(&vw2, i32(unconst_i32(-10)));
+  vw3[vw5.f0.r] += i32(any((*&vw6)[7][0][u32(unconst_u32(25))]));
+  var vf63: array<vec2<bool>, 10> = workgroupUniformLoad(&vw7);
+  vp2 = mat3x3f(f32(vw5.f0[1]), f32(vw5.f0[1]), f32(vw5.f0[1]), bitcast<f32>(vw5.f0[1]), f32(vw5.f0[1]), f32(vw5.f0[1]), f32(vw5.f0[1]), f32(vw5.f0[1]), bitcast<f32>(vw5.f0[1]));
+  vw7[u32(unconst_u32(95))] = vec2<bool>(bool(buffer21[1][0]));
+  let ptr27: ptr<workgroup, vec4u> = &vw5.f0;
+  vw6[7][u32(unconst_u32(118))][vec2u(vf63[9]).x] = vec2<bool>(bool(atomicLoad(&(*&vw4)[3])));
+  let ptr28: ptr<workgroup, vec2<bool>> = &vw7[9];
+  atomicSub(&vw2, i32(vw5.f0[1]));
+  let ptr29: ptr<workgroup, atomic<u32>> = &vw4[3];
+  vw5.f1 ^= vec2i(i32((*&buffer21)[1][0]));
+  let ptr30: ptr<workgroup, array<atomic<u32>, 4>> = &(*&vw4);
+  vf63[9] = vec2<bool>(bool(vw3[u32(unconst_u32(137))]));
+  vw3[u32(unconst_u32(212))] = i32((*&buffer21)[1][0]);
+  let vf64: u32 = atomicLoad(&(*&vw4)[3]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2224 */
+  offset: 2224,
+  bytesPerRow: 32000,
+  buffer: buffer20,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(293).fill(148), /* required buffer size: 293 */
+{offset: 293}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter1.label = '\uff62\u9b3d\u0d8f\u{1f85c}\u711b\u0844\u0d3b\u{1fe22}\u{1f91d}\u0988';
+} catch {}
+try {
+device0.queue.label = '\u{1f719}\u039e\u97b5\ua36e\u5f6b\u9da4\u09a2';
+} catch {}
+let renderPassEncoder0 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 974.2, g: -159.9, b: -248.6, a: 596.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView9,
+  depthSlice: 1,
+  clearValue: { r: -24.83, g: -597.0, b: 583.9, a: 516.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 244694304,
+});
+let sampler17 = device0.createSampler({
+  label: '\u0730\u88ef\ue7b6\ua820\uaef8\u2aed',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 48.64,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup11, new Uint32Array(860), 63, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 0, 9);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let img0 = await imageWithData(40, 63, '#10101010', '#20202020');
+let buffer22 = device0.createBuffer({
+  size: 20611,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 15.18,
+  lodMaxClamp: 54.52,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup3, new Uint32Array(622), 107, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(11, 25, 18, 2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 32, 212);
+} catch {}
+let buffer23 = device0.createBuffer({
+  size: 26472,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture25 = device0.createTexture({
+  label: '\ub9f4\u072f\u811e\u{1f755}\u{1fd26}',
+  size: [80, 96, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup12, new Uint32Array(578), 149, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2, new Uint32Array(884), 31, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer17, 'uint32', 10_944, 1_014);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer17, 0, 2_584);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 576 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 336 */
+  offset: 336,
+  bytesPerRow: 11264,
+  rowsPerImage: 64,
+  buffer: buffer13,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView23 = texture25.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder30 = commandEncoder29.beginComputePass({});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(966), 149, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -449.6, g: 19.25, b: 887.6, a: -559.2, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(7, 19, 7, 11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 22 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  label: '\u92c5\u2c4d\u{1fda5}\u0107\u{1febb}\u099e\u3537\uda09\ue4ba\u{1f815}\u43bc',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 44, resource: textureView2},
+    {binding: 47, resource: {buffer: buffer18, offset: 256, size: 6248}},
+  ],
+});
+let textureView24 = texture0.createView({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer14, 'uint32', 108, 74);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer19, 'uint16', 242, 1_452);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(buffer19, 848, buffer6, 1400, 584);
+} catch {}
+try {
+commandEncoder33.insertDebugMarker('\u9033');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 2004, new BigUint64Array(22262), 9022, 12);
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'gamma28curve'} });
+let buffer24 = device0.createBuffer({
+  size: 13991,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder31 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer22, 'uint32', 4_592, 225);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer20);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer19, 'uint16', 618, 266);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 22, y: 17, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 224 */
+  offset: 224,
+  bytesPerRow: 4864,
+  buffer: buffer10,
+}, {width: 8, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let texture26 = device0.createTexture({
+  size: [80, 96, 8],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder1 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{view: textureView21, loadOp: 'clear', storeOp: 'discard'}, {view: textureView20, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 355774805,
+});
+let renderBundle3 = renderBundleEncoder3.finish();
+try {
+computePassEncoder27.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(0, bindGroup5, new Uint32Array(1032), 48, 0);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\u9da1');
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let bindGroup14 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 44, resource: textureView8},
+    {binding: 47, resource: {buffer: buffer12, offset: 1792, size: 12453}},
+  ],
+});
+let buffer25 = device0.createBuffer({
+  size: 1720,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture27 = device0.createTexture({
+  size: {width: 40},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder32 = commandEncoder33.beginComputePass({label: '\u{1fd09}\u0807\u{1fc28}\u05c5\u{1f96c}\uaae3\u73ff'});
+let sampler19 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.93,
+  lodMaxClamp: 69.28,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint16', 50, 101);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 224 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 96 */
+  offset: 96,
+  bytesPerRow: 4352,
+  rowsPerImage: 213,
+  buffer: buffer5,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 10, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup9, new Uint32Array(2738), 1_882, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup11, new Uint32Array(579), 211, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 18, y: 1, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 11598,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView25 = texture17.createView({dimension: '2d'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, undefined, 0, 1_925_018_371);
+} catch {}
+document.body.prepend(img0);
+let texture28 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 19},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder33 = commandEncoder32.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u01e3\u08e4\uacf3\ucc45\u3c5b\u{1f6bd}\u{1f859}\u1b68\uf015',
+  entries: [
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer27 = device0.createBuffer({
+  size: 14464,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.01,
+  lodMaxClamp: 30.60,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(154), /* required buffer size: 22 */
+{offset: 22}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup15 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler5}]});
+let commandEncoder34 = device0.createCommandEncoder();
+let texture29 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView26 = texture16.createView({});
+let sampler21 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 12.23,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup6, new Uint32Array(1599), 109, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 813.6, g: -625.1, b: -148.7, a: 593.1, });
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+let bindGroup16 = device0.createBindGroup({label: '\u0e3f\u09dc\u1a07', layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler16}]});
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView27 = texture22.createView({dimension: '2d', mipLevelCount: 1});
+let texture30 = device0.createTexture({size: [256, 256, 24], mipLevelCount: 1, format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder34 = commandEncoder34.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 64 */
+  offset: 64,
+  buffer: buffer25,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt2020', transfer: 'iec6196624'} });
+let commandEncoder36 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet1, 187, 20, buffer12, 768);
+} catch {}
+try {
+computePassEncoder34.insertDebugMarker('\u2847');
+} catch {}
+let buffer28 = device0.createBuffer({label: '\u45c8\u0d41', size: 18519, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder37 = device0.createCommandEncoder({});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(70.46021310913676, 56.950583716578734, 4.903489585672127, 7.424304763730937, 0.241161427447401, 0.9749346429145443);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let buffer29 = device0.createBuffer({size: 2336, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder38 = device0.createCommandEncoder({label: '\u2ee0\u973c\u9d9b\u{1fdb5}'});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint32', 1_876, 1_764);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let textureView28 = texture22.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder35 = commandEncoder37.beginComputePass({label: '\u085d\u{1fcc1}\u{1f9f1}\u2af5\u73f1\ufac0'});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(2, bindGroup0, new Uint32Array(1448), 10, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(291);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let imageData4 = new ImageData(24, 108);
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+var<workgroup> vw8: S1;
+
+@id(12232) override override3 = false;
+
+struct T0 {
+  @align(2) f0: array<u32>,
+}
+
+var<workgroup> vw17: mat2x4h;
+
+var<private> vp4: VertexOutput1 = VertexOutput1();
+
+var<private> vp3: f32 = f32();
+
+var<workgroup> vw10: atomic<u32>;
+
+var<private> vp5: array<array<u32, 1>, 1> = array<array<u32, 1>, 1>(array(u32()));
+
+var<workgroup> vw18: mat4x2h;
+
+override override2: u32 = 176;
+
+struct S1 {
+  @location(1) @interpolate(linear) f0: vec4f,
+}
+
+var<workgroup> vw14: atomic<i32>;
+
+var<workgroup> vw16: T1;
+
+struct VertexOutput1 {
+  @builtin(position) f1: vec4f,
+}
+
+var<workgroup> vw12: array<atomic<i32>, 2>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T1 {
+  f0: array<atomic<u32>, 1>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw19: T1;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw11: array<vec4h, 15>;
+
+@id(61367) override override5: i32 = 26;
+
+var<workgroup> vw9: mat3x2f;
+
+@group(0) @binding(44) var tex2: texture_1d<i32>;
+
+@group(0) @binding(47) var<uniform> buffer30: i32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw13: atomic<i32>;
+
+var<workgroup> vw15: u32;
+
+override override4 = true;
+
+fn fn0(a0: VertexOutput1, a1: ptr<private, VertexOutput1>) -> S1 {
+  var out: S1;
+  vp4.f1 *= vec4f(bitcast<f32>(pack4xI8(vec4i(unconst_i32(50), unconst_i32(-40), unconst_i32(18), unconst_i32(-153)))));
+  let ptr31: ptr<private, array<u32, 1>> = &vp5[0];
+  let ptr32: ptr<private, VertexOutput1> = &(*a1);
+  out.f0 = vec4f(sign(f32(unconst_f32(0.3758))));
+  var vf65: f32 = (*a1).f1[1];
+  let vf66: u32 = select(u32(unconst_u32(73)), textureDimensions(tex2, 0i), bool(pack4xI8(vec4i(bitcast<i32>(textureDimensions(tex2))))));
+  var vf67: f16 = trunc(f16(unconst_f16(18891.5)));
+  let vf68: u32 = select(pack4xU8(vec4u((*ptr32).f1)), u32(unconst_u32(3)), bool(vp4.f1[2]));
+  vp4.f1 = a0.f1;
+  let ptr33: ptr<private, vec4f> = &(*a1).f1;
+  let vf69: f32 = acos(f32((*ptr31)[0]));
+  return out;
+}
+
+override override6: i32 = 466;
+
+@vertex @must_use
+fn vertex3(a0: S1, @location(6) a1: i32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  vp3 = f32(sin(vec4h(f16(textureNumLevels(tex2))))[0]);
+  vp5[u32(unconst_u32(46))][u32(unconst_u32(19))] |= vp5[0][0];
+  vp3 = vp4.f1[1];
+  let vf70: f32 = asinh(f32(unconst_f32(0.09735)));
+  vp5[u32(unconst_u32(145))][u32(unconst_u32(142))] ^= u32(a0.f0[2]);
+  var vf71: i32 = a1;
+  vf71 = bitcast<i32>(degrees(bitcast<vec2h>(override5)));
+  let ptr34: ptr<private, array<array<u32, 1>, 1>> = &vp5;
+  let ptr35: ptr<private, u32> = &(*ptr34)[0][0];
+  vp5[u32(unconst_u32(325))][textureNumLevels(tex2)] += u32(override4);
+  vp3 += f32(override4);
+  return out;
+}
+
+@fragment
+fn fragment3() {
+  let vf72: f32 = vp4.f1[1];
+  let ptr36: ptr<private, f32> = &vp3;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute5() {
+  vw8 = S1(vec4f(bitcast<f32>(atomicLoad(&vw13))));
+  atomicExchange(&vw12[u32(unconst_u32(100))], i32(unconst_i32(-155)));
+  let ptr37: ptr<workgroup, atomic<i32>> = &(*&vw12)[1];
+  let vf73: vec4i = textureLoad(tex2, i32(unconst_i32(0)), i32(unconst_i32(167)));
+  atomicMin(&vw10, u32(unconst_u32(42)));
+  let ptr38: ptr<uniform, i32> = &buffer30;
+  vp4.f1 -= vw8.f0;
+  vw17 = mat2x4h(vw11[14], vw11[14]);
+  let ptr39: ptr<workgroup, array<atomic<u32>, 1>> = &(*&vw16).f0;
+  let ptr40: ptr<workgroup, atomic<i32>> = &vw12[u32(vw11[14].b)];
+  let vf74: i32 = atomicExchange(&(*ptr40), bitcast<i32>(asinh(vec2h(vf73.ab))));
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute6(@builtin(global_invocation_id) a0: vec3u) {
+  let vf75: bool = override3;
+  atomicCompareExchangeWeak(&vw10, unconst_u32(166), unconst_u32(465));
+  atomicStore(&vw14, i32(unconst_i32(129)));
+  atomicCompareExchangeWeak(&vw16.f0[u32(unconst_u32(268))], unconst_u32(436), unconst_u32(122));
+  vp4 = VertexOutput1(vec4f(textureLoad(tex2, i32(unconst_i32(31)), vec4i(vp4.f1).r)));
+  vw9 = mat3x2f(f32(atomicLoad(&vw12[1])), bitcast<f32>(atomicLoad(&vw12[1])), bitcast<f32>(atomicLoad(&vw12[1])), f32(atomicLoad(&vw12[1])), bitcast<f32>(atomicLoad(&vw12[1])), f32(atomicLoad(&vw12[1])));
+  atomicSub(&vw13, i32(unconst_i32(157)));
+  let ptr41: ptr<workgroup, atomic<u32>> = &(*&vw19).f0[bitcast<u32>(atomicExchange(&vw14, i32(vw17[1][1])))];
+  let vf76: i32 = atomicExchange(&vw14, i32(atomicExchange(&(*&vw16).f0[0], u32(vw9[0][0]))));
+  vp5[u32(vw17[1][1])][u32(unconst_u32(403))] = atomicLoad(&(*&vw16).f0[0]);
+  vw9 = mat3x2f(vec2f(vw18[1]), vec2f(vw18[3]), vec2f(vw18[0]));
+  let vf77: i32 = atomicExchange(&(*&vw13), bitcast<i32>(vp4.f1[1]));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView29 = texture14.createView({mipLevelCount: 1});
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup8, new Uint32Array(3384), 98, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint16', 5_490, 3_581);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4368 */
+  offset: 4368,
+  bytesPerRow: 26624,
+  buffer: buffer8,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 48, new BigUint64Array(6234), 87, 608);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(64).fill(1), /* required buffer size: 64 */
+{offset: 64, rowsPerImage: 3}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img1 = await imageWithData(149, 1, '#10101010', '#20202020');
+let bindGroup17 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 47, resource: {buffer: buffer20, offset: 11776, size: 4351}},
+    {binding: 44, resource: textureView8},
+  ],
+});
+let computePassEncoder36 = commandEncoder35.beginComputePass({});
+let renderPassEncoder2 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{view: textureView21, loadOp: 'clear', storeOp: 'discard'}, {
+  view: textureView9,
+  depthSlice: 1,
+  clearValue: { r: -28.57, g: -618.5, b: -556.3, a: 572.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], depthReadOnly: true});
+let renderBundle4 = renderBundleEncoder4.finish({label: '\u7d9f\u0b8e\u75a9\u{1fde9}\ud3f1\u0738\u{1fbe3}\u0216'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup5, new Uint32Array(3151), 3_151, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup11, new Uint32Array(492), 134, 0);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, constants: {}}});
+let buffer31 = device0.createBuffer({
+  size: 3035,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture31 = device0.createTexture({
+  size: [10, 12, 19],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder37 = commandEncoder38.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3, renderBundle4, renderBundle3, renderBundle3, renderBundle4, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.draw(99, 45, 868_725_749, 1_088_370_133);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer0, 44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 162, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(344).fill(176), /* required buffer size: 344 */
+{offset: 344}, {width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise2;
+} catch {}
+let sampler22 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 3.477,
+  lodMaxClamp: 80.79,
+  compare: 'greater-equal',
+});
+let sampler23 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.68,
+  maxAnisotropy: 2,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder0.draw(131, 298, 725_284_430, 371_957_594);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 1424, new Float32Array(15955), 142, 1436);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer18, offset: 512, size: 636}},
+    {binding: 123, resource: textureView10},
+  ],
+});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.draw(7, 2, 1_153_694_897, 98_248_834);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer0, 292);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 4832, new BigUint64Array(7195), 229, 96);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let buffer32 = device0.createBuffer({size: 22009, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle5 = renderBundleEncoder5.finish({label: '\u03f4\u05da\ub8b0\u05ad\u0e54'});
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer24, 1_348);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer26, 40);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer14, 'uint16', 352, 517);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+let img2 = await imageWithData(36, 43, '#10101010', '#20202020');
+let bindGroup19 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 47, resource: {buffer: buffer27, offset: 1792}}, {binding: 44, resource: textureView1}],
+});
+let commandEncoder39 = device0.createCommandEncoder({label: '\u5cfb\uf95e\u039c\u216c\u0221\u{1f6c2}\u03ea\u{1f62a}\uc8c4\u8c1b\u056a'});
+let texture32 = device0.createTexture({
+  size: [20, 24, 1],
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup5, new Uint32Array(2393), 1_160, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(107, 152, 666_244_662, 3_021_763_994);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer25, 240, 50);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer29, 240, buffer25, 612, 20);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 32, y: 11, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder3 = commandEncoder39.beginRenderPass({
+  label: '\u{1fafd}\u0735\u{1fdc5}',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -414.4, g: -941.6, b: 40.02, a: -96.07, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView9,
+  depthSlice: 0,
+  clearValue: { r: -30.54, g: -654.4, b: -197.5, a: -621.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler24 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 99.52,
+});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup11, new Uint32Array(3783), 427, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer24, 1_576);
+} catch {}
+let arrayBuffer0 = buffer27.getMappedRange();
+let promise8 = device0.queue.onSubmittedWorkDone();
+let imageData5 = new ImageData(28, 20);
+let buffer33 = device0.createBuffer({size: 856, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder40 = device0.createCommandEncoder();
+let computePassEncoder38 = commandEncoder40.beginComputePass({label: '\u{1f773}\u{1fa38}\u75ad\ubb78\u0805\u1dfa\u73ee'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.51,
+  lodMaxClamp: 99.42,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer5, 92); };
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(9, 6, 8, 4);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer14, 692);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer18, offset: 2048, size: 2756}},
+    {binding: 123, resource: textureView29},
+  ],
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView30 = texture21.createView({});
+let externalTexture1 = device0.importExternalTexture({
+  label: '\u0bd6\u{1f6a6}\u0395\u0230\u{1fcfe}\u1223\u8e1f\ucee9',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder3.setViewport(33.861513243838665, 13.33706355559015, 0.3372008721734779, 45.500831420360235, 0.31061323596755896, 0.7922371590139742);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(746, 204, 106, 427_378_585, 2_270_433_117);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer22, 2_048);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer9, 4_120, 924);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 14, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture33 = device0.createTexture({
+  size: {width: 80},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 16.80,
+  lodMaxClamp: 67.35,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup20, new Uint32Array(698), 206, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroupsIndirect(buffer24, 448); };
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.draw(52, 146, 115_466_736, 2_204_495_393);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(70, 91, 263, 193_362_906, 1_073_780_852);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer12, 16_028);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+computePassEncoder28.setBindGroup(1, bindGroup12, new Uint32Array(1219), 20, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.draw(683, 62, 162_309_721, 355_882_768);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer5, 404);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer27, 'uint16', 350, 646);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer31, 80, 148);
+} catch {}
+try {
+  await promise6;
+} catch {}
+await gc();
+try {
+adapter0.label = '\u{1fb80}\u0559\u1bdd\u66f5\u0438\u0ebe\u0034\u42ba\u400c\u04e3';
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 123, resource: textureView25},
+    {binding: 67, resource: {buffer: buffer16, offset: 0, size: 104}},
+  ],
+});
+let texture34 = device0.createTexture({
+  size: [160, 150, 3],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView31 = texture8.createView({mipLevelCount: 1});
+let computePassEncoder39 = commandEncoder41.beginComputePass({label: '\u1e3c\u5f24\u23b2\u{1fe21}\u0e6e\u30d0\u8651\u{1f624}\ucd05'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm']});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.28,
+  lodMaxClamp: 91.58,
+  compare: 'greater',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup15, new Uint32Array(968), 22, 0);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.draw(189, 5, 2_983_368_907, 541_566_487);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer6, 1_112);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer0, 108);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup17, new Uint32Array(1168), 83, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer18, 'uint16', 2_912, 1_318);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer12, 0, 8_656);
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\u0036');
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u0262\u9efe\u0aa6\u13fa\u{1fcc5}\uc49c\uc59b\u5048'});
+let textureView32 = texture28.createView({label: '\u03c6\uc0be\u{1fa02}\u191d\u{1f637}\u{1fff4}\uaeba\u0a72\u4c1c'});
+let computePassEncoder40 = commandEncoder42.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(41, 34, 38, 619_981_766, 281_757_227);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer31, 352);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer17, 'uint16', 26, 752);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer22, 'uint32', 1_640, 2_802);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer7, 0, 295);
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'unspecified'} });
+let bindGroup22 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 275, resource: {buffer: buffer16, offset: 0, size: 24}}],
+});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder1.draw(368, 55, 63_344_061, 838_787_580);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(18, 466, 855, 440_037_065, 7_873_384);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer0, 548);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [{binding: 44, resource: textureView1}, {binding: 47, resource: {buffer: buffer5, offset: 0, size: 34}}],
+});
+let textureView33 = texture9.createView({});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer6, 488);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(695).fill(94), /* required buffer size: 695 */
+{offset: 695}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView34 = texture22.createView({mipLevelCount: 1, baseArrayLayer: 8, arrayLayerCount: 1});
+let sampler28 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.76,
+  lodMaxClamp: 45.47,
+  compare: 'less',
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(106, 27, 153, 918_875_200, 225_192_388);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer6, 1_768);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 136, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 33,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(23, 144, 57, 3_347_459, 1_760_877_502);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer17, 5_404);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer5, 380);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 372, new Float32Array(34275), 6279, 8);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  size: [10, 12, 19],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder41 = commandEncoder6.beginComputePass({});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup22, new Uint32Array(295), 15, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle1, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer9, 3_156);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer24, 712, buffer3, 964, 4204);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 25, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(86).fill(20), /* required buffer size: 86 */
+{offset: 86, bytesPerRow: 126}, {width: 7, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img1);
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte240m', transfer: 'log'} });
+let computePassEncoder42 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(1, bindGroup7, new Uint32Array(1799), 91, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.draw(227, 60, 58_067_464, 1_515_960_657);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(30, 69, 1, 281_198_218, 154_302_505);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer22, 4_716);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData4,
+  origin: { x: 3, y: 16 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 101});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.draw(522, 80, 95_216_974, 2_086_114_755);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(55, 19, 21, 344_806_685, 1_221_291_795);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer17, 2_648);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer14, 'uint16', 468, 1_205);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer17, 1_272, 1_468);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer6, 1216, buffer23, 5392, 212);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer9, 2600, 1280);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\u{1f944}');
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise3;
+} catch {}
+try {
+externalTexture0.label = '\u{1f6ad}\udc06\uda10\u098e';
+} catch {}
+let buffer34 = device0.createBuffer({
+  size: 22970,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let computePassEncoder43 = commandEncoder44.beginComputePass({});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], sampleCount: 1, depthReadOnly: true});
+let sampler29 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 73.23,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup3, new Uint32Array(88), 18, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup10, new Uint32Array(1007), 37, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer18, 'uint16', 442, 1_543);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer24, 0, 347);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u{1fd33}\u7f72\u4c99\ue1a2\ueb59\u{1fb00}\u0be1'});
+let texture36 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 38},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder44 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup23, new Uint32Array(1254), 102, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer34, 1_924);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer0, 40);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u6da7');
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder();
+let computePassEncoder45 = commandEncoder27.beginComputePass({});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint16', 6_740, 2_401);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer5, 0, 147);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u7551');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 15888, new DataView(new ArrayBuffer(23484)), 3817, 152);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(62).fill(152), /* required buffer size: 62 */
+{offset: 62, bytesPerRow: 58}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  label: '\u0400\u0656\u0fec\ue954\u0457\u8ae9\ucfbc\u4025\u0e78',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer7, offset: 256, size: 212}},
+    {binding: 123, resource: textureView15},
+  ],
+});
+let textureView35 = texture35.createView({dimension: '3d', mipLevelCount: 1});
+let texture37 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer27, 'uint16', 4_592, 3_173);
+} catch {}
+try {
+commandEncoder45.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1360 widthInBlocks: 85 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 464 */
+  offset: 464,
+  bytesPerRow: 29184,
+  buffer: buffer6,
+}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 177, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(213).fill(23), /* required buffer size: 213 */
+{offset: 213}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let computePassEncoder46 = commandEncoder46.beginComputePass({});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup11, new Uint32Array(3296), 862, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 3_888);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer23, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer17, 0, 206);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4070 */
+  offset: 4070,
+  buffer: buffer20,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule3, entryPoint: 'compute5', constants: {}}});
+let commandEncoder47 = device0.createCommandEncoder();
+let texture38 = device0.createTexture({
+  size: [160, 150, 5],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView36 = texture7.createView({dimension: '3d', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder47 = commandEncoder47.beginComputePass({});
+let renderPassEncoder4 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -119.2, g: -360.2, b: 689.0, a: -342.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView31,
+  depthSlice: 0,
+  clearValue: { r: -922.7, g: -731.3, b: -743.6, a: -74.78, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup22, new Uint32Array(557), 4, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(41, 16, 23, 504_823_141, 239_537_820);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer23, 'uint16', 172, 7_353);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture39 = device0.createTexture({
+  label: '\ue8a8\u0bda\u0454\u{1ff8c}\u4014\u{1f7f1}\ua596\u{1f653}\ucdf6\udf67',
+  size: {width: 160, height: 150, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup6, new Uint32Array(1626), 244, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.draw(38, 159, 847_111_047, 902_688_321);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(25, 49, 26, 142_387_293, 171_139_633);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 440);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer27, 0, 1_120);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup23, new Uint32Array(16), 0, 0);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let sampler30 = device0.createSampler({
+  label: '\u1856\u016c\ue200\u706c\ue13e\u080e\u064b\u2416\uc670\u{1f7a9}\u4a99',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.24,
+  compare: 'less',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(337);
+} catch {}
+let textureView37 = texture32.createView({label: '\uf22f\u171d\u03bf\ufa2d\u2f66\u4a7c\uf748\u0a65\u{1f7a2}\u05f5', aspect: 'depth-only'});
+let computePassEncoder48 = commandEncoder36.beginComputePass();
+let sampler31 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 65.91});
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer31, 732, 456);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 150, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData4,
+  origin: { x: 7, y: 29 },
+  flipY: true,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 49, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+document.body.prepend(img2);
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 136, resource: externalTexture2},
+    {binding: 145, resource: textureView27},
+    {binding: 33, resource: textureView32},
+  ],
+});
+let buffer35 = device0.createBuffer({
+  size: 14060,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder49 = commandEncoder48.beginComputePass({});
+let sampler32 = device0.createSampler({
+  label: '\u{1f6ac}\u0e68\u9239\u{1fa3c}\ucba2\u436f\u{1f9ac}\ucdf0\u29b0\u{1f8f1}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 67.42,
+  lodMaxClamp: 86.83,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer6, 'uint32', 888, 467);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer31, 0, 1_307);
+} catch {}
+let sampler33 = device0.createSampler({
+  label: '\u0589\u084d\u00bc\udaf0\udb10\ub00f\u4674',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.16,
+  lodMaxClamp: 99.31,
+  maxAnisotropy: 6,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup18, new Uint32Array(374), 15, 0);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer34, 'uint32', 16_744, 31);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer17, 2_348, 2_491);
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+await gc();
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture40 = device0.createTexture({
+  label: '\uf4f6\u{1fd62}\u0c06\u036b\u9095\ue803',
+  size: [320],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView38 = texture21.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder50 = commandEncoder3.beginComputePass({label: '\u{1f9de}\u5b66\u00c1\u0f1d\u1a83\u0501\u{1f957}\u{1f963}'});
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup22, new Uint32Array(805), 37, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle5, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer34, 'uint16', 3_810, 2_001);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({
+  size: [320, 300, 18],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView39 = texture8.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder51 = commandEncoder50.beginComputePass();
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder3.draw(322, 171, 1_950_106_805, 10_312_998);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+  await shaderModule3.getCompilationInfo();
+} catch {}
+let arrayBuffer1 = buffer27.getMappedRange(14464, 0);
+try {
+commandEncoder49.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1760 */
+  offset: 1760,
+  bytesPerRow: 7168,
+  rowsPerImage: 346,
+  buffer: buffer8,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData5,
+  origin: { x: 5, y: 5 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer36 = device0.createBuffer({size: 17161, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder51 = device0.createCommandEncoder({});
+let texture42 = device0.createTexture({
+  size: {width: 160, height: 150, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder49.beginComputePass();
+try {
+computePassEncoder26.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.draw(42, 29, 237_289_859, 71_257_855);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer12, 2_772, 12_179);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer8, 3460, buffer22, 4548, 460);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 72, new Float32Array(21227), 7780, 36);
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  label: '\u{1fd10}\uaffc\udad0\u0d53\ub868\u0e56\u629d\ueae4',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 136, resource: externalTexture2},
+    {binding: 33, resource: textureView35},
+    {binding: 145, resource: textureView27},
+  ],
+});
+let computePassEncoder53 = commandEncoder51.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer9, 244);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer14, 'uint32', 1_088, 168);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 152, new Float32Array(10329), 3040, 224);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 434,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 200,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder52 = device0.createCommandEncoder();
+let texture43 = device0.createTexture({
+  size: [80, 75, 1],
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture44 = device0.createTexture({
+  label: '\u{1f896}\u0d73\u9131\u9d84\u0b81\u9060\u0e9c\ub186\u0fb5',
+  size: {width: 80},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder54 = commandEncoder52.beginComputePass({label: '\u2d9e\u33a6\u0789\u{1f835}\u6ff5\u09cf\u0daa'});
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 89.96,
+  lodMaxClamp: 93.76,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder3.draw(58, 845, 1_099_865_076, 455_454_198);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer6, 1_336);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let buffer37 = device0.createBuffer({
+  label: '\u0b88\uf9bc\u8136\u{1fa36}\ub784\u{1fb4e}\ub3f5',
+  size: 17831,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  size: [320, 300, 1],
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture46 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let sampler35 = device0.createSampler({
+  label: '\u21b8\ua182\u27f1\u0887',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.69,
+  lodMaxClamp: 89.73,
+  compare: 'less-equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup22, new Uint32Array(1532), 548, 0);
+} catch {}
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 130, 1, 11_008_570, 1_706_186_284);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer22, 'uint32', 4_572, 16_039);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 16, y: 16, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3164 */
+  offset: 3164,
+  bytesPerRow: 20736,
+  buffer: buffer18,
+}, {width: 18, height: 21, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer3, 1424, 1456);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let texture47 = device0.createTexture({
+  label: '\u9a10\ua262\u0c6f\u{1fae7}\u0419\u0ba7\u0fa8\u6ff1\ue641\u{1f7ec}',
+  size: {width: 80, height: 96, depthOrArrayLayers: 102},
+  format: 'eac-r11unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture48 = device0.createTexture({
+  size: [160, 150, 5],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder55 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle4, renderBundle6, renderBundle3, renderBundle4, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer6, 164);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(1038), 52, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer6, 'uint32', 1_092, 236);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer9, 0, 85);
+} catch {}
+let textureView40 = texture46.createView({dimension: 'cube', baseArrayLayer: 5, arrayLayerCount: 6});
+let texture49 = device0.createTexture({size: [10, 12, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder56 = commandEncoder53.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup12, new Uint32Array(699), 124, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 13, 0, 688_491_400, 2_783_290_754);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer22, 7_564);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer0, 44);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup21, new Uint32Array(1873), 99, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 1880, new DataView(new ArrayBuffer(1988)), 67, 152);
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({});
+let textureView41 = texture49.createView({});
+let computePassEncoder57 = commandEncoder4.beginComputePass({});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(2, 74, 0, 1_447_996_981, 2_094_056_496);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup5, new Uint32Array(386), 51, 0);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 38, y: 41, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 74, y: 40, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 48, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 24, y: 44, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26_197).fill(78), /* required buffer size: 26_197 */
+{offset: 85, bytesPerRow: 52, rowsPerImage: 20}, {width: 4, height: 12, depthOrArrayLayers: 26});
+} catch {}
+let buffer38 = device0.createBuffer({label: '\ud36c\u82d0', size: 40461, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture50 = device0.createTexture({
+  label: '\u1119\u{1f6c1}',
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture51 = device0.createTexture({
+  label: '\u0d0d\u56e3\uf7f2\ucfce\u0539\udb48\ud8f9',
+  size: {width: 40, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView42 = texture30.createView({dimension: '2d', aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder58 = commandEncoder54.beginComputePass();
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer23, 0, 17_872);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer31, 804, 400);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder55 = device0.createCommandEncoder({});
+let computePassEncoder59 = commandEncoder55.beginComputePass({label: '\u0827\u0507\u81b5\u217e'});
+let sampler36 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.323,
+});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(76);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(1, 201, 0, -2_135_612_157, 1_144_169_467);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 5_824);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer27, 'uint16', 1_216, 3_814);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder8.draw(312, 195, 665_524_475, 209_306_696);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(22, 50, 10, 859_868_406, 155_470_539);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer17, 5_356);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer17, 'uint32', 3_904, 2_675);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise7;
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({label: '\u0db2\u01ef\u{1fbfb}'});
+let textureView43 = texture42.createView({aspect: 'all'});
+let computePassEncoder60 = commandEncoder56.beginComputePass({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(291), 1, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(293, 364, 923_991_515, 678_439_223);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 8, 0, 560_693_168, 407_788_188);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer18, 'uint32', 7_964, 3_214);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup14, new Uint32Array(4565), 347, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer22, 'uint16', 174, 8_352);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let buffer39 = device0.createBuffer({
+  label: '\ub406\u{1fad1}\u05e0\u60c7\u80fe\u8c73\u{1f739}\u0c94\u0656\u0fff',
+  size: 22421,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u0c9b\u0d15\uc2c2\u96b5\u{1fb3e}\u4f09'});
+let renderBundle9 = renderBundleEncoder9.finish();
+let sampler37 = device0.createSampler({
+  label: '\u05e0\u{1f77d}\u02e5\u017b\ue527\u013c\u6a2c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 4.754,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup9, new Uint32Array(383), 45, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(104, 101, 147, -1_874_923_759, 966_278_546);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer22, 5_308);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer34, 'uint32', 8_916, 4_565);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer20, 1104, buffer24, 308, 2588);
+} catch {}
+let texture52 = device0.createTexture({
+  size: [160, 150, 27],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler38 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 44.48,
+  lodMaxClamp: 76.45,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer31, 236);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer8, 0, 8_289);
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture53 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2uint'],
+});
+let textureView44 = texture30.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 4});
+let computePassEncoder61 = commandEncoder58.beginComputePass();
+try {
+computePassEncoder51.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup10, new Uint32Array(14), 4, 0);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(499);
+} catch {}
+try {
+renderPassEncoder4.draw(513, 381, 1_006_569_329, 35_977_778);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(4, 77, 168, 85_882_456, 489_297_967);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer23, 'uint32', 1_204, 546);
+} catch {}
+let promise11 = shaderModule2.getCompilationInfo();
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise10;
+} catch {}
+document.body.append(img1);
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 382,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let buffer40 = device0.createBuffer({size: 8972, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture54 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(3, bindGroup26, new Uint32Array(122), 25, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(111, 475, 414_327_466, 739_346_469);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer19, 'uint32', 748, 472);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer6, 1904, buffer39, 7416, 96);
+} catch {}
+let img3 = await imageWithData(39, 100, '#10101010', '#20202020');
+let bindGroup27 = device0.createBindGroup({
+  label: '\u{1fc53}\u238b\u{1fd62}\u{1fb63}\ube35',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 10, resource: textureView26},
+    {binding: 134, resource: {buffer: buffer31, offset: 0, size: 436}},
+    {binding: 51, resource: {buffer: buffer18, offset: 512, size: 2298}},
+    {binding: 43, resource: sampler7},
+    {binding: 34, resource: textureView15},
+    {binding: 133, resource: {buffer: buffer27, offset: 1280}},
+    {binding: 144, resource: textureView29},
+  ],
+});
+let buffer41 = device0.createBuffer({size: 716, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView45 = texture54.createView({label: '\ufe40\u03d0\u8a8d\u05f2\u5cff\u3c37\u3c3c'});
+let computePassEncoder62 = commandEncoder57.beginComputePass({label: '\u1443\u6529\uf42c\u{1fcad}\u0924\u{1f949}\u07cf'});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle9, renderBundle9, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(7, 64, 11, 1_018_593_564, 70_909_979);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer25, 136);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer14, 148);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+let texture55 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView46 = texture7.createView({mipLevelCount: 1});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup22, new Uint32Array(2349), 213, 0);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(29, 26, 5, 4);
+} catch {}
+try {
+renderPassEncoder4.draw(332, 202, 182_260_984, 363_072_170);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(269, 451, 192, 246_630_751, 642_950_403);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer0, 256);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(328).fill(78), /* required buffer size: 328 */
+{offset: 328}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({});
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer34, 404);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1519 */
+  offset: 1519,
+  bytesPerRow: 40448,
+  buffer: buffer24,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 12, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 6, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer42 = device0.createBuffer({
+  size: 18565,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture56 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 24},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder63 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup12, new Uint32Array(1719), 1_341, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(133);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(45, 262, 1, 555_979_975, 416_137_614);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer23, 'uint32', 1_592, 562);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+  await promise11;
+} catch {}
+let externalTexture4 = device0.importExternalTexture({label: '\u0681\u5781\uf834\u0678\u0789\u{1f88c}\u4740', source: videoFrame3});
+try {
+computePassEncoder56.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.draw(18, 56, 1_683_273_531, 668_777_354);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let texture57 = device0.createTexture({
+  size: [20, 24, 38],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder64 = commandEncoder39.beginComputePass();
+try {
+computePassEncoder57.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup23, new Uint32Array(2939), 430, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(495, 253, 1_676_919_068, 63_347_106);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer6, 4_224);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer17, 'uint32', 240, 7_243);
+} catch {}
+document.body.prepend(img1);
+let textureView47 = texture22.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+let sampler39 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 47.07,
+  lodMaxClamp: 48.50,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup6, new Uint32Array(543), 43, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer17, 'uint16', 500, 4_459);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 38}
+*/
+{
+  source: imageData4,
+  origin: { x: 3, y: 42 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 6, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let texture58 = device0.createTexture({
+  size: [10, 12, 1],
+  mipLevelCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView48 = texture37.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer14, 0); };
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(455, 110, 13, 54_005_687, 1_189_722_900);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer26, 312);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 136, resource: externalTexture4},
+    {binding: 145, resource: textureView43},
+    {binding: 33, resource: textureView35},
+  ],
+});
+let buffer43 = device0.createBuffer({
+  size: 22605,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder60 = device0.createCommandEncoder({});
+try {
+computePassEncoder38.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer0, 356);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer43, 1_136);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let commandEncoder61 = device0.createCommandEncoder({});
+let computePassEncoder65 = commandEncoder60.beginComputePass({});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup6, new Uint32Array(334), 11, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 11, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6880 */
+  offset: 6880,
+  bytesPerRow: 10496,
+  buffer: buffer8,
+}, {width: 14, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 352, new Int16Array(5411), 169, 108);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\u612f\u5780\u{1fa23}\u000c'});
+let computePassEncoder66 = commandEncoder62.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup18, new Uint32Array(1718), 11, 0);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let textureView49 = texture19.createView({baseMipLevel: 0, baseArrayLayer: 0, arrayLayerCount: 1});
+let commandEncoder63 = device0.createCommandEncoder({});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup14, new Uint32Array(571), 98, 0);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3920 */
+  offset: 3920,
+  bytesPerRow: 24064,
+  buffer: buffer22,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder64 = device0.createCommandEncoder({});
+let texture59 = device0.createTexture({
+  size: {width: 320},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView50 = texture41.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 7});
+let computePassEncoder67 = commandEncoder64.beginComputePass();
+try {
+computePassEncoder41.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer38, 20388, buffer42, 10500, 16);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(img0);
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 7, y: 8, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 87, y: 12, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte170m', transfer: 'pq'} });
+let texture60 = device0.createTexture({
+  size: [80, 75, 1],
+  mipLevelCount: 2,
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder68 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup0, new Uint32Array(458), 194, 0);
+} catch {}
+document.body.prepend(img0);
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer44 = device0.createBuffer({size: 3665, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView51 = texture28.createView({
+  label: '\u{1ff69}\u7e37\u0d2c\u{1fef2}\u08d1\ubd11\u{1fd7d}\u8d55\u076a\ucdb1\u0376',
+  format: 'rgb10a2uint',
+});
+let computePassEncoder69 = commandEncoder61.beginComputePass({label: '\u{1fbcd}\u32b9\u{1feee}\u{1ff9f}\u{1fa41}'});
+try {
+computePassEncoder69.setPipeline(pipeline4);
+} catch {}
+let sampler40 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.32,
+  lodMaxClamp: 66.24,
+  compare: 'never',
+});
+try {
+computePassEncoder48.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet1, 179, 15, buffer24, 0);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let buffer45 = device0.createBuffer({size: 9550, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder65 = device0.createCommandEncoder({});
+let sampler41 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.50,
+  compare: 'less',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup28, new Uint32Array(52), 9, 0);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1292 */
+  offset: 1280,
+  buffer: buffer38,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+await gc();
+let commandEncoder66 = device0.createCommandEncoder({label: '\u{1ff8d}\u252f\udcb7\u023a'});
+let computePassEncoder70 = commandEncoder66.beginComputePass({});
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer25);
+} catch {}
+let buffer46 = device0.createBuffer({
+  size: 13698,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder67 = device0.createCommandEncoder();
+let computePassEncoder71 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup15);
+} catch {}
+let buffer47 = device0.createBuffer({
+  size: 7570,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder68 = device0.createCommandEncoder({label: '\ubd16\u7be9\u{1fee0}'});
+let textureView52 = texture22.createView({
+  label: '\u{1feff}\u042b\u0046\ue18e\u0a53\uc53d',
+  mipLevelCount: 1,
+  baseArrayLayer: 5,
+  arrayLayerCount: 1,
+});
+let computePassEncoder72 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48).fill(252), /* required buffer size: 48 */
+{offset: 48}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView53 = texture52.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3});
+let textureView54 = texture58.createView({});
+let computePassEncoder73 = commandEncoder45.beginComputePass({});
+let renderPassEncoder5 = commandEncoder65.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 761.2, g: -838.3, b: 937.9, a: 90.15, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {view: textureView12, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+computePassEncoder63.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup15, new Uint32Array(1982), 8, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(8.016949743576633, 54.9628177434639, 25.040113991421094, 4.0924738779129255, 0.8832519133011517, 0.8963554320145093);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer17, 980);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.append(img2);
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte240m', transfer: 'smpteSt4281'} });
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture61 = device0.createTexture({size: {width: 80}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder74 = commandEncoder69.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(0, bindGroup7, new Uint32Array(542), 79, 0);
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView55 = texture16.createView({baseMipLevel: 0});
+let sampler42 = device0.createSampler({
+  label: '\u{1fed2}\u8223\u2530\u0128\uc22c\u0643',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 48.07,
+  lodMaxClamp: 96.85,
+});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup28, new Uint32Array(3694), 87, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer18, offset: 0, size: 6880}},
+    {binding: 123, resource: textureView10},
+  ],
+});
+let buffer48 = device0.createBuffer({size: 8122, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView56 = texture26.createView({baseMipLevel: 0, arrayLayerCount: 4});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 64, y: 24, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 100, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer41, offset: 512, size: 4}}],
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({
+  label: '\u0bc6\uaa8f\u53bb\u092c\u958d\uc197\u{1f830}\u68c3',
+  size: [40, 37, 1],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView57 = texture53.createView({label: '\u0c49\u07e1\u0245\u084d'});
+let computePassEncoder75 = commandEncoder70.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(0, bindGroup30, new Uint32Array(3556), 66, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(2174), 111, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: {buffer: buffer43, offset: 768, size: 13044}}],
+});
+try {
+renderPassEncoder5.setScissorRect(2, 15, 4, 22);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer14, 'uint16', 46, 140);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture63 = device0.createTexture({
+  size: [320, 300, 1],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer31, 0, 521);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer7, 384, buffer37, 2600, 2544);
+} catch {}
+let texture64 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder76 = commandEncoder71.beginComputePass({});
+try {
+computePassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder5.setViewport(41.60193832893362, 33.49092249074484, 19.5042318374058, 30.76286530044122, 0.6446701534316361, 0.7678034783334307);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer6, 180);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer22, 2_132);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 4, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(322).fill(255), /* required buffer size: 322 */
+{offset: 322}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let computePassEncoder77 = commandEncoder72.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer14, 224); };
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.draw(232, 90, 118_337_653, 358_867_097);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer9, 5_984);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let texture65 = device0.createTexture({
+  size: [160, 150, 10],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler43 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.204,
+  lodMaxClamp: 23.54,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(2, bindGroup7, new Uint32Array(945), 227, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup12, new Uint32Array(412), 189, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(46, 34, 3, 90_167_222, 549_070_740);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer35, 4_940);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer34, 572);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer43, 'uint16', 976, 1_884);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer27);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer49 = device0.createBuffer({
+  size: 6691,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder73 = device0.createCommandEncoder({label: '\u{1fe4b}\udbf3'});
+let computePassEncoder78 = commandEncoder73.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer31, 2_128); };
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup23, new Uint32Array(459), 21, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(62, 122, 1_267_130_099, 135_166_053);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(105, 18, 68, 251_846_974, 531_415_531);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer25, 28);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint16', 4_496, 4_380);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 150, depthOrArrayLayers: 18}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 4, y: 19, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder74 = device0.createCommandEncoder();
+let texture66 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture67 = device0.createTexture({
+  label: '\ub84b\u{1f8ba}',
+  size: [40, 48, 13],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder65.setBindGroup(1, bindGroup25, new Uint32Array(649), 303, 0);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10, new Uint32Array(6983), 1_605, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(371, 99, 20_418_148, 1_553_197_395);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer17, 5_620);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer27, 'uint16', 472, 865);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3248 */
+  offset: 3248,
+  bytesPerRow: 13056,
+  rowsPerImage: 550,
+  buffer: buffer32,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView58 = texture66.createView({baseArrayLayer: 0});
+let textureView59 = texture46.createView({baseArrayLayer: 1, arrayLayerCount: 9});
+let sampler44 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.94,
+  lodMaxClamp: 37.41,
+  compare: 'less-equal',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10, new Uint32Array(578), 177, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer26, 2_004);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer17, 5_720, 2_710);
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({});
+let textureView60 = texture54.createView({format: 'rgba8uint', baseArrayLayer: 0});
+let textureView61 = texture9.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(3, bindGroup7, new Uint32Array(2255), 165, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.draw(10, 97, 223_589_658, 180_647_759);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer9, 360);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer22, 15_544);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer9, 0, 1_964);
+} catch {}
+try {
+commandEncoder75.clearBuffer(buffer23, 15420);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 12544, new Int16Array(36327), 805, 2956);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 38}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer50 = device0.createBuffer({
+  size: 26482,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture68 = device0.createTexture({
+  label: '\u0b6a\u806f\uf88e\u1c0a\u4094',
+  size: {width: 40, height: 48, depthOrArrayLayers: 77},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroupsIndirect(buffer26, 580); };
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 17, y: 28, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4).fill(5), /* required buffer size: 4 */
+{offset: 4}, {width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 17, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView62 = texture65.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+let sampler45 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.72,
+  lodMaxClamp: 66.90,
+});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup25, new Uint32Array(1931), 253, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer0, 24);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer34, 5_596);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer46, 'uint32', 212, 1_148);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let buffer51 = device0.createBuffer({size: 4963, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView63 = texture43.createView({aspect: 'stencil-only'});
+let renderPassEncoder6 = commandEncoder75.beginRenderPass({
+  colorAttachments: [{view: textureView53, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup24, new Uint32Array(3014), 537, 0);
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup21, new Uint32Array(23), 3, 0);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+await gc();
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({size: [80, 96, 16], mipLevelCount: 2, format: 'rgba32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder79 = commandEncoder20.beginComputePass();
+try {
+renderPassEncoder6.end();
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  label: '\uf76b\u93f6\u020d\u{1f81a}\u09db\u6756\u{1fe1f}',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 33, resource: textureView32},
+    {binding: 145, resource: textureView43},
+    {binding: 136, resource: externalTexture0},
+  ],
+});
+let buffer52 = device0.createBuffer({
+  size: 6291,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer7, 192, buffer31, 1084, 212);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 384 */
+  offset: 384,
+  buffer: buffer52,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData6 = new ImageData(108, 44);
+let bindGroup33 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 434, resource: {buffer: buffer1, offset: 0}},
+    {binding: 54, resource: textureView49},
+    {binding: 6, resource: {buffer: buffer24, offset: 3840, size: 3004}},
+    {binding: 200, resource: textureView40},
+  ],
+});
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture70 = device0.createTexture({
+  label: '\u{1fbbb}\u6b06',
+  size: [256],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView64 = texture24.createView({dimension: '2d', baseArrayLayer: 25});
+let computePassEncoder80 = commandEncoder76.beginComputePass({});
+let renderPassEncoder7 = commandEncoder65.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 193.8, g: 791.1, b: -242.6, a: 982.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 265814428,
+});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+let buffer53 = device0.createBuffer({size: 7601, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  size: {width: 160, height: 150, depthOrArrayLayers: 5},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder81 = commandEncoder46.beginComputePass({});
+let sampler46 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.04,
+  lodMaxClamp: 97.23,
+});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(1, bindGroup7, new Uint32Array(1049), 153, 0);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+let textureView65 = texture39.createView({label: '\ubb0d\u{1f641}\u{1fe25}\u{1fb36}\uc302\u46ce'});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.891,
+  lodMaxClamp: 54.29,
+});
+try {
+computePassEncoder55.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 896 */
+  offset: 896,
+  bytesPerRow: 56320,
+  buffer: buffer28,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 9, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 24, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder();
+let texture72 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder8 = commandEncoder77.beginRenderPass({colorAttachments: [{view: textureView53, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler48 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.72,
+  lodMaxClamp: 52.18,
+  compare: 'less',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder79.copyBufferToBuffer(buffer5, 340, buffer39, 748, 180);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 768 */
+  offset: 768,
+  bytesPerRow: 9984,
+  buffer: buffer15,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 25, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 300, depthOrArrayLayers: 18}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 59, y: 196, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder75.finish({label: '\u0c0b\u{1ff54}\u{1f745}\u{1f881}\u0b35\u9676\u01eb'});
+let computePassEncoder82 = commandEncoder79.beginComputePass();
+let sampler49 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.72,
+  lodMaxClamp: 93.59,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup22, []);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u0a6d\u7373\u3955\u{1fdb8}',
+  entries: [
+    {
+      binding: 159,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({size: [20, 24, 1], format: 'rgba32float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+try {
+computePassEncoder68.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer5, 'uint32', 448, 9);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer6, 552, buffer3, 1000, 924);
+} catch {}
+let computePassEncoder83 = commandEncoder81.beginComputePass({label: '\uc87e\ub04d\u{1fd28}\u747d'});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer47);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2544 */
+  offset: 2544,
+  bytesPerRow: 1280,
+  buffer: buffer18,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder41.insertDebugMarker('\ube31');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(143).fill(132), /* required buffer size: 143 */
+{offset: 143, bytesPerRow: 322}, {width: 13, height: 28, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 150, depthOrArrayLayers: 18}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 9 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 0, y: 15, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let texture74 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 28},
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView66 = texture63.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder84 = commandEncoder74.beginComputePass({});
+let renderPassEncoder9 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{view: textureView50, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet1,
+});
+let sampler50 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.52,
+  lodMaxClamp: 90.91,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(3, bindGroup21, new Uint32Array(283), 78, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup4, new Uint32Array(2433), 455, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let texture75 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder85 = commandEncoder45.beginComputePass({});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -120.7, g: 37.80, b: 712.3, a: -521.0, });
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer25, 68, 78);
+} catch {}
+let computePassEncoder86 = commandEncoder82.beginComputePass({});
+try {
+computePassEncoder82.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup31, new Uint32Array(2735), 971, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer17, 0, 1_129);
+} catch {}
+let commandBuffer2 = commandEncoder78.finish({label: '\uf0e7\u040b\u0382\u5eac'});
+let sampler51 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.66,
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(0, bindGroup23, new Uint32Array(1533), 114, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer39, 'uint16', 142, 1_554);
+} catch {}
+try {
+computePassEncoder50.insertDebugMarker('\u03bc');
+} catch {}
+await gc();
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 47});
+let texture76 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView67 = texture75.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler52 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.76,
+  lodMaxClamp: 84.71,
+  maxAnisotropy: 16,
+});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup25, new Uint32Array(160), 6, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer12, 0, 4_721);
+} catch {}
+let texture77 = device0.createTexture({size: [20, 24, 1], format: 'rgba32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let sampler53 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 55.13,
+  lodMaxClamp: 78.46,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder8.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer39, 'uint16', 1_226, 5_822);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8164, new Float32Array(1578), 1201, 132);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1152 */
+  offset: 1152,
+  bytesPerRow: 22272,
+  buffer: buffer45,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 6, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 11, y: 23, z: 0},
+  aspect: 'all',
+}, new Uint8Array(49).fill(118), /* required buffer size: 49 */
+{offset: 49, bytesPerRow: 75}, {width: 35, height: 27, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder41.finish({});
+let sampler54 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 79.90,
+});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup26, new Uint32Array(824), 583, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup32, new Uint32Array(3096), 278, 0);
+} catch {}
+try {
+commandEncoder83.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1221 */
+  offset: 1221,
+  bytesPerRow: 10240,
+  buffer: buffer36,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 7, y: 13, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 19, y: 5, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: img2,
+  origin: { x: 8, y: 21 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rgba32uint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'point-list'},
+});
+let imageData7 = new ImageData(52, 180);
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 89,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 89, resource: {buffer: buffer42, offset: 2048, size: 1992}}],
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(0, bindGroup0, new Uint32Array(2343), 419, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer50, 'uint32', 1_728, 2_775);
+} catch {}
+let buffer54 = device0.createBuffer({
+  label: '\u{1fa24}\ub721\u84e5\uf095\u{1f9b8}\u75d4\ubc7f',
+  size: 11676,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView68 = texture25.createView({baseMipLevel: 0});
+let computePassEncoder87 = commandEncoder83.beginComputePass();
+try {
+computePassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer5, 0);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer50, 1228, buffer39, 440, 1444);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1593 */
+  offset: 1593,
+  buffer: buffer52,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 8, y: 4, z: 1},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({label: '\u6539\u7e3c\u511f\u2c2d\u7a3f\ub925\ub849\u{1f99e}'});
+let texture78 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 8},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise15 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView69 = texture22.createView({dimension: 'cube-array', mipLevelCount: 1});
+let texture79 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView70 = texture70.createView({format: 'rgba32uint', baseArrayLayer: 0});
+let computePassEncoder88 = commandEncoder84.beginComputePass();
+let renderPassEncoder10 = commandEncoder85.beginRenderPass({colorAttachments: [{view: textureView53, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder9.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -612.5, g: -11.54, b: 652.4, a: 14.97, });
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer24);
+} catch {}
+try {
+  await buffer32.mapAsync(GPUMapMode.WRITE, 0, 2508);
+} catch {}
+let buffer55 = device0.createBuffer({size: 6939, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture80 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture81 = device0.createTexture({
+  size: [10, 12, 19],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint'],
+});
+let sampler55 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.25,
+  lodMaxClamp: 82.96,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 89, resource: {buffer: buffer0, offset: 512, size: 16}}],
+});
+let commandEncoder86 = device0.createCommandEncoder();
+let texture82 = device0.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture83 = device0.createTexture({
+  size: {width: 320},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder89 = commandEncoder86.beginComputePass({label: '\u67ba\u706e\ud4ac\uaab8\u{1fdc4}\u{1ff53}\u{1ff85}\u4d1e\u1fa7\u2561'});
+let sampler56 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.89,
+  lodMaxClamp: 96.36,
+});
+try {
+computePassEncoder64.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup0, new Uint32Array(3695), 238, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer19, 'uint32', 252, 1_050);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u{1fc72}');
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture84 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 154},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder11 = commandEncoder87.beginRenderPass({
+  label: '\u{1f7aa}\u0b21\ue57b\u{1f634}\u0bcd\uae66\u0112\u29f7\ufcec',
+  colorAttachments: [{
+  view: textureView50,
+  clearValue: { r: 107.5, g: -775.6, b: -588.6, a: 645.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup3, new Uint32Array(1197), 201, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer6, 'uint32', 1_476, 1_603);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 4, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(512).fill(177), /* required buffer size: 512 */
+{offset: 512, bytesPerRow: 37, rowsPerImage: 18}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise15;
+} catch {}
+let buffer56 = device0.createBuffer({
+  label: '\u1591\u12a0\ua31b\u{1f976}\ucb01\u0f5b\u2943\u1ea0',
+  size: 4079,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture85 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup25, new Uint32Array(1412), 37, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer54, 'uint16', 682, 2_749);
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 54, resource: textureView27},
+    {binding: 6, resource: {buffer: buffer50, offset: 4096, size: 2612}},
+    {binding: 434, resource: {buffer: buffer14, offset: 0, size: 252}},
+    {binding: 200, resource: textureView40},
+  ],
+});
+let commandEncoder88 = device0.createCommandEncoder({label: '\u0180\u0fde\ud012'});
+let textureView71 = texture66.createView({});
+let textureView72 = texture60.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 65.73,
+  lodMaxClamp: 78.40,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup26, new Uint32Array(1853), 460, 0);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer17, 0, 3_495);
+} catch {}
+try {
+adapter0.label = '\u{1f979}\u22bb';
+} catch {}
+let textureView73 = texture75.createView({aspect: 'all', format: 'rgba32float'});
+let computePassEncoder90 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(0, bindGroup23, new Uint32Array(1165), 3, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7]);
+} catch {}
+try {
+externalTexture0.label = '\u{1fe38}\u0ce6\ufc88\u{1fc92}\u0354\uedf7\u0060\u{1fd42}\u6af3\u044a\u{1fa85}';
+} catch {}
+let textureView74 = texture81.createView({baseArrayLayer: 0});
+let computePassEncoder91 = commandEncoder63.beginComputePass({label: '\u6e74\uf652\u009d\u02eb\u{1fd27}\u0d6a\ub28b\u0ab5\u8773'});
+let renderPassEncoder12 = commandEncoder88.beginRenderPass({
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: 169.5, g: 167.5, b: -138.0, a: 540.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup20, new Uint32Array(781), 197, 0);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+let textureView75 = texture32.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder50.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -187.8, g: 612.9, b: -105.6, a: -680.8, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer46, 'uint16', 3_350, 807);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let buffer57 = device0.createBuffer({size: 6450, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let textureView76 = texture66.createView({});
+let sampler58 = device0.createSampler({
+  label: '\u099f\u0172\u0967\u761d\u1aa7\u{1fc5d}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 25.73,
+  lodMaxClamp: 98.98,
+  compare: 'less-equal',
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer9, 2_332, 2_075);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 150, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData3,
+  origin: { x: 15, y: 1 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 8, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let buffer58 = device0.createBuffer({
+  size: 18962,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView77 = texture54.createView({});
+let texture86 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm']});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer23, 'uint16', 12_678, 851);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer15, 1084, buffer46, 3388, 636);
+} catch {}
+let buffer59 = device0.createBuffer({
+  label: '\ub05f\u{1f975}\ub90a\u914a\u{1fbb8}\u09b4\u{1f995}\u08e8',
+  size: 3976,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView78 = texture48.createView({mipLevelCount: 1});
+let computePassEncoder92 = commandEncoder89.beginComputePass({label: '\u95a3\uc733\u9304\u07b4'});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder89.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup31, new Uint32Array(1140), 88, 0);
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 123, resource: textureView25}, {binding: 67, resource: {buffer: buffer54, offset: 1024}}],
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer7, 1_808); };
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup9, new Uint32Array(314), 32, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer17, 'uint32', 80, 3_952);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer50, 0, 5_183);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let buffer60 = device0.createBuffer({
+  size: 12141,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView79 = texture44.createView({});
+let renderPassEncoder13 = commandEncoder14.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 732.6, g: 364.1, b: 459.8, a: -337.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 240010182,
+});
+try {
+computePassEncoder88.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(1, bindGroup35, new Uint32Array(28), 1, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer31);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 77},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder93 = commandEncoder90.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup11, new Uint32Array(252), 143, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer57, 'uint32', 20, 978);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer6, 'uint16', 2_588, 507);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 14496, new BigUint64Array(7921), 3553, 472);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 24}
+*/
+{
+  source: imageData4,
+  origin: { x: 3, y: 37 },
+  flipY: false,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 4, y: 18, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  label: '\ufbe6\ucf03\u06b8',
+  layout: bindGroupLayout0,
+  entries: [{binding: 275, resource: {buffer: buffer42, offset: 1792, size: 3964}}],
+});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u{1fa8b}\u0cfc\u089a\uc277\uab18\u0bde\u7a20\ud2ef\u0fc7\uf14d'});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 923});
+let renderPassEncoder14 = commandEncoder91.beginRenderPass({colorAttachments: [{view: textureView64, loadOp: 'load', storeOp: 'store'}], maxDrawCount: 419479233});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer7, 204); };
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup22, new Uint32Array(1800), 344, 0);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -790.0, g: 742.6, b: -480.8, a: -437.8, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer39, 'uint32', 252, 12_918);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer17, 'uint16', 1_048, 2_862);
+} catch {}
+let texture88 = device0.createTexture({
+  size: [10],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler59 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.17,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer50, 'uint32', 828, 2_814);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(0, buffer58, 132);
+} catch {}
+let img4 = await imageWithData(113, 19, '#10101010', '#20202020');
+let buffer61 = device0.createBuffer({size: 771, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 668});
+let commandBuffer4 = commandEncoder31.finish({});
+let renderBundle10 = renderBundleEncoder10.finish();
+try {
+computePassEncoder22.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup36, new Uint32Array(6503), 1_694, 0);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(13, 48, 28, 14);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer19, 'uint32', 736, 746);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer20, 0, 2_007);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 600, new BigUint64Array(16055), 3584, 424);
+} catch {}
+let commandEncoder92 = device0.createCommandEncoder({});
+let textureView80 = texture63.createView({});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u0688');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer62 = device0.createBuffer({
+  size: 1967,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder94 = commandEncoder92.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroupsIndirect(buffer9, 2_124); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup11, new Uint32Array(698), 78, 0);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let buffer63 = device0.createBuffer({
+  size: 908,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer24);
+} catch {}
+let arrayBuffer2 = buffer63.getMappedRange();
+let commandEncoder93 = device0.createCommandEncoder();
+let texture89 = device0.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder95 = commandEncoder93.beginComputePass();
+try {
+computePassEncoder76.setBindGroup(3, bindGroup35, new Uint32Array(232), 30, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup15, new Uint32Array(2576), 1_165, 0);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(181);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer23, 0);
+} catch {}
+let buffer64 = device0.createBuffer({
+  size: 3691,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder94 = device0.createCommandEncoder();
+let renderPassEncoder15 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: -254.4, g: 805.8, b: 351.7, a: -682.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroupsIndirect(buffer6, 364); };
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer58, 1_904, 152);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 144, resource: textureView29},
+    {binding: 34, resource: textureView29},
+    {binding: 133, resource: {buffer: buffer3, offset: 0, size: 694}},
+    {binding: 134, resource: {buffer: buffer22, offset: 5632, size: 64}},
+    {binding: 10, resource: textureView55},
+    {binding: 43, resource: sampler7},
+    {binding: 51, resource: {buffer: buffer43, offset: 1024, size: 5603}},
+  ],
+});
+let commandEncoder95 = device0.createCommandEncoder({});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(querySet5, 34, 2, buffer16, 256);
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 144, resource: textureView29},
+    {binding: 43, resource: sampler54},
+    {binding: 10, resource: textureView26},
+    {binding: 134, resource: {buffer: buffer54, offset: 2048}},
+    {binding: 34, resource: textureView29},
+    {binding: 51, resource: {buffer: buffer61, offset: 0, size: 62}},
+    {binding: 133, resource: {buffer: buffer58, offset: 5120, size: 1906}},
+  ],
+});
+let commandEncoder96 = device0.createCommandEncoder();
+let texture90 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder96 = commandEncoder95.beginComputePass({});
+let renderPassEncoder16 = commandEncoder96.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  clearValue: { r: 727.3, g: 871.8, b: -358.1, a: -345.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder71.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer60, 'uint16', 5_912, 763);
+} catch {}
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+externalTexture3.label = '\u0c4d\u{1ff8c}\u{1fe42}\u9842\u083e';
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder();
+let textureView81 = texture41.createView({label: '\u34c5\u1996\u7b49\ub6a2\u9f04', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder97 = commandEncoder97.beginComputePass();
+try {
+computePassEncoder78.setBindGroup(1, bindGroup11);
+} catch {}
+let bindGroup41 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 25, resource: {buffer: buffer25, offset: 0}}]});
+let buffer65 = device0.createBuffer({
+  size: 8196,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture91 = device0.createTexture({
+  size: [40, 37, 1],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler60 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 68.29,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder79.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(0, 1, 17, 1);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer9, 'uint32', 2_316, 875);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer5, 0);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer14, 420); };
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer22, 'uint32', 1_880, 865);
+} catch {}
+let texture92 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 13},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder98 = commandEncoder91.beginComputePass({});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup1, new Uint32Array(2724), 309, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer23, 'uint32', 7_764, 41);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 0, y: 37, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 256 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 504 */
+  offset: 504,
+  bytesPerRow: 46336,
+  buffer: buffer57,
+}, {width: 32, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 42, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(85), /* required buffer size: 29 */
+{offset: 29, bytesPerRow: 259, rowsPerImage: 57}, {width: 13, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+await gc();
+let commandEncoder98 = device0.createCommandEncoder();
+let texture93 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView82 = texture14.createView({label: '\ubc25\u0821\u99bd\udd6d\u8866\u0323\u5f98', mipLevelCount: 1});
+let computePassEncoder99 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder97.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup15, new Uint32Array(3205), 321, 0);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(1038);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer5, 0);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer64, 3688, buffer23, 4372, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder99 = device0.createCommandEncoder({});
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.468,
+  lodMaxClamp: 20.41,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup23, new Uint32Array(64), 21, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(68);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(8, 4, 15, 5);
+} catch {}
+let buffer66 = device0.createBuffer({size: 18441, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture94 = device0.createTexture({
+  size: [10, 12, 1],
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture95 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 16},
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder100 = commandEncoder85.beginComputePass({});
+let sampler62 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 67.41,
+  lodMaxClamp: 90.57,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 551.7, g: 199.1, b: -154.6, a: -605.8, });
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 20904 */
+  offset: 2984,
+  bytesPerRow: 1792,
+  buffer: buffer50,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 11, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(122).fill(161), /* required buffer size: 122 */
+{offset: 122, rowsPerImage: 122}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 16}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 272,
+        attributes: [
+          {format: 'sint32x4', offset: 16, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list'},
+});
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView58}, {binding: 47, resource: textureView52}],
+});
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture96 = device0.createTexture({
+  label: '\u00b4\u0a4c\u1e44\ud706\u0d1f\u5d11\uf4b6\u7577',
+  size: {width: 320, height: 300, depthOrArrayLayers: 10},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler63 = device0.createSampler({
+  label: '\u0a19\u03a7\u{1fce2}\u{1fa2e}\u34fc\u332b\u01a5\u0158\ud0f0',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.11,
+  lodMaxClamp: 95.59,
+});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup5, new Uint32Array(559), 304, 0);
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 123, resource: textureView80},
+    {binding: 67, resource: {buffer: buffer42, offset: 768, size: 284}},
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer20, 0, 3_997);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(203, 56);
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 275, resource: {buffer: buffer3, offset: 4608, size: 108}}],
+});
+let buffer67 = device0.createBuffer({size: 10446, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder101 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 516});
+let computePassEncoder101 = commandEncoder100.beginComputePass();
+try {
+computePassEncoder33.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(623), 41, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer56, 2_016);
+} catch {}
+let arrayBuffer3 = buffer32.getMappedRange(928, 220);
+try {
+commandEncoder99.resolveQuerySet(querySet6, 38, 48, buffer19, 2304);
+} catch {}
+let texture97 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture98 = device0.createTexture({
+  label: '\u50c5\ue549\u1bde\u0894\uf1e9\u5201\u015c\u8fa0\u03d2\u0dd8\ud2e2',
+  size: [80, 96, 220],
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView83 = texture86.createView({mipLevelCount: 1});
+let renderPassEncoder17 = commandEncoder99.beginRenderPass({
+  label: '\u0b8f\uf1ea\u14fe\u{1f89e}\u0a1f\u{1f6cd}\u{1ffcb}\u2461\u{1fcbf}\u{1f88e}',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: 556.4, g: 781.4, b: 419.0, a: 684.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 71302577,
+});
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer64, 220, 3008);
+} catch {}
+document.body.append(img0);
+let img5 = await imageWithData(99, 3, '#10101010', '#20202020');
+let buffer68 = device0.createBuffer({size: 4094, usage: GPUBufferUsage.MAP_READ});
+let textureView84 = texture44.createView({dimension: '1d'});
+let computePassEncoder102 = commandEncoder98.beginComputePass();
+let sampler64 = device0.createSampler({
+  label: '\u{1f8a7}\u{1fed1}\ua34e\ub87b\u{1fca7}\u366d',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 17.39,
+  lodMaxClamp: 40.51,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup43, new Uint32Array(330), 75, 0);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(201);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+document.body.prepend(img5);
+let texture99 = device0.createTexture({
+  size: {width: 20},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView85 = texture65.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder18 = commandEncoder101.beginRenderPass({
+  label: '\ua3f7\u0433\u0940',
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -263.7, g: -670.6, b: -335.1, a: 26.03, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 45267888,
+});
+try {
+computePassEncoder98.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup38, new Uint32Array(19), 2, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(118);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 309.4, g: -350.4, b: 399.0, a: -565.7, });
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer1, 'uint16', 16, 7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 2, y: 8, z: 24},
+  aspect: 'all',
+}, new Uint8Array(145_925).fill(99), /* required buffer size: 145_925 */
+{offset: 7, bytesPerRow: 305, rowsPerImage: 25}, {width: 8, height: 4, depthOrArrayLayers: 20});
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 89, resource: {buffer: buffer25, offset: 0, size: 32}}],
+});
+let commandEncoder102 = device0.createCommandEncoder({label: '\u0ecc\u{1fd04}\u089d\u{1ff7c}\u10cc\u{1ff84}\u06a1\ubd18\u341e\u8935'});
+let texture100 = device0.createTexture({
+  size: [40, 37, 1],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler65 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.82,
+  lodMaxClamp: 82.64,
+});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder55); computePassEncoder55.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup29, new Uint32Array(2373), 191, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder102.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 15, y: 76, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 984 */
+  offset: 984,
+  bytesPerRow: 23040,
+  buffer: buffer8,
+}, {width: 8, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 1744, new Float32Array(726), 30, 152);
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+let textureView86 = texture46.createView({dimension: 'cube', baseArrayLayer: 2});
+let texture101 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 3},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder95.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2928 */
+  offset: 2928,
+  bytesPerRow: 2816,
+  buffer: buffer13,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 3, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 200, new Float32Array(6194), 776, 16);
+} catch {}
+document.body.append(img5);
+try {
+adapter1.label = '\u1759\u0edc\u00b9\u07c1\u07e1\u00aa\u7479';
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 1112});
+let texture102 = device0.createTexture({
+  size: {width: 256},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(2, bindGroup24, new Uint32Array(2969), 854, 0);
+} catch {}
+try {
+renderPassEncoder16.setViewport(264.5093623830524, 266.4619212852279, 8.698264876184105, 13.810706494896458, 0.6363827906341719, 0.6983954852518158);
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder({label: '\u1d29\u3ed6'});
+let textureView87 = texture82.createView({dimension: '1d'});
+let textureView88 = texture76.createView({dimension: '2d-array'});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(0, bindGroup4, new Uint32Array(503), 2, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder69.insertDebugMarker('\u4733');
+} catch {}
+let texture103 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder103 = commandEncoder103.beginComputePass({});
+try {
+computePassEncoder100.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup13, new Uint32Array(441), 138, 0);
+} catch {}
+try {
+renderPassEncoder17.setViewport(14.63073029758542, 60.45611897449801, 122.25307669222227, 16.78640253345917, 0.3304213393214849, 0.8841858509437799);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer17, 'uint32', 6_804, 4_717);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer63, 88, 46);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let bindGroup46 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 44, resource: textureView8},
+    {binding: 47, resource: {buffer: buffer7, offset: 0, size: 687}},
+  ],
+});
+let buffer69 = device0.createBuffer({
+  label: '\u065a\u{1ff1e}\u0674\u{1f748}\ucc0d\u{1f8be}',
+  size: 10311,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let renderPassEncoder19 = commandEncoder102.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  clearValue: { r: 410.5, g: -909.7, b: 131.7, a: -796.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer1, 'uint16', 10, 1);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires pointer_composite_access;
+
+struct T0 {
+  @size(32) f0: array<array<array<array<u32, 1>, 1>, 1>, 4>,
+}
+
+var<workgroup> vw33: FragmentOutput3;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw20: T0;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw26: atomic<i32>;
+
+var<workgroup> vw24: i32;
+
+var<workgroup> vw32: T0;
+
+var<workgroup> vw25: T0;
+
+var<workgroup> vw37: FragmentOutput3;
+
+struct VertexOutput2 {
+  @invariant @builtin(position) f2: vec4f,
+  @location(4) f3: u32,
+}
+
+var<workgroup> vw29: T0;
+
+var<workgroup> vw21: mat2x4h;
+
+struct FragmentOutput3 {
+  @location(0) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+}
+
+var<workgroup> vw23: VertexOutput2;
+
+var<workgroup> vw30: array<atomic<u32>, 11>;
+
+var<private> vp6: array<f32, 5> = array<f32, 5>();
+
+var<workgroup> vw36: array<vec4i, 3>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T1 {
+  f0: array<u32>,
+}
+
+var<workgroup> vw27: VertexOutput2;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(47) var<uniform> buffer70: f32;
+
+var<workgroup> vw22: f16;
+
+@group(0) @binding(44) var tex3: texture_1d<i32>;
+
+var<workgroup> vw31: atomic<i32>;
+
+var<workgroup> vw35: array<array<mat2x2h, 1>, 10>;
+
+var<workgroup> vw28: u32;
+
+var<workgroup> vw34: VertexOutput2;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@vertex
+fn vertex4() -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f3 = pack4xU8(vec4u(unpack4x8snorm(u32(unconst_u32(169)))));
+  vp6[u32(unconst_u32(131))] = vp6[4];
+  var vf78: vec4h = acosh(vec4h(unconst_f16(4682.9), unconst_f16(2187.5), unconst_f16(15828.2), unconst_f16(7338.8)));
+  let vf79: u32 = textureNumLevels(tex3);
+  let vf80: u32 = textureDimensions(tex3, 0i);
+  out.f3 = pack2x16snorm(unpack2x16float(countOneBits(vec3u(u32(determinant(mat2x2f(unconst_f32(0.2977), unconst_f32(0.2351), unconst_f32(-0.05241), unconst_f32(-0.1870))))))[2]));
+  let vf81: vec3f = cos(vec3f(unconst_f32(0.2487), unconst_f32(0.00554), unconst_f32(0.2118)));
+  out.f3 <<= textureDimensions(tex3);
+  out.f2 -= vec4f(acosh(vec4h(unconst_f16(11818.5), unconst_f16(81.79), unconst_f16(18846.6), unconst_f16(3029.4))));
+  out.f3 = bitcast<u32>(determinant(mat4x4f(unconst_f32(0.3908), unconst_f32(0.2731), unconst_f32(-0.02328), unconst_f32(0.1754), unconst_f32(-0.1950), unconst_f32(0.07410), unconst_f32(0.05836), unconst_f32(0.4131), unconst_f32(0.2282), unconst_f32(0.07718), unconst_f32(0.03421), unconst_f32(0.2271), unconst_f32(0.04141), unconst_f32(0.1364), unconst_f32(0.1896), unconst_f32(0.05815))));
+  var vf82: u32 = vf79;
+  let vf83: u32 = vf79;
+  out = VertexOutput2(unpack2x16float(u32(unconst_u32(308))).xxxx, pack2x16snorm(unpack2x16float(u32(unconst_u32(308)))));
+  let ptr42: ptr<private, f32> = &vp6[4];
+  out = VertexOutput2(vec4f(vf78), pack4xU8Clamp(vec4u(vf78)));
+  vp6[textureNumLevels(tex3)] *= vp6[4];
+  var vf84: vec3f = vf81;
+  let ptr43: ptr<function, vec4h> = &vf78;
+  let ptr44: ptr<private, f32> = &vp6[4];
+  out.f2 = vec4f(vf81[2]);
+  let ptr45: ptr<private, f32> = &(*ptr42);
+  vf78 = vec4h(f16((*ptr45)));
+  return out;
+}
+
+@fragment
+fn fragment4() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  let vf85: u32 = pack4xI8(vec4i(bitcast<i32>(vp6[u32(unconst_u32(150))])));
+  var vf86: vec4f = unpack4x8unorm(u32(unconst_u32(82)));
+  let ptr46: ptr<private, f32> = &vp6[4];
+  out.f0 += vec4u(u32((*&buffer70)));
+  let ptr47: ptr<private, f32> = &(*ptr46);
+  var vf87: u32 = pack4xI8(unpack4xI8(pack4x8snorm(vec4f(vp6[4]))));
+  var vf88: u32 = pack4x8snorm(vec4f(bitcast<f32>(pack4xU8(vec4u(unconst_u32(121), unconst_u32(8), unconst_u32(203), unconst_u32(31))))));
+  vf86 += vec4f(acosh(vec2h(unconst_f16(8470.6), unconst_f16(7841.3))).gggr);
+  let ptr48: ptr<private, f32> = &(*ptr47);
+  vf88 <<= bitcast<u32>(vp6[u32(unconst_u32(433))]);
+  let vf89: vec4f = refract(vec4f(unconst_f32(0.01445), unconst_f32(-0.2181), unconst_f32(0.3997), unconst_f32(0.3406)), vec4f(unconst_f32(0.03299), unconst_f32(-0.1028), unconst_f32(0.04863), unconst_f32(0.2431)), f32(unconst_f32(0.05381)));
+  let ptr49: ptr<private, f32> = &vp6[bitcast<u32>(unpack4x8unorm(u32(unconst_u32(14))).x)];
+  out.f1 |= pack4x8unorm(vec4f(unconst_f32(0.06544), unconst_f32(0.07440), unconst_f32(0.07174), unconst_f32(0.1949)));
+  let ptr50: ptr<function, u32> = &vf88;
+  let ptr51: ptr<private, f32> = &(*ptr49);
+  let ptr52: ptr<function, u32> = &vf88;
+  vf88 ^= bitcast<u32>((*ptr49));
+  var vf90: vec4f = unpack4x8unorm(u32(unconst_u32(403)));
+  let ptr53: ptr<private, f32> = &(*ptr49);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  let ptr54: ptr<workgroup, array<u32, 1>> = &(*&vw32).f0[3][0][0];
+  vw33 = FragmentOutput3(vec4u(u32(atomicLoad(&vw31))), bitcast<u32>(atomicLoad(&vw31)));
+  vw28 ^= (*&vw25).f0[3][0][0][0];
+  vw35[u32(unconst_u32(73))][u32(unconst_u32(264))] = mat2x2h(f16((*&vw25).f0[3][0][0][0]), f16((*&vw25).f0[3][0][0][0]), f16((*&vw25).f0[3][0][0][0]), f16((*&vw25).f0[3][0][0][0]));
+  vw21 += mat2x4h(f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]), f16((*&vw32).f0[3][0][0][0]));
+  let ptr55: ptr<workgroup, array<array<array<u32, 1>, 1>, 1>> = &vw32.f0[3];
+  let ptr56: ptr<workgroup, u32> = &(*&vw27).f3;
+  let vf91: i32 = atomicExchange(&(*&vw31), i32(unconst_i32(176)));
+  atomicCompareExchangeWeak(&vw26, unconst_i32(153), unconst_i32(49));
+  let ptr57: ptr<workgroup, array<array<u32, 1>, 1>> = &(*ptr55)[0];
+  let ptr58: ptr<workgroup, i32> = &vw24;
+  let ptr59: ptr<workgroup, u32> = &(*&vw34).f3;
+  let ptr60: ptr<workgroup, array<array<u32, 1>, 1>> = &(*&vw29).f0[3][u32(unconst_u32(71))];
+  let vf92: i32 = atomicLoad(&(*&vw31));
+  vw20.f0[(*&vw25).f0[3][0][u32(unconst_u32(277))][0]][(*ptr55)[0][0][0]][(*&vw37).f1][u32(unconst_u32(247))] <<= (*ptr54)[0];
+  let ptr61: ptr<workgroup, u32> = &(*&vw23).f3;
+  vw20 = T0(array<array<array<array<u32, 1>, 1>, 1>, 4>(array<array<array<u32, 1>, 1>, 1>(array<array<u32, 1>, 1>(array<u32, 1>(vw37.f0[3]))), array<array<array<u32, 1>, 1>, 1>(array<array<u32, 1>, 1>(array<u32, 1>(vw37.f0[3]))), array<array<array<u32, 1>, 1>, 1>(array<array<u32, 1>, 1>(array<u32, 1>(vw37.f0[3]))), array<array<array<u32, 1>, 1>, 1>(array<array<u32, 1>, 1>(array<u32, 1>(vw37.f0[3])))));
+  vw33.f0 <<= vec4u((*ptr55)[0][0][0]);
+  vw33.f1 *= pack4x8unorm((*&vw34).f2);
+  let ptr62: ptr<workgroup, vec4f> = &(*&vw23).f2;
+  let ptr63: ptr<workgroup, u32> = &(*&vw23).f3;
+  vw33 = (*&vw37);
+  vw22 = f16(vw25.f0[3][0][0][0]);
+  vw34 = VertexOutput2(vec4f(vw35[9][0][1].rrrg), bitcast<u32>(vw35[9][0][1]));
+}`,
+  sourceMap: {},
+});
+let buffer71 = device0.createBuffer({size: 8803, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder105 = device0.createCommandEncoder({});
+let commandBuffer5 = commandEncoder58.finish({});
+let sampler66 = device0.createSampler({
+  label: '\ue13c\uead6\ub581\u28ba\u0389\u8522\uaaf8',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 91.49,
+  compare: 'less',
+});
+try {
+computePassEncoder76.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer4 = buffer32.getMappedRange(0, 228);
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+let buffer72 = device0.createBuffer({size: 21688, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let sampler67 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 48.77,
+  lodMaxClamp: 90.37,
+});
+try {
+computePassEncoder65.setBindGroup(1, bindGroup9, []);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle7]);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+await gc();
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'iec6196624'} });
+let buffer73 = device0.createBuffer({
+  size: 9268,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder106 = device0.createCommandEncoder({});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(3, bindGroup41, new Uint32Array(745), 32, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise16;
+} catch {}
+await gc();
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'smpte240m'} });
+let commandEncoder107 = device0.createCommandEncoder({});
+try {
+renderPassEncoder17.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 254.9, g: 933.2, b: -964.3, a: 603.8, });
+} catch {}
+try {
+commandEncoder104.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 640 */
+  offset: 640,
+  buffer: buffer39,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+await gc();
+let commandEncoder108 = device0.createCommandEncoder({label: '\ud4fc\ud6f7\u{1f827}\u0d1e\ucfbd\u6189\ub01c\u{1ffc8}\ue8b1\u{1f96a}'});
+let computePassEncoder104 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder102.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer49);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer52, 424, buffer51, 148, 372);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer37, 356, 3996);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\ud11f');
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 348, resource: textureView24},
+    {binding: 234, resource: sampler54},
+    {binding: 354, resource: {buffer: buffer54, offset: 3840}},
+    {binding: 37, resource: externalTexture2},
+  ],
+});
+let commandEncoder109 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: [80, 75, 10],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup43, new Uint32Array(3901), 230, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer63);
+} catch {}
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 272 */
+  offset: 272,
+  bytesPerRow: 29184,
+  buffer: buffer71,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 1, y: 19, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(140, 73);
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'iec6196624'} });
+let bindGroup48 = device0.createBindGroup({
+  label: '\u009b\u1484\u7db0\u7052',
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: {buffer: buffer14, offset: 0, size: 436}}],
+});
+let computePassEncoder105 = commandEncoder94.beginComputePass({});
+try {
+renderPassEncoder16.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer46, 'uint16', 1_924, 1_365);
+} catch {}
+let arrayBuffer5 = buffer32.getMappedRange(1152, 40);
+try {
+commandEncoder108.resolveQuerySet(querySet5, 255, 318, buffer9, 4864);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'log'} });
+let sampler68 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 23.49,
+  compare: 'always',
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup15, new Uint32Array(1093), 57, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup5, new Uint32Array(3731), 388, 0);
+} catch {}
+try {
+buffer47.destroy();
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 1536 widthInBlocks: 96 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 688 */
+  offset: 688,
+  buffer: buffer25,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 96, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder104.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  bytesPerRow: 16640,
+  buffer: buffer31,
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 47, resource: {buffer: buffer46, offset: 12288, size: 739}},
+    {binding: 44, resource: textureView2},
+  ],
+});
+let textureView89 = texture16.createView({});
+let renderPassEncoder20 = commandEncoder108.beginRenderPass({
+  colorAttachments: [{view: textureView81, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 125634456,
+});
+let sampler69 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 51.81,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup9, new Uint32Array(217), 9, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup10, new Uint32Array(956), 394, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer64, 'uint32', 1_460, 1_514);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({label: '\ue14f\u28b2\u89a7\u{1fe70}\u0ef5'});
+let computePassEncoder106 = commandEncoder110.beginComputePass({});
+let sampler70 = device0.createSampler({
+  label: '\ud420\u6370\u9e13\u548f',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 39.18,
+  lodMaxClamp: 88.53,
+});
+try {
+computePassEncoder105.setPipeline(pipeline4);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 3, y: 12, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer74 = device0.createBuffer({
+  label: '\u9888\u{1fc9a}\u3e0d',
+  size: 9732,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup42, new Uint32Array(1771), 108, 0);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer50, 5552, buffer33, 4, 108);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 6, y: 14, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 11, y: 18, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let textureView90 = texture76.createView({
+  label: '\u{1f8b7}\udaff\u277d\u095a\uc307\uf40d\u0008\u6d1e\udb79\u0a17\u{1fd43}',
+  dimension: '2d-array',
+});
+let textureView91 = texture100.createView({label: '\ucc6e\u9238\u0384\u5bef\u3aa0\ud94e\uea6a', baseMipLevel: 0});
+let computePassEncoder107 = commandEncoder104.beginComputePass({});
+let renderPassEncoder21 = commandEncoder107.beginRenderPass({
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: 439.1, g: -966.1, b: -226.3, a: -753.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 163631338,
+});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 448.1, g: 56.81, b: -103.4, a: -193.1, });
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer62, 'uint32', 248, 6);
+} catch {}
+try {
+commandEncoder109.copyBufferToBuffer(buffer20, 20832, buffer22, 7076, 2780);
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({label: '\u32b9\u{1f6a7}\u2432\u{1fd75}\u0472'});
+let texture105 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder108 = commandEncoder111.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroupsIndirect(buffer62, 44); };
+} catch {}
+try {
+computePassEncoder70.end();
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer14);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'r8snorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(img2);
+let commandEncoder112 = device0.createCommandEncoder({});
+let textureView92 = texture99.createView({arrayLayerCount: 1});
+let computePassEncoder109 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(3, bindGroup24, new Uint32Array(3316), 1_169, 0);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer3, offset: 512, size: 892}}],
+});
+let commandEncoder113 = device0.createCommandEncoder({});
+let computePassEncoder110 = commandEncoder66.beginComputePass({});
+try {
+computePassEncoder110.setPipeline(pipeline3);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder({label: '\uf780\u0dc8\u80f4\u0565\u658c'});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 1076});
+let texture106 = device0.createTexture({size: {width: 20}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup9, new Uint32Array(620), 272, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle7, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer58, 2_040);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+  await promise17;
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  label: '\u8386\u5beb\ude22\u{1f838}',
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 54, resource: textureView63},
+    {binding: 434, resource: {buffer: buffer64, offset: 1024, size: 1968}},
+    {binding: 200, resource: textureView40},
+    {binding: 6, resource: {buffer: buffer42, offset: 0, size: 1688}},
+  ],
+});
+let commandEncoder115 = device0.createCommandEncoder({});
+let textureView93 = texture8.createView({mipLevelCount: 1});
+let computePassEncoder111 = commandEncoder115.beginComputePass({label: '\u7235\u1cf3\ueecb\u0d62\u0b82\u20c1\ub99d\ud32d\u51e5'});
+let sampler71 = device0.createSampler({addressModeW: 'clamp-to-edge', lodMinClamp: 95.05, lodMaxClamp: 99.95});
+try {
+computePassEncoder103.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 196, new BigUint64Array(2370), 467, 32);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let buffer75 = device0.createBuffer({
+  size: 9186,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture107 = device0.createTexture({
+  label: '\u{1fc57}\uabba\u03a0\u0d65\u0201\u467b\u{1f8f0}\u7b22\uc788\ud5bc\uba0d',
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup24, new Uint32Array(225), 6, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroups(1, 3); };
+} catch {}
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer50, 17588, buffer55, 1240, 260);
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 43, resource: sampler62},
+    {binding: 51, resource: {buffer: buffer25, offset: 256}},
+    {binding: 134, resource: {buffer: buffer42, offset: 1280, size: 4760}},
+    {binding: 133, resource: {buffer: buffer54, offset: 2560}},
+    {binding: 10, resource: textureView89},
+    {binding: 144, resource: textureView37},
+    {binding: 34, resource: textureView29},
+  ],
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let textureView94 = texture89.createView({baseArrayLayer: 0});
+let renderPassEncoder22 = commandEncoder114.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: -423.9, g: 318.9, b: 820.5, a: -68.37, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler72 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 86.15,
+  lodMaxClamp: 91.40,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer60, 'uint16', 68, 1_372);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer17, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 20, new Int16Array(5748), 468, 24);
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 34, resource: textureView29},
+    {binding: 51, resource: {buffer: buffer75, offset: 7424, size: 742}},
+    {binding: 144, resource: textureView15},
+    {binding: 134, resource: {buffer: buffer34, offset: 2560, size: 248}},
+    {binding: 43, resource: sampler51},
+    {binding: 133, resource: {buffer: buffer14, offset: 256, size: 228}},
+    {binding: 10, resource: textureView55},
+  ],
+});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup3, new Uint32Array(1125), 13, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup18, new Uint32Array(3333), 224, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer18, 'uint32', 4_952, 2_288);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 16}
+*/
+{
+  source: img5,
+  origin: { x: 17, y: 0 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 361});
+let textureView95 = texture88.createView({label: '\ud78e\u6b37\ud08e\u0443\u0aa8'});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer27, 'uint16', 612, 6);
+} catch {}
+document.body.prepend(canvas0);
+let commandBuffer6 = commandEncoder105.finish();
+try {
+renderPassEncoder12.setIndexBuffer(buffer27, 'uint32', 604, 481);
+} catch {}
+document.body.prepend(img4);
+let computePassEncoder112 = commandEncoder116.beginComputePass({label: '\u4f3e\u12cd\u7c94\ua172\u0fbd\u0bc8\u38b1\u0cae\u06ca\u3782\u{1fd37}'});
+let sampler73 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.46,
+  lodMaxClamp: 73.77,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder22.setBlendConstant({ r: -445.2, g: -446.3, b: 721.1, a: 529.8, });
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(355);
+} catch {}
+try {
+renderPassEncoder22.setViewport(151.34668626035995, 104.43178300506995, 8.186771129821006, 42.384168404502965, 0.3383701441553092, 0.4807004156150535);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer25, 356, 593);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder();
+let sampler74 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 83.96,
+  compare: 'always',
+});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup38, new Uint32Array(493), 33, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 12544,
+  buffer: buffer48,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture108 = device0.createTexture({
+  size: [20, 24, 54],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView96 = texture85.createView({dimension: '1d'});
+let computePassEncoder113 = commandEncoder118.beginComputePass({label: '\u8a2e\u{1fe33}\u7de0\u0cab\u0b86\u359e\u0bca'});
+try {
+computePassEncoder112.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup41, new Uint32Array(667), 90, 0);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1796 */
+  offset: 1796,
+  buffer: buffer19,
+}, {
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder96.insertDebugMarker('\u157d');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 196});
+let computePassEncoder114 = commandEncoder117.beginComputePass({label: '\u{1f62d}\ud6f0\ue1ee\u5339\u08c7\u8e2e\uf983\u875e\u{1fdb9}\u9a4c\u0039'});
+let sampler75 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 83.98,
+});
+try {
+computePassEncoder109.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup24, new Uint32Array(54), 5, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer54, 'uint16', 1_062, 2_332);
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet5, 210, 37, buffer75, 512);
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({});
+let computePassEncoder115 = commandEncoder119.beginComputePass();
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup0, new Uint32Array(2290), 151, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7]);
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView71}, {binding: 47, resource: textureView28}],
+});
+let buffer76 = device0.createBuffer({
+  size: 5979,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView97 = texture52.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 9});
+let sampler76 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.01,
+  lodMaxClamp: 73.39,
+});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup20, new Uint32Array(1598), 90, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup45, new Uint32Array(1242), 273, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer5, 'uint16', 354, 90);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, undefined, 0);
+} catch {}
+try {
+commandEncoder112.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 3, y: 57, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({});
+let texture109 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture76.createView({dimension: '2d-array'});
+let computePassEncoder116 = commandEncoder4.beginComputePass();
+try {
+computePassEncoder62.setBindGroup(1, bindGroup32, new Uint32Array(788), 82, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(21, 41, 15, 3);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(25, 52);
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'iec6196624'} });
+let texture110 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(0, bindGroup23, new Uint32Array(974), 76, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer9, 4_936); };
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: 206.7, g: -737.5, b: -175.2, a: -325.0, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer9, 'uint16', 8_168, 1_159);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData8 = new ImageData(52, 24);
+let bindGroup55 = device0.createBindGroup({
+  label: '\u00b7\uc784\u0562\u7d91\u702d\uceb9\uac56',
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 159, resource: {buffer: buffer26, offset: 0, size: 2988}},
+    {binding: 72, resource: textureView37},
+  ],
+});
+let textureView99 = texture99.createView({baseMipLevel: 0});
+let texture111 = device0.createTexture({
+  size: [80, 96, 154],
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView100 = texture52.createView({mipLevelCount: 1, baseArrayLayer: 12, arrayLayerCount: 3});
+try {
+computePassEncoder115.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer34, 'uint16', 2_170, 5_298);
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 4212,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture112 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder117 = commandEncoder112.beginComputePass({});
+try {
+computePassEncoder88.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer78 = device0.createBuffer({
+  label: '\u0c71\u9ea3\u{1fab3}\u675c\uf7e0\u8499',
+  size: 11499,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+  mappedAtCreation: false,
+});
+let computePassEncoder118 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup45, new Uint32Array(1492), 115, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12]});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 602});
+let textureView101 = texture52.createView({
+  label: '\u{1f624}\u79a3\ucd37\uf4d5\u{1f764}\u{1fc7b}\u3aec\u0a5a\u0424\u{1f954}',
+  dimension: '2d-array',
+  format: 'rgba32float',
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+  arrayLayerCount: 1,
+});
+let texture113 = device0.createTexture({
+  label: '\u{1f9f7}\u{1fe96}\u0cd4\uad6f\u{1f95d}\ue734\u0a14\u6acc\u{1f94b}\u0be6\uf742',
+  size: {width: 40, height: 48, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36 */
+  offset: 36,
+  bytesPerRow: 5120,
+  rowsPerImage: 36,
+  buffer: buffer69,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 2, y: 17, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder113.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 1, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+offscreenCanvas1.width = 148;
+let shaderModule5 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+override override14: u32 = 158;
+
+struct T0 {
+  f0: vec2u,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override9: i32 = 180;
+
+fn fn0() -> T0 {
+  var out: T0;
+  let vf93: f16 = distance(vec4h(unconst_f16(3408.3), unconst_f16(27528.2), unconst_f16(12733.9), unconst_f16(589.7)), vec4h(unconst_f16(20381.6), unconst_f16(4613.6), unconst_f16(741.5), unconst_f16(13826.2)));
+  let vf94: bool = any(bool(unconst_bool(false)));
+  var vf95: vec3h = refract(vec3h(unconst_f16(5982.8), unconst_f16(25816.0), unconst_f16(39739.1)), vec3h(f16(override13)), f16(unconst_f16(493.8)));
+  out.f0 |= vec2u(countLeadingZeros(u32(distance(tan(vec2h(radians(vec4f(bitcast<f32>(override9))).br)).xyxy, vec4h(unconst_f16(7104.3), unconst_f16(7466.2), unconst_f16(11500.0), unconst_f16(12339.4))))));
+  let vf96: vec3f = acos(vec3f(unconst_f32(0.04288), unconst_f32(0.2067), unconst_f32(0.05401)));
+  vf95 = tanh(vec4h(unconst_f16(4573.2), unconst_f16(18403.5), unconst_f16(944.2), unconst_f16(-5797.7))).bra;
+  out.f0 = vec2u(inverseSqrt(vec2h(unconst_f16(7216.9), unconst_f16(4987.2))));
+  var vf97: vec3h = trunc(vec3h(unconst_f16(-56056.7), unconst_f16(26677.4), unconst_f16(7610.3)));
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(54269) override override7: u32 = 139;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(159) var<storage, read_write> buffer79: T1;
+
+struct T1 {
+  @size(36) f0: array<u32>,
+}
+
+@id(3321) override override8: u32 = 70;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct T2 {
+  @size(36) f0: array<u32>,
+}
+
+@id(5303) override override13 = true;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override11 = -71;
+
+override override12: i32 = 108;
+
+@id(2497) override override10 = 0.07718;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8() {
+  var vf98 = fn0();
+  vf98 = T0(vf98.f0);
+  let vf99: bool = override13;
+  var vf100 = fn0();
+  var vf101 = fn0();
+  vf98.f0 = vec2u(vf100.f0[1]);
+  let vf102: i32 = override9;
+  vf98 = T0(vec2u(tan(vec2h(vf101.f0))));
+  fn0();
+  vf100 = T0(vec2u(u32(override9)));
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer80 = device0.createBuffer({size: 6956, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder121 = device0.createCommandEncoder({});
+let texture114 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas2.getContext('webgpu');
+let texture115 = device0.createTexture({
+  label: '\u53d1\u43ec\uf554\u477c\uec63',
+  size: {width: 40, height: 48, depthOrArrayLayers: 33},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder115.setBindGroup(3, bindGroup2, new Uint32Array(1036), 68, 0);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle7]);
+} catch {}
+let arrayBuffer6 = buffer74.getMappedRange(576, 2328);
+try {
+commandEncoder120.insertDebugMarker('\u0fec');
+} catch {}
+let video0 = await videoWithData(119);
+let computePassEncoder119 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder113.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer54, 'uint16', 644, 164);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer54, 684);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let shaderModule6 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+fn fn0() -> array<f32, 31> {
+  var out: array<f32, 31>;
+  vp7 = modf(cos(vec3f(unconst_f32(-0.02982), unconst_f32(0.01975), unconst_f32(0.3598))).x);
+  out[bitcast<u32>(atan2(vec3f(unconst_f32(0.07818), unconst_f32(0.1633), unconst_f32(0.1144)), bitcast<vec3f>(textureDimensions(tex4).grg)).z)] = vp7.fract;
+  vp7 = modf(vp7.whole);
+  return out;
+}
+
+struct T2 {
+  @size(36) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput4 {
+  @location(3) @interpolate(flat, center) f0: u32,
+  @location(0) @interpolate(flat, center) f1: vec4u,
+}
+
+struct T0 {
+  @size(36) f0: array<u32>,
+}
+
+struct T1 {
+  @size(36) f0: array<u32>,
+}
+
+@group(0) @binding(72) var tex4: texture_2d<f32>;
+
+var<private> vp7 = modf(f32());
+
+var<workgroup> vw38: FragmentOutput4;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw39: atomic<u32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput3 {
+  @invariant @builtin(position) f4: vec4f,
+}
+
+@group(0) @binding(159) var<storage, read_write> buffer81: array<array<array<array<f16, 3>, 1>, 3>, 2>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex5() -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f4 += vec4f(bitcast<f32>(pack2x16unorm(vec2f(unconst_f32(-0.02881), unconst_f32(0.3309)))));
+  let vf103: f32 = acosh(f32(unconst_f32(0.4537)));
+  vp7 = modf(f32(any(vec2<bool>(cosh(vec3f(unconst_f32(0.1758), unconst_f32(-0.1878), unconst_f32(0.00451))).gg))));
+  var vf104: u32 = textureNumLevels(tex4);
+  var vf105: mat2x4f = transpose(mat4x2f(unconst_f32(0.4131), unconst_f32(0.08525), unconst_f32(0.5764), unconst_f32(0.1112), unconst_f32(0.2158), unconst_f32(0.3601), unconst_f32(0.00465), unconst_f32(0.2552)));
+  vf105 += mat2x4f(f32(vf104), bitcast<f32>(vf104), bitcast<f32>(vf104), bitcast<f32>(vf104), f32(vf104), f32(vf104), bitcast<f32>(vf104), f32(vf104));
+  let vf106: u32 = pack2x16float(vec2f(normalize(vec2h(unpack2x16snorm(dot4U8Packed(u32(unconst_u32(5)), u32(unconst_u32(8))))))));
+  let ptr64: ptr<private, f32> = &vp7.fract;
+  out.f4 = vec4f(acosh(bitcast<f32>(textureNumLevels(tex4))));
+  out.f4 = unpack4x8snorm(vf106);
+  let vf107: u32 = dot4U8Packed(u32(unconst_u32(214)), u32(trunc(vec4h(f16(vf106)))[0]));
+  return out;
+}
+
+@fragment
+fn fragment5() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  discard;
+  out.f1 >>= unpack4xU8(u32(buffer81[1][2][0][2]));
+  buffer81[u32(buffer81[1][2][0][2])][u32(unconst_u32(42))][0][u32(unconst_u32(2))] = (*&buffer81)[1][2][0][2];
+  vp7 = modf(f32(buffer81[1][2][0][2]));
+  let ptr65: ptr<storage, array<array<array<f16, 3>, 1>, 3>, read_write> = &(*&buffer81)[1];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9() {
+  var vf108: u32 = atomicLoad(&(*&vw39));
+  var vf109 = fn0();
+  vf109[30] = vf109[30];
+  atomicStore(&vw39, u32(unconst_u32(41)));
+  var vf110 = fn0();
+  let ptr66: ptr<function, array<f32, 31>> = &vf110;
+  fn0();
+  vf110[u32(unconst_u32(90))] = vf110[30];
+  var vf111 = fn0();
+  fn0();
+  let vf112: vec3f = asin(vec3f(unconst_f32(0.1433), unconst_f32(0.03822), unconst_f32(0.2758)));
+  fn0();
+  let ptr67: ptr<workgroup, u32> = &(*&vw38).f0;
+  var vf113 = fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({label: '\u01f8\u0672\u059a\u0319\u26a1', type: 'occlusion', count: 401});
+let textureView102 = texture59.createView({});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup46, new Uint32Array(571), 93, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 105.3, g: 569.3, b: 29.73, a: 552.6, });
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(390);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer37);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 89, resource: {buffer: buffer62, offset: 0, size: 292}}],
+});
+let computePassEncoder120 = commandEncoder113.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({source: video0});
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroupsIndirect(buffer5, 4); };
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(99);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2]);
+} catch {}
+let imageData9 = new ImageData(28, 112);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u43e3\u0f27\u{1f731}',
+  colorFormats: ['rgba32uint', 'r8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: false,
+});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup23, new Uint32Array(1969), 1_063, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer57, 'uint32', 1_480, 499);
+} catch {}
+let imageData10 = new ImageData(4, 4);
+let pipelineLayout7 = device0.createPipelineLayout({label: '\u7bbd\u0cec\u1720\u{1feab}\u385d\uaf2d\u{1fdef}', bindGroupLayouts: []});
+let commandEncoder123 = device0.createCommandEncoder({label: '\u0faa\u8207\u{1f8e9}\u0d61\u9d89'});
+let computePassEncoder121 = commandEncoder120.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer49, 16, 553);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 8, y: 9, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas1.getContext('webgpu');
+video0.width = 32;
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+var<private> vp9 = array(array(modf(vec2f()), modf(vec2f())));
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0(a0: array<f32, 29>, a1: mat2x3f, a2: array<bool, 11>, a3: FragmentOutput5, a4: ptr<uniform, FragmentOutput5>) -> mat4x4f {
+  var out: mat4x4f;
+  vp8[u32(unconst_u32(143))] = modf(vec4h(f16(textureNumLevels(tex5))));
+  vp8[u32(unconst_u32(48))] = modf(reflect(vec3h(a3.f1.zyz), vec3h(unconst_f16(19577.5), unconst_f16(8401.8), unconst_f16(4408.8))).rgrb);
+  out = mat4x4f(bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), bitcast<f32>(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))), f32(pack4xU8(vec4u(unconst_u32(615), unconst_u32(409), unconst_u32(32), unconst_u32(608)))));
+  let ptr68 = &vp9[0];
+  let vf114: FragmentOutput5 = a3;
+  let vf115: u32 = textureNumLevels(tex5);
+  let vf116: u32 = vf114.f0;
+  let vf117: vec4f = vf114.f1;
+  let vf118: vec4f = textureLoad(tex5, bitcast<vec2i>(vp8[0].fract), i32(unconst_i32(35)));
+  let ptr69: ptr<uniform, vec4f> = &(*a4).f1;
+  vp8[u32(unconst_u32(103))] = modf(vec4h(vf114.f1));
+  var vf119: vec4h = exp2(vec4h(unconst_f16(-15370.9), unconst_f16(9835.3), unconst_f16(4270.3), unconst_f16(11306.1)));
+  out += mat4x4f(vec4f(vp8[u32(unconst_u32(71))].whole), vec4f(vp8[u32(unconst_u32(71))].whole), vec4f(vp8[u32(unconst_u32(71))].whole), vec4f(vp8[u32(unconst_u32(71))].whole));
+  vp8[pack4xI8(vec4i(unconst_i32(97), unconst_i32(13), unconst_i32(47), unconst_i32(216)))].whole = vec4h(unpack4x8unorm(u32(unconst_u32(152))));
+  let vf120: vec3f = acosh(vec3f(unconst_f32(0.5295), unconst_f32(0.4595), unconst_f32(0.06583)));
+  let ptr70: ptr<private, vec2f> = &vp9[0][1].fract;
+  out = mat4x4f((*ptr68)[1].whole.rgrg, (*ptr68)[1].whole.gggg, (*ptr68)[1].whole.grrg, (*ptr68)[1].whole.xyyy);
+  vp8[u32(unconst_u32(812))] = modf(bitcast<vec4h>((*ptr68)[1].whole));
+  vp8[vec2u((*ptr68)[1].fract)[1]] = modf(bitcast<vec4h>(textureDimensions(tex5, i32(unconst_i32(47)))));
+  vp9[u32(unconst_u32(296))][pack4xU8(vec4u((*ptr70).rrrr))] = modf(vec2f(pow(f32((*a4).f0), vp9[0][1].whole[0])));
+  vf119 = vec4h(f16((*a4).f0));
+  var vf121: f32 = a3.f1[3];
+  let ptr71: ptr<function, f32> = &vf121;
+  let ptr72 = &(*ptr68);
+  vp8[u32(unconst_u32(1))].whole -= bitcast<vec4h>((*ptr72)[u32(unconst_u32(226))].fract);
+  return out;
+}
+
+struct FragmentOutput5 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) @interpolate(flat) f1: vec4f,
+}
+
+struct VertexOutput4 {
+  @location(8) @interpolate(flat, centroid) f5: vec2f,
+  @builtin(position) f6: vec4f,
+  @location(4) f7: vec4f,
+}
+
+@group(0) @binding(159) var<storage, read_write> buffer82: array<array<array<array<array<array<array<f16, 1>, 3>, 1>, 1>, 3>, 2>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @align(2) f0: array<atomic<u32>, 1>,
+  @align(2) @size(68) f1: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp8 = array(modf(vec4h()));
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(72) var tex5: texture_2d<f32>;
+
+@vertex
+fn vertex6() -> VertexOutput4 {
+  var out: VertexOutput4;
+  out.f7 = atanh(vec4f(unconst_f32(0.3559), unconst_f32(0.1164), unconst_f32(0.1383), unconst_f32(0.01123)));
+  vp9[u32(unconst_u32(25))][1] = modf(vec2f(countTrailingZeros(vec3i(unconst_i32(280), unconst_i32(143), unconst_i32(86))).zx));
+  let vf122: vec3i = countTrailingZeros(vec3i(unconst_i32(134), unconst_i32(24), unconst_i32(29)));
+  out.f6 *= bitcast<vec4f>(insertBits(vec2i(unconst_i32(447), unconst_i32(147)), vec2i(bitcast<i32>(pack2x16float(vec2f(unconst_f32(0.2153), unconst_f32(0.2910))))), u32(unconst_u32(149)), pack4x8snorm(vec4f(unconst_f32(0.2296), unconst_f32(0.2147), unconst_f32(0.2241), unconst_f32(0.2842)))).ggrg);
+  let vf123: i32 = dot4I8Packed(u32(dot4I8Packed(u32(vp9[0][1].whole.y), pack4x8snorm(exp(bitcast<vec4f>(countTrailingZeros(vec3i(unconst_i32(49), unconst_i32(-313), unconst_i32(119))).xxxz))))), pack2x16float(vec2f(unconst_f32(0.00544), unconst_f32(0.06357))));
+  var vf124: u32 = pack4x8snorm(vec4f(unconst_f32(0.02141), unconst_f32(-0.1144), unconst_f32(0.1845), unconst_f32(0.02898)));
+  let vf125: f16 = distance(vec2h(unconst_f16(9134.6), unconst_f16(14374.2)), bitcast<vec2h>(dot4U8Packed(u32(unconst_u32(67)), u32(unconst_u32(90)))));
+  return out;
+}
+
+@fragment
+fn fragment6(@location(4) a0: u32) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  buffer82[u32(unconst_u32(8))][pack2x16snorm(vp9[0][1].fract)][u32((*&buffer82)[u32(unconst_u32(121))][1][2][0][0][2][0])][u32(unconst_u32(207))][u32(buffer82[arrayLength(&buffer82)][1][2][0][0][2][0])][u32(unconst_u32(222))][0] = buffer82[arrayLength(&buffer82)][1][2][0][u32(unconst_u32(348))][2][0];
+  let ptr73: ptr<storage, array<array<array<array<array<array<f16, 1>, 3>, 1>, 1>, 3>, 2>, read_write> = &buffer82[i32(unconst_i32(65))];
+  let ptr74: ptr<storage, array<array<array<array<array<array<array<f16, 1>, 3>, 1>, 1>, 3>, 2>>, read_write> = &buffer82;
+  out = FragmentOutput5(u32((*ptr74)[arrayLength(&(*ptr74))][1][2][0][0][2][0]), vec4f(f32((*ptr74)[arrayLength(&(*ptr74))][1][2][0][0][2][0])));
+  out.f1 = vec4f(dot(vec4f(f32(buffer82[arrayLength(&buffer82)][1][2][0][u32(unconst_u32(92))][2][0])), vec4f(f32((*&buffer82)[arrayLength(&(*&buffer82))][1][2][0][0][u32((*ptr74)[arrayLength(&(*ptr74))][1][2][0][0][2][0])][0]))));
+  let ptr75: ptr<storage, array<array<f16, 1>, 3>, read_write> = &(*&buffer82)[arrayLength(&(*&buffer82))][1][2][0][0];
+  let ptr76: ptr<storage, array<array<array<array<array<array<f16, 1>, 3>, 1>, 1>, 3>, 2>, read_write> = &buffer82[u32(unconst_u32(301))];
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 2)
+fn compute10() {
+  vp9[u32(unconst_u32(50))][1].fract = vp9[0][1].whole;
+  vp8[u32(unconst_u32(62))] = modf(vec4h(fma(vec2h(vp9[0][1].fract).x, f16(unconst_f16(13154.4)), mix(vec3h(unconst_f16(35933.2), unconst_f16(8936.6), unconst_f16(22348.4)), vec3h(textureLoad(tex5, vec2i(unconst_i32(451), unconst_i32(37)), bitcast<i32>(exp2(f32(unconst_f32(0.01408))))).wxz), vec3h(unconst_f16(1095.0), unconst_f16(31232.8), unconst_f16(36798.2)))[2])));
+  vp9[u32(unconst_u32(429))][u32(unconst_u32(138))].fract = vp9[0][1].fract;
+  vp8[firstLeadingBit(u32(exp2(f32(unconst_f32(-0.4049)))))].whole = vec4h(f16(fma(vp9[0][1].whole.x, f32(unconst_f32(0.02046)), distance(vec2f(unconst_f32(0.08643), unconst_f32(0.09061)), vp9[0][1].fract))));
+  let ptr77 = &vp9[0];
+  let ptr78 = &vp9[0][1];
+  vp9[vec3u(mix(vec3h(f16(firstLeadingBit(u32(unconst_u32(19))))), vec3h(unconst_f16(1049.3), unconst_f16(31203.3), unconst_f16(3673.2)), vec3h((*ptr77)[1].fract.ggr))).b][pack4x8unorm(vec4f(unconst_f32(0.05197), unconst_f32(-0.2176), unconst_f32(0.3205), unconst_f32(0.08427)))] = modf(unpack2x16unorm(dot4U8Packed(u32(unconst_u32(82)), textureNumLevels(tex5))));
+  let vf126: bool = all(bool(vp9[u32(unconst_u32(64))][1].whole[1]));
+  vp8[u32(unconst_u32(307))] = modf(bitcast<vec4h>(vp9[0][1].fract));
+  vp8[u32(unconst_u32(253))] = modf(vec4h(f16(exp(f32(unconst_f32(0.09789))))));
+}`,
+});
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 150,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 168,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer83 = device0.createBuffer({size: 3782, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView103 = texture101.createView({arrayLayerCount: 1});
+let computePassEncoder122 = commandEncoder123.beginComputePass({label: '\u788a\u{1fa4f}\u28b9\u{1f9b2}\u43d7\u0f2d\u551f\ud1f2\u8e76\u0f16'});
+try {
+computePassEncoder112.setBindGroup(1, bindGroup50, new Uint32Array(916), 205, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer75, 'uint16', 78, 1_743);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1520 */
+  offset: 1520,
+  buffer: buffer19,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise19;
+} catch {}
+await gc();
+let commandEncoder124 = device0.createCommandEncoder({label: '\u0aee\u0631\ubf9b\u8862\uaa20\u{1f977}\u1feb\u09c9\u8cd9'});
+let texture116 = device0.createTexture({
+  size: [80, 75, 17],
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler77 = device0.createSampler({
+  label: '\ubc7c\u{1fdc2}\u0459\u{1f9e3}\u7c03\ubc10\uc7c9\u{1f6a3}\u215f\u6964\u0471',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 39.25,
+  lodMaxClamp: 88.73,
+});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(0, bindGroup18, new Uint32Array(100), 16, 0);
+} catch {}
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup53, new Uint32Array(2284), 3, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer71, 112);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer29, 112, buffer23, 4524, 84);
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte170m', transfer: 'linear'} });
+let commandEncoder125 = device0.createCommandEncoder({});
+let commandBuffer7 = commandEncoder50.finish({label: '\u0f5f\ue9ae\u010f\u03ab'});
+let texture117 = device0.createTexture({
+  size: [80],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView104 = texture92.createView({label: '\u5ba6\u{1f67b}\ua3a4', baseArrayLayer: 1, arrayLayerCount: 3});
+let renderPassEncoder23 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{
+  view: textureView101,
+  clearValue: { r: 756.9, g: 436.8, b: -173.2, a: -279.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup18, new Uint32Array(1972), 400, 0);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'film', transfer: 'smpte170m'} });
+let bindGroup57 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView60}]});
+let commandEncoder126 = device0.createCommandEncoder({});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(22);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer62, 'uint32', 504, 80);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData11 = new ImageData(28, 12);
+let commandEncoder127 = device0.createCommandEncoder({});
+let textureView105 = texture70.createView({label: '\u1369\u572e\uce99\u2e6d\uafc7\uacdf\u1e35', format: 'rgba32uint', arrayLayerCount: 1});
+let sampler78 = device0.createSampler({
+  label: '\u08e2\u16f1\ue961\u05e1\u{1f62f}\u62e4\uff48\u0b19\u136d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 54.67,
+  lodMaxClamp: 68.08,
+  compare: 'never',
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer54, 'uint32', 600, 220);
+} catch {}
+try {
+commandEncoder126.resolveQuerySet(querySet3, 4, 25, buffer49, 1280);
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let computePassEncoder123 = commandEncoder124.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup11, new Uint32Array(2245), 269, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder119.insertDebugMarker('\u0c68');
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 6847,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let texture118 = device0.createTexture({
+  size: [80, 75, 11],
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder124 = commandEncoder126.beginComputePass({});
+let renderPassEncoder24 = commandEncoder128.beginRenderPass({
+  colorAttachments: [{
+  view: textureView74,
+  depthSlice: 8,
+  clearValue: { r: -17.11, g: -876.0, b: 659.3, a: -706.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+computePassEncoder101.setBindGroup(1, bindGroup4, new Uint32Array(664), 54, 0);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup22, new Uint32Array(2305), 403, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer6, 'uint16', 3_628, 563);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder({label: '\uaa8d\u0afe'});
+let renderPassEncoder25 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{view: textureView64, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 172732912,
+});
+let externalTexture11 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(3, bindGroup50, new Uint32Array(2417), 285, 0);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer57, 'uint32', 1_876, 490);
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView76}, {binding: 47, resource: textureView34}],
+});
+let textureView106 = texture38.createView({label: '\u9f2e\u20d1\u{1f98d}\u08b6\uc10f', mipLevelCount: 1});
+let computePassEncoder125 = commandEncoder127.beginComputePass();
+try {
+renderPassEncoder25.setScissorRect(8, 0, 1, 2);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer59, 'uint16', 788, 663);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 112 */
+  offset: 112,
+  bytesPerRow: 5120,
+  buffer: buffer73,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let textureView107 = texture77.createView({dimension: '2d-array', baseMipLevel: 0});
+let computePassEncoder126 = commandEncoder129.beginComputePass({});
+try {
+computePassEncoder79.setBindGroup(2, bindGroup28, new Uint32Array(298), 106, 0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer43);
+} catch {}
+try {
+  await promise20;
+} catch {}
+document.body.append(canvas0);
+offscreenCanvas1.height = 66;
+let sampler79 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 56.71,
+  compare: 'greater',
+});
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2]);
+} catch {}
+document.body.append(video0);
+try {
+globalThis.someLabel = externalTexture10.label;
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  label: '\uc006\ued93\u02e1\ua15e\ue5c7\u098a\uafb9',
+  layout: bindGroupLayout9,
+  entries: [{binding: 382, resource: textureView77}],
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u026c\u11d9\u0b7a\u{1fdca}\u01d2\u{1f713}\udede\u95ed\u3926\u8918',
+  colorFormats: ['rgba8uint'],
+});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(0, bindGroup25, new Uint32Array(625), 11, 0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup48, []);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 10, resource: textureView16},
+    {binding: 34, resource: textureView15},
+    {binding: 144, resource: textureView82},
+    {binding: 51, resource: {buffer: buffer25, offset: 0, size: 121}},
+    {binding: 43, resource: sampler36},
+    {binding: 133, resource: {buffer: buffer63, offset: 0}},
+    {binding: 134, resource: {buffer: buffer77, offset: 2048}},
+  ],
+});
+let textureView108 = texture70.createView({label: '\uf2ab\u7b1c\u0aa6\u{1fa42}\u0528\u2218\u8466', mipLevelCount: 1});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let externalTexture12 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder13.setScissorRect(2, 3, 9, 8);
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+let texture119 = device0.createTexture({size: [20, 24, 6], format: 'rgba8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder127 = commandEncoder130.beginComputePass({});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup21, new Uint32Array(807), 20, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer18, 'uint32', 1_360, 4);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer9, 20_712);
+} catch {}
+document.body.prepend(img5);
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({label: '\ud67e\u3cb9\u8211\u079a\u04d6\ub9fd'});
+let texture120 = device0.createTexture({
+  size: [80, 96, 154],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer23, 'uint32', 3_972, 3_214);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer31, 0, 329);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: imageData6,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let buffer85 = device0.createBuffer({
+  size: 49,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture121 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 154},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView109 = texture38.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder128 = commandEncoder131.beginComputePass({});
+try {
+computePassEncoder122.setBindGroup(3, bindGroup25, new Uint32Array(1119), 390, 0);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle7]);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+video0.height = 37;
+await gc();
+let commandEncoder132 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder132.beginComputePass();
+try {
+renderPassEncoder24.setVertexBuffer(0, buffer17, 0);
+} catch {}
+let arrayBuffer7 = buffer32.getMappedRange(232, 20);
+try {
+device0.queue.writeBuffer(buffer66, 1040, new Float32Array(34714), 3267, 1072);
+} catch {}
+document.body.prepend(video0);
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'gamma28curve'} });
+let bindGroup61 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler12}]});
+let buffer86 = device0.createBuffer({
+  size: 26664,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder133 = device0.createCommandEncoder({label: '\u1973\u36cc'});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup48, new Uint32Array(1782), 205, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer45);
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({label: '\u0bae\u0db9\u0257\u729f'});
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer24, 4_044, 1_391);
+} catch {}
+try {
+commandEncoder133.copyBufferToBuffer(buffer25, 36, buffer34, 1288, 4);
+} catch {}
+try {
+commandEncoder133.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 448 */
+  offset: 448,
+  buffer: buffer7,
+}, {
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 17, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer37, 2520, 6448);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(254).fill(170), /* required buffer size: 254 */
+{offset: 254}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: video0,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 19, y: 6, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup62 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler69}]});
+let commandEncoder135 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder130 = commandEncoder133.beginComputePass({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], stencilReadOnly: true});
+try {
+computePassEncoder116.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer65, 0, 757);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup4, new Uint32Array(6204), 2_391, 0);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3610 */
+  offset: 3610,
+  bytesPerRow: 23296,
+  buffer: buffer67,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 3, y: 32, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 75, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer87 = device0.createBuffer({size: 17623, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView110 = texture99.createView({});
+let renderBundle13 = renderBundleEncoder13.finish({});
+let sampler80 = device0.createSampler({
+  label: '\u6f4f\u0afb\u093b\uf46e\uc475\uf772\uf639\u0425\u{1fc62}\u72c5',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.95,
+  lodMaxClamp: 92.52,
+  compare: 'never',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup22, new Uint32Array(673), 93, 0);
+} catch {}
+try {
+computePassEncoder116.end();
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 2376, new Int16Array(2686), 85, 804);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 6, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer88 = device0.createBuffer({size: 2858, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder136 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder136.finish({});
+let textureView111 = texture4.createView({arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer43, 0, 46);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup63 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 54, resource: textureView65},
+    {binding: 434, resource: {buffer: buffer56, offset: 1024, size: 396}},
+    {binding: 6, resource: {buffer: buffer61, offset: 256, size: 24}},
+    {binding: 200, resource: textureView40},
+  ],
+});
+let textureView112 = texture121.createView({baseArrayLayer: 0});
+let computePassEncoder131 = commandEncoder135.beginComputePass({});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.921,
+  lodMaxClamp: 87.00,
+  compare: 'greater',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer27, 2_220, 51);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let computePassEncoder132 = commandEncoder134.beginComputePass({});
+let sampler82 = device0.createSampler({
+  label: '\u7cf6\u90de\u1ca0\u6cb1\ua2af\ub716\u0d32\u0282\ud501',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.53,
+});
+try {
+computePassEncoder130.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup33, new Uint32Array(1601), 41, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+let arrayBuffer8 = buffer74.getMappedRange(88, 116);
+try {
+buffer75.unmap();
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer49, 124, buffer65, 388, 1080);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 628 */
+  offset: 628,
+  bytesPerRow: 4864,
+  buffer: buffer64,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 51, y: 48, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 46, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1704 */
+  offset: 1704,
+  bytesPerRow: 38144,
+  buffer: buffer75,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\u9b54');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(212).fill(125), /* required buffer size: 212 */
+{offset: 212}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer89 = device0.createBuffer({size: 533, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandBuffer9 = commandEncoder4.finish({});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup12, new Uint32Array(154), 20, 0);
+} catch {}
+try {
+computePassEncoder52.pushDebugGroup('\u263c');
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u01a9');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 0, y: 36, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView113 = texture4.createView({dimension: '3d', baseMipLevel: 0});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+computePassEncoder130.setBindGroup(0, bindGroup48, new Uint32Array(1702), 28, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroupsIndirect(buffer73, 528); };
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup13, new Uint32Array(1219), 25, 0);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct S2 {
+  @builtin(local_invocation_id) @size(16) f0: vec3u,
+  @builtin(local_invocation_index) f1: u32,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(159) var<storage, read_write> buffer90: array<array<f16, 3>, 6>;
+
+@group(0) @binding(72) var tex6: texture_2d<f32>;
+
+struct T0 {
+  @size(36) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp10 = frexp(f16());
+
+struct FragmentOutput6 {
+  @location(1) f0: vec2f,
+  @location(0) f1: vec4u,
+  @location(7) f2: vec4i,
+}
+
+@fragment
+fn fragment7() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  let vf127: u32 = textureNumLevels(tex6);
+  var vf128: vec2u = textureDimensions(tex6, i32(unconst_i32(139)));
+  out = FragmentOutput6(bitcast<vec2f>(countTrailingZeros(unpack4xU8(u32((*&buffer90)[5][2]))).ra), countTrailingZeros(unpack4xU8(u32((*&buffer90)[5][2]))), vec4i(countTrailingZeros(unpack4xU8(u32((*&buffer90)[5][2])))));
+  var vf129: vec2u = textureDimensions(tex6, i32(unconst_i32(18)));
+  let ptr79: ptr<storage, array<array<f16, 3>, 6>, read_write> = &(*&buffer90);
+  vf128 = vec2u(u32((*ptr79)[5][2]));
+  vf128 *= vec2u(u32(buffer90[u32((*&buffer90)[5][u32(unconst_u32(283))])][2]));
+  out.f1 ^= vf129.yxxy;
+  var vf130: vec3f = ceil(vec3f(f32((*&buffer90)[5][2])));
+  out.f1 -= bitcast<vec4u>(ceil(vec3f(unconst_f32(0.2696), unconst_f32(0.1845), unconst_f32(0.2051))).rgbr);
+  vf129 |= vec2u(vf130.xy);
+  buffer90[u32(unconst_u32(19))][u32((*ptr79)[5][2])] = vec2h(vf129).x;
+  vf130 *= vec3f(textureDimensions(tex6, i32(unconst_i32(76))).rgg);
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute11(a0: S2, @builtin(num_workgroups) a1: vec3u, @builtin(global_invocation_id) a2: vec3u) {
+  var vf131: S2 = a0;
+  vf131 = S2(vec3u(u32(vp10.exp)), bitcast<u32>(vp10.exp));
+  let ptr80: ptr<function, vec3u> = &vf131.f0;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder128.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'smpte240m'} });
+try {
+computePassEncoder105.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup32, new Uint32Array(1466), 65, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer49, 96, 1_023);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext4 = canvas1.getContext('webgpu');
+let commandEncoder137 = device0.createCommandEncoder({});
+let computePassEncoder133 = commandEncoder137.beginComputePass({});
+try {
+computePassEncoder132.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer65, 0);
+} catch {}
+let arrayBuffer9 = buffer74.getMappedRange(0, 0);
+let imageBitmap2 = await createImageBitmap(videoFrame5);
+let commandEncoder138 = device0.createCommandEncoder({});
+let renderPassEncoder26 = commandEncoder138.beginRenderPass({
+  label: '\u43bd\u039d\u0a2e\udd0b\u{1fd0d}\ua40d\u{1fc1d}\u{1f874}\u{1fb00}',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: 417.8, g: -509.9, b: 238.7, a: -634.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup44, new Uint32Array(2171), 50, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2]);
+} catch {}
+try {
+computePassEncoder52.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append(img4);
+let buffer91 = device0.createBuffer({
+  size: 22729,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder139 = device0.createCommandEncoder({});
+let computePassEncoder134 = commandEncoder139.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup62, []);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup49, new Uint32Array(6624), 1_009, 0);
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 33, resource: textureView91},
+    {binding: 136, resource: externalTexture11},
+    {binding: 145, resource: textureView27},
+  ],
+});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -262.6, g: 391.7, b: 818.6, a: 782.5, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(15, 1, 0, 10);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer14, 'uint32', 4, 747);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(102).fill(85), /* required buffer size: 102 */
+{offset: 102, bytesPerRow: 30}, {width: 1, height: 64, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder();
+let computePassEncoder135 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup51, new Uint32Array(57), 34, 0);
+} catch {}
+let commandEncoder141 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 1034});
+let computePassEncoder136 = commandEncoder141.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup18, new Uint32Array(132), 16, 0);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer64, 'uint32', 252, 539);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 10180, new DataView(new ArrayBuffer(2518)), 346, 4);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer92 = device0.createBuffer({
+  size: 6220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView114 = texture33.createView({mipLevelCount: 1});
+try {
+computePassEncoder111.setBindGroup(0, bindGroup9, new Uint32Array(2590), 75, 0);
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder11.setViewport(120.45027737553963, 179.02539790448597, 181.448530145558, 116.97747040810998, 0.711852362396049, 0.769721608827257);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer75, 'uint32', 3_048, 260);
+} catch {}
+try {
+computePassEncoder12.pushDebugGroup('\u{1fee4}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'log'} });
+let shaderModule9 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+fn fn1() -> array<f16, 11> {
+  var out: array<f16, 11>;
+  let ptr86: ptr<private, array<array<f16, 1>, 1>> = &vp17[119][0][0][0];
+  let vf135: u32 = textureNumLevels(tex7);
+  var vf136: u32 = vf135;
+  vp17[u32(vp14.f0[0])][u32(unconst_u32(38))][u32(unconst_u32(56))][u32(vp17[119][0][0][0][0][0])][u32(unconst_u32(87))][u32(unconst_u32(25))] *= vp17[119][0][0][0][0][0];
+  vf136 ^= u32(vp17[119][0][0][0][0][0]);
+  var vf137: f16 = override18;
+  vp11.f8 *= vec4f(f32(vp17[119][0][0][0][0][0]));
+  var vf138: vec4i = textureLoad(tex7, vec3i(vp13.fract).x, i32(override20));
+  let ptr87: ptr<uniform, f16> = &(*&buffer93)[u32(unconst_u32(231))];
+  vf136 = u32(vp17[119][0][0][0][0][0]);
+  vf136 = u32(vp17[119][0][0][0][0][0]);
+  vf136 = u32(vp12[3]);
+  vp14 = S3(vec4h(f16(vp16.f0)), vec4h(f16(vp16.f0)));
+  let ptr88: ptr<uniform, array<f16, 2>> = &(*&buffer93);
+  let ptr89: ptr<private, array<f16, 1>> = &vp17[119][0][0][0][0];
+  vp13 = modf(vec3f(f32((*ptr86)[0][0])));
+  var vf139: f16 = override15;
+  textureBarrier();
+  let ptr90: ptr<uniform, f16> = &(*&buffer93)[1];
+  let ptr91: ptr<private, f16> = &(*ptr86)[0][0];
+  let ptr92: ptr<uniform, f16> = &(*ptr87);
+  let ptr93: ptr<private, array<f16, 1>> = &(*ptr86)[0];
+  out[u32(unconst_u32(237))] = f16(textureLoad(tex7, i32(unconst_i32(340)), vec4i(vp14.f1)[2]).b);
+  let ptr94: ptr<private, array<array<array<array<f16, 1>, 1>, 1>, 1>> = &vp17[119][0];
+  return out;
+}
+
+var<private> vp16: T0 = T0(u32());
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput7 {
+  @location(4) @interpolate(flat) f0: i32,
+  @location(1) @interpolate(flat) f1: vec4u,
+  @location(0) f2: vec4u,
+}
+
+var<private> vp14: S3 = S3(vec4h(), vec4h());
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct S3 {
+  @location(9) f0: vec4h,
+  @location(6) f1: vec4h,
+}
+
+override override20: f16 = 13410.4;
+
+@id(46079) override override17: i32 = 86;
+
+@group(0) @binding(47) var<uniform> buffer93: array<f16, 2>;
+
+fn fn0() -> vec4<bool> {
+  var out: vec4<bool>;
+  vp15 = modf(vec4h(f16(override17)));
+  vp13 = modf(vec3f(f32(buffer93[1])));
+  let ptr81: ptr<private, array<array<f16, 1>, 1>> = &vp17[119][0][0][0];
+  out = vec4<bool>(bool(vp17[119][0][0][0][0][0]));
+  var vf132: f16 = override18;
+  var vf133: vec4h = log2(vec4h(unconst_f16(28041.4), unconst_f16(921.8), unconst_f16(1210.9), unconst_f16(-2421.2)));
+  let ptr82: ptr<private, vec4h> = &vp12;
+  let ptr83: ptr<private, array<f16, 1>> = &vp17[119][0][0][0][0];
+  let ptr84: ptr<private, array<f16, 1>> = &vp17[119][0][0][0][u32(unconst_u32(238))];
+  var vf134: f16 = override20;
+  let ptr85: ptr<private, vec4h> = &vp15.fract;
+  return out;
+}
+
+alias vec3b = vec3<bool>;
+
+override override16: f16 = 7828.9;
+
+var<private> vp13 = modf(vec3f());
+
+var<private> vp11: VertexOutput5 = VertexOutput5();
+
+var<private> vp17: array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>, 120> = array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>, 120>(array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>(array<f16, 1>(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array(array(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>())))), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array(array<array<f16, 1>, 1>()))), array(array(array<array<array<f16, 1>, 1>, 1>())), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array<array<f16, 1>, 1>()))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>())), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array<array<f16, 1>, 1>(array<f16, 1>(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array(array<f16, 1>(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array(array(array(array(array<f16, 1>(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>())))), array(array(array<array<array<f16, 1>, 1>, 1>())), array(array(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array(array(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>())), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>(array<f16, 1>())))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array<array<f16, 1>, 1>()))), array(array(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>())), array(array(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>()))), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array(array(array(array(array<f16, 1>())))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array(array(array<array<f16, 1>, 1>()))), array(array(array(array<array<f16, 1>, 1>(array<f16, 1>())))), array(array(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>()))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>())), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array(array(f16()))))), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array(array(array<f16, 1>())))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array(array<f16, 1>())))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array(array<array<f16, 1>, 1>(array<f16, 1>())))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array(array<f16, 1>())))), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array(array(array(array<array<f16, 1>, 1>(array<f16, 1>())))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>())), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array(array<array<array<f16, 1>, 1>, 1>())), array(array(array(array(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array(array(array<array<f16, 1>, 1>()))), array(array(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>())), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array<array<array<f16, 1>, 1>, 1>())), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array<array<f16, 1>, 1>(array<f16, 1>(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array(array(array(array<array<f16, 1>, 1>(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array(array<array<array<f16, 1>, 1>, 1>(array<array<f16, 1>, 1>(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array<array<f16, 1>, 1>(array<f16, 1>(f16()))))), array(array<array<array<array<f16, 1>, 1>, 1>, 1>()), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(), array(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array(f16()))))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array(array<array<f16, 1>, 1>()))), array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>(array<array<array<array<f16, 1>, 1>, 1>, 1>(array<array<array<f16, 1>, 1>, 1>(array(array<f16, 1>(f16()))))));
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp15 = modf(vec4h());
+
+struct VertexOutput5 {
+  @builtin(position) f8: vec4f,
+}
+
+override override18: f16 = 4769.5;
+
+struct T0 {
+  f0: u32,
+}
+
+var<private> vp12: vec4h = vec4h();
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(42093) override override15: f16 = 4983.7;
+
+@group(0) @binding(44) var tex7: texture_1d<i32>;
+
+override override19: i32 = 0;
+
+@vertex
+fn vertex7(a0: S3, @location(1) @interpolate(flat, centroid) a1: vec2h, @location(3) a2: vec2f) -> VertexOutput5 {
+  var out: VertexOutput5;
+  let ptr95: ptr<private, f16> = &vp17[119][0][0][0][0][u32(unconst_u32(104))];
+  vp12 = vec4h(vp17[119][0][u32(unconst_u32(37))][0][0][0]);
+  let vf140: vec4f = unpack4x8snorm(u32(unconst_u32(338)));
+  let ptr96: ptr<private, vec4f> = &vp11.f8;
+  let ptr97: ptr<private, array<f16, 1>> = &vp17[119][0][0][0][0];
+  let vf141: u32 = textureNumLevels(tex7);
+  vp11.f8 = (*ptr96);
+  let ptr98: ptr<private, array<f16, 1>> = &(*ptr97);
+  let ptr99: ptr<private, f16> = &(*ptr97)[u32(a0.f0.b)];
+  vp12 = vec4h(vp13.whole.xyyy);
+  vp14 = S3(vec4h(f16(vp11.f8[1])), vec4h(f16(vp11.f8[1])));
+  vp12 += vec4h(atan2(vec3f(unconst_f32(0.1136), unconst_f32(-0.1424), unconst_f32(0.00887)), vec3f(unconst_f32(0.2192), unconst_f32(0.1530), unconst_f32(0.07654))).grgb);
+  let ptr100: ptr<private, array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>, 120>> = &vp17;
+  vp16 = T0(bitcast<u32>(vp13.whole.g));
+  let ptr101: ptr<private, array<array<f16, 1>, 1>> = &(*ptr100)[119][0][0][0];
+  out.f8 *= vec4f(f32((*ptr100)[119][0][0][0][0][0]));
+  var vf142: vec4h = a0.f1;
+  let ptr102: ptr<private, array<f16, 1>> = &(*ptr98);
+  let vf143: u32 = vf141;
+  return out;
+}
+
+@fragment
+fn fragment8() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  vp14.f1 = vec4h(buffer93[1]);
+  discard;
+  let ptr103: ptr<private, array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>> = &vp17[u32(unconst_u32(23))];
+  vp14.f1 -= vec4h(vp17[119][0][0][0][0][0]);
+  let ptr104: ptr<private, array<array<array<array<f16, 1>, 1>, 1>, 1>> = &(*ptr103)[pack2x16snorm(vec2f(f32((*ptr103)[0][0][0][0][0])))];
+  vp12 = vec4h((*ptr104)[0][0][0][0]);
+  vp15.whole += vec4h(vp17[119][0][0][0][0][0]);
+  var vf144 = fn0();
+  var vf145: f32 = vp11.f8[3];
+  let ptr105: ptr<private, array<array<array<f16, 1>, 1>, 1>> = &(*ptr104)[0];
+  let ptr106: ptr<private, array<array<array<array<f16, 1>, 1>, 1>, 1>> = &(*ptr103)[u32(unconst_u32(50))];
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer94 = device0.createBuffer({
+  label: '\u03b7\u0241\u00ce\ud4ab',
+  size: 9231,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView115 = texture66.createView({mipLevelCount: 1});
+let texture123 = device0.createTexture({
+  label: '\ub702\u0ff3\u{1fd4a}\uc15c\u6828\ua4b9',
+  size: {width: 10},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer76, 1_072); };
+} catch {}
+try {
+renderPassEncoder9.setViewport(90.24536708203345, 196.1563443376548, 40.10882244564379, 35.101237854574514, 0.01624986277252971, 0.4826734368126275);
+} catch {}
+try {
+texture41.destroy();
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder({label: '\u{1f990}\u{1f9d5}\u{1fb1c}'});
+let textureView116 = texture117.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder137 = commandEncoder142.beginComputePass({});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer75, 'uint32', 1_440, 197);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer85, 24, 6);
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let textureView117 = texture33.createView({label: '\uf92d\u0abf', aspect: 'all'});
+let texture124 = device0.createTexture({size: [10, 12, 19], dimension: '3d', format: 'r8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView118 = texture27.createView({label: '\u{1fba6}\ua6bc\u048a\u{1fdb2}'});
+let computePassEncoder138 = commandEncoder143.beginComputePass({});
+try {
+computePassEncoder72.setBindGroup(2, bindGroup55, new Uint32Array(1223), 166, 0);
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(26);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer33);
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 275, resource: {buffer: buffer34, offset: 2304, size: 5520}}],
+});
+let texture125 = device0.createTexture({
+  label: '\uf165\u08a8\uc988\u27fc\u7350\u5115\u67e1\uffe8',
+  size: [80, 96, 32],
+  mipLevelCount: 4,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroupsIndirect(buffer7, 2_272); };
+} catch {}
+let computePassEncoder139 = commandEncoder17.beginComputePass();
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder125.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup50);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let bindGroup66 = device0.createBindGroup({
+  label: '\uea5d\u36b1\uc195\u0242\u1b66\uf3a6\u1765',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 34, resource: textureView37},
+    {binding: 10, resource: textureView16},
+    {binding: 43, resource: sampler47},
+    {binding: 51, resource: {buffer: buffer18, offset: 1536, size: 9476}},
+    {binding: 134, resource: {buffer: buffer40, offset: 768, size: 684}},
+    {binding: 133, resource: {buffer: buffer11, offset: 2560, size: 1516}},
+    {binding: 144, resource: textureView15},
+  ],
+});
+let textureView119 = texture37.createView({mipLevelCount: 1});
+let sampler83 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 39.67,
+  lodMaxClamp: 84.11,
+});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup53, new Uint32Array(1319), 384, 0);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer92);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup28, new Uint32Array(1593), 56, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer23, 5_940);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 109, resource: textureView29},
+    {binding: 168, resource: {buffer: buffer46, offset: 4608, size: 2205}},
+    {binding: 150, resource: textureView93},
+    {binding: 93, resource: textureView82},
+  ],
+});
+let querySet15 = device0.createQuerySet({
+  label: '\u4fc4\u0ae3\u5aee\u9579\u0abe\u0759\u{1fb3e}\ue063\uc349\u7e25',
+  type: 'occlusion',
+  count: 440,
+});
+let texture126 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroupsIndirect(buffer31, 668); };
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer78, 'uint32', 3_980, 2_662);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup38);
+} catch {}
+let arrayBuffer10 = buffer32.getMappedRange(312, 28);
+try {
+renderPassEncoder23.insertDebugMarker('\u0bc1');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: canvas0,
+  origin: { x: 41, y: 12 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 4, y: 10, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup68 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView60}]});
+let buffer95 = device0.createBuffer({
+  size: 6487,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let computePassEncoder140 = commandEncoder144.beginComputePass({});
+let sampler84 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.667,
+  lodMaxClamp: 32.38,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup58, []);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup29, new Uint32Array(2598), 71, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer59, 'uint16', 80, 398);
+} catch {}
+try {
+computePassEncoder12.popDebugGroup();
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 159, resource: {buffer: buffer50, offset: 2560, size: 4072}},
+    {binding: 72, resource: textureView25},
+  ],
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup16, new Uint32Array(4605), 704, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroupsIndirect(buffer31, 1_396); };
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer73, 560, 537);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer34, 'uint32', 1_216, 4_688);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let renderPassEncoder27 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView97,
+  clearValue: { r: -645.8, g: -247.5, b: 42.74, a: -497.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle14 = renderBundleEncoder14.finish();
+try {
+computePassEncoder136.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(2); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(172).fill(179), /* required buffer size: 172 */
+{offset: 172, bytesPerRow: 17, rowsPerImage: 71}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder9.label = '\u{1f7b6}\ub4d3\u0bfd\uf2f1\u20b0\ue057\u{1ff8c}\uca90\ubfe3\u7cf4';
+} catch {}
+let texture127 = device0.createTexture({
+  size: {width: 10},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture13 = device0.importExternalTexture({source: video0});
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer73, 0, 1_000);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 544, new Int16Array(29273), 9148, 428);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 26, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(155).fill(171), /* required buffer size: 155 */
+{offset: 155, bytesPerRow: 36}, {width: 19, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let buffer96 = device0.createBuffer({
+  size: 15970,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder146 = device0.createCommandEncoder();
+let texture128 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder141 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder138.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup66, new Uint32Array(2233), 9, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7]);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 2908, new BigUint64Array(1590), 231, 40);
+} catch {}
+let imageBitmap3 = await createImageBitmap(offscreenCanvas1);
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer75, offset: 1280, size: 540}},
+    {binding: 123, resource: textureView81},
+  ],
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup48, new Uint32Array(170), 64, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup67, new Uint32Array(6174), 576, 0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle7, renderBundle7, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(247.68438627168206, 101.94393901107777, 15.748584957399578, 143.68927505874657, 0.46551033477887904, 0.5187818165718306);
+} catch {}
+try {
+buffer86.unmap();
+} catch {}
+let img6 = await imageWithData(194, 112, '#10101010', '#20202020');
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer86, 372, new Int16Array(12611), 3);
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+computePassEncoder103.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(0, bindGroup58, new Uint32Array(3301), 324, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup68, new Uint32Array(808), 4, 0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer71, 0, 314);
+} catch {}
+let bindGroup71 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView60}]});
+let buffer97 = device0.createBuffer({
+  size: 22694,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandBuffer10 = commandEncoder73.finish({});
+let texture129 = device0.createTexture({
+  label: '\u{1fc3c}\uc080\ua6ef\u{1f601}',
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView120 = texture45.createView({dimension: '2d-array'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 37, depthOrArrayLayers: 17}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture116,
+  mipLevel: 1,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'unspecified'} });
+let bindGroup72 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 150, resource: textureView106},
+    {binding: 93, resource: textureView37},
+    {binding: 109, resource: textureView29},
+    {binding: 168, resource: {buffer: buffer7, offset: 1536, size: 1053}},
+  ],
+});
+let commandEncoder147 = device0.createCommandEncoder({});
+let texture130 = gpuCanvasContext0.getCurrentTexture();
+let textureView121 = texture21.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder142 = commandEncoder147.beginComputePass({label: '\ua420\u002f\ua34d\u{1fe2f}\u2c49\u{1fc8e}\uda10'});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder142.setPipeline(pipeline2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroupsIndirect(buffer0, 92); };
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 31, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2_166).fill(2), /* required buffer size: 2_166 */
+{offset: 141, bytesPerRow: 25, rowsPerImage: 59}, {width: 0, height: 23, depthOrArrayLayers: 2});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 200, resource: textureView86},
+    {binding: 6, resource: {buffer: buffer7, offset: 0, size: 752}},
+    {binding: 434, resource: {buffer: buffer43, offset: 4352, size: 1160}},
+    {binding: 54, resource: textureView65},
+  ],
+});
+let textureView122 = texture18.createView({mipLevelCount: 1});
+let sampler85 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.39,
+  lodMaxClamp: 27.22,
+});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup6, new Uint32Array(635), 127, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer92, 116, 496);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 38}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 63, y: 20 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture10.label = '\ufcd0\u311e\u3e36\u03d7\u{1fead}\u78bd\u472c\u020a';
+} catch {}
+let sampler86 = device0.createSampler({
+  label: '\u6a10\uc353',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.06,
+  lodMaxClamp: 96.51,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder108.setBindGroup(2, bindGroup12, new Uint32Array(2033), 11, 0);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -636.4, g: 736.6, b: -476.8, a: -531.3, });
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let texture131 = device0.createTexture({
+  size: [320],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder88); computePassEncoder88.dispatchWorkgroupsIndirect(buffer22, 1_600); };
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer37, 2_284);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+  await promise22;
+} catch {}
+let buffer98 = device0.createBuffer({
+  label: '\u{1fad0}\u{1fb75}\u4b28\u6e81\u0569\u10b7\u020d',
+  size: 65536,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let sampler87 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 46.58,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer8, 988, 5_970);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3]});
+let sampler88 = device0.createSampler({
+  label: '\u4479\u{1ff14}\uaf3c\u{1fa08}\uf534\u7d92\uc9e5\uda3f\u98a9\u5111',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.091,
+  lodMaxClamp: 23.95,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup6, new Uint32Array(310), 115, 0);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(123);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+let arrayBuffer11 = buffer74.getMappedRange(208, 0);
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(18_628).fill(197), /* required buffer size: 18_628 */
+{offset: 29, bytesPerRow: 87, rowsPerImage: 69}, {width: 17, height: 7, depthOrArrayLayers: 4});
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer42, offset: 768, size: 1776}},
+    {binding: 123, resource: textureView4},
+  ],
+});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 1733});
+let texture132 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 98},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture133 = gpuCanvasContext3.getCurrentTexture();
+let sampler89 = device0.createSampler({
+  label: '\u{1fa6e}\u05a4\u3547\u0754\u0ccd\u27f6\ucb93\u0599\ubbbf\u{1fbaf}',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 41.23,
+  lodMaxClamp: 61.70,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(1, 12, 9, 3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(149).fill(217), /* required buffer size: 149 */
+{offset: 149, rowsPerImage: 201}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\u01ac\u0419\u{1fd9f}\u4227\u7fdc\u{1fc38}\u4dd5\u60ad',
+  code: `
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+@id(7228) override override22 = 0.1360;
+
+var<workgroup> vw42: VertexOutput6;
+
+var<workgroup> vw41: vec2i;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override27: f16 = 5048.3;
+
+var<private> vp18: bool = bool();
+
+struct VertexOutput6 {
+  @builtin(position) f9: vec4f,
+  @location(9) @interpolate(flat, centroid) f10: vec4f,
+}
+
+var<workgroup> vw43: atomic<i32>;
+
+@id(53987) override override29: f16 = 3079.5;
+
+@group(0) @binding(72) var tex8: texture_2d<f32>;
+
+struct T0 {
+  @align(2) f0: atomic<i32>,
+  @size(32) f1: array<u32>,
+}
+
+@id(7664) override override26: f16 = 13414.4;
+
+override override21: u32 = 86;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw44: atomic<i32>;
+
+var<workgroup> vw40: VertexOutput6;
+
+fn fn0() {
+  var vf146: u32 = override24;
+  vp18 = bool(override26);
+  vf146 = u32(atan2(f32(unconst_f32(0.2599)), bitcast<f32>(textureDimensions(tex8).x)));
+  vp18 = bool(override29);
+  var vf147: u32 = override28;
+  var vf148: vec3f = log2(vec3f(override22));
+  vf148 = sqrt(vf148.bggb).gar;
+  vf148 *= vf148;
+  vf146 = pack4x8unorm(sqrt(vec4f(atan2(f32(unconst_f32(0.07526)), f32(override29)))));
+  vf148 = log2(vec3f(unconst_f32(0.2188), unconst_f32(0.1883), unconst_f32(0.5113)));
+}
+
+@id(6135) override override25: u32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override23: f16 = -9944.1;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(159) var<storage, read_write> buffer99: array<array<f16, 9>, 2>;
+
+@id(42962) override override24: u32 = 159;
+
+override override28: u32 = 10;
+
+fn fn1() -> VertexOutput6 {
+  var out: VertexOutput6;
+  let ptr107: ptr<workgroup, vec4f> = &vw42.f10;
+  vw41 = vec2i(i32(pack4xU8Clamp(vec4u(unconst_u32(36), unconst_u32(419), unconst_u32(156), unconst_u32(183)))));
+  fn0();
+  fn0();
+  vw41 += vec2i(i32((*&vw40).f10[3]));
+  out.f9 = vec4f((*&vw40).f9[3]);
+  return out;
+}
+
+@vertex
+fn vertex8(@builtin(vertex_index) a0: u32, @location(11) a1: vec4h) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f10 = unpack4x8snorm(textureNumLevels(tex8));
+  let vf149: u32 = override21;
+  let vf150: vec4u = unpack4xU8(u32(degrees(f32(unconst_f32(0.04364)))));
+  var vf151: vec2u = textureDimensions(tex8, i32(unconst_i32(153)));
+  out = VertexOutput6(vec4f(bitcast<f32>(override25)), unpack4x8snorm(override25));
+  vf151 ^= vf150.wz;
+  var vf152: u32 = a0;
+  out.f9 = vec4f(f32(a1[3]));
+  let vf153: vec2u = textureDimensions(tex8, i32(unconst_i32(189)));
+  var vf154: vec4u = unpack4xU8(pack4xU8Clamp(unpack4xU8(u32(refract(vec4h(unconst_f16(5617.6), unconst_f16(4981.9), unconst_f16(3644.2), unconst_f16(4249.6)), vec4h(f16(degrees(f32(unconst_f32(0.4855))))), f16(override21))[1]))));
+  let vf155: vec4h = a1;
+  let vf156: u32 = textureNumLevels(tex8);
+  let ptr108: ptr<private, bool> = &vp18;
+  let ptr109: ptr<function, vec2u> = &vf151;
+  vf154 >>= bitcast<vec4u>(abs(vec2i(bitcast<i32>(vf154[2]))).grrr);
+  var vf157: u32 = (*ptr109)[0];
+  let ptr110: ptr<private, bool> = &(*ptr108);
+  let vf158: vec4h = a1;
+  return out;
+}`,
+  sourceMap: {},
+});
+let bindGroup75 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView76}, {binding: 47, resource: textureView52}],
+});
+let buffer100 = device0.createBuffer({size: 225, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let commandEncoder148 = device0.createCommandEncoder({});
+let textureView123 = texture99.createView({});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup46, new Uint32Array(4596), 819, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer19, 'uint16', 128, 27);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 38, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_050).fill(250), /* required buffer size: 1_050 */
+{offset: 282, bytesPerRow: 108}, {width: 3, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 656});
+let computePassEncoder143 = commandEncoder148.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder54); computePassEncoder54.dispatchWorkgroupsIndirect(buffer71, 164); };
+} catch {}
+try {
+computePassEncoder88.end();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer84, 'uint16', 3_544, 993);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(5, buffer20, 0, 25_953);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append(canvas1);
+let textureView124 = texture42.createView({label: '\u0096\uc3ae\u0ba9\u0d4d\u0d00\ufb9e', dimension: '2d-array'});
+let computePassEncoder144 = commandEncoder84.beginComputePass();
+let sampler90 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.63,
+  lodMaxClamp: 87.79,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder143.setPipeline(pipeline1);
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder({});
+let computePassEncoder145 = commandEncoder149.beginComputePass({label: '\uaf17\uf73b\u0161\u07c1'});
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroupsIndirect(buffer58, 3_016); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup48, new Uint32Array(179), 13, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer78, 'uint32', 1_284, 1_064);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let bindGroup76 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView60}]});
+let buffer101 = device0.createBuffer({size: 2160, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder150 = device0.createCommandEncoder({});
+try {
+computePassEncoder144.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -299.7, g: -515.1, b: -318.6, a: -877.7, });
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer54, 0, 2_882);
+} catch {}
+try {
+adapter1.label = '\u0d20\u8b04';
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 37, resource: externalTexture0},
+    {binding: 234, resource: sampler3},
+    {binding: 348, resource: textureView24},
+    {binding: 354, resource: {buffer: buffer3, offset: 256, size: 2864}},
+  ],
+});
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u{1fd83}\u0860\u05bd\ub8ee\u24e0\u{1ffd4}\uae40\u{1f9b2}\u{1fa7c}', bindGroupLayouts: []});
+let texture134 = device0.createTexture({
+  label: '\u{1fc4b}\u0d1a\u0df5\uce71\u0600',
+  size: [10],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder146 = commandEncoder150.beginComputePass({});
+let sampler91 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.92,
+  lodMaxClamp: 98.31,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroupsIndirect(buffer14, 180); };
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle14, renderBundle14, renderBundle14]);
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder({});
+let textureView125 = texture22.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let computePassEncoder147 = commandEncoder151.beginComputePass({});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint']});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let arrayBuffer12 = buffer74.getMappedRange(216, 68);
+try {
+device0.queue.writeBuffer(buffer37, 1840, new Float32Array(5330), 2592, 156);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let buffer102 = device0.createBuffer({
+  size: 7501,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture135 = device0.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler92 = device0.createSampler({
+  label: '\u0c74\u0fd1\ud8b9\u{1fc86}\u5b3c\u{1f9c7}\u087d\u307a\u8e46\u{1ffbd}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.50,
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup67, new Uint32Array(54), 2, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer97, 'uint16', 5_048, 2_880);
+} catch {}
+let arrayBuffer13 = buffer74.getMappedRange(24, 0);
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'display-p3'});
+} catch {}
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer65, 'uint16', 230, 6_145);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 11024 */
+  offset: 6416,
+  bytesPerRow: 1536,
+  buffer: buffer50,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 11},
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule8,
+  constants: {},
+  targets: [{format: 'rgba32uint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    constants: {6_135: 0},
+    buffers: [
+      {
+        arrayStride: 64,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 0, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+let computePassEncoder148 = commandEncoder52.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup34, new Uint32Array(628), 53, 0);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u9428');
+} catch {}
+document.body.append(img5);
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroups(2, 2); };
+} catch {}
+try {
+renderPassEncoder20.setViewport(270.8368800822505, 70.71749774686681, 37.25878860716185, 80.18420592133559, 0.296000862419714, 0.4401708184363069);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let texture136 = device0.createTexture({size: [320], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder148.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup11, new Uint32Array(434), 53, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+let commandEncoder152 = device0.createCommandEncoder({});
+let textureView126 = texture11.createView({label: '\u04ab\u0809\u0880', baseArrayLayer: 5, arrayLayerCount: 13});
+let computePassEncoder149 = commandEncoder152.beginComputePass();
+try {
+computePassEncoder62.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup9, new Uint32Array(3985), 2_205, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 4780, new Float32Array(956), 144, 324);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(134).fill(49), /* required buffer size: 134 */
+{offset: 134}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 38, y: 0 },
+  flipY: true,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 8, y: 16, z: 28},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule8, constants: {}}});
+try {
+computePassEncoder100.setBindGroup(1, bindGroup73, new Uint32Array(7616), 1_100, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer71, 0, 3_393);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let sampler93 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.76,
+  lodMaxClamp: 82.60,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder146.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer54, 'uint16', 1_392, 2_372);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer49, 0);
+} catch {}
+let arrayBuffer14 = buffer74.getMappedRange(2904, 2080);
+try {
+device0.queue.writeBuffer(buffer97, 6308, new Float32Array(3604), 608, 544);
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule9, targets: [{format: 'rgba8uint'}]},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex7',
+    buffers: [
+      {
+        arrayStride: 480,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 44, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 92, shaderLocation: 6},
+          {format: 'float16x2', offset: 24, shaderLocation: 1},
+          {format: 'float16x2', offset: 20, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt709', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer103 = device0.createBuffer({
+  size: 26133,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture137 = device0.createTexture({
+  size: [320, 300, 10],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup70, new Uint32Array(1662), 1, 0);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: 861.2, g: -23.70, b: 347.2, a: -935.3, });
+} catch {}
+try {
+renderPassEncoder9.setViewport(49.04563029286191, 118.60867254078914, 27.366348593233703, 52.42940193137763, 0.9144936395903787, 0.9705502768614128);
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({label: '\ud7e0\u{1fd47}'});
+let texture138 = device0.createTexture({
+  label: '\u151e\u7bb7\ub865\u0a27\u0179\u07b5\u{1f939}\ufb7e\u596f',
+  size: [20, 24, 23],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView127 = texture16.createView({});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup53, new Uint32Array(1486), 488, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer85, 'uint32', 4, 17);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+document.body.append(img2);
+let commandEncoder154 = device0.createCommandEncoder();
+let computePassEncoder150 = commandEncoder154.beginComputePass();
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+let sampler94 = device0.createSampler({
+  label: '\u5016\u2a1d\u0b0f\uf246\u4c87\u0541\ucb68\u{1fec0}',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.04,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder105.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+computePassEncoder148.setBindGroup(1, bindGroup4, new Uint32Array(768), 208, 0);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup41, new Uint32Array(2471), 126, 0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer43, 2_916, 7_084);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer75, 'uint16', 2_794, 92);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer96, 1736, buffer58, 7316, 5864);
+} catch {}
+try {
+commandEncoder153.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5760 */
+  offset: 5760,
+  bytesPerRow: 3584,
+  buffer: buffer24,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder120.insertDebugMarker('\u1e8c');
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'pq'} });
+let buffer104 = device0.createBuffer({
+  label: '\u04a9\ue096\u1165\u{1fd21}\u737d\ud1ec\u0f5b',
+  size: 832,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder155 = device0.createCommandEncoder();
+let computePassEncoder151 = commandEncoder153.beginComputePass({});
+try {
+computePassEncoder148.setBindGroup(1, bindGroup74, new Uint32Array(1421), 102, 0);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup26, new Uint32Array(2712), 121, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer84, 'uint32', 620, 35);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer92, 2_884, 21);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let imageData12 = new ImageData(4, 64);
+let commandEncoder156 = device0.createCommandEncoder();
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer39, 'uint32', 3_096, 3_036);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup71, new Uint32Array(2567), 664, 0);
+} catch {}
+try {
+commandEncoder156.copyTextureToTexture({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer105 = device0.createBuffer({
+  label: '\u082d\u66fe\u83ee\u{1f82d}\u10f1\u{1fc86}',
+  size: 14177,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder157 = device0.createCommandEncoder({});
+let texture139 = device0.createTexture({
+  size: [160, 150, 5],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(3, bindGroup55, new Uint32Array(409), 83, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup22, new Uint32Array(143), 73, 0);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(3, 1, 0, 1);
+} catch {}
+try {
+renderPassEncoder20.setViewport(260.01604859382564, 28.303091739923058, 1.3231883110289493, 93.85461487248334, 0.878653590958058, 0.9216093226656549);
+} catch {}
+document.body.prepend(canvas1);
+let imageData13 = new ImageData(100, 8);
+let computePassEncoder152 = commandEncoder157.beginComputePass({});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+computePassEncoder152.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup74, new Uint32Array(774), 105, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer49, 1_416, 624);
+} catch {}
+try {
+commandEncoder155.copyBufferToBuffer(buffer89, 84, buffer49, 348, 68);
+} catch {}
+let buffer106 = device0.createBuffer({
+  size: 2031,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let texture140 = device0.createTexture({
+  size: [20, 24, 38],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView128 = texture101.createView({
+  label: '\u{1fe3d}\u{1ffd4}\uf6da',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'rgb10a2uint',
+  arrayLayerCount: 1,
+});
+let computePassEncoder153 = commandEncoder155.beginComputePass({});
+let renderPassEncoder28 = commandEncoder156.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 563.9, g: 207.8, b: -701.3, a: 705.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+computePassEncoder103.setBindGroup(0, bindGroup20, new Uint32Array(8441), 2_135, 0);
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup74);
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(24, 0, 0, 12);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer98, 'uint32', 12_584, 6_951);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer64, 'uint16', 40, 130);
+} catch {}
+try {
+globalThis.someLabel = textureView113.label;
+} catch {}
+let computePassEncoder154 = commandEncoder68.beginComputePass({});
+let sampler95 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.25,
+  lodMaxClamp: 81.57,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup17, new Uint32Array(7449), 3_537, 0);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup72, new Uint32Array(511), 147, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer27, 'uint16', 1_462, 2_180);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer12);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u{1ff40}\u{1f6b5}',
+  entries: [
+    {
+      binding: 224,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 429,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 314,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 315,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let texture141 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture142 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 39},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup45, new Uint32Array(43), 6, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer54, 0, 5_712);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer104, 244, buffer96, 2976, 200);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture143 = device0.createTexture({
+  size: [320],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture144 = device0.createTexture({
+  label: '\u0ded\u09d7',
+  size: {width: 10, height: 12, depthOrArrayLayers: 19},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder155 = commandEncoder158.beginComputePass({});
+let renderPassEncoder29 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{view: textureView74, depthSlice: 16, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet15,
+});
+try {
+computePassEncoder155.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer72, 'uint32', 1_204, 6_241);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer86);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let video1 = await videoWithData(37);
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpte240m', transfer: 'log'} });
+let texture145 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture146 = device0.createTexture({
+  label: '\u{1ffee}\u22d3\u0d64\u6e36\u0f1d',
+  size: [40],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder28.setIndexBuffer(buffer5, 'uint16', 58, 53);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup35, new Uint32Array(5201), 383, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer105, 'uint32', 968, 438);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer54);
+} catch {}
+let texture147 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle17 = renderBundleEncoder17.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder115); computePassEncoder115.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer17, 'uint16', 2_856, 1_116);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer66, 3448, new Float32Array(5902), 1278, 192);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({label: '\u3f2a\u058d\uc874\u{1f8a3}', layout: pipelineLayout6, compute: {module: shaderModule7}});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 47, resource: textureView52}, {binding: 24, resource: textureView58}],
+});
+let textureView129 = texture145.createView({});
+let texture148 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 123},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let textureView130 = texture30.createView({baseArrayLayer: 13, arrayLayerCount: 5});
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 23, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(25).fill(81), /* required buffer size: 25 */
+{offset: 25, bytesPerRow: 118}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture149 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(0, bindGroup61, new Uint32Array(926), 108, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup41, new Uint32Array(590), 153, 0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(198.1921661175369, 85.2706239245001, 48.07521383226701, 72.0641789796168, 0.6479720353526554, 0.8663237824415183);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer65, 'uint32', 888, 293);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer85, 0, 10);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let imageData14 = new ImageData(76, 16);
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'gamma22curve'} });
+let buffer107 = device0.createBuffer({size: 17314, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder159 = device0.createCommandEncoder({label: '\u5279\u{1f977}\udfd4\u1e37\uef9b'});
+let computePassEncoder156 = commandEncoder159.beginComputePass();
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer50, 0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+buffer101.unmap();
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder115); computePassEncoder115.dispatchWorkgroupsIndirect(buffer73, 480); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+renderPassEncoder23.setViewport(64.29902827441956, 63.352257778612206, 91.61798600213444, 13.037726375921572, 0.25588198446225463, 0.5589466991266983);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer42, 0, 3_416);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(53).fill(244), /* required buffer size: 53 */
+{offset: 53}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer108 = device0.createBuffer({size: 29204, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup41, new Uint32Array(536), 431, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer103, 0);
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 142,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer109 = device0.createBuffer({
+  size: 2337,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder160 = device0.createCommandEncoder({});
+let renderBundle18 = renderBundleEncoder18.finish();
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup56, new Uint32Array(454), 164, 0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer34, 'uint32', 4_000, 1_504);
+} catch {}
+let computePassEncoder157 = commandEncoder160.beginComputePass({});
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline10);
+} catch {}
+let arrayBuffer15 = buffer74.getMappedRange(8, 0);
+let textureView131 = texture145.createView({label: '\u0192\u0c4f\u050e\u0bff\u569d\uddac'});
+let textureView132 = texture73.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder158 = commandEncoder119.beginComputePass({});
+try {
+computePassEncoder157.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer102);
+} catch {}
+let sampler96 = device0.createSampler({
+  label: '\u{1fd22}\ud78d\ucd51\u{1f606}\u4d82\ua240\u3add\u7776\ue9a1\u1bc9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 46.10,
+  lodMaxClamp: 95.42,
+});
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer37, 0, 340);
+} catch {}
+await gc();
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 846});
+let texture150 = device0.createTexture({
+  size: {width: 320},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView133 = texture143.createView({});
+let sampler97 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 26.97,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder21.setIndexBuffer(buffer88, 'uint16', 398, 212);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(6, buffer25, 428, 106);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 146, y: 10 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 314, resource: {buffer: buffer105, offset: 4864, size: 980}},
+    {binding: 429, resource: textureView25},
+    {binding: 224, resource: {buffer: buffer61, offset: 256, size: 12}},
+    {binding: 56, resource: textureView133},
+    {binding: 315, resource: textureView117},
+  ],
+});
+let texture151 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup41, new Uint32Array(832), 68, 0);
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.setViewport(142.50404491122958, 29.658008740947267, 2.159046842136105, 101.23077581732807, 0.9907901038023197, 0.9986698435323494);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u5ffd\u0bea\u3c8a\u0f2e\u0089\u049a',
+  entries: [
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 198, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }},
+    {
+      binding: 153,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 135,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 150,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 220,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup80 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 47, resource: textureView107}, {binding: 24, resource: textureView76}],
+});
+let texture152 = device0.createTexture({
+  label: '\ua7f3\u1d25\u00f2\u0061\u0d3a\u0077\u0c41\u769b',
+  size: [80],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView134 = texture58.createView({dimension: '2d'});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer50, 0, 440);
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let texture153 = device0.createTexture({
+  size: [160],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView135 = texture85.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder158.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer102, 'uint32', 68, 486);
+} catch {}
+let arrayBuffer16 = buffer74.getMappedRange(16, 0);
+let imageData15 = new ImageData(32, 32);
+let commandEncoder161 = device0.createCommandEncoder({label: '\u{1fddb}\u{1fb36}\u0a2d\u{1f6f6}\u0e99\u0c29\u{1fb32}\u{1f861}\u02f9\u05ae'});
+let texture154 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture155 = device0.createTexture({
+  size: {width: 20, height: 24, depthOrArrayLayers: 9},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup74, new Uint32Array(594), 151, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer43, 3_808, 1_518);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 832 */
+  offset: 832,
+  bytesPerRow: 26624,
+  buffer: buffer59,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 13, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 108, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView136 = texture154.createView({dimension: '2d-array', aspect: 'all'});
+let textureView137 = texture117.createView({arrayLayerCount: 1});
+let computePassEncoder159 = commandEncoder161.beginComputePass({});
+try {
+computePassEncoder159.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup53, new Uint32Array(891), 131, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer7, 1_812);
+} catch {}
+let promise25 = shaderModule4.getCompilationInfo();
+let commandEncoder162 = device0.createCommandEncoder();
+let texture156 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture157 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 154},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder160 = commandEncoder162.beginComputePass({});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup44, new Uint32Array(21), 7, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7, renderBundle7, renderBundle7, renderBundle7, renderBundle7, renderBundle7, renderBundle7, renderBundle7]);
+} catch {}
+let texture158 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler98 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.64,
+});
+try {
+computePassEncoder125.setBindGroup(0, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup54, new Uint32Array(756), 73, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 6176, new Float32Array(16752), 596, 664);
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u663d\udb5c\u{1f970}\u{1f78c}\ue6e0\u{1fce6}',
+  entries: [{binding: 365, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }}],
+});
+let buffer110 = device0.createBuffer({
+  size: 3772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+let textureView138 = texture152.createView({label: '\u043b\u3d85\u00f1\u{1fb32}\u10d3\u681e\u08d6\ub221', format: 'rgba32sint'});
+let textureView139 = texture14.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder105.setBindGroup(3, bindGroup61, []);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer73);
+} catch {}
+let arrayBuffer17 = buffer74.getMappedRange(288, 8);
+try {
+commandEncoder163.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 1,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer111 = device0.createBuffer({size: 2617, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder164 = device0.createCommandEncoder({});
+let textureView140 = texture154.createView({label: '\u7233\u{1fd02}\u0491\u0fdf\u86d0\u0a28\u06ea', dimension: '2d-array'});
+let sampler99 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.98,
+  compare: 'less',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder125); computePassEncoder125.dispatchWorkgroupsIndirect(buffer105, 1_732); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup67);
+} catch {}
+let commandEncoder165 = device0.createCommandEncoder({});
+let computePassEncoder161 = commandEncoder163.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroups(1); };
+} catch {}
+try {
+commandEncoder165.copyBufferToTexture({
+  /* bytesInLastRow: 628 widthInBlocks: 157 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1388 */
+  offset: 1388,
+  bytesPerRow: 7424,
+  buffer: buffer19,
+}, {
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 157, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder164.resolveQuerySet(querySet18, 33, 427, buffer35, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 5252, new BigUint64Array(6273), 1678, 488);
+} catch {}
+let texture159 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  mipLevelCount: 2,
+  format: 'eac-r11unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder30 = commandEncoder164.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 919.5, g: -880.6, b: -890.4, a: -417.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish();
+try {
+computePassEncoder161.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle2]);
+} catch {}
+try {
+commandEncoder165.copyBufferToBuffer(buffer91, 140, buffer39, 1776, 2096);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 2}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 3, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 142, resource: {buffer: buffer61, offset: 0, size: 91}}],
+});
+let buffer112 = device0.createBuffer({size: 8335, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder166 = device0.createCommandEncoder({label: '\u9a9a\uf662\u{1fc63}\u0ef8\uc557\u8d9d\u6d99\u{1fd89}\ud7a6'});
+let texture160 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder162 = commandEncoder166.beginComputePass({});
+let renderPassEncoder31 = commandEncoder165.beginRenderPass({colorAttachments: [{view: textureView132, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder159.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(16, 11, 2, 22);
+} catch {}
+try {
+  await buffer32.mapAsync(GPUMapMode.WRITE, 2200, 1468);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(113).fill(25), /* required buffer size: 113 */
+{offset: 113, bytesPerRow: 395}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise25;
+} catch {}
+let textureView141 = texture69.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer6, 'uint32', 472, 426);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 39, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(3_583).fill(139), /* required buffer size: 3_583 */
+{offset: 94, bytesPerRow: 45}, {width: 6, height: 78, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise26;
+} catch {}
+let buffer113 = device0.createBuffer({
+  size: 8614,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView142 = texture13.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder125); computePassEncoder125.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup68, new Uint32Array(17), 14, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer105, 'uint16', 386, 1_085);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer85);
+} catch {}
+try {
+renderPassEncoder16.insertDebugMarker('\u{1ff0c}');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 220, new DataView(new ArrayBuffer(19856)), 4390, 408);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video1.height = 85;
+let bindGroup82 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 142, resource: {buffer: buffer52, offset: 2816, size: 34}}],
+});
+let commandEncoder167 = device0.createCommandEncoder();
+let computePassEncoder163 = commandEncoder167.beginComputePass({});
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer31, 0, 950);
+} catch {}
+try {
+renderPassEncoder18.pushDebugGroup('\u02b4');
+} catch {}
+try {
+renderPassEncoder18.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 61, y: 67, z: 3},
+  aspect: 'all',
+}, new Uint8Array(66_882).fill(34), /* required buffer size: 66_882 */
+{offset: 92, bytesPerRow: 149, rowsPerImage: 181}, {width: 38, height: 87, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video1.height = 1;
+let bindGroup83 = device0.createBindGroup({
+  label: '\u04b6\u2056\u11e9',
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 434, resource: {buffer: buffer25, offset: 512}},
+    {binding: 54, resource: textureView27},
+    {binding: 200, resource: textureView86},
+    {binding: 6, resource: {buffer: buffer34, offset: 512, size: 860}},
+  ],
+});
+let texture161 = device0.createTexture({
+  label: '\u0899\udad0\u07f0\u829c\uee23\uf814\u{1fa4b}',
+  size: {width: 40, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView143 = texture0.createView({arrayLayerCount: 1});
+let sampler100 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.06,
+  lodMaxClamp: 84.81,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+computePassEncoder126.setBindGroup(3, bindGroup56, new Uint32Array(1992), 319, 0);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer5, 0);
+} catch {}
+let imageData16 = new ImageData(24, 20);
+let texture162 = device0.createTexture({
+  size: [160, 150, 5],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup14, new Uint32Array(1288), 470, 0);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer23, 656, 2_018);
+} catch {}
+try {
+  await promise24;
+} catch {}
+document.body.prepend(canvas1);
+let buffer114 = device0.createBuffer({
+  label: '\uec0a\u{1fbda}',
+  size: 161,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder162.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(248);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer5, 0, 110);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 7, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+adapter0.label = '\u1a14\u{1f7da}\ue0ce\u23b6\u842e\u014c\u{1fc55}\u{1ffa0}\u0156\u0e8a';
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({label: '\u05c0\ufc00\ud30d\uffa0\ueefe\u{1fe69}\ubd0f', type: 'occlusion', count: 263});
+let renderPassEncoder32 = commandEncoder168.beginRenderPass({colorAttachments: [{view: textureView122, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder125); computePassEncoder125.dispatchWorkgroupsIndirect(buffer63, 24); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup45, new Uint32Array(7832), 412, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(112);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer107, 'uint16', 1_502, 8);
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder({label: '\u742d\ubbfe\u{1f7fb}\u{1fa59}\uc30f\u{1f8d4}\u1be6'});
+let texture163 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 45},
+  mipLevelCount: 6,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder164 = commandEncoder169.beginComputePass({});
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup81);
+} catch {}
+try {
+texture38.label = '\u42d8\u5dde\ue198\u{1fcc2}\u0267\u0019\u086a\u3d27\u1193';
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 96,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 443,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 215,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 329,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 358,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 347, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {binding: 434, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 64,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 485,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 264, hasDynamicOffset: false },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 278, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+  ],
+});
+let bindGroup84 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 89, resource: {buffer: buffer77, offset: 3840}}]});
+let texture164 = device0.createTexture({
+  label: '\ufe20\u{1fc76}\ua611\u053d\u{1feb1}\uec72\u2cfc',
+  size: {width: 320, height: 300, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture165 = device0.createTexture({
+  size: [40, 48, 2],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup35, new Uint32Array(133), 24, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup69);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup41, new Uint32Array(618), 70, 0);
+} catch {}
+try {
+computePassEncoder159.insertDebugMarker('\u0af1');
+} catch {}
+try {
+renderPassEncoder19.insertDebugMarker('\u0dbb');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+await gc();
+let canvas2 = document.createElement('canvas');
+let texture166 = device0.createTexture({
+  size: [320, 300, 10],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder20.setIndexBuffer(buffer105, 'uint16', 2_302, 747);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder170 = device0.createCommandEncoder({});
+let texture167 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder165 = commandEncoder170.beginComputePass({});
+let sampler101 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 44.86,
+});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+computePassEncoder47.pushDebugGroup('\u3b4c');
+} catch {}
+try {
+computePassEncoder47.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 108, new Float32Array(4181));
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder();
+let textureView144 = texture164.createView({});
+let textureView145 = texture149.createView({});
+let computePassEncoder166 = commandEncoder171.beginComputePass({label: '\u8782\u0c25\u0909\u084a\u6d5a\u9d8f'});
+let sampler102 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMinClamp: 60.41, lodMaxClamp: 68.12});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, buffer94, 0);
+} catch {}
+let textureView146 = texture167.createView({format: 'rgba16uint', mipLevelCount: 1});
+let textureView147 = texture109.createView({});
+try {
+computePassEncoder162.setBindGroup(3, bindGroup50, new Uint32Array(3036), 15, 0);
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup25, new Uint32Array(2783), 391, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 24}
+*/
+{
+  source: imageData16,
+  origin: { x: 3, y: 2 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 25, y: 44, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.width = 156;
+let buffer115 = device0.createBuffer({size: 17409, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let texture168 = device0.createTexture({
+  label: '\ud7d9\u5483\u{1fc6a}\u624c\u7a16\ue594',
+  size: {width: 20, height: 24, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture169 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 122},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture170 = gpuCanvasContext2.getCurrentTexture();
+let sampler103 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder165.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 1,
+  origin: {x: 1, y: 9, z: 5},
+  aspect: 'all',
+}, new Uint8Array(627).fill(85), /* required buffer size: 627 */
+{offset: 12, bytesPerRow: 41, rowsPerImage: 3}, {width: 9, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let buffer116 = device0.createBuffer({
+  label: '\u6265\u09de\u{1f6f3}\u00f4\u{1f80f}\u{1f9e1}\u01e5\u{1ffa0}\u{1fdc5}',
+  size: 19423,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder172 = device0.createCommandEncoder({label: '\ub25a\uca7a\u4996\u{1fedb}\uc028'});
+let texture171 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder167 = commandEncoder172.beginComputePass({});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup1, new Uint32Array(141), 23, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(23, 24, 12, 5);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer115, 'uint32', 252, 7_275);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 13, y: 39, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = canvas2.getContext('webgpu');
+document.body.append(img0);
+let imageBitmap4 = await createImageBitmap(videoFrame2);
+let texture172 = device0.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture173 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup77, new Uint32Array(941), 157, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let video2 = await videoWithData(119);
+let commandEncoder173 = device0.createCommandEncoder({});
+let texture174 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture175 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 154},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder168 = commandEncoder173.beginComputePass({});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer14, 60); };
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer84, 'uint16', 970, 1_370);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer43, 11_568, 2_007);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn0() -> f16 {
+  var out: f16;
+  var vf159: u32 = dot(vec2u(u32(override31)), vec2u(unconst_u32(60), unconst_u32(242)));
+  return out;
+}
+
+struct T1 {
+  @size(8) f0: array<array<array<vec2h, 1>, 1>, 1>,
+}
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(72) var tex9: texture_2d<f32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override31 = 0.00887;
+
+fn fn1() -> f16 {
+  var out: f16;
+  let ptr111: ptr<workgroup, atomic<u32>> = &vw45;
+  out = f16(fract(bitcast<vec3f>(textureDimensions(tex9).grr))[0]);
+  atomicAdd(&vw45, u32(unconst_u32(107)));
+  var vf160: vec3h = normalize(vec3h(unconst_f16(1053.5), unconst_f16(3763.5), unconst_f16(1386.0)));
+  fn0();
+  vf160 = vec3h(unpack2x16float(u32(unconst_u32(296))).ggg);
+  atomicExchange(&vw45, u32(unconst_u32(31)));
+  var vf161 = fn0();
+  vf160 -= vec3h(f16(override30));
+  out = ceil(vec2h(unconst_f16(4313.3), unconst_f16(8504.2)))[1];
+  vf160 += vec3h(f16(atomicLoad(&(*&vw45))));
+  var vf162 = fn0();
+  vf161 += f16(dot4I8Packed(u32(unconst_u32(375)), bitcast<u32>(dot(vec2f(unconst_f32(-0.4085), unconst_f32(0.02599)), vec2f(unconst_f32(-0.1167), unconst_f32(0.2427))))));
+  fn0();
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(36) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw45: atomic<u32>;
+
+@id(34408) override override30 = 0.01030;
+
+fn fn2() -> VertexOutput7 {
+  var out: VertexOutput7;
+  out.f22 >>= textureDimensions(tex9).rgrg;
+  let ptr112: ptr<storage, T0, read_write> = &(*&buffer117);
+  out.f24 |= bitcast<vec4i>(radians(vec4f(unconst_f32(0.09999), unconst_f32(0.1107), unconst_f32(-0.09498), unconst_f32(0.1542))));
+  let vf163: vec4f = radians(abs(vec2f(unconst_f32(-0.05204), unconst_f32(0.1183))).grrg);
+  out.f11 += i32(radians(vec4f(unconst_f32(-0.06570), unconst_f32(0.1027), unconst_f32(-0.3880), unconst_f32(0.00870))).r);
+  let ptr113: ptr<storage, u32, read_write> = &buffer117.f0[u32(unconst_u32(70))];
+  out.f13 += vec4f(f32((*ptr112).f0[arrayLength(&(*ptr112).f0) - 1]));
+  out.f20 = textureLoad(tex9, vec2i(unpack2x16snorm(u32(unconst_u32(68)))), i32(unconst_i32(120)));
+  let ptr114: ptr<storage, u32, read_write> = &(*ptr112).f0[pack2x16unorm(acos(unpack2x16snorm((*ptr112).f0[u32(unconst_u32(143))])))];
+  let vf164: vec2u = textureDimensions(tex9, i32(tanh(vec3f(vf163[1])).r));
+  out.f25 = vec2h(abs(vec2f(unconst_f32(-0.02487), unconst_f32(0.05793))));
+  out.f13 = bitcast<vec4f>(countTrailingZeros(vec3i(unconst_i32(10), unconst_i32(8), unconst_i32(379))).grgb);
+  var vf165: u32 = arrayLength(&buffer117.f0);
+  out.f17 = bitcast<i32>(abs(abs(vec2f(bitcast<f32>(arrayLength(&(*&buffer117).f0)))))[0]);
+  let ptr115: ptr<storage, T0, read_write> = &(*ptr112);
+  out.f18 = vec4f(bitcast<f32>((*ptr115).f0[u32(unconst_u32(20))]));
+  var vf166: vec4f = mix(unpack4x8snorm((*ptr113)), vec4f(countTrailingZeros(vec3i(unconst_i32(5), unconst_i32(726), unconst_i32(8))).rbgb), f32(buffer117.f0[u32(unconst_u32(21))]));
+  var vf167: vec4f = vf163;
+  out.f23 *= exp(exp(vec4f(unconst_f32(0.04000), unconst_f32(0.1286), unconst_f32(0.09716), unconst_f32(0.00445))))[1];
+  let vf168: f32 = abs(f32(unconst_f32(0.2635)));
+  let ptr116: ptr<storage, array<u32>, read_write> = &buffer117.f0;
+  let ptr117: ptr<storage, array<u32>, read_write> = &(*ptr112).f0;
+  let ptr118: ptr<function, u32> = &vf165;
+  out.f25 -= vec2h(tanh(refract(vec2f(unconst_f32(0.3061), unconst_f32(0.00563)), vec2f(unconst_f32(0.01699), unconst_f32(0.2050)), f32(unconst_f32(0.07324))).ggg).xx);
+  let ptr119: ptr<function, u32> = &(*ptr118);
+  return out;
+}
+
+struct FragmentOutput8 {
+  @location(0) @interpolate(linear, center) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+}
+
+override override32: u32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput7 {
+  @location(14) f11: i32,
+  @location(13) @interpolate(flat, sample) f12: vec2i,
+  @location(11) f13: vec4f,
+  @location(8) f14: vec4u,
+  @location(6) @interpolate(flat, center) f15: vec4f,
+  @location(5) f16: vec4i,
+  @location(15) @interpolate(flat, sample) f17: i32,
+  @location(12) @interpolate(perspective, centroid) f18: vec4f,
+  @location(4) @interpolate(flat) f19: vec2f,
+  @builtin(position) f20: vec4f,
+  @location(2) @interpolate(perspective) f21: f32,
+  @location(3) @interpolate(flat, center) f22: vec4u,
+  @location(0) @interpolate(perspective, centroid) f23: f32,
+  @location(10) f24: vec4i,
+  @location(7) f25: vec2h,
+}
+
+@group(0) @binding(159) var<storage, read_write> buffer117: T0;
+
+@vertex @must_use
+fn vertex9(@location(13) @interpolate(flat, sample) a0: vec2u, @location(9) @interpolate(perspective, centroid) a1: vec4f, @location(15) a2: f16, @location(3) a3: vec4u, @location(7) @interpolate(linear) a4: f16, @builtin(instance_index) a5: u32, @builtin(vertex_index) a6: u32, @location(14) @interpolate(flat, sample) a7: vec4u, @location(12) a8: i32, @location(1) a9: i32, @location(10) a10: f16) -> VertexOutput7 {
+  var out: VertexOutput7;
+  var vf169 = fn0();
+  out.f23 -= bitcast<vec2f>(textureDimensions(tex9, i32(unconst_i32(301)))).g;
+  var vf170: vec3f = ceil(vec3f(cos(vec4h(vf169)).aag));
+  let vf171: vec4u = a3;
+  fn0();
+  out.f24 = vec4i(bitcast<i32>(override30));
+  return out;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  var vf172 = fn2();
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView148 = texture171.createView({
+  label: '\u{1ff38}\u{1fb0e}\u314e\u58c0\ue607\u798d\uc509\u{1f862}\ud54c',
+  dimension: 'cube',
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+});
+let textureView149 = texture162.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder97.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(video1);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder174 = device0.createCommandEncoder();
+let textureView150 = texture172.createView({});
+let renderPassEncoder33 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView74,
+  depthSlice: 18,
+  clearValue: { r: 840.6, g: 73.21, b: -434.4, a: -521.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet18,
+});
+try {
+computePassEncoder122.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(471).fill(51), /* required buffer size: 471 */
+{offset: 471, bytesPerRow: 148}, {width: 10, height: 36, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup85 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 134, resource: {buffer: buffer62, offset: 0, size: 408}},
+    {binding: 133, resource: {buffer: buffer1, offset: 0}},
+    {binding: 51, resource: {buffer: buffer106, offset: 768, size: 464}},
+    {binding: 34, resource: textureView15},
+    {binding: 43, resource: sampler11},
+    {binding: 144, resource: textureView37},
+    {binding: 10, resource: textureView89},
+  ],
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let renderPassEncoder34 = commandEncoder175.beginRenderPass({
+  colorAttachments: [{
+  view: textureView103,
+  clearValue: { r: 330.0, g: -41.22, b: 3.533, a: -655.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 285368771,
+});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup61, new Uint32Array(1693), 85, 0);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(136);
+} catch {}
+let imageData17 = new ImageData(60, 60);
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'gamma28curve'} });
+let bindGroup86 = device0.createBindGroup({
+  label: '\u0cf0\u{1fd89}\u0057',
+  layout: bindGroupLayout11,
+  entries: [{binding: 47, resource: textureView124}, {binding: 24, resource: textureView71}],
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder176 = device0.createCommandEncoder({});
+let textureView151 = texture11.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 6});
+let computePassEncoder169 = commandEncoder176.beginComputePass();
+try {
+computePassEncoder109.setBindGroup(2, bindGroup85, new Uint32Array(2458), 12, 0);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer17, 'uint16', 6_156, 2_176);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer8, 2_700);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture176 = device0.createTexture({size: [40], dimension: '1d', format: 'rgba32uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let textureView152 = texture8.createView({mipLevelCount: 1});
+try {
+computePassEncoder161.setBindGroup(1, bindGroup57, new Uint32Array(804), 266, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup41, new Uint32Array(824), 300, 0);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle19, renderBundle7, renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer78, 'uint16', 3_558, 1_390);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(3, buffer56, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 23, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(60).fill(234), /* required buffer size: 60 */
+{offset: 60, rowsPerImage: 74}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.label = '\u02f3\u{1f9cf}\ua8bd\u0363\u5852\u{1fff1}\u{1f6e9}\ucfe6\ufe11';
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let commandEncoder177 = device0.createCommandEncoder({});
+let commandBuffer11 = commandEncoder177.finish();
+try {
+computePassEncoder142.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup64, []);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+buffer73.unmap();
+} catch {}
+let buffer118 = device0.createBuffer({size: 3557, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder178 = device0.createCommandEncoder({});
+try {
+device0.lost.then(r => { log('device0 lost!'); log(r.message, r.reason); });
+} catch {}
+try {
+computePassEncoder113.insertDebugMarker('\ucf63');
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u06b6');
+} catch {}
+document.body.append(video1);
+let buffer119 = device0.createBuffer({size: 760, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder179 = device0.createCommandEncoder({});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup63, new Uint32Array(2561), 4, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup45, new Uint32Array(2835), 470, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer95, 'uint16', 542, 1_182);
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 315, resource: textureView117},
+    {binding: 429, resource: textureView82},
+    {binding: 56, resource: textureView129},
+    {binding: 314, resource: {buffer: buffer102, offset: 0, size: 1800}},
+    {binding: 224, resource: {buffer: buffer25, offset: 256, size: 116}},
+  ],
+});
+let texture177 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder170 = commandEncoder178.beginComputePass({});
+try {
+computePassEncoder156.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 2632, new DataView(new ArrayBuffer(2902)), 114, 652);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 43, y: 5, z: 1},
+  aspect: 'all',
+}, new Uint8Array(848_234).fill(51), /* required buffer size: 848_234 */
+{offset: 48, bytesPerRow: 1673, rowsPerImage: 113}, {width: 103, height: 55, depthOrArrayLayers: 5});
+} catch {}
+let texture178 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder171 = commandEncoder179.beginComputePass({});
+let renderPassEncoder35 = commandEncoder37.beginRenderPass({colorAttachments: [{view: textureView128, loadOp: 'load', storeOp: 'store'}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder122); computePassEncoder122.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup65, []);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(canvas2);
+let texture179 = device0.createTexture({
+  label: '\u9c47\uc469\u{1f69f}\u01b5\u{1f7f6}\ud8a5\ufcb0\uf938\u6cd0',
+  size: {width: 20, height: 24, depthOrArrayLayers: 38},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup8, new Uint32Array(1402), 35, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder125); computePassEncoder125.dispatchWorkgroupsIndirect(buffer7, 1_776); };
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder33.beginOcclusionQuery(70);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(3, 211, 12, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(19_446).fill(69), /* required buffer size: 19_446 */
+{offset: 142, bytesPerRow: 127, rowsPerImage: 19}, {width: 7, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let promise27 = device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule4}});
+let bindGroup88 = device0.createBindGroup({
+  label: '\u0767\u{1f73b}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView115}, {binding: 47, resource: textureView52}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder122); computePassEncoder122.dispatchWorkgroupsIndirect(buffer5, 48); };
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline3);
+} catch {}
+let imageData18 = new ImageData(32, 172);
+let shaderModule12 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput8 {
+  @builtin(position) f26: vec4f,
+  @location(4) f27: vec2u,
+  @location(2) @interpolate(perspective, sample) f28: f32,
+  @location(14) @interpolate(flat, center) f29: i32,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(47) var<uniform> buffer120: vec2h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0() -> mat3x3f {
+  var out: mat3x3f;
+  let vf173: vec4h = log2(vec4h(unconst_f16(20237.8), unconst_f16(21967.0), unconst_f16(4085.5), unconst_f16(12648.9)));
+  out = mat3x3f(f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]));
+  out = mat3x3f(bitcast<vec3f>(firstLeadingBit(vec4i(log2(vec4h(f16(pack4xI8Clamp(vec4i(i32(buffer120[0])))))))).yyz), vec3f(firstLeadingBit(vec4i(log2(vec4h(f16(pack4xI8Clamp(vec4i(i32(buffer120[0])))))))).xzy), vec3f(firstLeadingBit(vec4i(log2(vec4h(f16(pack4xI8Clamp(vec4i(i32(buffer120[0])))))))).wyy));
+  out += mat3x3f(f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]));
+  let vf174: u32 = pack4xI8Clamp(vec4i(mix(vec4h(unconst_f16(1927.3), unconst_f16(27861.7), unconst_f16(10322.9), unconst_f16(4900.1)), vec4h(unconst_f16(2750.1), unconst_f16(11267.4), unconst_f16(849.2), unconst_f16(-2989.9)), f16(unconst_f16(8585.2)))));
+  var vf175: u32 = pack4xI8Clamp(firstLeadingBit(vec4i(i32(buffer120[0]))));
+  vf175 >>= u32(buffer120[0]);
+  out = mat3x3f(vec3f((*&buffer120).yyy), vec3f((*&buffer120).yyx), vec3f((*&buffer120).ggg));
+  out = mat3x3f(bitcast<f32>(pack4x8unorm(vec4f((*&buffer120).yxyx))), f32(pack4x8unorm(vec4f((*&buffer120).yxyx))), bitcast<f32>(pack4x8unorm(vec4f((*&buffer120).yxyx))), bitcast<f32>(pack4x8unorm(vec4f((*&buffer120).yxyx))), bitcast<f32>(pack4x8unorm(vec4f((*&buffer120).yxyx))), f32(pack4x8unorm(vec4f((*&buffer120).yxyx))), bitcast<f32>(pack4x8unorm(vec4f((*&buffer120).yxyx))), bitcast<f32>(pack4x8unorm(vec4f((*&buffer120).yxyx))), f32(pack4x8unorm(vec4f((*&buffer120).yxyx))));
+  let vf176: mat3x2f = transpose(mat2x3f(unconst_f32(0.4677), unconst_f32(0.1020), unconst_f32(0.1816), unconst_f32(0.5214), unconst_f32(0.05915), unconst_f32(-0.2814)));
+  var vf177: mat3x2f = transpose(mat2x3f(f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0])));
+  let ptr120: ptr<uniform, vec2h> = &buffer120;
+  vf175 = pack4xI8Clamp(vec4i(unconst_i32(31), unconst_i32(92), unconst_i32(-438), unconst_i32(-382)));
+  vf175 = pack4xI8Clamp(vec4i(i32((*&buffer120)[1])));
+  let vf178: f16 = buffer120[0];
+  let vf179: f32 = vf176[0][1];
+  var vf180: vec4u = unpack4xU8(u32(unconst_u32(212)));
+  vf180 -= vec4u(vf180[0]);
+  vf180 <<= vec4u(pack4xI8Clamp(firstLeadingBit(vec4i(i32(log2(f32(pack4xI8Clamp(vec4i(i32(vf178))))))))));
+  var vf181: f32 = vf177[1][1];
+  vf181 = f32(buffer120[0]);
+  var vf182: u32 = pack4xI8Clamp(vec4i((*ptr120).grgg));
+  vf180 += vec4u(vf175);
+  var vf183: f32 = vf176[0][1];
+  return out;
+}
+
+fn fn1(a0: array<array<array<array<vec4f, 1>, 1>, 1>, 3>) -> mat2x4h {
+  var out: mat2x4h;
+  let vf184: array<vec4f, 1> = a0[2][0][0];
+  out += mat2x4h(vec4h(a0[2][0][0][0]), vec4h(a0[2][0][0][0]));
+  out = mat2x4h(f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))), f16(pack2x16float(vec2f(clamp(vec4u(unconst_u32(229), unconst_u32(10), unconst_u32(153), unconst_u32(74)), vec4u(unconst_u32(87), unconst_u32(22), unconst_u32(799), unconst_u32(218)), vec4u(unconst_u32(316), unconst_u32(70), unconst_u32(7), unconst_u32(310))).aa))));
+  let vf185: vec4f = vf184[0];
+  var vf186: array<array<array<vec4f, 1>, 1>, 1> = a0[2];
+  vf186[u32(asin(vec3h(tan(vec3f(unconst_f32(0.3638), unconst_f32(0.1152), unconst_f32(-0.05271))))).g)][pack4x8unorm(a0[2][0][0][u32(unconst_u32(88))])][0] -= vf184[0];
+  let vf187: u32 = textureDimensions(tex10);
+  let ptr121: ptr<function, array<vec4f, 1>> = &vf186[0][0];
+  var vf188: array<array<array<vec4f, 1>, 1>, 1> = a0[u32(unconst_u32(235))];
+  vf188[pack2x16unorm(vec2f((*ptr121)[0][2]))][u32(vf188[0][0][0].z)][pack4x8unorm(vf188[0][0][0])] += vf186[bitcast<u32>(a0[2][0][0][0][1])][0][0];
+  out = mat2x4h(vec4h(vf186[0][0][0]), vec4h(vf186[0][0][0]));
+  var vf189: u32 = textureDimensions(tex10);
+  vf189 = pack4xU8(bitcast<vec4u>(vf188[0][0][0]));
+  vf188[u32(unconst_u32(60))][0][pack4x8unorm(vf185)] *= a0[2][0][0][0];
+  vf188[u32(unconst_u32(9))][u32((*ptr121)[0][2])][u32(unconst_u32(40))] *= vf188[0][0][0];
+  var vf190: vec4i = firstLeadingBit(vec4i(unconst_i32(191), unconst_i32(883), unconst_i32(301), unconst_i32(135)));
+  let vf191: vec4i = unpack4xI8(u32(unconst_u32(429)));
+  out = mat2x4h(vec4h(vf186[0][0][u32(unconst_u32(197))]), vec4h(vf186[0][0][u32(unconst_u32(197))]));
+  let ptr122: ptr<function, array<array<vec4f, 1>, 1>> = &vf188[0];
+  var vf192: array<array<vec4f, 1>, 1> = a0[2][0];
+  return out;
+}
+
+struct T0 {
+  @align(2) f0: array<u32>,
+}
+
+fn fn2() -> mat3x4f {
+  var out: mat3x4f;
+  let vf193: u32 = textureDimensions(tex10, 0i);
+  out = mat3x4f(f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]), f32(buffer120[0]));
+  out = mat3x4f(vec4f(firstLeadingBit(vec4u(buffer120.grgr))), vec4f(firstLeadingBit(vec4u(buffer120.grgr))), bitcast<vec4f>(firstLeadingBit(vec4u(buffer120.grgr))));
+  out += mat3x4f(f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))), f32(sinh(f16(textureNumLevels(tex10)))));
+  var vf194: vec4i = textureLoad(tex10, i32(unconst_i32(140)), bitcast<vec4i>(unpack4x8snorm(u32(unconst_u32(4))))[3]);
+  let vf195: f16 = (*&buffer120)[1];
+  out -= mat3x4f(bitcast<f32>(vf194[1]), bitcast<f32>(vf194[1]), f32(vf194[1]), bitcast<f32>(vf194[1]), bitcast<f32>(vf194[1]), f32(vf194[1]), bitcast<f32>(vf194[1]), bitcast<f32>(vf194[1]), bitcast<f32>(vf194[1]), bitcast<f32>(vf194[1]), f32(vf194[1]), f32(vf194[1]));
+  var vf196 = fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(round(bitcast<vec2f>(textureLoad(tex10, bitcast<i32>(unpack4x8snorm(u32(unconst_u32(248)))[2]), i32(unconst_i32(35))).xy)).rggr))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(round(bitcast<vec2f>(textureLoad(tex10, bitcast<i32>(unpack4x8snorm(u32(unconst_u32(248)))[2]), i32(unconst_i32(35))).xy)).gggg))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(round(bitcast<vec2f>(textureLoad(tex10, bitcast<i32>(unpack4x8snorm(u32(unconst_u32(248)))[2]), i32(unconst_i32(35))).xy)).rrrg)))));
+  var vf197: vec4i = textureLoad(tex10, i32(vf196[1].r), i32(unconst_i32(172)));
+  fn0();
+  return out;
+}
+
+@group(0) @binding(44) var tex10: texture_1d<i32>;
+
+@vertex
+fn vertex10(@location(1) @interpolate(flat) a0: vec2i, @location(0) a1: i32) -> VertexOutput8 {
+  var out: VertexOutput8;
+  fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(countOneBits(vec3i(unconst_i32(290), unconst_i32(150), unconst_i32(220))).zxyx)))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(countOneBits(vec3i(unconst_i32(290), unconst_i32(150), unconst_i32(220))).bbgr)))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(countOneBits(vec3i(unconst_i32(290), unconst_i32(150), unconst_i32(220))).gbrr))))));
+  let vf198: vec4h = sinh(vec4h(unconst_f16(19430.8), unconst_f16(2362.5), unconst_f16(-7014.4), unconst_f16(15229.5)));
+  out = VertexOutput8(vec4f(distance(vec2f(unconst_f32(0.03732), unconst_f32(0.1800)), vec2f(unconst_f32(0.4705), unconst_f32(0.01120)))), vec2u(u32(distance(vec2f(unconst_f32(0.03732), unconst_f32(0.1800)), vec2f(unconst_f32(0.4705), unconst_f32(0.01120))))), distance(vec2f(unconst_f32(0.03732), unconst_f32(0.1800)), vec2f(unconst_f32(0.4705), unconst_f32(0.01120))), bitcast<i32>(distance(vec2f(unconst_f32(0.03732), unconst_f32(0.1800)), vec2f(unconst_f32(0.4705), unconst_f32(0.01120)))));
+  out.f29 *= bitcast<i32>(countOneBits(vec2u(unconst_u32(737), unconst_u32(82))).g);
+  var vf199 = fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(unpack4x8snorm(textureDimensions(tex10, 0i))))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(bitcast<f32>(textureDimensions(tex10, 0i)))))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(f32(textureDimensions(tex10, 0i))))))));
+  let ptr123: ptr<function, mat2x4h> = &vf199;
+  vf199 = mat2x4h(atan(vec3h(unconst_f16(2295.3), unconst_f16(29449.0), unconst_f16(16523.8))).rgrg, atan(vec3h(unconst_f16(2295.3), unconst_f16(29449.0), unconst_f16(16523.8))).yyyx);
+  vf199 = mat2x4h(f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])), f16(log2(vec4f((*ptr123)[1])[2])));
+  out.f28 = bitcast<f32>(a1);
+  out.f27 ^= vec2u(pack2x16unorm(vec2f(unconst_f32(0.4082), unconst_f32(0.1047))));
+  out.f26 = unpack4x8unorm(textureNumLevels(tex10));
+  vf199 = mat2x4h(vf198, vf198);
+  var vf200 = fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(f32(all(bool(unconst_bool(false)))))))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(f32(all(bool(unconst_bool(false)))))))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(f32(all(bool(unconst_bool(false))))))))));
+  let vf201: i32 = a1;
+  let vf202: f32 = log2(f32(unconst_f32(-0.03286)));
+  let vf203: i32 = a0[0];
+  fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(atan(vf199[0].ara).yyxz)))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(atan(vf199[0].ara).zyyz)))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(atan(vf199[0].ara).xyyy))))));
+  fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(normalize(bitcast<vec2f>(vf199[1])).yyxy))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(normalize(bitcast<vec2f>(vf199[1])).xyyx))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(normalize(bitcast<vec2f>(vf199[1])).xyyy)))));
+  var vf204 = fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(bitcast<vec4f>(a0.rrrr)))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(a0.grgg)))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(bitcast<vec4f>(a0.xxyx))))));
+  out.f26 -= vec4f(vf202);
+  fn1(array<array<array<array<vec4f, 1>, 1>, 1>, 3>(array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(unpack4x8snorm(firstLeadingBit(u32(unconst_u32(174))))))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(unpack4x8unorm(firstLeadingBit(u32(unconst_u32(174))))))), array<array<array<vec4f, 1>, 1>, 1>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(bitcast<f32>(firstLeadingBit(u32(unconst_u32(174))))))))));
+  let vf205: vec2f = faceForward(bitcast<vec2f>(vf200[0]), vec2f(f32(atanh(vf200[0].b))), vec2f(unconst_f32(0.1968), unconst_f32(0.1255)));
+  out.f27 |= bitcast<vec2u>(textureLoad(tex10, i32(unconst_i32(239)), i32(unconst_i32(294))).gr);
+  let ptr124: ptr<function, mat2x4h> = &vf204;
+  return out;
+}
+
+@fragment
+fn fragment10() -> @location(200) @interpolate(flat, centroid) vec4u {
+  var out: vec4u;
+  var vf206 = fn0();
+  out *= vec4u(u32(all(bool(unconst_bool(false)))));
+  vf206 = mat3x3f(f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]), f32((*&buffer120)[0]));
+  out = vec4u(u32(all(bool(unconst_bool(false)))));
+  let vf207: vec2f = unpack2x16float(u32(unconst_u32(64)));
+  vf206 -= mat3x3f(mix(vec3f(unconst_f32(-0.1058), unconst_f32(0.2643), unconst_f32(0.3487)), unpack2x16float(u32(unconst_u32(64))).xxy, f32(unconst_f32(0.2842))), mix(vec3f(unconst_f32(-0.1058), unconst_f32(0.2643), unconst_f32(0.3487)), unpack2x16float(u32(unconst_u32(64))).xxy, f32(unconst_f32(0.2842))), mix(vec3f(unconst_f32(-0.1058), unconst_f32(0.2643), unconst_f32(0.3487)), unpack2x16float(u32(unconst_u32(64))).xxy, f32(unconst_f32(0.2842))));
+  var vf208 = fn0();
+  let vf209: vec3h = reflect(vec3h(unconst_f16(8494.4), unconst_f16(9866.2), unconst_f16(27647.0)), vec3h(vf208[0]));
+  vf206 = mat3x3f(vf208[0], vf208[0], vf208[0]);
+  var vf210 = fn0();
+  var vf211 = fn0();
+  fn0();
+  let ptr125: ptr<uniform, vec2h> = &buffer120;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute12() {
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView153 = texture85.createView({label: '\uf050\u{1fec3}\u040a'});
+let sampler104 = device0.createSampler({
+  label: '\u5049\u{1f610}\u0964\uc6ba\u03bd\ubbaf\uf5fb\u46d2\uda90\u0806',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.59,
+  lodMaxClamp: 86.09,
+});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup50, new Uint32Array(1210), 10, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let bindGroup89 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: {buffer: buffer75, offset: 1280, size: 1924}}],
+});
+let buffer121 = device0.createBuffer({
+  size: 15885,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder180 = device0.createCommandEncoder({});
+let textureView154 = texture22.createView({label: '\u015c\u{1fbed}\u2fd5', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder172 = commandEncoder180.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(3, bindGroup22, new Uint32Array(1313), 72, 0);
+} catch {}
+try {
+computePassEncoder125.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup50, new Uint32Array(5163), 785, 0);
+} catch {}
+try {
+renderPassEncoder33.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer114);
+} catch {}
+try {
+buffer73.unmap();
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\u8d42');
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer18, offset: 2304, size: 2388}}],
+});
+let commandBuffer12 = commandEncoder127.finish({});
+try {
+computePassEncoder146.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer113, 772, 782);
+} catch {}
+let buffer122 = device0.createBuffer({
+  label: '\u90ce\u{1fa56}\u0f33\u78ff\u6d01\u0256\u0ba6\u69a9\u18e9',
+  size: 14732,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder181 = device0.createCommandEncoder({});
+let texture180 = device0.createTexture({
+  size: {width: 40},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView155 = texture60.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler105 = device0.createSampler({
+  label: '\u00f1\u0afb\u{1f647}\u9f9f\u9a22\u1236\u04e1\u07c8\u069a\u3357',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.11,
+  lodMaxClamp: 99.32,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder122); computePassEncoder122.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup61, new Uint32Array(215), 78, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder35.setViewport(16.283901149660753, 6.101140918021074, 1.9733640562624968, 4.450946675414981, 0.09490252166723567, 0.9907312031833568);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer39, 'uint16', 1_600, 866);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer50, 0, 97);
+} catch {}
+try {
+buffer119.unmap();
+} catch {}
+try {
+commandEncoder181.copyBufferToBuffer(buffer116, 152, buffer121, 3452, 7164);
+} catch {}
+try {
+commandEncoder181.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1968 */
+  offset: 1968,
+  buffer: buffer52,
+}, {
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let imageData19 = new ImageData(40, 8);
+let bindGroup91 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView115}, {binding: 47, resource: textureView124}],
+});
+let commandEncoder182 = device0.createCommandEncoder({});
+let texture181 = device0.createTexture({
+  label: '\u{1fe60}\uf7d5\u92dd\u{1fcf6}\ua4b5\ub6a4\u074d\ucc0e',
+  size: [256, 256, 24],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup5, new Uint32Array(2490), 2_411, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer121, 'uint16', 1_804, 603);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer113, 1_828, 934);
+} catch {}
+try {
+commandEncoder181.copyTextureToTexture({
+  texture: texture158,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 56, resource: textureView131},
+    {binding: 315, resource: textureView114},
+    {binding: 224, resource: {buffer: buffer16, offset: 0, size: 80}},
+    {binding: 314, resource: {buffer: buffer105, offset: 2048, size: 1048}},
+    {binding: 429, resource: textureView82},
+  ],
+});
+let buffer123 = device0.createBuffer({
+  size: 458,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder173 = commandEncoder182.beginComputePass();
+let renderPassEncoder36 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  clearValue: { r: 777.7, g: 931.8, b: 33.85, a: -991.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView39,
+  depthSlice: 0,
+  clearValue: { r: 880.3, g: 201.2, b: -650.5, a: 755.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder102); computePassEncoder102.dispatchWorkgroupsIndirect(buffer123, 4); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'unspecified', transfer: 'iec61966-2-1'} });
+let bindGroup93 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 34, resource: textureView37},
+    {binding: 133, resource: {buffer: buffer3, offset: 256, size: 738}},
+    {binding: 51, resource: {buffer: buffer110, offset: 0}},
+    {binding: 134, resource: {buffer: buffer16, offset: 0, size: 308}},
+    {binding: 10, resource: textureView89},
+    {binding: 43, resource: sampler82},
+    {binding: 144, resource: textureView37},
+  ],
+});
+try {
+computePassEncoder148.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder157.setBindGroup(1, bindGroup1, new Uint32Array(904), 12, 0);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup16, new Uint32Array(1151), 243, 0);
+} catch {}
+try {
+renderPassEncoder12.setViewport(96.03646288141275, 46.26214309528662, 35.36631262982194, 44.15948631131246, 0.20976639604197023, 0.7355540225906096);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer27);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 1320, new Float32Array(1463), 227, 144);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup66, new Uint32Array(1181), 0, 0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer121, 'uint32', 596, 1_396);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer58, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 16}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt2020', transfer: 'pq'} });
+let buffer124 = device0.createBuffer({size: 25255, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder183 = device0.createCommandEncoder({});
+let texture182 = device0.createTexture({
+  label: '\u3aba\u03f9\u5da9\u696c',
+  size: {width: 160, height: 150, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler106 = device0.createSampler({
+  label: '\u0303\u09af\udcca',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.81,
+  lodMaxClamp: 79.79,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+computePassEncoder102.end();
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(1, buffer62, 0, 696);
+} catch {}
+video2.height = 5;
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], stencilReadOnly: true});
+let renderBundle20 = renderBundleEncoder20.finish({});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame19});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup90);
+} catch {}
+try {
+computePassEncoder122.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup49, new Uint32Array(31), 19, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle8, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(6, buffer114, 16, 6);
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'iec6196624'} });
+let commandEncoder184 = device0.createCommandEncoder();
+let texture183 = device0.createTexture({
+  size: [80, 96, 154],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView156 = texture55.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder174 = commandEncoder183.beginComputePass({});
+try {
+computePassEncoder155.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup42, new Uint32Array(905), 95, 0);
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  label: '\uc777\u7042\u66b7\u3bac\u2791\u7a08',
+  layout: bindGroupLayout18,
+  entries: [{binding: 365, resource: sampler90}],
+});
+let commandEncoder185 = device0.createCommandEncoder({label: '\u0a45\ud3fd\u5b71\ue271\u{1fd18}\u0a4f\u{1fc04}\u0de9\u0043\u0e82'});
+let commandBuffer13 = commandEncoder184.finish({});
+let texture184 = device0.createTexture({
+  size: [160, 150, 5],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView157 = texture28.createView({});
+let computePassEncoder175 = commandEncoder98.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder122); computePassEncoder122.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup5, new Uint32Array(5079), 126, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer60, 0);
+} catch {}
+try {
+commandEncoder185.copyBufferToBuffer(buffer64, 1192, buffer14, 368, 376);
+} catch {}
+document.body.append(video2);
+let texture185 = device0.createTexture({
+  label: '\u4f09\u0c59\u{1fcda}\u0205\u00aa\u{1ff35}\u0c3a\u{1f8cb}\u0fdf',
+  size: [80, 96, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler107 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.80,
+});
+try {
+computePassEncoder130.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder163.setBindGroup(0, bindGroup46, new Uint32Array(62), 7, 0);
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder185.copyBufferToBuffer(buffer96, 884, buffer113, 288, 2844);
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8536 */
+  offset: 8536,
+  buffer: buffer45,
+}, {
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer50, 'uint16', 40, 7_278);
+} catch {}
+let promise28 = device0.popErrorScope();
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 96 */
+  offset: 96,
+  bytesPerRow: 17152,
+  rowsPerImage: 367,
+  buffer: buffer41,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 4, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let commandEncoder186 = device0.createCommandEncoder({});
+try {
+renderPassEncoder16.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(79);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer60);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u029b');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+document.body.append(img0);
+offscreenCanvas2.height = 93;
+let textureView158 = texture164.createView({});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup70, new Uint32Array(2633), 228, 0);
+} catch {}
+try {
+computePassEncoder122.end();
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+commandEncoder123.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 94, y: 134, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 42},
+  aspect: 'all',
+},
+{width: 14, height: 6, depthOrArrayLayers: 5});
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img5);
+let buffer125 = device0.createBuffer({
+  label: '\u{1facb}\ub571\ub0af',
+  size: 10433,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder187 = device0.createCommandEncoder({label: '\u0cfa\u{1ffc8}\u06f5\u{1fca0}\ueacc\u33ba\udc38'});
+let bindGroup95 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler15}]});
+let buffer126 = device0.createBuffer({
+  label: '\u{1f984}\u007d\u{1fa9d}\u{1feb0}\u672c\u{1f629}\u9e32\u0b22\uabf0\u0606',
+  size: 28556,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder188 = device0.createCommandEncoder({});
+let computePassEncoder176 = commandEncoder187.beginComputePass({});
+let sampler108 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.823,
+  lodMaxClamp: 55.22,
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup68, new Uint32Array(4516), 533, 0);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer75, 'uint32', 816, 355);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup96 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 200, resource: textureView86},
+    {binding: 54, resource: textureView27},
+    {binding: 434, resource: {buffer: buffer3, offset: 1024, size: 632}},
+    {binding: 6, resource: {buffer: buffer1, offset: 0}},
+  ],
+});
+let buffer127 = device0.createBuffer({size: 6112, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandBuffer14 = commandEncoder123.finish({label: '\uab08\u021a'});
+let textureView159 = texture166.createView({mipLevelCount: 1});
+let textureView160 = texture110.createView({label: '\ua07f\u666b\u{1fa43}\ub987\u0c17\u0337\ub889'});
+let computePassEncoder177 = commandEncoder186.beginComputePass({label: '\u{1f60e}\ueac2\uadcd\u3701\ubc17\uba0e\u0378\uff85\u2d4c'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup0, new Uint32Array(37), 2, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer122, 572);
+} catch {}
+let computePassEncoder178 = commandEncoder185.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup29, new Uint32Array(39), 5, 0);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup43, new Uint32Array(356), 101, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle7, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(6, buffer102, 36, 86);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder189 = device0.createCommandEncoder();
+let texture186 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 19},
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder179 = commandEncoder188.beginComputePass({});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup70, new Uint32Array(4589), 1_969, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer103, 'uint32', 2_300, 142);
+} catch {}
+try {
+commandEncoder189.copyTextureToTexture({
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 145, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 42, y: 83, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 12, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer113, 1832, new BigUint64Array(4196), 812, 48);
+} catch {}
+let commandEncoder190 = device0.createCommandEncoder({});
+let texture187 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView161 = texture166.createView({});
+let computePassEncoder180 = commandEncoder190.beginComputePass({});
+let renderPassEncoder37 = commandEncoder189.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  clearValue: { r: 783.6, g: -936.0, b: 300.6, a: 809.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline3);
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 72, resource: textureView85},
+    {binding: 159, resource: {buffer: buffer123, offset: 0, size: 40}},
+  ],
+});
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture188 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder181 = commandEncoder191.beginComputePass({});
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer60, 0, 498);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(41_191).fill(244), /* required buffer size: 41_191 */
+{offset: 101, bytesPerRow: 579}, {width: 35, height: 71, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder76.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer58, 0);
+} catch {}
+try {
+adapter1.label = '\u{1fc9c}\u{1f816}\ufb74\ub2b7';
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let computePassEncoder182 = commandEncoder192.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup12, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroups(3); };
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer84, 'uint16', 5_714, 134);
+} catch {}
+try {
+computePassEncoder64.pushDebugGroup('\u006c');
+} catch {}
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 371});
+let textureView162 = texture7.createView({label: '\u065c\uef49\u5c1b\u0ea5\udb53\ub1f6\u0bc2\u9d0d'});
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroupsIndirect(buffer5, 252); };
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup48, new Uint32Array(22), 0, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer54);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 756, new Int16Array(9744), 991, 168);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle14, renderBundle14, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer37);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 4, y: 18, z: 0},
+  aspect: 'all',
+}, new Uint8Array(20).fill(237), /* required buffer size: 20 */
+{offset: 20}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer128 = device0.createBuffer({
+  label: '\u{1fec4}\u{1f974}\u{1fa40}\u47ac\u021d',
+  size: 12612,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+  mappedAtCreation: true,
+});
+let commandEncoder193 = device0.createCommandEncoder({});
+let texture189 = device0.createTexture({
+  size: [40],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView163 = texture163.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 21});
+let computePassEncoder183 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder183.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4_294_967_294, undefined, 32_147_784, 3_669_305_392);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 2084, new BigUint64Array(6518), 1711, 44);
+} catch {}
+await gc();
+let bindGroup98 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 142, resource: {buffer: buffer58, offset: 256, size: 2670}}],
+});
+let texture190 = device0.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView164 = texture145.createView({});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup80);
+} catch {}
+let img7 = await imageWithData(31, 5, '#10101010', '#20202020');
+let bindGroup99 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 134, resource: {buffer: buffer54, offset: 2304}},
+    {binding: 43, resource: sampler72},
+    {binding: 10, resource: textureView26},
+    {binding: 144, resource: textureView37},
+    {binding: 51, resource: {buffer: buffer126, offset: 4352, size: 456}},
+    {binding: 133, resource: {buffer: buffer26, offset: 256, size: 3049}},
+    {binding: 34, resource: textureView29},
+  ],
+});
+let texture191 = device0.createTexture({
+  label: '\ud670\u46ba\u1e44\u0524\u1e4d\u4747\u2553\u{1fb7e}',
+  size: {width: 80, height: 75, depthOrArrayLayers: 80},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup82);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup42);
+} catch {}
+document.body.append(img3);
+try {
+renderPassEncoder7.setIndexBuffer(buffer108, 'uint32', 1_188, 2_418);
+} catch {}
+let texture192 = device0.createTexture({
+  size: [80, 75, 1],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView165 = texture76.createView({mipLevelCount: 1});
+try {
+computePassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer57, 'uint16', 84, 605);
+} catch {}
+document.body.prepend(canvas1);
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let buffer129 = device0.createBuffer({
+  label: '\u{1ff7d}\u{1fd11}\ufe96\u37c8\u8e24\u0d3f\u9a7c',
+  size: 4409,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let textureView166 = texture171.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 2});
+let textureView167 = texture176.createView({});
+let sampler109 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.16,
+  lodMaxClamp: 82.97,
+});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle17, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder27.setViewport(90.59932761969904, 133.6533010585981, 52.943146878921425, 0.2438061311821889, 0.703693774389769, 0.7214245127366105);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+let buffer130 = device0.createBuffer({
+  label: '\ud754\u00ed\ucd58\u0e35\u7c45\u1cd8\u6188\u0e19',
+  size: 936,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(2, bindGroup57, new Uint32Array(398), 0, 0);
+} catch {}
+try {
+renderPassEncoder11.setViewport(9.906410460045159, 251.68024469372614, 304.4970945897099, 28.030770783159994, 0.6946639587474983, 0.7271524734653493);
+} catch {}
+try {
+computePassEncoder154.insertDebugMarker('\ue428');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture185,
+  mipLevel: 0,
+  origin: {x: 7, y: 12, z: 0},
+  aspect: 'all',
+}, new Uint8Array(163).fill(146), /* required buffer size: 163 */
+{offset: 163, bytesPerRow: 177}, {width: 4, height: 5, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video1);
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView168 = texture43.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroups(1); };
+} catch {}
+try {
+commandEncoder194.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 152 */
+  offset: 152,
+  bytesPerRow: 15104,
+  rowsPerImage: 18,
+  buffer: buffer13,
+}, {
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 8, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder64.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 9, y: 26, z: 0},
+  aspect: 'all',
+}, new Uint8Array(401).fill(127), /* required buffer size: 401 */
+{offset: 79, bytesPerRow: 18}, {width: 16, height: 18, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({});
+try {
+computePassEncoder181.setBindGroup(3, bindGroup29, new Uint32Array(103), 36, 0);
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(100);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer12, 0, 2_090);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 2280, new Int16Array(18206), 1018, 456);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(176).fill(106), /* required buffer size: 176 */
+{offset: 176}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer131 = device0.createBuffer({size: 485, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder196 = device0.createCommandEncoder({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle22 = renderBundleEncoder22.finish({label: '\ufbb4\u7b90\u2289\u1c67\u{1faeb}\u{1f6e5}\u{1f6b0}\u1f93'});
+let sampler110 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.19,
+  lodMaxClamp: 53.98,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder21.setViewport(59.53454977537774, 57.73661201142323, 71.3730077743805, 79.78296256602411, 0.6055336734293089, 0.9271575834738641);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer60, 'uint16', 308, 804);
+} catch {}
+try {
+commandEncoder196.copyTextureToTexture({
+  texture: texture192,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer14, commandBuffer13]);
+} catch {}
+let commandEncoder197 = device0.createCommandEncoder({});
+let texture193 = device0.createTexture({
+  size: [40, 48, 5],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView169 = texture98.createView({
+  label: '\ubdb7\uc1ef\u5c56\ue906\ua066\u0ca0',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 54,
+});
+let renderPassEncoder38 = commandEncoder195.beginRenderPass({colorAttachments: [{view: textureView97, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler111 = device0.createSampler({
+  label: '\u89fb\u9bda\ubd2d\ud137\uedad\u86b4\u0c03\u3d5a\u5016\u{1fa38}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.99,
+  lodMaxClamp: 93.28,
+});
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup33, new Uint32Array(399), 93, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle19, renderBundle19, renderBundle14, renderBundle19, renderBundle19, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer86, 'uint32', 2_912, 573);
+} catch {}
+try {
+computePassEncoder167.insertDebugMarker('\u33a4');
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\u8df6');
+} catch {}
+let texture194 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView170 = texture34.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder184 = commandEncoder194.beginComputePass();
+try {
+computePassEncoder60.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+  await buffer28.mapAsync(GPUMapMode.WRITE, 9688, 3344);
+} catch {}
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'bt2020_12bit'} });
+let textureView171 = texture69.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler112 = device0.createSampler({
+  label: '\uf646\u0e96',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.19,
+  lodMaxClamp: 98.92,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder156.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup41, new Uint32Array(607), 357, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer56, 'uint16', 1_990, 436);
+} catch {}
+try {
+commandEncoder197.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2532 */
+  offset: 2532,
+  buffer: buffer48,
+}, {
+  texture: texture193,
+  mipLevel: 1,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let textureView172 = texture172.createView({});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup3, new Uint32Array(2027), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder130); computePassEncoder130.dispatchWorkgroupsIndirect(buffer126, 3_184); };
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(264);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+await gc();
+let buffer132 = device0.createBuffer({size: 10483, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture195 = gpuCanvasContext2.getCurrentTexture();
+try {
+renderPassEncoder34.executeBundles([renderBundle17]);
+} catch {}
+try {
+commandEncoder196.resolveQuerySet(querySet12, 22, 39, buffer16, 256);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let imageData20 = new ImageData(24, 68);
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'film', transfer: 'log'} });
+let computePassEncoder185 = commandEncoder196.beginComputePass({});
+try {
+computePassEncoder71.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup9, new Uint32Array(93), 21, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle19, renderBundle19, renderBundle14]);
+} catch {}
+let imageData21 = new ImageData(16, 96);
+let pipelineLayout13 = device0.createPipelineLayout({label: '\u{1fea2}\u{1fc05}\u0b32\u72cb\u04bd\u0f98\uca78\u0e24\ub037', bindGroupLayouts: []});
+let computePassEncoder186 = commandEncoder197.beginComputePass();
+let sampler113 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.84,
+  lodMaxClamp: 98.69,
+  maxAnisotropy: 7,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 4, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(126_422).fill(67), /* required buffer size: 126_422 */
+{offset: 86, bytesPerRow: 240, rowsPerImage: 75}, {width: 6, height: 2, depthOrArrayLayers: 8});
+} catch {}
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let textureView173 = texture76.createView({});
+let texture196 = device0.createTexture({
+  label: '\ue3a7\u{1f923}\u0dcc\ubcce\u4886\u3e8e\u{1f68b}\u{1fa75}\u13d0\u8166\u0911',
+  size: [80, 75, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler114 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.75,
+  lodMaxClamp: 91.71,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder130.end();
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder133.copyBufferToBuffer(buffer67, 4664, buffer78, 428, 508);
+} catch {}
+try {
+commandEncoder133.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 336 */
+  offset: 336,
+  bytesPerRow: 9728,
+  buffer: buffer59,
+}, {
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView77}]});
+let commandEncoder198 = device0.createCommandEncoder({label: '\u{1f9ad}\ufb93\u0dae\u85f4\u04ad'});
+let textureView174 = texture44.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder187 = commandEncoder198.beginComputePass({});
+try {
+renderPassEncoder18.executeBundles([renderBundle17, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer127, 112, 243);
+} catch {}
+let bindGroup101 = device0.createBindGroup({
+  label: '\ubc66\u{1f84e}\u0a2a\u03af\u929b\ub842\uf945\u3c45\u618f\u5803\u{1f6da}',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 133, resource: {buffer: buffer58, offset: 1536, size: 981}},
+    {binding: 10, resource: textureView127},
+    {binding: 34, resource: textureView29},
+    {binding: 43, resource: sampler61},
+    {binding: 144, resource: textureView37},
+    {binding: 134, resource: {buffer: buffer7, offset: 256, size: 560}},
+    {binding: 51, resource: {buffer: buffer63, offset: 0}},
+  ],
+});
+let textureView175 = texture102.createView({label: '\ue936\ud86a\udfd5'});
+let computePassEncoder188 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup74, new Uint32Array(818), 152, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup94, []);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -684.0, g: 901.2, b: -54.76, a: -963.8, });
+} catch {}
+document.body.append(img1);
+let bindGroup102 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [
+    {binding: 198, resource: {buffer: buffer76, offset: 1280, size: 1534}},
+    {binding: 153, resource: {buffer: buffer91, offset: 7680, size: 4548}},
+    {binding: 220, resource: textureView151},
+    {binding: 150, resource: textureView138},
+    {binding: 135, resource: sampler23},
+    {binding: 66, resource: textureView140},
+  ],
+});
+let textureView176 = texture152.createView({baseArrayLayer: 0});
+let texture197 = device0.createTexture({
+  label: '\u4ee1\ubc82\u081e\u{1fd65}\u5b8a\u{1fc47}\u0ff0\u0d59',
+  size: [320],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup95, new Uint32Array(1129), 42, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer22, 'uint16', 770, 220);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer27, 3_888, 964);
+} catch {}
+let bindGroup103 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView45}]});
+let texture198 = gpuCanvasContext5.getCurrentTexture();
+let textureView177 = texture62.createView({label: '\u701e\u4f59\u72c2\u4a5f\ua210'});
+try {
+computePassEncoder188.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(video2);
+try {
+computePassEncoder187.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup74, new Uint32Array(871), 31, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer17, 0, 187);
+} catch {}
+let bindGroup104 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 354, resource: {buffer: buffer24, offset: 2560, size: 1380}},
+    {binding: 37, resource: externalTexture15},
+    {binding: 234, resource: sampler83},
+    {binding: 348, resource: textureView143},
+  ],
+});
+try {
+renderPassEncoder31.setIndexBuffer(buffer23, 'uint32', 688, 13_367);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer125, 0, 4_548);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(119).fill(14), /* required buffer size: 119 */
+{offset: 119}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder199 = device0.createCommandEncoder();
+let sampler115 = device0.createSampler({addressModeU: 'clamp-to-edge', mipmapFilter: 'linear', lodMinClamp: 29.21, lodMaxClamp: 48.80});
+try {
+computePassEncoder183.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup103, new Uint32Array(302), 10, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(13);
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer100, 8, 16);
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({label: '\ua875\ue37f'});
+let computePassEncoder189 = commandEncoder199.beginComputePass();
+try {
+computePassEncoder184.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup98, new Uint32Array(1502), 5, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer46, 'uint16', 338, 1_112);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer113, 456);
+} catch {}
+let computePassEncoder190 = commandEncoder200.beginComputePass();
+let sampler116 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'mirror-repeat', lodMinClamp: 60.15, lodMaxClamp: 70.20});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup101, new Uint32Array(274), 30, 0);
+} catch {}
+try {
+computePassEncoder189.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer88, 'uint16', 432, 600);
+} catch {}
+try {
+computePassEncoder177.insertDebugMarker('\u0c56');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder();
+let texture199 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 111},
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder191 = commandEncoder201.beginComputePass();
+try {
+computePassEncoder34.setBindGroup(2, bindGroup68);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer58);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 1320, new BigUint64Array(17966), 15, 68);
+} catch {}
+await gc();
+try {
+computePassEncoder190.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer18, 'uint32', 14_772, 391);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 1168, new DataView(new ArrayBuffer(604)), 65, 80);
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 51, resource: {buffer: buffer112, offset: 1792, size: 1218}},
+    {binding: 133, resource: {buffer: buffer12, offset: 2048, size: 216}},
+    {binding: 34, resource: textureView82},
+    {binding: 144, resource: textureView37},
+    {binding: 43, resource: sampler21},
+    {binding: 10, resource: textureView89},
+    {binding: 134, resource: {buffer: buffer122, offset: 512}},
+  ],
+});
+try {
+computePassEncoder106.setBindGroup(3, bindGroup39, new Uint32Array(840), 27, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer58, 'uint32', 1_428, 303);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(6, buffer62);
+} catch {}
+let arrayBuffer18 = buffer28.getMappedRange(9688, 384);
+try {
+buffer77.unmap();
+} catch {}
+video2.width = 42;
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 159, resource: {buffer: buffer26, offset: 512, size: 64}},
+    {binding: 72, resource: textureView85},
+  ],
+});
+let texture200 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder99.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle10, renderBundle20]);
+} catch {}
+let buffer133 = device0.createBuffer({size: 1071, usage: GPUBufferUsage.UNIFORM});
+let texture201 = device0.createTexture({size: {width: 40}, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(7, buffer5, 0, 199);
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  label: '\u378c\u45ca\ub9d2\u006e\u6dcb\u366f\u68e1',
+  layout: bindGroupLayout5,
+  entries: [{binding: 282, resource: sampler94}],
+});
+let buffer134 = device0.createBuffer({
+  size: 3148,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture202 = device0.createTexture({size: [256], dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup9, new Uint32Array(3596), 304, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer98, 'uint32', 8_784, 597);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer113, 4_052, 514);
+} catch {}
+let buffer135 = device0.createBuffer({
+  size: 13461,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView178 = texture178.createView({format: 'rgba8uint'});
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup28);
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder({});
+let texture203 = device0.createTexture({
+  size: {width: 160, height: 150, depthOrArrayLayers: 4},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture204 = gpuCanvasContext2.getCurrentTexture();
+let textureView179 = texture85.createView({});
+try {
+computePassEncoder178.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer23, 'uint32', 14_456, 4_734);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer114, 64, 1);
+} catch {}
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3344 */
+  offset: 3344,
+  bytesPerRow: 8192,
+  buffer: buffer72,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({});
+let texture205 = device0.createTexture({
+  label: '\u{1f790}\u0e07\ua42e\u821e\ueb7e',
+  size: {width: 40, height: 37, depthOrArrayLayers: 71},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder39 = commandEncoder203.beginRenderPass({
+  colorAttachments: [{
+  view: textureView169,
+  clearValue: { r: 26.29, g: -332.9, b: 408.7, a: -789.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler117 = device0.createSampler({
+  label: '\u0a8f\u{1fe38}\u{1fc1a}\u{1f942}\u{1fece}\u0dab\u{1f98b}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.03,
+  lodMaxClamp: 55.44,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup3, new Uint32Array(3502), 1, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer110, 'uint32', 72, 455);
+} catch {}
+try {
+buffer80.unmap();
+} catch {}
+try {
+commandEncoder202.copyBufferToBuffer(buffer72, 1852, buffer128, 4912, 108);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let commandEncoder204 = device0.createCommandEncoder();
+let texture206 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 24},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture207 = gpuCanvasContext4.getCurrentTexture();
+try {
+computePassEncoder3.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer14, 'uint32', 32, 1_210);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 38}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise31;
+} catch {}
+let texture208 = device0.createTexture({
+  size: [80, 96, 154],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture209 = gpuCanvasContext5.getCurrentTexture();
+let textureView180 = texture82.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder21.setStencilReference(1121);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer98, 'uint32', 1_872, 13_907);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer27, 0, 9_220);
+} catch {}
+try {
+buffer130.unmap();
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u{1fb77}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img3);
+let buffer136 = device0.createBuffer({
+  label: '\u59cf\u{1f6cc}\u0011\u7f4a\u1626\u07f9\u984b\u2002\ud17b\u4615',
+  size: 1714,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView181 = texture184.createView({});
+let sampler118 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 67.80,
+  lodMaxClamp: 97.81,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup73);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup34, new Uint32Array(3296), 381, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 22784,
+  buffer: buffer89,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 17, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 45}
+*/
+{
+  source: imageData1,
+  origin: { x: 4, y: 4 },
+  flipY: true,
+}, {
+  texture: texture163,
+  mipLevel: 2,
+  origin: {x: 4, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView115}, {binding: 47, resource: textureView28}],
+});
+let buffer137 = device0.createBuffer({size: 964, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView182 = texture77.createView({dimension: '2d-array'});
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer106, 24, 109);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 746 */
+  offset: 746,
+  buffer: buffer13,
+}, {
+  texture: texture174,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video2);
+let commandEncoder205 = device0.createCommandEncoder({});
+let computePassEncoder192 = commandEncoder202.beginComputePass({});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer20, 9_628, 8_681);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer108, 1188, new Float32Array(1934));
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await promise27;
+let imageData22 = new ImageData(16, 12);
+let commandEncoder206 = device0.createCommandEncoder();
+let sampler119 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'nearest', lodMinClamp: 78.17, lodMaxClamp: 78.57});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame16, colorSpace: 'srgb'});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup39, []);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup49, new Uint32Array(597), 32, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle7, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer128, 'uint32', 1_532, 1_306);
+} catch {}
+try {
+commandEncoder204.copyBufferToTexture({
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 634 */
+  offset: 634,
+  bytesPerRow: 79616,
+  buffer: buffer46,
+}, {
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 17, y: 2, z: 6},
+  aspect: 'all',
+}, {width: 7, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u67cf');
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba32uint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex1', buffers: []},
+  primitive: {unclippedDepth: true},
+});
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'pq'} });
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 354, resource: {buffer: buffer136, offset: 0, size: 28}},
+    {binding: 37, resource: externalTexture11},
+    {binding: 234, resource: sampler8},
+    {binding: 348, resource: textureView143},
+  ],
+});
+let texture210 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView183 = texture75.createView({arrayLayerCount: 1});
+let computePassEncoder193 = commandEncoder205.beginComputePass();
+let externalTexture17 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder193.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer23);
+} catch {}
+try {
+commandEncoder206.copyBufferToBuffer(buffer114, 4, buffer66, 8480, 8);
+} catch {}
+try {
+commandEncoder204.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2608 */
+  offset: 2608,
+  bytesPerRow: 20224,
+  buffer: buffer24,
+}, {
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup110 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 47, resource: textureView124}, {binding: 24, resource: textureView76}],
+});
+let renderPassEncoder40 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  clearValue: { r: 974.0, g: -415.5, b: 115.5, a: 15.20, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 662982302,
+});
+try {
+computePassEncoder154.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup95, new Uint32Array(3089), 453, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer115, 'uint32', 512, 4_062);
+} catch {}
+try {
+commandEncoder204.resolveQuerySet(querySet11, 47, 4, buffer24, 768);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 17}
+*/
+{
+  source: imageData6,
+  origin: { x: 18, y: 19 },
+  flipY: false,
+}, {
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 25, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 19, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame30 = new VideoFrame(img4, {timestamp: 0});
+let textureView184 = texture171.createView({label: '\ud2b8\u0a53\u{1f603}\u6c37', dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 2});
+let texture211 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 13},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView185 = texture5.createView({label: '\ue33e\u8809\u0549\u3d18\ud872\u0b0b\u0e7c', dimension: '3d', mipLevelCount: 1});
+let sampler120 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMinClamp: 92.60, lodMaxClamp: 96.89});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup103);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(14, 170);
+let bindGroup111 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 44, resource: textureView176},
+    {binding: 47, resource: {buffer: buffer46, offset: 1024, size: 1319}},
+  ],
+});
+let commandEncoder207 = device0.createCommandEncoder({});
+try {
+renderPassEncoder32.setIndexBuffer(buffer18, 'uint32', 1_768, 2_464);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise32;
+} catch {}
+let commandEncoder208 = device0.createCommandEncoder({label: '\u65ec\u5a17\u{1ff6d}\u64d6\u3c1b\u{1f8d2}'});
+let texture212 = device0.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView186 = texture86.createView({dimension: '3d', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder194 = commandEncoder208.beginComputePass({});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup93, new Uint32Array(1217), 489, 0);
+} catch {}
+try {
+commandEncoder207.copyTextureToTexture({
+  texture: texture211,
+  mipLevel: 0,
+  origin: {x: 124, y: 100, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: imageData4,
+  origin: { x: 11, y: 14 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 37},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let querySet21 = device0.createQuerySet({label: '\ud919\u036b\u0b57', type: 'occlusion', count: 570});
+let textureView187 = texture17.createView({baseArrayLayer: 28, arrayLayerCount: 12});
+let renderPassEncoder41 = commandEncoder204.beginRenderPass({
+  colorAttachments: [{
+  view: textureView74,
+  depthSlice: 11,
+  clearValue: { r: -712.2, g: 272.5, b: -883.7, a: 934.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler121 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMaxClamp: 79.57,
+  compare: 'less',
+});
+try {
+computePassEncoder194.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup6, new Uint32Array(1485), 269, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle19]);
+} catch {}
+try {
+buffer96.unmap();
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+try {
+  await promise33;
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  label: '\u3ab0\u0207\u4fcf\u4079\u084a\u55e5\u{1f997}\u29da\u09cc\u{1f8ad}\u0155',
+  layout: bindGroupLayout3,
+  entries: [{binding: 123, resource: textureView37}, {binding: 67, resource: {buffer: buffer101, offset: 0}}],
+});
+let buffer138 = device0.createBuffer({
+  size: 13891,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder209 = device0.createCommandEncoder();
+let textureView188 = texture202.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder195 = commandEncoder207.beginComputePass({});
+try {
+computePassEncoder105.setBindGroup(2, bindGroup63, []);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer107, 'uint32', 6_956, 880);
+} catch {}
+document.body.prepend(img5);
+try {
+globalThis.someLabel = sampler4.label;
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer139 = device0.createBuffer({
+  size: 13021,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder210 = device0.createCommandEncoder({});
+let computePassEncoder196 = commandEncoder210.beginComputePass({});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup107);
+} catch {}
+document.body.append(video0);
+let computePassEncoder197 = commandEncoder209.beginComputePass({label: '\u393e\u0896\u07c8\ua591\u4ed3'});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup61);
+} catch {}
+let bindGroup113 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler73}]});
+let buffer140 = device0.createBuffer({
+  size: 9290,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder211 = device0.createCommandEncoder({});
+let computePassEncoder198 = commandEncoder211.beginComputePass({});
+try {
+computePassEncoder196.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle19, renderBundle19, renderBundle19, renderBundle7, renderBundle7, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(311.9647462175542, 148.80703365962853, 2.6756972911747945, 132.89679990046014, 0.07304240121215089, 0.4428721394480722);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer54, 'uint32', 2_540, 1_783);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+let texture213 = device0.createTexture({
+  size: [256, 256, 559],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler122 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 79.03,
+  lodMaxClamp: 81.65,
+});
+try {
+computePassEncoder145.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle17]);
+} catch {}
+try {
+computePassEncoder69.insertDebugMarker('\u0e5b');
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame31 = new VideoFrame(img2, {timestamp: 0});
+let sampler123 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.58,
+  lodMaxClamp: 71.20,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder145); computePassEncoder145.dispatchWorkgroups(1); };
+} catch {}
+let textureView189 = texture188.createView({mipLevelCount: 1});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+computePassEncoder182.setBindGroup(2, bindGroup80, new Uint32Array(3633), 1_027, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer31);
+} catch {}
+let textureView190 = texture89.createView({dimension: '1d'});
+let sampler124 = device0.createSampler({
+  label: '\u4e7c\u{1fd37}\u62cf\u055a\u1aa2',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  lodMinClamp: 53.37,
+  lodMaxClamp: 67.69,
+  compare: 'not-equal',
+});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame7});
+try {
+renderPassEncoder25.setIndexBuffer(buffer72, 'uint32', 3_308, 4_538);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer24);
+} catch {}
+let video3 = await videoWithData(45);
+let commandEncoder212 = device0.createCommandEncoder({});
+let texture214 = device0.createTexture({size: {width: 320}, dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup80, new Uint32Array(28), 5, 0);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(7, buffer140, 0, 1_228);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 2172, new BigUint64Array(28811), 1981, 408);
+} catch {}
+await gc();
+let texture215 = device0.createTexture({
+  size: [40, 37, 256],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView191 = texture56.createView({dimension: '2d-array', baseArrayLayer: 1, arrayLayerCount: 3});
+let computePassEncoder199 = commandEncoder212.beginComputePass();
+try {
+computePassEncoder142.setBindGroup(2, bindGroup108, new Uint32Array(2812), 115, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle2, renderBundle2, renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageData19);
+let commandEncoder213 = device0.createCommandEncoder({});
+let computePassEncoder200 = commandEncoder213.beginComputePass();
+try {
+computePassEncoder85.setBindGroup(3, bindGroup113, new Uint32Array(742), 58, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer102, 'uint16', 2_332, 1_126);
+} catch {}
+let textureView192 = texture92.createView({arrayLayerCount: 3});
+try {
+computePassEncoder199.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer115, 'uint32', 5_472, 1_408);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer31, 1_372, 808);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let videoFrame32 = new VideoFrame(videoFrame9, {timestamp: 0});
+let commandEncoder214 = device0.createCommandEncoder({});
+let computePassEncoder201 = commandEncoder214.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+computePassEncoder198.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup79, new Uint32Array(1452), 364, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 12, new Float32Array(109), 35, 8);
+} catch {}
+let buffer141 = device0.createBuffer({
+  size: 1113,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder215 = device0.createCommandEncoder({label: '\u0bfd\u8bcb\ub958\ud8f4\ubb48\u4b34\u0e1a\u22f7\u1763'});
+let computePassEncoder202 = commandEncoder215.beginComputePass({});
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup113, new Uint32Array(880), 92, 0);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer45, 'uint16', 3_460, 809);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let commandEncoder216 = device0.createCommandEncoder({});
+let textureView193 = texture50.createView({});
+let computePassEncoder203 = commandEncoder216.beginComputePass({label: '\u0a24\ub8bb\u5c3e\u879a\u0ed4\u07eb\u207c\u0802\ub5a2\u138d\u96f1'});
+try {
+renderPassEncoder24.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer57, 'uint32', 288, 826);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView194 = texture135.createView({});
+let texture216 = device0.createTexture({
+  label: '\u0285\u0189',
+  size: {width: 10, height: 12, depthOrArrayLayers: 25},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder145.end();
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder202.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer46, 'uint32', 5_016, 2);
+} catch {}
+try {
+renderPassEncoder32.insertDebugMarker('\u41dd');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 892, new Float32Array(237), 33, 48);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder217 = device0.createCommandEncoder({});
+let computePassEncoder204 = commandEncoder217.beginComputePass({label: '\u09a5\u18c0\u90fb\u5c05\u95c3\u618f\u061e\ud396\u0fb9'});
+let renderPassEncoder42 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{
+  view: textureView189,
+  clearValue: { r: -1.101, g: 837.4, b: 33.50, a: -133.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 342349083,
+});
+let arrayBuffer19 = buffer32.getMappedRange(2936, 8);
+let texture217 = gpuCanvasContext6.getCurrentTexture();
+try {
+computePassEncoder172.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+  await shaderModule9.getCompilationInfo();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 7, y: 29, z: 76},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup114 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler1}]});
+let commandEncoder218 = device0.createCommandEncoder({});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder200.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle19, renderBundle19, renderBundle19]);
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder();
+let textureView195 = texture99.createView({mipLevelCount: 1});
+try {
+renderPassEncoder38.setVertexBuffer(6, buffer37, 672, 14_949);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer130, 228, new DataView(new ArrayBuffer(235)), 19, 36);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 93, resource: textureView15},
+    {binding: 109, resource: textureView29},
+    {binding: 168, resource: {buffer: buffer141, offset: 0, size: 183}},
+    {binding: 150, resource: textureView9},
+  ],
+});
+let commandEncoder220 = device0.createCommandEncoder({});
+let texture218 = device0.createTexture({
+  size: [160, 150, 5],
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder43 = commandEncoder219.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  clearValue: { r: 713.3, g: 443.3, b: 806.3, a: 971.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 240101488,
+});
+try {
+computePassEncoder195.setBindGroup(3, bindGroup66, new Uint32Array(2060), 1_083, 0);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer20 = buffer28.getMappedRange(10072, 2176);
+try {
+computePassEncoder141.insertDebugMarker('\u9000');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture219 = device0.createTexture({
+  label: '\u19f0\u{1f847}\u5614\u{1f760}\ubbfb\uadf2\u0840\u08c0\u8a8b',
+  size: [40, 37, 1],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler125 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.75,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder25.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -160.5, g: 621.0, b: 527.8, a: -191.3, });
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer39, 'uint16', 68, 13);
+} catch {}
+try {
+commandEncoder218.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2960 */
+  offset: 904,
+  bytesPerRow: 1024,
+  buffer: buffer112,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 6},
+  aspect: 'all',
+}, {width: 4, height: 12, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder220.resolveQuerySet(querySet13, 86, 34, buffer97, 1536);
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  label: '\ub566\u0c75\u0ce2\u{1f8e7}\u0733',
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 429, resource: textureView80},
+    {binding: 224, resource: {buffer: buffer91, offset: 1280, size: 60}},
+    {binding: 315, resource: textureView117},
+    {binding: 56, resource: textureView133},
+    {binding: 314, resource: {buffer: buffer64, offset: 1280, size: 28}},
+  ],
+});
+let texture220 = device0.createTexture({size: [160, 150, 65], mipLevelCount: 3, format: 'rgba8uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView196 = texture55.createView({label: '\u07b3\uc557\u08c2\u{1fd66}\u9e5d\u5dd0\u429e', dimension: '2d-array'});
+let renderPassEncoder44 = commandEncoder218.beginRenderPass({colorAttachments: [{view: textureView101, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder204.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(2, bindGroup39, new Uint32Array(108), 7, 0);
+} catch {}
+try {
+commandEncoder220.copyBufferToBuffer(buffer100, 20, buffer57, 2452, 0);
+} catch {}
+await gc();
+let textureView197 = texture148.createView({dimension: '2d', baseArrayLayer: 10});
+let computePassEncoder205 = commandEncoder220.beginComputePass();
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup116);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer20, 0, 1_054);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+texture65.label = '\u{1fbad}\u42b8\u{1ffe2}\u1eff\u{1f60c}\u{1fc93}\u{1fff5}\u0077\u76a6\u07f0\u986d';
+} catch {}
+let bindGroup117 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [
+    {binding: 25, resource: textureView29},
+    {binding: 278, resource: sampler37},
+    {binding: 18, resource: textureView148},
+    {binding: 4, resource: {buffer: buffer16, offset: 0, size: 128}},
+    {binding: 36, resource: textureView124},
+    {binding: 358, resource: {buffer: buffer135, offset: 512, size: 56}},
+    {binding: 215, resource: textureView90},
+    {binding: 443, resource: textureView150},
+    {binding: 485, resource: {buffer: buffer60, offset: 7936, size: 716}},
+    {binding: 73, resource: {buffer: buffer95, offset: 1024, size: 196}},
+    {binding: 40, resource: textureView161},
+    {binding: 434, resource: sampler91},
+    {binding: 23, resource: textureView65},
+    {binding: 14, resource: textureView4},
+    {binding: 64, resource: textureView146},
+    {binding: 105, resource: {buffer: buffer22, offset: 768, size: 8396}},
+    {binding: 347, resource: sampler116},
+    {binding: 329, resource: textureView15},
+    {binding: 96, resource: textureView158},
+  ],
+});
+let commandEncoder221 = device0.createCommandEncoder();
+let textureView198 = texture17.createView({label: '\u{1ff3c}\u25a7\u{1f70c}\u0a23\u0b79\u0f02', dimension: '2d', baseArrayLayer: 27});
+let computePassEncoder206 = commandEncoder221.beginComputePass({});
+try {
+computePassEncoder203.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup115);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup61, new Uint32Array(1161), 240, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture142,
+  mipLevel: 0,
+  origin: {x: 6, y: 4, z: 5},
+  aspect: 'all',
+}, new Uint8Array(112).fill(115), /* required buffer size: 112 */
+{offset: 23, bytesPerRow: 27, rowsPerImage: 20}, {width: 2, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let imageData23 = new ImageData(84, 72);
+let textureView199 = texture48.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup54);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer106);
+} catch {}
+let buffer142 = device0.createBuffer({
+  size: 21685,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder222 = device0.createCommandEncoder({});
+let texture221 = device0.createTexture({
+  size: [160],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup76);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup94, new Uint32Array(1674), 149, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer86, 'uint16', 4_710, 897);
+} catch {}
+try {
+buffer118.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(150).fill(170), /* required buffer size: 150 */
+{offset: 150}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData24 = new ImageData(8, 68);
+let textureView200 = texture37.createView({label: '\u{1f735}\u410e\u0ed1\ua0f7\u0a90\u02bb', dimension: '2d-array', mipLevelCount: 1});
+let sampler126 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 75.10,
+  lodMaxClamp: 95.89,
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup69, new Uint32Array(757), 479, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer9, 'uint16', 3_082, 512);
+} catch {}
+try {
+commandEncoder222.copyBufferToBuffer(buffer7, 1464, buffer80, 512, 820);
+} catch {}
+try {
+commandEncoder222.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 17, y: 8, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 8, new DataView(new ArrayBuffer(737)), 7, 4);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(77, 15);
+let textureView201 = texture95.createView({dimension: '2d', format: 'r8unorm', baseArrayLayer: 5});
+try {
+computePassEncoder175.setBindGroup(1, bindGroup75, new Uint32Array(416), 2, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer104, 72, new BigUint64Array(7664), 2537, 8);
+} catch {}
+let commandEncoder223 = device0.createCommandEncoder({});
+let computePassEncoder207 = commandEncoder223.beginComputePass();
+let externalTexture19 = device0.importExternalTexture({source: videoFrame7, colorSpace: 'display-p3'});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+computePassEncoder201.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer64, 164, new BigUint64Array(17171), 512, 32);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(44) var tex11: texture_1d<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(47) var<uniform> buffer143: array<array<f16, 2>, 1>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S4 {
+  @builtin(global_invocation_id) @size(16) f0: vec3u,
+}
+
+fn fn0() -> array<array<f16, 2>, 1> {
+  var out: array<array<f16, 2>, 1>;
+  storageBarrier();
+  let ptr126: ptr<uniform, f16> = &buffer143[0][1];
+  var vf212: vec2h = select(vec2h(unconst_f16(4569.8), unconst_f16(46311.0)), bitcast<vec2h>(pack4xI8(vec4i(unconst_i32(70), unconst_i32(152), unconst_i32(192), unconst_i32(412)))), bool(unconst_bool(false)));
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw46: array<atomic<i32>, 1>;
+
+fn fn1(a0: vec4f) -> S4 {
+  var out: S4;
+  out = S4(vec3u(tan(vec3h(refract(vec2f(smoothstep(f32(unconst_f32(-0.2540)), a0[0], f32(unconst_f32(0.2761)))), vec2f(unconst_f32(0.1131), unconst_f32(0.07296)), f32(unpack4xI8(u32(sqrt(sinh(vec2h(atan2(vec3f(unconst_f32(0.08082), unconst_f32(0.06366), unconst_f32(0.00810)), bitcast<vec3f>(textureLoad(tex11, i32(textureDimensions(tex11, 0i)), i32(unconst_i32(21))).zxz)).gb)).yyy).g)).g)).yxx))));
+  out.f0 >>= vec3u(u32(dot(vec3f(unconst_f32(0.04783), unconst_f32(0.2483), unconst_f32(0.1736)), vec3f(unconst_f32(0.2088), unconst_f32(0.01726), unconst_f32(0.1130)))));
+  var vf213: vec4h = sqrt(vec4h(unconst_f16(-9992.4), unconst_f16(8394.9), unconst_f16(10501.3), unconst_f16(1440.1)));
+  let vf214: u32 = textureNumLevels(tex11);
+  out.f0 <<= vec3u(countOneBits(u32(unconst_u32(290))));
+  let vf215: u32 = pack4x8snorm(vec4f(bitcast<f32>(textureDimensions(tex11, 0i))));
+  vf213 = vec4h(f16(tanh(f32(unconst_f32(0.7238)))));
+  out.f0 <<= vec3u(countOneBits(u32(unconst_u32(4))));
+  let vf216: u32 = vf215;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute13(a0: S4) {
+  atomicXor(&vw46[bitcast<u32>(atomicExchange(&vw46[0], i32(a0.f0.y)))], atomicLoad(&vw46[0]));
+  let ptr127: ptr<workgroup, atomic<i32>> = &vw46[vec3u(reflect(vec3f(f32(buffer143[0][1])), vec3f(f32(textureDimensions(tex11, 0i)))))[2]];
+  let vf217: vec3f = reflect(vec3f(unconst_f32(0.08124), unconst_f32(0.03456), unconst_f32(0.1193)), vec3f(f32((*&buffer143)[0][u32(unconst_u32(65))])));
+  var vf218 = fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture222 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 76},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder45 = commandEncoder222.beginRenderPass({colorAttachments: [{view: textureView103, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder132.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup95, new Uint32Array(1227), 1_074, 0);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+externalTexture18.label = '\u929c\u{1f636}';
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder({});
+let sampler127 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.82,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup76);
+} catch {}
+try {
+commandEncoder224.copyTextureToBuffer({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 116 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1408 */
+  offset: 1292,
+  buffer: buffer49,
+}, {width: 29, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder224.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 97, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 180, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas1);
+let computePassEncoder208 = commandEncoder224.beginComputePass({});
+try {
+computePassEncoder83.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder207.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer78, 'uint16', 2_754, 2_975);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer144 = device0.createBuffer({size: 10026, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let texture223 = device0.createTexture({size: [256], dimension: '1d', format: 'rgba8uint', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder189.setBindGroup(2, bindGroup78, new Uint32Array(249), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroupsIndirect(buffer26, 5_000); };
+} catch {}
+try {
+computePassEncoder197.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle17]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(138).fill(78), /* required buffer size: 138 */
+{offset: 138, bytesPerRow: 65}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder225 = device0.createCommandEncoder({});
+let textureView202 = texture198.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder29.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 23});
+let textureView203 = texture196.createView({dimension: '2d-array'});
+let sampler128 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.01,
+  lodMaxClamp: 97.13,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder201.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 588, new Int16Array(1785), 62, 116);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData8,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 483;
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt2020', transfer: 'gamma22curve'} });
+let commandEncoder226 = device0.createCommandEncoder();
+try {
+renderPassEncoder28.setIndexBuffer(buffer34, 'uint32', 1_332, 2_280);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas4.getContext('webgpu');
+let imageData25 = new ImageData(44, 32);
+let commandEncoder227 = device0.createCommandEncoder({});
+let texture224 = device0.createTexture({
+  size: [80, 75, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder209 = commandEncoder227.beginComputePass({});
+try {
+renderPassEncoder33.beginOcclusionQuery(189);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer105, 'uint32', 908, 4_619);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer12);
+} catch {}
+try {
+commandEncoder226.copyBufferToBuffer(buffer71, 596, buffer83, 988, 2792);
+} catch {}
+try {
+commandEncoder226.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 10, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3208 */
+  offset: 3208,
+  bytesPerRow: 21504,
+  buffer: buffer121,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 9, y: 63, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer145 = device0.createBuffer({label: '\u6730\ua350\u2a5d\u{1f664}\u3abe\u35ef\u0a5d', size: 1657, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder228 = device0.createCommandEncoder();
+let textureView204 = texture6.createView({format: 'rgba32uint', baseMipLevel: 0, baseArrayLayer: 0});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint', 'r8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder150.setBindGroup(1, bindGroup29, new Uint32Array(1526), 371, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder67); computePassEncoder67.dispatchWorkgroupsIndirect(buffer14, 296); };
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup89, new Uint32Array(1854), 156, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+buffer96.unmap();
+} catch {}
+try {
+commandEncoder228.clearBuffer(buffer110);
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: {buffer: buffer3, offset: 2304, size: 1208}}],
+});
+let textureView205 = texture174.createView({mipLevelCount: 1});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(0, bindGroup77, new Uint32Array(2743), 510, 0);
+} catch {}
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+computePassEncoder204.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup36, new Uint32Array(1397), 82, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer50, 'uint16', 3_002, 2_447);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer63, 0, 56);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let imageData26 = new ImageData(12, 4);
+let computePassEncoder210 = commandEncoder228.beginComputePass({});
+try {
+computePassEncoder208.setBindGroup(2, bindGroup64, []);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder33.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let buffer146 = device0.createBuffer({size: 38694, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder211 = commandEncoder225.beginComputePass({});
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup73, new Uint32Array(1622), 143, 0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 84.78, g: 848.8, b: 928.2, a: -133.7, });
+} catch {}
+try {
+renderPassEncoder37.setViewport(9.050766250026243, 14.660456464121268, 0.2327077112472836, 2.7038039892730055, 0.6960906792561482, 0.9497885436054361);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer139);
+} catch {}
+let texture225 = device0.createTexture({size: [40], dimension: '1d', format: 'rgba8uint', usage: GPUTextureUsage.COPY_DST});
+let textureView206 = texture105.createView({});
+try {
+computePassEncoder192.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+computePassEncoder206.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup103);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle16, renderBundle12]);
+} catch {}
+let arrayBuffer21 = buffer28.getMappedRange(12504, 120);
+try {
+commandEncoder226.copyBufferToBuffer(buffer7, 360, buffer55, 408, 2748);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u{1feff}\u8fe1\u{1fa79}\u{1f858}\ue26b',
+  entries: [
+    {
+      binding: 321,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 337,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 348, resource: textureView143},
+    {binding: 354, resource: {buffer: buffer43, offset: 2560, size: 2664}},
+    {binding: 37, resource: externalTexture11},
+    {binding: 234, resource: sampler57},
+  ],
+});
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView207 = texture168.createView({dimension: '2d-array', aspect: 'depth-only', arrayLayerCount: 1});
+let computePassEncoder212 = commandEncoder226.beginComputePass({});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+computePassEncoder205.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup10, new Uint32Array(7), 0, 0);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer14, 'uint16', 274, 6);
+} catch {}
+let arrayBuffer22 = buffer32.getMappedRange(2968, 52);
+let buffer147 = device0.createBuffer({
+  size: 17999,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder229 = device0.createCommandEncoder({});
+let textureView208 = texture186.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+let renderPassEncoder46 = commandEncoder229.beginRenderPass({
+  colorAttachments: [{
+  view: textureView193,
+  depthSlice: 1,
+  clearValue: { r: 250.5, g: 71.62, b: -399.6, a: 249.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView93,
+  depthSlice: 1,
+  clearValue: { r: 64.96, g: 984.5, b: -966.8, a: -496.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder200.setBindGroup(1, bindGroup108, new Uint32Array(3766), 489, 0);
+} catch {}
+try {
+adapter0.label = '\u{1f7d2}\u{1faad}\u596e\ue946\u0d14\u005c\u186a\u0816\u3ff4';
+} catch {}
+try {
+globalThis.someLabel = externalTexture17.label;
+} catch {}
+let buffer148 = device0.createBuffer({
+  size: 3209,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder230 = device0.createCommandEncoder({});
+let texture226 = device0.createTexture({size: {width: 160}, dimension: '1d', format: 'rgba32uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView209 = texture158.createView({});
+let computePassEncoder213 = commandEncoder230.beginComputePass({});
+try {
+computePassEncoder209.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup0, new Uint32Array(226), 9, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer103, 'uint16', 1_560, 4_258);
+} catch {}
+try {
+commandEncoder64.clearBuffer(buffer96, 280, 1416);
+} catch {}
+document.body.prepend(video2);
+let commandEncoder231 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 142});
+let texture227 = device0.createTexture({
+  size: [40, 48, 1],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderPassEncoder47 = commandEncoder64.beginRenderPass({
+  label: '\u012d\ud49d\u{1f90d}\u0bb1\uf054\ueca0',
+  colorAttachments: [{
+  view: textureView189,
+  clearValue: { r: 88.69, g: -263.7, b: 772.3, a: -335.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder212.setPipeline(pipeline3);
+} catch {}
+document.body.prepend(video0);
+let bindGroup120 = device0.createBindGroup({
+  label: '\u7553\u{1f87e}\ua749\u04f9\u0384\u0ba3\u448e',
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer134, offset: 0, size: 224}}],
+});
+let computePassEncoder214 = commandEncoder231.beginComputePass({label: '\u0108\uc735\u67f9\u0dfc\uadf6\u{1f8e5}\u58ef'});
+let externalTexture20 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder214.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup98, new Uint32Array(3045), 1_027, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle19, renderBundle7]);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+await gc();
+let commandEncoder232 = device0.createCommandEncoder({label: '\u724e\u03b7\u0a61\uab5e\u{1f991}\u0faa\u0c8a\u21be\ua00b\ue154'});
+let texture228 = device0.createTexture({size: [20, 24, 38], dimension: '3d', format: 'r8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder215 = commandEncoder232.beginComputePass();
+try {
+computePassEncoder160.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+computePassEncoder159.pushDebugGroup('\uf385');
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 37, resource: externalTexture12},
+    {binding: 348, resource: textureView24},
+    {binding: 234, resource: sampler127},
+    {binding: 354, resource: {buffer: buffer110, offset: 256}},
+  ],
+});
+let commandEncoder233 = device0.createCommandEncoder({});
+let commandBuffer15 = commandEncoder233.finish({});
+let texture229 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView210 = texture95.createView({dimension: '2d', baseMipLevel: 0});
+try {
+computePassEncoder169.setBindGroup(1, bindGroup94);
+} catch {}
+try {
+computePassEncoder211.setBindGroup(3, bindGroup28, new Uint32Array(2185), 670, 0);
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer142, 0);
+} catch {}
+try {
+buffer136.unmap();
+} catch {}
+try {
+computePassEncoder159.popDebugGroup();
+} catch {}
+document.body.append(img1);
+let commandEncoder234 = device0.createCommandEncoder({});
+let textureView211 = texture186.createView({label: '\u07f3\u0dee\u0d96', dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder216 = commandEncoder234.beginComputePass({});
+let sampler129 = device0.createSampler({
+  label: '\u0453\u0152\ud8fc\u0d43\u{1fe43}\u{1f7e8}\u{1f784}\udd5e\u{1fe63}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 9.742,
+  lodMaxClamp: 22.56,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder96.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+computePassEncoder162.setBindGroup(0, bindGroup45, new Uint32Array(2594), 213, 0);
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer39, 'uint16', 602, 1_571);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer43, 6_060);
+} catch {}
+let video4 = await videoWithData(103);
+let textureView212 = texture190.createView({aspect: 'all', format: 'r8unorm'});
+try {
+computePassEncoder152.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup0, new Uint32Array(1587), 260, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -99.08, g: 977.3, b: 968.9, a: -391.5, });
+} catch {}
+let arrayBuffer23 = buffer28.getMappedRange(12248, 52);
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup75, new Uint32Array(667), 329, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer54);
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+let texture230 = device0.createTexture({
+  label: '\u2fab\ucc3b\u202f\u3cb1',
+  size: [320, 300, 136],
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView213 = texture84.createView({baseMipLevel: 0, baseArrayLayer: 0});
+try {
+renderPassEncoder8.setIndexBuffer(buffer19, 'uint32', 92, 666);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer73, 0, 371);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer86, 4456, new Int16Array(1105), 79);
+} catch {}
+let texture231 = device0.createTexture({size: [40, 37, 1], format: 'rgba32float', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder194.setBindGroup(3, bindGroup57, new Uint32Array(1754), 507, 0);
+} catch {}
+try {
+computePassEncoder215.setPipeline(pipeline2);
+} catch {}
+try {
+globalThis.someLabel = externalTexture19.label;
+} catch {}
+let textureView214 = texture116.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 4});
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: {buffer: buffer3, offset: 4096, size: 3124}}],
+});
+let sampler130 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.97,
+});
+try {
+computePassEncoder128.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer121, 'uint16', 2_096, 80);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(2, buffer106, 200);
+} catch {}
+try {
+buffer105.unmap();
+} catch {}
+let promise36 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: imageData7,
+  origin: { x: 3, y: 61 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 15, y: 2, z: 38},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(img7);
+let commandEncoder235 = device0.createCommandEncoder({});
+let textureView215 = texture99.createView({});
+let sampler131 = device0.createSampler({addressModeW: 'clamp-to-edge', mipmapFilter: 'nearest', lodMinClamp: 4.071, lodMaxClamp: 27.55});
+try {
+computePassEncoder213.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+buffer140.unmap();
+} catch {}
+try {
+commandEncoder235.clearBuffer(buffer6, 1620, 740);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer111, 320, new DataView(new ArrayBuffer(10591)), 1192, 108);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let textureView216 = texture65.createView({label: '\u{1fd10}\u{1fd39}\u05b2\uef2f\uf740', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+commandEncoder235.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 112 */
+  offset: 112,
+  buffer: buffer129,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder236 = device0.createCommandEncoder({});
+let texture232 = device0.createTexture({size: {width: 256}, dimension: '1d', format: 'r8unorm', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder48 = commandEncoder236.beginRenderPass({colorAttachments: [{view: textureView189, loadOp: 'load', storeOp: 'discard'}]});
+let sampler132 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.49,
+  compare: 'always',
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame18});
+try {
+commandEncoder235.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4092 */
+  offset: 4092,
+  bytesPerRow: 8704,
+  rowsPerImage: 1579,
+  buffer: buffer140,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer149 = device0.createBuffer({size: 23939, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let textureView217 = texture186.createView({baseArrayLayer: 6, arrayLayerCount: 3});
+let sampler133 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.51,
+  lodMaxClamp: 91.93,
+});
+let canvas3 = document.createElement('canvas');
+let video5 = await videoWithData(49);
+let commandEncoder237 = device0.createCommandEncoder({label: '\u0402\ud421\u065b\u09bc\u814b\u0cc3\u0198\u{1f8d3}\ua7b6\u0a5e'});
+let computePassEncoder217 = commandEncoder237.beginComputePass({});
+let sampler134 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 77.85,
+});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup5, new Uint32Array(941), 280, 0);
+} catch {}
+let commandEncoder238 = device0.createCommandEncoder({});
+let computePassEncoder218 = commandEncoder235.beginComputePass({label: '\ucfd5\u0eb6\u0478\u3c09\uf7fd\u{1fa7c}\u9e3f\uef12\u{1f9a0}\u28bd\u0a18'});
+let sampler135 = device0.createSampler({
+  label: '\ue503\u04e0\u{1fa8f}\uedc2\u07c6\u94b4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.53,
+});
+try {
+computePassEncoder201.setBindGroup(0, bindGroup67, new Uint32Array(2080), 806, 0);
+} catch {}
+try {
+computePassEncoder218.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(12, 0, 14, 5);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(82).fill(232), /* required buffer size: 82 */
+{offset: 82, bytesPerRow: 1}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let texture233 = device0.createTexture({
+  label: '\u77df\ub180\u{1fea1}\u06e9\u{1f6f4}\u0464\ua291',
+  size: [160, 150, 1],
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba32float'],
+});
+let renderPassEncoder49 = commandEncoder238.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  clearValue: { r: -75.87, g: 2.361, b: -248.2, a: 855.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView152,
+  depthSlice: 0,
+  clearValue: { r: 97.80, g: 988.1, b: -340.8, a: -18.49, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler136 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.21,
+  compare: 'greater',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer125, 0, 5_126);
+} catch {}
+await gc();
+let buffer150 = device0.createBuffer({
+  size: 7841,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture234 = device0.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler137 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 8.438,
+  lodMaxClamp: 36.26,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder217.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup74, new Uint32Array(881), 5, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 24}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 38, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise36;
+} catch {}
+let textureView218 = texture90.createView({baseMipLevel: 0, baseArrayLayer: 0});
+document.body.prepend(video5);
+let shaderModule14 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+var<private> vp19 = modf(vec3h());
+
+var<workgroup> vw47: mat2x3f;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw50: mat4x3h;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(72) var tex12: texture_2d<f32>;
+
+var<workgroup> vw56: mat3x2h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn fn2() -> T0 {
+  var out: T0;
+  fn1(VertexOutput9(bitcast<vec4f>((*&vw54).f0.gggr)));
+  var vf226: f32 = (*&vw47)[1][2];
+  fn0(S5(vec4f(vw49[0][4].yxxy), vec4u(vw49[0][4].xxyx)), mat4x3h((*&vw49)[0][4].yxx, (*&vw49)[0][4].ggg, (*&vw49)[0][4].xxy, (*&vw49)[0][4].rgr));
+  var vf227 = fn0(S5(vec4f((*&vw57).f0.grrr), bitcast<vec4u>((*&vw57).f0.yxxx)), (*&vw50));
+  vw47 += mat2x3f(vec3f((*&vw50)[0]), vec3f((*&vw50)[2]));
+  var vf228 = fn1(VertexOutput9(vec4f(f32((*&vw54).f0[0]))));
+  fn0(S5(vec4f((*&vw52).f1), (*&vw52).f1), mat4x3h(workgroupUniformLoad(&vw49)[0][4].yxx, workgroupUniformLoad(&vw49)[0][4].ggg, workgroupUniformLoad(&vw49)[0][4].xyy, workgroupUniformLoad(&vw49)[0][4].rgg));
+  fn0(S5(vec4f(f32(atomicLoad(&vw58))), vec4u(u32(atomicLoad(&vw58)))), mat4x3h(f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3]), f16(vf228[3])));
+  vw51 = vec2<bool>((*&vw53)[12].f0);
+  var vf229 = fn0(S5(textureLoad(tex12, vec2i(unconst_i32(162), unconst_i32(81)), i32(unconst_i32(8))), bitcast<vec4u>(textureLoad(tex12, vec2i(unconst_i32(162), unconst_i32(81)), i32(unconst_i32(8))))), mat4x3h(vec3h((*&vw57).f0.xxy), vec3h((*&vw57).f0.ggg), vec3h((*&vw57).f0.grr), vec3h((*&vw57).f0.yxx)));
+  let ptr128: ptr<workgroup, mat3x2h> = &(*&vw56);
+  return out;
+}
+
+var<workgroup> vw52: S5;
+
+struct T1 {
+  @size(36) f0: array<array<atomic<i32>, 1>>,
+}
+
+fn fn0(a0: S5, a1: mat4x3h) -> array<i32, 6> {
+  var out: array<i32, 6>;
+  let vf219: f16 = distance(vec4h(tan(f16(radians(vec4f(f32(a1[3][0])))[1]))), vec4h(unconst_f16(5266.3), unconst_f16(10016.2), unconst_f16(14286.5), unconst_f16(5210.2)));
+  var vf220: S5 = a0;
+  vp19 = modf(vec3h(f16(pack4xU8Clamp(vec4u(unconst_u32(49), unconst_u32(250), unconst_u32(21), unconst_u32(135))))));
+  return out;
+}
+
+var<workgroup> vw54: S6;
+
+var<workgroup> vw53: array<S6, 13>;
+
+var<workgroup> vw57: S6;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw58: atomic<i32>;
+
+var<workgroup> vw51: vec2<bool>;
+
+struct S5 {
+  @location(7) f0: vec4f,
+  @location(15) @interpolate(flat) f1: vec4u,
+}
+
+@group(0) @binding(159) var<storage, read_write> buffer151: T1;
+
+struct S6 {
+  @location(3) f0: vec2i,
+}
+
+struct T0 {
+  @align(4) f0: vec2f,
+  @align(4) @size(32) f1: vec4u,
+}
+
+var<workgroup> vw49: array<array<vec2h, 5>, 1>;
+
+var<workgroup> vw48: mat2x3h;
+
+struct VertexOutput9 {
+  @builtin(position) f30: vec4f,
+}
+
+fn fn1(a0: VertexOutput9) -> vec4<bool> {
+  var out: vec4<bool>;
+  var vf221: vec2u = textureDimensions(tex12, bitcast<i32>(textureDimensions(tex12, i32(unconst_i32(165))).y));
+  vf221 -= vec2u(vp19.fract.zy);
+  vp19 = modf(log(vec2h(atanh(vec2f(unconst_f32(0.02599), unconst_f32(0.5174))))).xxy);
+  let vf222: VertexOutput9 = a0;
+  vp19.fract -= vec3h(f16(pack4xI8(vec4i(unconst_i32(399), unconst_i32(122), unconst_i32(57), unconst_i32(-6)))));
+  var vf223: vec4f = vf222.f30;
+  out = vec4<bool>(asin(vec4f(unconst_f32(0.00020), unconst_f32(0.04478), unconst_f32(0.06387), unconst_f32(0.1599))));
+  var vf224: vec2h = log(vec2h(unconst_f16(-3773.1), unconst_f16(5001.7)));
+  let vf225: vec4f = vf222.f30;
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw55: bool;
+
+@vertex @must_use
+fn vertex11(@location(5) @interpolate(linear) a0: vec2h, @location(6) @interpolate(linear) a1: vec2f, @location(11) a2: vec2f, @location(2) @interpolate(flat) a3: vec4i, a4: S5, @location(8) @interpolate(linear) a5: f16, a6: S6) -> VertexOutput9 {
+  var out: VertexOutput9;
+  let vf230: vec4f = a4.f0;
+  vp19 = modf(vec3h(a0[0]));
+  var vf231 = fn0(S5(atanh(vec3f(unconst_f32(0.08518), unconst_f32(-0.6633), unconst_f32(-0.1171))).xxzx, bitcast<vec4u>(atanh(vec3f(unconst_f32(0.08518), unconst_f32(-0.6633), unconst_f32(-0.1171))).yyyx)), mat4x3h(vec3h(unpack2x16unorm(u32(unconst_u32(58))).yxy), vec3h(unpack2x16unorm(u32(unconst_u32(58))).rgg), vec3h(unpack2x16unorm(u32(unconst_u32(58))).yxx), vec3h(unpack2x16unorm(u32(unconst_u32(58))).yyx)));
+  return out;
+}
+
+@fragment
+fn fragment11() -> @location(200) @interpolate(flat) vec4f {
+  var out: vec4f;
+  atomicCompareExchangeWeak(&buffer151.f0[u32(unconst_u32(129))][0], unconst_i32(135), unconst_i32(326));
+  vp19 = modf(vec3h(f16(extractBits(i32(unconst_i32(-60)), u32(unconst_u32(188)), u32(unconst_u32(110))))));
+  vp19.fract += vec3h(quantizeToF16(vec3f(f32(sinh(f16(arrayLength(&(*&buffer151).f0)))))));
+  let ptr129: ptr<storage, atomic<i32>, read_write> = &(*&buffer151).f0[arrayLength(&(*&buffer151).f0)][0];
+  var vf232 = fn1(VertexOutput9(vec4f(vp19.fract.brbb)));
+  atomicMax(&buffer151.f0[u32(atomicLoad(&(*&buffer151).f0[arrayLength(&(*&buffer151).f0)][0]))][u32(unconst_u32(49))], vec3i(vp19.whole)[2]);
+  out *= vec4f(bitcast<f32>(atomicLoad(&(*ptr129))));
+  fn1(VertexOutput9(vec4f(f32(atomicLoad(&buffer151.f0[arrayLength(&buffer151.f0)][0])))));
+  vp19 = modf(vec3h(f16(pack4xU8(vec4u(firstTrailingBit(vec3i(unconst_i32(-112), unconst_i32(48), unconst_i32(33))).zzyy)))));
+  let vf233: vec3f = sinh(vec3f(unconst_f32(0.00963), unconst_f32(0.01993), unconst_f32(0.1397)));
+  out = bitcast<vec4f>(textureDimensions(tex12, i32(unconst_i32(-138))).grrg);
+  var vf234: vec3i = firstTrailingBit(vec3i(bitcast<i32>(pack4xU8(vec4u(unconst_u32(0), unconst_u32(186), unconst_u32(462), unconst_u32(197))))));
+  var vf235: vec2u = textureDimensions(tex12);
+  var vf236: bool = any(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false), unconst_bool(false)));
+  let ptr130: ptr<storage, atomic<i32>, read_write> = &(*ptr129);
+  vp19 = modf(vec3h(step(f16(unconst_f16(2339.2)), f16(unconst_f16(1504.3)))));
+  out = vec4f(bitcast<f32>(atomicLoad(&(*ptr130))));
+  fn1(VertexOutput9(quantizeToF16(vec3f(unconst_f32(0.5383), unconst_f32(0.3199), unconst_f32(-0.05391))).rrbr));
+  vf235 *= vec2u(u32(atomicLoad(&(*&buffer151).f0[arrayLength(&(*&buffer151).f0)][0])));
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 2)
+fn compute14() {
+  vw57 = (*&vw53)[12];
+  atomicStore(&vw58, workgroupUniformLoad(&vw53)[12].f0.g);
+  vw57 = S6(bitcast<vec2i>(workgroupUniformLoad(&vw52).f1.ga));
+  var vf237: f16 = vw49[0][4][1];
+  let ptr131: ptr<workgroup, vec2h> = &(*&vw49)[0][4];
+  fn2();
+  vw53[u32(unconst_u32(124))] = S6(vec2i(vw52.f1.ar));
+  let ptr132: ptr<workgroup, array<array<vec2h, 5>, 1>> = &vw49;
+  let ptr133: ptr<workgroup, array<vec2h, 5>> = &(*&vw49)[0];
+  vp19 = modf(vec3h(textureDimensions(tex12, i32(unconst_i32(217))).ggr));
+  fn0(S5(vec4f((*ptr133)[4].xyyy), vec4u((*ptr133)[4].rgrg)), mat4x3h(vec3h(vw57.f0.yyy), vec3h(vw57.f0.ggg), vec3h(vw57.f0.grr), vec3h(vw57.f0.xxy)));
+  fn0(S5(vec4f(faceForward(vec3h(workgroupUniformLoad(&vw54).f0.grr), vw50[3], vec3h(unconst_f16(-10951.9), unconst_f16(15050.2), unconst_f16(33702.8))).rggb), vec4u(faceForward(vec3h(workgroupUniformLoad(&vw54).f0.grr), vw50[3], vec3h(unconst_f16(-10951.9), unconst_f16(15050.2), unconst_f16(33702.8))).grbg)), mat4x3h((*ptr132)[u32(unconst_u32(98))][4].yyy, (*ptr132)[u32(unconst_u32(98))][4].yxy, (*ptr132)[u32(unconst_u32(98))][4].grr, (*ptr132)[u32(unconst_u32(98))][4].yxy));
+  var vf238 = fn0(S5(vec4f(exp(vec2h(unconst_f16(13859.4), unconst_f16(5754.9))).rrgg), vec4u(exp(vec2h(unconst_f16(13859.4), unconst_f16(5754.9))).rrgg)), mat4x3h(vec3h(workgroupUniformLoad(&vw57).f0.rgg), vec3h(workgroupUniformLoad(&vw57).f0.rgg), vec3h(workgroupUniformLoad(&vw57).f0.yyy), vec3h(workgroupUniformLoad(&vw57).f0.rrr)));
+  var vf239 = fn0(S5(textureLoad(tex12, vec2i(unconst_i32(87), unconst_i32(22)), i32(unconst_i32(-22))), vec4u(textureLoad(tex12, vec2i(unconst_i32(87), unconst_i32(22)), i32(unconst_i32(-22))))), mat4x3h(f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1]), f16((*&vw52).f0[1])));
+  vf237 = f16(atomicLoad(&vw58));
+  let vf240: i32 = atomicLoad(&vw58);
+  vw51 = vec2<bool>(bool((*&vw57).f0[1]));
+  fn1(VertexOutput9(vec4f(vw49[vec3u((*&vw50)[1]).y][4].rrgg)));
+  fn1(VertexOutput9(vec4f(vw52.f1)));
+  var vf241 = fn2();
+  var vf242 = fn2();
+}`,
+  hints: {},
+});
+let buffer152 = device0.createBuffer({size: 18537, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder217.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer60, 'uint16', 3_644, 2_658);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(1, buffer86, 10_956, 907);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 37, y: 64, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer153 = device0.createBuffer({
+  size: 2124,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let texture235 = device0.createTexture({
+  size: [80, 75, 1],
+  sampleCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView219 = texture19.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder173.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+computePassEncoder154.setBindGroup(3, bindGroup101, new Uint32Array(85), 25, 0);
+} catch {}
+let bindGroup123 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [
+    {binding: 443, resource: textureView172},
+    {binding: 36, resource: textureView56},
+    {binding: 96, resource: textureView158},
+    {binding: 25, resource: textureView37},
+    {binding: 4, resource: {buffer: buffer118, offset: 256, size: 1368}},
+    {binding: 358, resource: {buffer: buffer40, offset: 1792}},
+    {binding: 73, resource: {buffer: buffer35, offset: 1536}},
+    {binding: 485, resource: {buffer: buffer20, offset: 2304, size: 1586}},
+    {binding: 23, resource: textureView169},
+    {binding: 18, resource: textureView166},
+    {binding: 329, resource: textureView165},
+    {binding: 14, resource: textureView81},
+    {binding: 215, resource: textureView62},
+    {binding: 278, resource: sampler78},
+    {binding: 40, resource: textureView146},
+    {binding: 347, resource: sampler29},
+    {binding: 105, resource: {buffer: buffer26, offset: 5120, size: 1396}},
+    {binding: 434, resource: sampler89},
+    {binding: 64, resource: textureView146},
+  ],
+});
+let buffer154 = device0.createBuffer({size: 8025, usage: GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup101, new Uint32Array(2891), 350, 0);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer17, 0, 3_481);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+await gc();
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\u02e0\ub9e8',
+  entries: [
+    {
+      binding: 81,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView220 = texture93.createView({label: '\u9bca\u{1fa25}\u0a74\u8821\u4c0c\u2673\u{1f95e}\u{1feec}\u{1f77a}'});
+try {
+computePassEncoder65.pushDebugGroup('\u0f7f');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer138, 1176, new Int16Array(3596), 184, 652);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+adapter1.label = '\u25b6\u455e\ua803\ue6e2\u{1f97d}\u{1fa50}\u{1f9be}';
+} catch {}
+try {
+canvas3.getContext('bitmaprenderer');
+} catch {}
+let buffer155 = device0.createBuffer({size: 2584, usage: GPUBufferUsage.MAP_READ});
+let texture236 = device0.createTexture({
+  label: '\u0626\u4c37\ucbd1\u0913\u08cb\u0206\u4260\u{1ff26}',
+  size: [10, 12, 19],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder20.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder41.setViewport(8.01777469198233, 6.886464884911604, 1.917314536795682, 3.658795068564271, 0.5994479497267251, 0.7059448614571542);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer50, 7_020, 1_378);
+} catch {}
+try {
+  await shaderModule12.getCompilationInfo();
+} catch {}
+let buffer156 = device0.createBuffer({size: 21872, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView221 = texture184.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup6, new Uint32Array(526), 75, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer97, 1808, new BigUint64Array(8225), 773, 548);
+} catch {}
+video2.width = 11;
+let shaderModule15 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(36) f0: u32,
+}
+
+@group(0) @binding(72) var tex13: texture_2d<f32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw65: array<array<f32, 2>, 2>;
+
+var<workgroup> vw61: array<i32, 9>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw63: array<u32, 7>;
+
+var<workgroup> vw64: T0;
+
+@group(0) @binding(159) var<storage, read_write> buffer157: T1;
+
+var<workgroup> vw60: T0;
+
+var<workgroup> vw59: atomic<u32>;
+
+var<private> vp20: T0 = T0();
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(42395) override override33 = false;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  @size(36) f0: array<u32>,
+}
+
+var<workgroup> vw62: T0;
+
+@fragment
+fn fragment12() -> @location(200) vec4f {
+  var out: vec4f;
+  buffer157 = buffer157;
+  out *= vec4f(atan2(f32(insertBits(textureDimensions(tex13, i32(unconst_i32(-49))).r, u32(unconst_u32(108)), u32(unconst_u32(71)), u32(unconst_u32(75)))), f32(buffer157.f0[arrayLength(&buffer157.f0) - 1])));
+  let ptr134: ptr<storage, u32, read_write> = &(*&buffer157).f0[pack4xU8Clamp(bitcast<vec4u>(insertBits(vec4i(unconst_i32(420), unconst_i32(335), unconst_i32(291), unconst_i32(-119)), unpack4xI8(arrayLength(&(*&buffer157).f0)), textureDimensions(tex13)[1], u32(unconst_u32(114)))))];
+  let ptr135: ptr<private, u32> = &vp20.f0;
+  let ptr136: ptr<storage, u32, read_write> = &buffer157.f0[bitcast<u32>(textureLoad(tex13, vec2i(unconst_i32(-111), unconst_i32(530)), vec2i(textureDimensions(tex13, i32(length(f16(unconst_f16(-27261.0)))))).x).a)];
+  let ptr137: ptr<storage, array<u32>, read_write> = &(*&buffer157).f0;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute15(@builtin(global_invocation_id) a0: vec3u) {
+  let ptr138: ptr<workgroup, u32> = &(*&vw60).f0;
+  let vf243: u32 = atomicExchange(&(*&vw59), u32(unconst_u32(230)));
+  vp20.f0 += (*&vw64).f0;
+  var vf244: u32 = vf243;
+  let ptr139: ptr<workgroup, atomic<u32>> = &(*&vw59);
+  let ptr140: ptr<workgroup, i32> = &(*&vw61)[8];
+  let vf245: i32 = insertBits(i32(unconst_i32(37)), i32(workgroupUniformLoad(&vw64).f0), u32(unconst_u32(162)), u32(unconst_u32(313)));
+  let ptr141: ptr<workgroup, u32> = &vw63[6];
+  var vf246: vec3h = cross(vec3h(f16(vw61[8])), vec3h(f16(vw60.f0)));
+  vw60.f0 *= (*&vw64).f0;
+  var vf247: u32 = vf243;
+  vw65[a0[0]][u32(unconst_u32(25))] = inverseSqrt(f32(pack4x8snorm(vec4f((*&vw65)[1][1]))));
+  vf244 *= vw62.f0;
+  let ptr142: ptr<function, vec3h> = &vf246;
+  let ptr143: ptr<workgroup, u32> = &(*&vw64).f0;
+  let ptr144: ptr<workgroup, u32> = &(*&vw60).f0;
+  var vf248: array<i32, 9> = workgroupUniformLoad(&vw61);
+  vf246 -= vec3h(f16((*&vw65)[1][1]));
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute16(@builtin(local_invocation_index) a0: u32) {
+  vw60 = T0((*&vw63)[6]);
+  vw64.f0 += vw62.f0;
+  let ptr145: ptr<workgroup, u32> = &vw62.f0;
+  let ptr146: ptr<workgroup, u32> = &vw60.f0;
+  let ptr147: ptr<workgroup, i32> = &(*&vw61)[8];
+  let ptr148: ptr<workgroup, f32> = &vw65[1][1];
+  let ptr149: ptr<workgroup, f32> = &(*&vw65)[1][u32(unconst_u32(548))];
+  let ptr150: ptr<workgroup, u32> = &vw62.f0;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 314, resource: {buffer: buffer148, offset: 0, size: 116}},
+    {binding: 224, resource: {buffer: buffer138, offset: 2816, size: 156}},
+    {binding: 429, resource: textureView25},
+    {binding: 56, resource: textureView131},
+    {binding: 315, resource: textureView117},
+  ],
+});
+try {
+computePassEncoder166.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+computePassEncoder100.setBindGroup(2, bindGroup86, new Uint32Array(1748), 578, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle18, renderBundle0, renderBundle11, renderBundle18, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer140, 'uint16', 346, 19);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 9, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let textureView222 = texture41.createView({mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 2});
+let texture237 = device0.createTexture({
+  size: {width: 10},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder170.setBindGroup(3, bindGroup114, new Uint32Array(5514), 497, 0);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 269.0, g: 495.9, b: -833.3, a: -825.6, });
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(1, buffer109);
+} catch {}
+try {
+computePassEncoder65.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 4084, new Int16Array(4495), 860, 1608);
+} catch {}
+let buffer158 = device0.createBuffer({
+  label: '\u0476\udbed\u9737\u{1f78f}\u4cfe\u{1fdac}\u{1fe0a}',
+  size: 5896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+  mappedAtCreation: false,
+});
+let commandEncoder239 = device0.createCommandEncoder({});
+let textureView223 = texture56.createView({dimension: '2d'});
+try {
+computePassEncoder199.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle17, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder21.setViewport(12.5496842759458, 106.72378969184997, 142.40858827189797, 31.876366937185775, 0.022362938365994123, 0.5626955993007833);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+  await promise35;
+} catch {}
+await gc();
+let bindGroup125 = device0.createBindGroup({
+  label: '\u3ae8\u3a3c',
+  layout: bindGroupLayout2,
+  entries: [{binding: 44, resource: textureView209}, {binding: 47, resource: {buffer: buffer25, offset: 0}}],
+});
+let commandEncoder240 = device0.createCommandEncoder({label: '\ud0b2\u093e\ue429\u0c46\u0110\u4e68\ua356\u071f\u4053'});
+let computePassEncoder219 = commandEncoder239.beginComputePass({});
+let sampler138 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.54,
+  maxAnisotropy: 4,
+});
+let externalTexture22 = device0.importExternalTexture({source: video4});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup25, new Uint32Array(3920), 882, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup80);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 372, new BigUint64Array(6868), 750, 76);
+} catch {}
+document.body.prepend(video0);
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer159 = device0.createBuffer({size: 6201, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let textureView224 = texture218.createView({dimension: '2d', baseMipLevel: 0});
+let computePassEncoder220 = commandEncoder240.beginComputePass({label: '\u4cf6\u9af7\u{1fdff}\u8c94\u476a\u54d5\udc45\u{1fe7d}\u{1f703}\u{1f81c}'});
+let sampler139 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder219.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup90, new Uint32Array(861), 320, 0);
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'iec61966-2-1'} });
+let bindGroup126 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 67, resource: {buffer: buffer138, offset: 0, size: 40}},
+    {binding: 123, resource: textureView10},
+  ],
+});
+try {
+computePassEncoder107.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder186.setBindGroup(3, bindGroup80, new Uint32Array(1181), 53, 0);
+} catch {}
+try {
+computePassEncoder220.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup79, new Uint32Array(136), 24, 0);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(17, 3, 0, 19);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer138, 'uint16', 1_208, 2_158);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2043 */
+  offset: 2043,
+  bytesPerRow: 10496,
+  buffer: buffer129,
+}, {
+  texture: texture190,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder99.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 12, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 656 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 976 */
+  offset: 976,
+  bytesPerRow: 23552,
+  buffer: buffer83,
+}, {width: 41, height: 93, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise34;
+} catch {}
+let imageData27 = new ImageData(44, 88);
+let commandEncoder241 = device0.createCommandEncoder({});
+let textureView225 = texture33.createView({aspect: 'all'});
+let sampler140 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.15,
+});
+try {
+computePassEncoder187.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup95, new Uint32Array(1051), 42, 0);
+} catch {}
+try {
+renderPassEncoder32.setScissorRect(77, 15, 2, 8);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer50);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u2f77\u{1fa69}\uafeb\u2a54\u00e8\u5b4c',
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T1 {
+  f0: array<u32>,
+}
+
+struct T0 {
+  @size(4) f0: f16,
+}
+
+struct FragmentOutput9 {
+  @location(0) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+}
+
+@group(0) @binding(47) var<uniform> buffer160: array<u32, 1>;
+
+@group(0) @binding(44) var tex14: texture_1d<i32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn2() -> mat2x3h {
+  var out: mat2x3h;
+  var vf252: vec3f = atan2(vec3f(unconst_f32(0.01735), unconst_f32(0.1105), unconst_f32(0.00964)), vec3f(bitcast<f32>(textureDimensions(tex14))));
+  var vf253: f32 = vf252[1];
+  let vf254: vec3f = ldexp(vec3f(unconst_f32(0.2482), unconst_f32(0.02641), unconst_f32(0.03768)), vec3i(i32(pack2x16unorm(vec2f(f32(textureNumLevels(tex14)))))));
+  let vf255: vec2f = fma(vec2f(unconst_f32(0.04749), unconst_f32(0.1226)), vec2f(unconst_f32(0.3392), unconst_f32(0.4430)), vec2f(unconst_f32(0.2524), unconst_f32(0.1297)));
+  vf253 += bitcast<f32>(pack2x16snorm(vec2f(f32(buffer160[0]))));
+  vf253 = bitcast<f32>(textureDimensions(tex14, 0i));
+  let vf256: vec3h = select(vec3h(f16(pow(f32(unconst_f32(0.2939)), vf255[0]))), vec3h(unconst_f16(4375.1), unconst_f16(3391.4), unconst_f16(7544.4)), vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true)));
+  let ptr152: ptr<uniform, u32> = &(*&buffer160)[0];
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn0(a0: ptr<uniform, T0>) -> array<array<f16, 1>, 102> {
+  var out: array<array<f16, 1>, 102>;
+  out[vec4u(cos(vec4f(unconst_f32(0.3538), unconst_f32(0.1545), unconst_f32(0.04406), unconst_f32(0.08106)))).a][pack2x16unorm(cosh(vec2f(f32((*a0).f0))))] *= f16(all(vec2<bool>(unconst_bool(true), unconst_bool(false))));
+  vp21 = vec2h(floor(vec2f(unconst_f32(0.03019), unconst_f32(0.01061))))[1];
+  let ptr151: ptr<private, f16> = &vp21;
+  out[u32((*a0).f0)][u32(unconst_u32(311))] = vec2h(cosh(ldexp(vec4f(unconst_f32(0.1050), unconst_f32(-0.02195), unconst_f32(0.2058), unconst_f32(0.02669)), vec4i(unconst_i32(211), unconst_i32(68), unconst_i32(112), unconst_i32(49))).xy)).r;
+  let vf249: vec2f = atanh(vec2f(unconst_f32(0.4171), unconst_f32(0.08836)));
+  return out;
+}
+
+struct VertexOutput10 {
+  @builtin(position) f31: vec4f,
+  @location(11) @interpolate(flat, centroid) f32: vec2u,
+}
+
+fn fn1(a0: ptr<storage, array<u32>, read_write>) -> array<T0, 3> {
+  var out: array<T0, 3>;
+  out[u32(unconst_u32(178))].f0 = f16(arrayLength(&(*a0)));
+  out[u32(unconst_u32(419))] = T0(mix(vec3h(unconst_f16(4598.3), unconst_f16(7464.2), unconst_f16(15550.6)), vec3h(unconst_f16(2909.1), unconst_f16(10826.9), unconst_f16(8253.6)), cos(vec4h(unconst_f16(16527.6), unconst_f16(12078.6), unconst_f16(1557.3), unconst_f16(752.9)))[0])[2]);
+  let vf250: vec3h = normalize(vec3h(unconst_f16(15087.0), unconst_f16(10723.5), unconst_f16(2849.5)));
+  vp21 = f16(determinant(mat4x4f(unconst_f32(0.1444), unconst_f32(0.04537), unconst_f32(0.1864), unconst_f32(0.01535), unconst_f32(0.2634), unconst_f32(0.3415), unconst_f32(0.5347), unconst_f32(-0.07960), unconst_f32(0.08667), unconst_f32(0.08646), unconst_f32(0.1305), unconst_f32(0.05852), unconst_f32(-0.1629), unconst_f32(0.00940), unconst_f32(0.3977), unconst_f32(0.2833))));
+  vp21 = f16(fma(unpack2x16unorm((*a0)[u32(unconst_u32(124))]), vec2f(f32((*a0)[i32(unconst_i32(201))])), vec2f(unconst_f32(0.03295), unconst_f32(0.2059))).r);
+  (*a0)[u32(unconst_u32(250))] = u32(transpose(mat2x3f(unconst_f32(-0.3920), unconst_f32(0.1863), unconst_f32(0.02300), unconst_f32(0.1492), unconst_f32(0.5137), unconst_f32(0.04502)))[2][1]);
+  out[u32(unconst_u32(85))].f0 -= vf250[2];
+  out[u32(unconst_u32(219))].f0 -= f16((*a0)[i32(unconst_i32(13))]);
+  out[2].f0 = f16((*a0)[arrayLength(&(*a0))]);
+  out[u32(vf250[2])] = T0(f16(dot4U8Packed(u32(unconst_u32(23)), u32(vp21))));
+  (*a0)[vec3u(normalize(vec3h(f16(pack4xU8Clamp(vec4u(unconst_u32(125), unconst_u32(9), unconst_u32(539), unconst_u32(56)))))))[2]] |= bitcast<u32>(determinant(mat4x4f(sqrt(vec4f(bitcast<f32>(textureDimensions(tex14, 0i)))), sqrt(vec4f(bitcast<f32>(textureDimensions(tex14, 0i)))), sqrt(vec4f(bitcast<f32>(textureDimensions(tex14, 0i)))), sqrt(vec4f(bitcast<f32>(textureDimensions(tex14, 0i)))))));
+  let vf251: u32 = dot4U8Packed(u32(unconst_u32(446)), u32(unconst_u32(161)));
+  (*a0)[pack4xU8Clamp(vec4u(cos(vec4h(unconst_f16(12642.2), unconst_f16(15409.4), unconst_f16(13833.9), unconst_f16(5596.1)))))] <<= arrayLength(&(*a0));
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp21: f16 = f16();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex12(@location(1) @interpolate(flat, sample) a0: i32) -> VertexOutput10 {
+  var out: VertexOutput10;
+  out.f31 -= vec4f(f32(countOneBits(i32(degrees(f32(unconst_f32(0.3650)))))));
+  vp21 = exp(f16(a0));
+  var vf257: f16 = exp(f16(unconst_f16(818.5)));
+  return out;
+}
+
+@fragment
+fn fragment13(@builtin(position) a0: vec4f) -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  out.f1 >>= buffer160[u32(unconst_u32(96))];
+  let vf258: u32 = pack4xU8(bitcast<vec4u>(a0));
+  let ptr153: ptr<uniform, u32> = &(*&buffer160)[0];
+  var vf259: u32 = pack4x8snorm(vec4f(unconst_f32(0.07295), unconst_f32(0.1458), unconst_f32(0.08467), unconst_f32(0.07073)));
+  var vf260: f16 = length(vec2h(atan(bitcast<vec4f>(unpack4xI8(pack4x8snorm(vec4f(unconst_f32(0.01466), unconst_f32(-0.1306), unconst_f32(0.01683), unconst_f32(0.04793)))))).rg));
+  vf259 = pack4x8snorm(atan2(vec4f(unconst_f32(0.2110), unconst_f32(0.03551), unconst_f32(0.03701), unconst_f32(-0.1595)), vec4f(unconst_f32(0.3744), unconst_f32(0.02744), unconst_f32(0.1697), unconst_f32(0.2634))));
+  out.f1 += pack2x16snorm(pow(vec2f(unconst_f32(0.1211), unconst_f32(0.00413)), unpack2x16unorm(buffer160[u32(unconst_u32(45))])));
+  var vf261: u32 = pack4x8snorm(vec4f(unconst_f32(0.01355), unconst_f32(0.07954), unconst_f32(0.00930), unconst_f32(0.1761)));
+  let ptr154: ptr<function, f16> = &vf260;
+  out.f1 ^= (*&buffer160)[buffer160[u32(unconst_u32(67))]];
+  var vf262: u32 = pack4x8snorm(vec4f(unconst_f32(0.04971), unconst_f32(-0.1576), unconst_f32(0.09092), unconst_f32(0.05665)));
+  vf259 >>= vf259;
+  out.f1 &= bitcast<vec3u>(exp2(vec3f(f32((*ptr154)))))[0];
+  let ptr155: ptr<function, u32> = &vf259;
+  vf262 -= (*ptr153);
+  let ptr156: ptr<function, f16> = &(*ptr154);
+  let ptr157: ptr<function, u32> = &vf259;
+  vp21 += f16((*&buffer160)[u32(unconst_u32(225))]);
+  let vf263: vec3h = asinh(vec3h(f16(buffer160[0])));
+  let vf264: vec4f = atan(unpack4x8snorm((*ptr155)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute17() {
+  let ptr158: ptr<uniform, u32> = &buffer160[0];
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute18() {
+  vp21 -= vec2h(refract(tan(vec2f(unconst_f32(0.04226), unconst_f32(0.06354))), unpack2x16snorm(buffer160[0]), f32(unconst_f32(0.1646)))).r;
+  let ptr159: ptr<uniform, u32> = &(*&buffer160)[0];
+  fn2();
+  vp21 -= vec2h(saturate(vec2f(bitcast<f32>((*&buffer160)[0]))))[1];
+  var vf265: vec2f = saturate(vec2f(unconst_f32(0.2882), unconst_f32(-0.06924)));
+  var vf266: vec4i = textureLoad(tex14, vec4i(smoothstep(vec4h(unconst_f16(202.3), unconst_f16(10532.6), unconst_f16(1798.7), unconst_f16(1890.9)), vec4h(unconst_f16(10333.7), unconst_f16(1242.7), unconst_f16(4551.6), unconst_f16(3081.9)), vec4h(unconst_f16(1859.2), unconst_f16(11059.2), unconst_f16(13796.2), unconst_f16(17468.0)))).w, i32(unconst_i32(346)));
+  let vf267: u32 = textureDimensions(tex14);
+  vf266 = vec4i(bitcast<i32>(textureDimensions(tex14)));
+  vf266 &= bitcast<vec4i>(refract(vec2f(bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.2152), unconst_f32(0.04347))))), vec2f(unconst_f32(0.02725), unconst_f32(0.1173)), f32(unconst_f32(0.1755))).rgrr);
+  var vf268: u32 = textureNumLevels(tex14);
+}`,
+  hints: {},
+});
+let bindGroup127 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler133}]});
+let buffer161 = device0.createBuffer({
+  size: 7753,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder242 = device0.createCommandEncoder({});
+let computePassEncoder221 = commandEncoder99.beginComputePass({});
+let sampler141 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.388,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder30.setIndexBuffer(buffer156, 'uint32', 728, 552);
+} catch {}
+let bindGroup128 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer50, offset: 13568, size: 3020}}],
+});
+let commandEncoder243 = device0.createCommandEncoder({label: '\u2551\u12d6\u9edb\u0d3c\u646b\u{1fc21}\u0fc1\u{1fcca}'});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: [undefined], depthReadOnly: true});
+let externalTexture23 = device0.importExternalTexture({source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder221.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(457);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup119, new Uint32Array(6115), 1_492, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 5540, new BigUint64Array(2934), 177, 12);
+} catch {}
+let commandEncoder244 = device0.createCommandEncoder({label: '\u0735\u0cb3'});
+let renderPassEncoder50 = commandEncoder242.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: 358.4, g: 696.6, b: -823.5, a: -822.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 32090756,
+});
+let sampler142 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.06,
+  lodMaxClamp: 61.14,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer65, 'uint16', 1_048, 1_125);
+} catch {}
+try {
+commandEncoder244.copyTextureToBuffer({
+  texture: texture231,
+  mipLevel: 0,
+  origin: {x: 12, y: 11, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 560 */
+  offset: 560,
+  bytesPerRow: 1024,
+  buffer: buffer65,
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView226 = texture230.createView({aspect: 'all', baseArrayLayer: 2, arrayLayerCount: 19});
+let textureView227 = texture41.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let renderPassEncoder51 = commandEncoder244.beginRenderPass({
+  colorAttachments: [{view: textureView103, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 64029879,
+});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup93, new Uint32Array(60), 1, 0);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup42, new Uint32Array(1098), 110, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(5, buffer37, 3_456);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+pipelineLayout16.label = '\u0ca7\u{1fb06}\u0a4d\u0eb6\u012f\uc8b8\u64a7\u0d76\u{1f854}\u00a5';
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 275, resource: {buffer: buffer18, offset: 2560, size: 2624}}],
+});
+let renderPassEncoder52 = commandEncoder241.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: -270.0, g: -123.5, b: 352.7, a: 760.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 161600679,
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({label: '\u368a\ud3bc\u5508\ucaf0\u56f1\u17e9', colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+let externalTexture24 = device0.importExternalTexture({label: '\ue860\u6621\u59f1\u01f7\u7aae\u518e\u044f', source: video4});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer19, 'uint16', 1_266, 332);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4, buffer121, 1_628);
+} catch {}
+try {
+commandEncoder243.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 649 */
+  offset: 649,
+  buffer: buffer8,
+}, {
+  texture: texture213,
+  mipLevel: 5,
+  origin: {x: 8, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup130 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 142, resource: {buffer: buffer62, offset: 0, size: 313}}],
+});
+let commandEncoder245 = device0.createCommandEncoder({label: '\u{1fb87}\u{1f792}\u0a27\uc928'});
+let computePassEncoder222 = commandEncoder245.beginComputePass({});
+let sampler143 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.90,
+  lodMaxClamp: 93.95,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder222.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer109, 164, 325);
+} catch {}
+try {
+commandEncoder243.copyBufferToBuffer(buffer19, 1664, buffer86, 1040, 60);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer84, 2080, new DataView(new ArrayBuffer(1539)), 312, 44);
+} catch {}
+let buffer162 = device0.createBuffer({size: 2662, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder246 = device0.createCommandEncoder({});
+let textureView228 = texture142.createView({dimension: '2d', format: 'rgb10a2uint', baseArrayLayer: 7});
+let renderPassEncoder53 = commandEncoder246.beginRenderPass({
+  colorAttachments: [{
+  view: textureView128,
+  clearValue: { r: 469.9, g: 708.2, b: -394.0, a: -82.93, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle24 = renderBundleEncoder25.finish();
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer86, 996, 7_388);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer123);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let imageData28 = new ImageData(24, 32);
+let bindGroup131 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 9, resource: textureView64}]});
+let commandEncoder247 = device0.createCommandEncoder({label: '\u{1fb48}\u0205\u0ee0'});
+let commandBuffer16 = commandEncoder247.finish({});
+let texture238 = device0.createTexture({
+  size: [256, 256, 24],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(3, bindGroup25, new Uint32Array(76), 21, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup125);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer39, 'uint16', 4_904, 900);
+} catch {}
+try {
+commandEncoder243.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4560 */
+  offset: 4560,
+  bytesPerRow: 45312,
+  rowsPerImage: 936,
+  buffer: buffer49,
+}, {
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(video2);
+let commandEncoder248 = device0.createCommandEncoder({});
+try {
+commandEncoder243.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 30288 */
+  offset: 6464,
+  bytesPerRow: 256,
+  rowsPerImage: 90,
+  buffer: buffer146,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 5, y: 12, z: 3},
+  aspect: 'all',
+}, {width: 1, height: 4, depthOrArrayLayers: 2});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let texture239 = device0.createTexture({
+  label: '\u{1f6ad}\u006c',
+  size: {width: 80, height: 75, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle25 = renderBundleEncoder24.finish({label: '\u26c9\u{1f94c}\u{1f63d}'});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup17, new Uint32Array(596), 17, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer65, 'uint16', 2_766, 1_783);
+} catch {}
+try {
+commandEncoder248.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2484 */
+  offset: 2484,
+  bytesPerRow: 12288,
+  buffer: buffer105,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext8 = canvas4.getContext('webgpu');
+let bindGroup132 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 142, resource: {buffer: buffer150, offset: 2304, size: 313}}],
+});
+let textureView229 = texture155.createView({mipLevelCount: 1, arrayLayerCount: 5});
+let computePassEncoder223 = commandEncoder243.beginComputePass({});
+let renderPassEncoder54 = commandEncoder248.beginRenderPass({colorAttachments: [{view: textureView74, depthSlice: 1, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup106);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer95, 'uint16', 410, 1_054);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer24);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView230 = texture199.createView({
+  label: '\ua23f\u{1fd7e}\u82d8\u3598',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 11,
+  arrayLayerCount: 46,
+});
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 22, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder165.insertDebugMarker('\u0593');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 676, new DataView(new ArrayBuffer(4038)), 34, 72);
+} catch {}
+let buffer163 = device0.createBuffer({
+  size: 2288,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder249 = device0.createCommandEncoder({label: '\u{1f8de}\u0d84\ue9d4\u{1fda5}\u{1f818}\u{1fef8}'});
+let texture240 = device0.createTexture({
+  label: '\u{1f7f7}\u6e8b\ud8b1\ua513\u1f13\u{1f7fe}',
+  size: [320],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder55 = commandEncoder249.beginRenderPass({
+  label: '\u2a09\u02dc\u0d8e\u0d0e\ucc2e\u262d\u{1ff49}\u{1fe89}\u014a',
+  colorAttachments: [{
+  view: textureView224,
+  clearValue: { r: -112.1, g: 811.9, b: -363.9, a: -164.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 133577327,
+});
+try {
+computePassEncoder223.setPipeline(pipeline10);
+} catch {}
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpteRp431', transfer: 'linear'} });
+let buffer164 = device0.createBuffer({size: 3075, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder250 = device0.createCommandEncoder();
+let textureView231 = texture98.createView({mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 18});
+let sampler144 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.30,
+  lodMaxClamp: 57.55,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder120.setBindGroup(0, bindGroup86, new Uint32Array(565), 14, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup4, new Uint32Array(1152), 836, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+commandEncoder250.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 476 */
+  offset: 476,
+  buffer: buffer129,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame33,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 1, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer17 = commandEncoder25.finish();
+let texture241 = gpuCanvasContext5.getCurrentTexture();
+let textureView232 = texture37.createView({mipLevelCount: 1});
+let computePassEncoder224 = commandEncoder250.beginComputePass({});
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle24]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder224.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(13, 8, 9, 0);
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup133 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 275, resource: {buffer: buffer77, offset: 512}}]});
+let buffer165 = device0.createBuffer({
+  size: 22783,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder251 = device0.createCommandEncoder({});
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup5, new Uint32Array(2901), 110, 0);
+} catch {}
+try {
+commandEncoder251.copyBufferToBuffer(buffer20, 5168, buffer149, 152, 7876);
+} catch {}
+try {
+commandEncoder251.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 267 */
+  offset: 267,
+  bytesPerRow: 14336,
+  buffer: buffer159,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 0, y: 21, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer166 = device0.createBuffer({size: 4499, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder252 = device0.createCommandEncoder();
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 2756});
+let texture242 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 19},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView233 = texture117.createView({label: '\uc93b\uf920\u3edc\u0b36\u9945\u690c\udad5\u92de\u01db\u0801'});
+try {
+computePassEncoder148.setBindGroup(3, bindGroup100);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup71, new Uint32Array(1558), 159, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(1, buffer8, 0);
+} catch {}
+try {
+commandEncoder251.copyBufferToTexture({
+  /* bytesInLastRow: 1056 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1184 */
+  offset: 1184,
+  buffer: buffer98,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise38 = device0.queue.onSubmittedWorkDone();
+let bindGroup134 = device0.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 81, resource: textureView115}]});
+let commandEncoder253 = device0.createCommandEncoder();
+let textureView234 = texture18.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder56 = commandEncoder252.beginRenderPass({
+  label: '\u{1ff5b}\uccd7',
+  colorAttachments: [{
+  view: textureView228,
+  clearValue: { r: 197.4, g: -482.9, b: -513.1, a: -458.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 40517765,
+});
+try {
+renderPassEncoder24.executeBundles([renderBundle24]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 16}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder254 = device0.createCommandEncoder();
+let sampler145 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.33,
+  lodMaxClamp: 71.42,
+});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup118);
+} catch {}
+let arrayBuffer24 = buffer74.getMappedRange(312, 68);
+try {
+globalThis.someLabel = texture112.label;
+} catch {}
+let commandEncoder255 = device0.createCommandEncoder({});
+let texture243 = gpuCanvasContext5.getCurrentTexture();
+let computePassEncoder225 = commandEncoder253.beginComputePass({});
+try {
+computePassEncoder105.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder225.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(3, bindGroup25, new Uint32Array(1373), 18, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer165, 'uint32', 3_468, 2_728);
+} catch {}
+try {
+commandEncoder255.copyBufferToBuffer(buffer105, 364, buffer25, 48, 420);
+} catch {}
+try {
+commandEncoder251.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1056 */
+  offset: 1056,
+  bytesPerRow: 6400,
+  buffer: buffer67,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture244 = device0.createTexture({
+  label: '\u8136\u{1f74d}\uebdd',
+  size: {width: 80, height: 75, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint'],
+});
+let computePassEncoder226 = commandEncoder255.beginComputePass({});
+let renderPassEncoder57 = commandEncoder251.beginRenderPass({colorAttachments: [{view: textureView156, loadOp: 'load', storeOp: 'discard'}]});
+let externalTexture25 = device0.importExternalTexture({source: video3, colorSpace: 'display-p3'});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup29, []);
+} catch {}
+try {
+computePassEncoder204.pushDebugGroup('\u{1fdbe}');
+} catch {}
+let texture245 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 30},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder58 = commandEncoder254.beginRenderPass({
+  colorAttachments: [{
+  view: textureView224,
+  clearValue: { r: -254.6, g: -785.6, b: 108.1, a: -124.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 41666642,
+});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup131);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer144, 900); };
+} catch {}
+try {
+computePassEncoder226.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup113);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(6, buffer104);
+} catch {}
+let commandEncoder256 = device0.createCommandEncoder({});
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer5, 0, 198);
+} catch {}
+let bindGroup135 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 9, resource: {buffer: buffer112, offset: 1280, size: 1163}}],
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder257 = device0.createCommandEncoder({label: '\u06c7\u{1ffa6}\u024e\ub86a\u0ebf\u07eb\u{1f731}\uac97\u0c43\u2ce2'});
+let texture246 = gpuCanvasContext5.getCurrentTexture();
+let textureView235 = texture192.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer37, 2_796, 1_509);
+} catch {}
+let texture247 = device0.createTexture({
+  size: {width: 20},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder227 = commandEncoder257.beginComputePass({});
+try {
+computePassEncoder186.setBindGroup(1, bindGroup12, new Uint32Array(30), 4, 0);
+} catch {}
+try {
+computePassEncoder227.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 1, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(456).fill(129), /* required buffer size: 456 */
+{offset: 456, bytesPerRow: 10}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 3, y: 3, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u0a6f\u{1f7fc}\u290a',
+  entries: [
+    {
+      binding: 40,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let textureView236 = texture246.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder40.setIndexBuffer(buffer77, 'uint16', 6, 767);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer17);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer9, 7668, 704);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 756, new Float32Array(4071), 1127, 1316);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: img2,
+  origin: { x: 4, y: 2 },
+  flipY: false,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 30, y: 6, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder258 = device0.createCommandEncoder();
+let texture248 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder228 = commandEncoder256.beginComputePass({});
+let renderPassEncoder59 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView214,
+  clearValue: { r: -952.2, g: -676.1, b: -713.2, a: -927.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler146 = device0.createSampler({
+  label: '\u0e10\u0499',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.01,
+  lodMaxClamp: 99.77,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder117); computePassEncoder117.dispatchWorkgroupsIndirect(buffer5, 0); };
+} catch {}
+try {
+computePassEncoder228.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(1, buffer85, 0, 4);
+} catch {}
+let commandEncoder259 = device0.createCommandEncoder({label: '\u{1ffc2}\u695e\u{1f666}\u0b8b\u{1f9bf}\u{1fb3c}\u05af\u0c24'});
+let computePassEncoder229 = commandEncoder259.beginComputePass({});
+let renderPassEncoder60 = commandEncoder258.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 534.0, g: 488.0, b: -214.0, a: 858.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView12, depthSlice: 0, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 113035474,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder117); computePassEncoder117.dispatchWorkgroupsIndirect(buffer43, 572); };
+} catch {}
+try {
+computePassEncoder229.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle7, renderBundle7, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder28.setViewport(32.15672585301638, 46.31470278152584, 5.797708488143038, 1.199644706457858, 0.9720154077500885, 0.9979905977163257);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer71, 1_584);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(39).fill(145), /* required buffer size: 39 */
+{offset: 39, bytesPerRow: 356, rowsPerImage: 15}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 0, y: 18 },
+  flipY: true,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData29 = new ImageData(32, 60);
+let bindGroup136 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 136, resource: externalTexture22},
+    {binding: 145, resource: textureView63},
+    {binding: 33, resource: textureView78},
+  ],
+});
+try {
+computePassEncoder177.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+computePassEncoder147.setBindGroup(0, bindGroup102, new Uint32Array(2081), 299, 1);
+} catch {}
+try {
+renderPassEncoder46.setBlendConstant({ r: -319.1, g: 498.9, b: 848.8, a: 45.86, });
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+computePassEncoder213.setBindGroup(1, bindGroup78, new Uint32Array(4912), 767, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(101).fill(230), /* required buffer size: 101 */
+{offset: 101, bytesPerRow: 225}, {width: 5, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise37;
+} catch {}
+let commandEncoder260 = device0.createCommandEncoder({});
+let externalTexture26 = device0.importExternalTexture({source: video4});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup136);
+} catch {}
+try {
+commandEncoder260.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 576 */
+  offset: 576,
+  bytesPerRow: 13824,
+  buffer: buffer36,
+}, {
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView237 = texture68.createView({});
+try {
+computePassEncoder150.setBindGroup(1, bindGroup104, new Uint32Array(4518), 1_189, 0);
+} catch {}
+try {
+computePassEncoder117.end();
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup98, new Uint32Array(2442), 361, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer138, 'uint32', 328, 5_567);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer132, 4004, buffer103, 4992, 604);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17, commandBuffer16]);
+} catch {}
+await gc();
+let bindGroup137 = device0.createBindGroup({
+  label: '\u{1f6bf}\uf8a7\u1aa5\u08e9',
+  layout: bindGroupLayout16,
+  entries: [{binding: 142, resource: {buffer: buffer27, offset: 0}}],
+});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 15});
+let texture249 = device0.createTexture({
+  size: [160, 150, 44],
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder230 = commandEncoder112.beginComputePass({});
+try {
+computePassEncoder230.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder55.setViewport(156.44194126066122, 114.18828300455051, 0.45559254926406995, 21.115881785253453, 0.09780261991709316, 0.8671558782755446);
+} catch {}
+let promise39 = shaderModule2.getCompilationInfo();
+try {
+buffer125.unmap();
+} catch {}
+try {
+  await buffer44.mapAsync(GPUMapMode.WRITE, 0, 916);
+} catch {}
+try {
+commandEncoder260.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1688 */
+  offset: 1688,
+  bytesPerRow: 25088,
+  buffer: buffer18,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder260.copyTextureToTexture({
+  texture: texture242,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 7, y: 21, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder231 = commandEncoder260.beginComputePass();
+try {
+computePassEncoder83.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer108, 'uint16', 9_158, 5_399);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: img1,
+  origin: { x: 9, y: 0 },
+  flipY: true,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 48, y: 14, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas2);
+try {
+adapter0.label = '\u8726\u0253\ucf39\u5837\u856f\u0cd1\u{1fcae}';
+} catch {}
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder261 = device0.createCommandEncoder({});
+let renderPassEncoder61 = commandEncoder261.beginRenderPass({
+  colorAttachments: [{
+  view: textureView189,
+  clearValue: { r: 541.2, g: 560.1, b: -397.5, a: 317.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 25378016,
+});
+let sampler147 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.8667,
+  lodMaxClamp: 59.18,
+  compare: 'less',
+});
+try {
+computePassEncoder231.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer5, 'uint32', 120, 121);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer129, 'uint32', 908, 437);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(229), /* required buffer size: 6 */
+{offset: 6}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder262 = device0.createCommandEncoder({label: '\u1fbf\u{1fcb0}\u7cbc\u6f0d'});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 639});
+let sampler148 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.18,
+  lodMaxClamp: 93.57,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder96.setBindGroup(3, bindGroup120);
+} catch {}
+try {
+computePassEncoder181.end();
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer128, 'uint16', 832, 2_764);
+} catch {}
+let imageData30 = new ImageData(24, 84);
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt709', transfer: 'smpte240m'} });
+try {
+renderPassEncoder19.setIndexBuffer(buffer141, 'uint32', 164, 28);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+commandEncoder262.copyBufferToBuffer(buffer19, 480, buffer83, 52, 1628);
+} catch {}
+try {
+commandEncoder262.copyTextureToTexture({
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder204.popDebugGroup();
+} catch {}
+let texture250 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 112},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView238 = texture37.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder232 = commandEncoder191.beginComputePass({});
+let renderPassEncoder62 = commandEncoder262.beginRenderPass({
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: 357.9, g: -216.6, b: -871.0, a: -739.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 39578923,
+});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup130, new Uint32Array(2544), 159, 0);
+} catch {}
+try {
+computePassEncoder232.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer128, 'uint32', 564, 1_877);
+} catch {}
+document.body.prepend(video4);
+let bindGroup138 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 136, resource: externalTexture13},
+    {binding: 33, resource: textureView161},
+    {binding: 145, resource: textureView64},
+  ],
+});
+let buffer167 = device0.createBuffer({
+  size: 5825,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder263 = device0.createCommandEncoder({});
+let computePassEncoder233 = commandEncoder263.beginComputePass();
+try {
+computePassEncoder233.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup34, new Uint32Array(5511), 353, 0);
+} catch {}
+try {
+renderPassEncoder43.pushDebugGroup('\u0281');
+} catch {}
+let buffer168 = device0.createBuffer({
+  size: 15514,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler149 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.27,
+  lodMaxClamp: 40.94,
+  compare: 'greater',
+  maxAnisotropy: 20,
+});
+let sampler150 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.18,
+  lodMaxClamp: 49.34,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder189.setBindGroup(3, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup115, new Uint32Array(1332), 18, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: video5,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 7, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let buffer169 = device0.createBuffer({
+  size: 12106,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder173.setBindGroup(2, bindGroup117);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup65, new Uint32Array(2771), 236, 0);
+} catch {}
+try {
+renderPassEncoder43.popDebugGroup();
+} catch {}
+let textureView239 = texture165.createView({format: 'rgba32uint', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder208.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer1, 'uint32', 36, 2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 16}
+*/
+{
+  source: imageData27,
+  origin: { x: 18, y: 4 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(146, 234);
+try {
+computePassEncoder38.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4, buffer142, 96, 1_694);
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+let textureView240 = texture28.createView({label: '\u3500\u71af\u1e46\ub0c8\u05fa\u0a7b\u{1fa5b}\u02cc\u08e0\ubeef'});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup119);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup62, new Uint32Array(512), 20, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer110, 'uint16', 874, 152);
+} catch {}
+try {
+gpuCanvasContext8.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas5.getContext('webgpu');
+let textureView241 = texture87.createView({arrayLayerCount: 1});
+try {
+computePassEncoder81.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup92, new Uint32Array(1628), 83, 0);
+} catch {}
+try {
+renderPassEncoder53.setScissorRect(3, 2, 5, 1);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer75, 'uint32', 420, 976);
+} catch {}
+let arrayBuffer25 = buffer28.getMappedRange(12312, 40);
+try {
+device0.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(24).fill(175), /* required buffer size: 24 */
+{offset: 24, bytesPerRow: 789}, {width: 189, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 24, depthOrArrayLayers: 38}
+*/
+{
+  source: imageData15,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u85a7\u0e86\u02f1\u6070\u01d1\u07fc\u3731\u3ddd';
+} catch {}
+let texture251 = device0.createTexture({
+  size: {width: 160, height: 150, depthOrArrayLayers: 5},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture252 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder169.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup73, new Uint32Array(2482), 733, 0);
+} catch {}
+let arrayBuffer26 = buffer28.getMappedRange(12304, 0);
+let commandEncoder264 = device0.createCommandEncoder();
+let computePassEncoder234 = commandEncoder264.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+computePassEncoder234.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup14, new Uint32Array(508), 56, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle14, renderBundle19, renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer6, 'uint32', 2_824, 311);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer37, 0);
+} catch {}
+let arrayBuffer27 = buffer74.getMappedRange(32, 4);
+let bindGroup139 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView60}]});
+try {
+computePassEncoder147.setBindGroup(1, bindGroup132);
+} catch {}
+try {
+computePassEncoder228.setBindGroup(2, bindGroup118, new Uint32Array(1484), 177, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer135, 972, 2_308);
+} catch {}
+try {
+texture149.destroy();
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2568, new Int16Array(1974), 183, 240);
+} catch {}
+let commandEncoder265 = device0.createCommandEncoder({label: '\u{1fcfc}\u6df0\u4293\ud37a\uf22c\u8d6a\u{1f7a2}\u9f18\u{1fdf2}\u507b\u0e19'});
+let textureView242 = texture26.createView({dimension: '2d', arrayLayerCount: 1});
+let computePassEncoder235 = commandEncoder265.beginComputePass({});
+try {
+computePassEncoder166.setBindGroup(3, bindGroup100);
+} catch {}
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+computePassEncoder235.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(1, 26, 23, 15);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(7, buffer168, 1_568, 1_318);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 368 */
+  offset: 368,
+  buffer: buffer73,
+}, {
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture244,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 17}
+*/
+{
+  source: img1,
+  origin: { x: 72, y: 0 },
+  flipY: true,
+}, {
+  texture: texture116,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let shaderModule17 = device0.createShaderModule({
+  label: '\u0481\u7ced\u6b3d\u7f4d\u0f61\u{1ff75}\u0733\u1c0e\u0b97\ud61e\u0d6b',
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+override override37 = false;
+
+override override48 = false;
+
+@id(3866) override override42: u32 = 195;
+
+override override46 = 0.00325;
+
+struct VertexOutput11 {
+  @location(7) @interpolate(flat, centroid) f33: vec4i,
+  @location(4) f34: f16,
+  @builtin(position) f35: vec4f,
+  @location(0) f36: f32,
+  @location(1) f37: f32,
+  @location(10) @interpolate(flat, centroid) f38: u32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(46397) override override45: f16 = 26320.7;
+
+@id(34800) override override34: f16 = 25801.6;
+
+override override40: i32 = 55;
+
+@id(28275) override override39: f16 = 12851.8;
+
+@id(4410) override override35 = true;
+
+@id(51095) override override47: i32 = 5;
+
+override override49 = 0.01441;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0() -> mat2x2h {
+  var out: mat2x2h;
+  out = mat2x2h(f16(pack4x8unorm(vec4f(f32(textureNumLevels(tex15))))), f16(pack4x8unorm(vec4f(f32(textureNumLevels(tex15))))), f16(pack4x8unorm(vec4f(f32(textureNumLevels(tex15))))), f16(pack4x8unorm(vec4f(f32(textureNumLevels(tex15))))));
+  out = mat2x2h(f16(cosh(f32(unconst_f32(0.4260)))), f16(cosh(f32(unconst_f32(0.4260)))), f16(cosh(f32(unconst_f32(0.4260)))), f16(cosh(f32(unconst_f32(0.4260)))));
+  let vf269: vec3h = inverseSqrt(vec3h(unconst_f16(208.0), unconst_f16(1212.5), unconst_f16(5492.9)));
+  var vf270: u32 = pack4xI8(bitcast<vec4i>(textureDimensions(tex15).xyxx));
+  out = mat2x2h(f16(override48), f16(override48), f16(override48), f16(override48));
+  let vf271: u32 = textureNumLevels(tex15);
+  out = mat2x2h(f16(pack4x8unorm(vec4f(f32(override35)))), f16(pack4x8unorm(vec4f(f32(override35)))), f16(pack4x8unorm(vec4f(f32(override35)))), f16(pack4x8unorm(vec4f(f32(override35)))));
+  var vf272: u32 = vf271;
+  var vf273: u32 = pack4x8unorm(vec4f(unconst_f32(0.1015), unconst_f32(0.3809), unconst_f32(0.01233), unconst_f32(0.1971)));
+  var vf274: f32 = atan(f32(unconst_f32(0.3666)));
+  let vf275: u32 = pack4x8unorm(vec4f(unconst_f32(-0.03861), unconst_f32(0.3355), unconst_f32(0.05656), unconst_f32(0.2061)));
+  vf270 &= pack4xU8Clamp(vec4u(unconst_u32(24), unconst_u32(50), unconst_u32(471), unconst_u32(439)));
+  let vf276: u32 = pack4xI8(vec4i(i32(exp(f32(unconst_f32(0.01930))))));
+  out = mat2x2h(f16(cosh(f32(unconst_f32(0.01604)))), f16(cosh(f32(unconst_f32(0.01604)))), f16(cosh(f32(unconst_f32(0.01604)))), f16(cosh(f32(unconst_f32(0.01604)))));
+  vf274 = f32(vf272);
+  vf274 -= textureLoad(tex15, vec2i(unconst_i32(48), unconst_i32(212)), i32(unconst_i32(782))).g;
+  vf270 = u32(override47);
+  var vf277: vec2f = unpack2x16float(u32(unconst_u32(38)));
+  var vf278: u32 = pack4x8unorm(vec4f(unconst_f32(0.08543), unconst_f32(0.00064), unconst_f32(0.09018), unconst_f32(0.2837)));
+  return out;
+}
+
+@id(14442) override override44: i32 = 13;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@id(19823) override override36: u32 = 503;
+
+@id(27566) override override41: f16 = 3789.8;
+
+@group(0) @binding(123) var tex15: texture_2d<f32>;
+
+struct T1 {
+  @align(2) @size(48) f0: array<atomic<u32>>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @align(2) @size(48) f0: array<u32>,
+}
+
+var<workgroup> vw66: atomic<i32>;
+
+@id(1027) override override43: u32 = 457;
+
+struct S7 {
+  @builtin(vertex_index) f0: u32,
+  @location(9) @interpolate(linear) f1: f32,
+  @location(11) @interpolate(linear, center) f2: f16,
+  @location(4) @interpolate(flat, centroid) f3: i32,
+  @location(13) @interpolate(flat, sample) f4: vec2i,
+  @location(1) f5: i32,
+  @builtin(instance_index) f6: u32,
+}
+
+override override38 = false;
+
+@group(0) @binding(67) var<storage, read_write> buffer170: array<VertexOutput11>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@vertex
+fn vertex13(a0: S7) -> VertexOutput11 {
+  var out: VertexOutput11;
+  var vf279 = fn0();
+  fn0();
+  out.f38 += pack2x16float(sin(vec2f(a0.f4)));
+  fn0();
+  let vf280: S7 = a0;
+  out.f34 = vec4h(sinh(vec4f(unconst_f32(0.1733), unconst_f32(0.06767), unconst_f32(0.1253), unconst_f32(0.2025)))).x;
+  out.f33 += vec4i(vf279[1].xyyx);
+  var vf281 = fn0();
+  let vf282: f16 = a0.f2;
+  var vf283 = fn0();
+  let vf284: f16 = a0.f2;
+  fn0();
+  out.f33 &= vec4i(min(vec2u(unconst_u32(84), unconst_u32(291)), vec2u(bitcast<u32>(vf280.f3))).xyyy);
+  var vf285: f16 = sqrt(f16(unconst_f16(15737.1)));
+  vf283 = mat2x2h(vec2h(vf280.f4), vec2h(vf280.f4));
+  vf281 = mat2x2h(vec2h(min(vec2u(unconst_u32(261), unconst_u32(49)), vec2u(bitcast<u32>(vf280.f3)))), vec2h(min(vec2u(unconst_u32(261), unconst_u32(49)), vec2u(bitcast<u32>(vf280.f3)))));
+  vf279 = mat2x2h(vec2h(textureDimensions(tex15, bitcast<i32>(override42))), vec2h(textureDimensions(tex15, bitcast<i32>(override42))));
+  vf279 = mat2x2h(vec2h(vf280.f4), vec2h(vf280.f4));
+  let vf286: f16 = a0.f2;
+  out.f38 = a0.f6;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute19(@builtin(local_invocation_id) a0: vec3u) {
+  buffer170[u32(override40)] = VertexOutput11(vec4i(faceForward(vec2h(textureDimensions(tex15, atomicLoad(&(*&vw66)))), vec2h(unconst_f16(5481.0), unconst_f16(3912.2)), vec2h(unconst_f16(3750.6), unconst_f16(9469.0))).grgr), faceForward(vec2h(textureDimensions(tex15, atomicLoad(&(*&vw66)))), vec2h(unconst_f16(5481.0), unconst_f16(3912.2)), vec2h(unconst_f16(3750.6), unconst_f16(9469.0)))[0], vec4f(faceForward(vec2h(textureDimensions(tex15, atomicLoad(&(*&vw66)))), vec2h(unconst_f16(5481.0), unconst_f16(3912.2)), vec2h(unconst_f16(3750.6), unconst_f16(9469.0))).xxxy), bitcast<f32>(faceForward(vec2h(textureDimensions(tex15, atomicLoad(&(*&vw66)))), vec2h(unconst_f16(5481.0), unconst_f16(3912.2)), vec2h(unconst_f16(3750.6), unconst_f16(9469.0)))), bitcast<f32>(faceForward(vec2h(textureDimensions(tex15, atomicLoad(&(*&vw66)))), vec2h(unconst_f16(5481.0), unconst_f16(3912.2)), vec2h(unconst_f16(3750.6), unconst_f16(9469.0)))), bitcast<u32>(faceForward(vec2h(textureDimensions(tex15, atomicLoad(&(*&vw66)))), vec2h(unconst_f16(5481.0), unconst_f16(3912.2)), vec2h(unconst_f16(3750.6), unconst_f16(9469.0)))));
+  textureBarrier();
+  var vf287: vec3f = radians(vec3f(countLeadingZeros(vec3i(i32(override46)))));
+  var vf288: u32 = pack2x16snorm(vec2f(unconst_f32(0.01588), unconst_f32(0.2874)));
+  vf288 = (*&buffer170)[arrayLength(&(*&buffer170))].f38;
+  vf288 = u32(buffer170[arrayLength(&buffer170)].f34);
+  vf287 += vec3f((*&buffer170)[arrayLength(&(*&buffer170))].f33.wyy);
+  buffer170[u32(unconst_u32(164))].f36 = f32((*&buffer170)[arrayLength(&(*&buffer170))].f33[0]);
+  buffer170[u32(unconst_u32(156))] = VertexOutput11(buffer170[arrayLength(&buffer170)].f33, f16(buffer170[arrayLength(&buffer170)].f33[2]), bitcast<vec4f>(buffer170[arrayLength(&buffer170)].f33), f32(buffer170[arrayLength(&buffer170)].f33[3]), bitcast<vec4f>(buffer170[arrayLength(&buffer170)].f33)[0], pack4xI8Clamp(buffer170[arrayLength(&buffer170)].f33));
+  vf287 = vec3f((*&buffer170)[arrayLength(&(*&buffer170))].f33.agg);
+  let ptr160: ptr<storage, u32, read_write> = &(*&buffer170)[arrayLength(&(*&buffer170))].f38;
+  let ptr161: ptr<storage, f32, read_write> = &(*&buffer170)[arrayLength(&(*&buffer170))].f36;
+  vf287 -= vec3f(countLeadingZeros(vec3u((*&buffer170)[arrayLength(&(*&buffer170))].f35.gbg)));
+  buffer170[u32(unconst_u32(259))] = VertexOutput11(vec4i(radians(vec3f(unconst_f32(0.2006), unconst_f32(0.08948), unconst_f32(-0.01428))).yyyz), vec3h(radians(vec3f(unconst_f32(0.2006), unconst_f32(0.08948), unconst_f32(-0.01428))))[0], radians(vec3f(unconst_f32(0.2006), unconst_f32(0.08948), unconst_f32(-0.01428))).zxxx, radians(vec3f(unconst_f32(0.2006), unconst_f32(0.08948), unconst_f32(-0.01428))).z, radians(vec3f(unconst_f32(0.2006), unconst_f32(0.08948), unconst_f32(-0.01428))).z, u32(radians(vec3f(unconst_f32(0.2006), unconst_f32(0.08948), unconst_f32(-0.01428))).z));
+  let vf289: vec2f = normalize(vec2f(unconst_f32(0.1846), unconst_f32(0.06450)));
+}`,
+  sourceMap: {},
+});
+let texture253 = device0.createTexture({
+  size: {width: 160, height: 150, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView243 = texture190.createView({aspect: 'all'});
+try {
+computePassEncoder228.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle19, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder39.setStencilReference(38);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 400 */
+  offset: 400,
+  bytesPerRow: 8704,
+  buffer: buffer163,
+}, {
+  texture: texture163,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer171 = device0.createBuffer({
+  size: 163,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder266 = device0.createCommandEncoder();
+let texture254 = device0.createTexture({size: [10], dimension: '1d', format: 'rgba8uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let computePassEncoder236 = commandEncoder266.beginComputePass({});
+try {
+computePassEncoder201.setBindGroup(1, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup104, new Uint32Array(696), 136, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle19, renderBundle7, renderBundle7, renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder28.setStencilReference(224);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer45, 'uint16', 178, 1_813);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(3, buffer104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(184).fill(51), /* required buffer size: 184 */
+{offset: 184, rowsPerImage: 7}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55); };
+} catch {}
+let buffer172 = device0.createBuffer({
+  size: 15896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView244 = texture106.createView({});
+let computePassEncoder237 = commandEncoder54.beginComputePass({});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+computePassEncoder237.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer92, 0);
+} catch {}
+document.body.prepend(video2);
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer165, offset: 2048, size: 8132}}],
+});
+let texture255 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 151},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder131.setBindGroup(2, bindGroup8, new Uint32Array(389), 50, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder267 = device0.createCommandEncoder({});
+let computePassEncoder238 = commandEncoder267.beginComputePass({});
+let sampler151 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 39.53,
+  lodMaxClamp: 54.87,
+});
+let externalTexture27 = device0.importExternalTexture({label: '\u8e0f\ua308\u{1f85d}', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder236.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer163, 'uint32', 412, 189);
+} catch {}
+let buffer173 = device0.createBuffer({
+  size: 25120,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder42.beginOcclusionQuery(31);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle17]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 18, depthOrArrayLayers: 17}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture116,
+  mipLevel: 2,
+  origin: {x: 0, y: 4, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 244,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 452,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture256 = device0.createTexture({
+  size: [20, 24, 38],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView245 = texture192.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler152 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.80,
+  compare: 'greater',
+});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup77, new Uint32Array(676), 97, 0);
+} catch {}
+try {
+renderPassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { log('device0 lost!'); log(message, reason); });
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+commandEncoder254.copyBufferToTexture({
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1600 */
+  offset: 1600,
+  rowsPerImage: 171,
+  buffer: buffer59,
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder254.resolveQuerySet(querySet23, 25, 21, buffer161, 1280);
+} catch {}
+let textureView246 = texture75.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder239 = commandEncoder254.beginComputePass({});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame21});
+try {
+renderPassEncoder40.executeBundles([renderBundle19, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(5, buffer142, 0);
+} catch {}
+let bindGroup141 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [
+    {binding: 220, resource: textureView25},
+    {binding: 198, resource: {buffer: buffer26, offset: 512, size: 473}},
+    {binding: 153, resource: {buffer: buffer11, offset: 3072, size: 559}},
+    {binding: 150, resource: textureView209},
+    {binding: 135, resource: sampler55},
+    {binding: 66, resource: textureView136},
+  ],
+});
+let buffer174 = device0.createBuffer({
+  size: 6180,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder268 = device0.createCommandEncoder({label: '\u1788\u6519\u{1f65b}'});
+let texture257 = device0.createTexture({
+  label: '\u{1fd29}\u{1fb5e}\ueea1\u015d\u{1fcfd}\u02ae\ue955\u{1f7c5}',
+  size: {width: 40, height: 48, depthOrArrayLayers: 77},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler153 = device0.createSampler({
+  label: '\u0c3f\u0b66\u{1fb87}\udd9a\uc808\uc858',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 94.61,
+  lodMaxClamp: 97.55,
+  compare: 'never',
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder239.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup34, new Uint32Array(2441), 1_197, 0);
+} catch {}
+let commandEncoder269 = device0.createCommandEncoder({});
+let texture258 = device0.createTexture({
+  label: '\udccc\u079b\u04a6',
+  size: {width: 80, height: 75, depthOrArrayLayers: 230},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup6, new Uint32Array(29), 6, 0);
+} catch {}
+try {
+buffer144.unmap();
+} catch {}
+try {
+commandEncoder269.copyTextureToTexture({
+  texture: texture211,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder270 = device0.createCommandEncoder();
+let computePassEncoder240 = commandEncoder269.beginComputePass({});
+let renderPassEncoder63 = commandEncoder270.beginRenderPass({
+  colorAttachments: [{
+  view: textureView224,
+  clearValue: { r: 164.7, g: 814.2, b: 12.48, a: 792.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 1304599,
+});
+let sampler154 = device0.createSampler({
+  label: '\udd9c\u{1fc22}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.62,
+  lodMaxClamp: 94.47,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder111.setBindGroup(0, bindGroup10, new Uint32Array(407), 0, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup137);
+} catch {}
+try {
+commandEncoder268.copyBufferToBuffer(buffer38, 9568, buffer114, 36, 44);
+} catch {}
+try {
+commandEncoder268.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 192 */
+  offset: 192,
+  bytesPerRow: 3584,
+  buffer: buffer98,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 408, new BigUint64Array(89), 2, 24);
+} catch {}
+let video6 = await videoWithData(119);
+let videoFrame37 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let textureView247 = texture162.createView({mipLevelCount: 1});
+let computePassEncoder241 = commandEncoder268.beginComputePass({});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder225.setBindGroup(0, bindGroup128);
+} catch {}
+try {
+computePassEncoder241.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer105, 'uint16', 3_810, 2_073);
+} catch {}
+let textureView248 = texture76.createView({label: '\u2a8f\u01dc\u0577\u033b', dimension: '2d-array', baseMipLevel: 0});
+let renderBundle26 = renderBundleEncoder26.finish({});
+let sampler155 = device0.createSampler({
+  label: '\u0a67\u94bc\u062d\u0d2a\u8cff\uf124\u11ab\u1efa\u{1f8e2}\u91bf\uad58',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.50,
+  lodMaxClamp: 79.95,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder203.setBindGroup(3, bindGroup118);
+} catch {}
+let texture259 = device0.createTexture({
+  size: {width: 80, height: 75, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder182.setBindGroup(2, bindGroup7, new Uint32Array(1111), 230, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup104);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer49, 832);
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+computePassEncoder164.setBindGroup(3, bindGroup141, new Uint32Array(3686), 447, 1);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle11]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder271.copyTextureToTexture({
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 24, y: 3, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder271.clearBuffer(buffer77, 392);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(918).fill(77), /* required buffer size: 918 */
+{offset: 918, bytesPerRow: 98}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise39;
+} catch {}
+let texture260 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup117, new Uint32Array(124), 8, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+commandEncoder271.resolveQuerySet(querySet8, 122, 32, buffer50, 8960);
+} catch {}
+try {
+computePassEncoder213.pushDebugGroup('\u091f');
+} catch {}
+document.body.append(canvas3);
+let buffer175 = device0.createBuffer({
+  size: 32,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder272 = device0.createCommandEncoder({});
+let sampler156 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.74,
+  lodMaxClamp: 96.79,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder110.setBindGroup(1, bindGroup58, new Uint32Array(4167), 775, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder240.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer129, 'uint16', 856, 21);
+} catch {}
+try {
+  await buffer68.mapAsync(GPUMapMode.READ, 192, 604);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise38;
+} catch {}
+let bindGroup142 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [
+    {binding: 198, resource: {buffer: buffer91, offset: 4608, size: 262}},
+    {binding: 153, resource: {buffer: buffer130, offset: 0}},
+    {binding: 150, resource: textureView138},
+    {binding: 135, resource: sampler5},
+    {binding: 220, resource: textureView210},
+    {binding: 66, resource: textureView226},
+  ],
+});
+let buffer176 = device0.createBuffer({size: 27198, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder273 = device0.createCommandEncoder({});
+try {
+computePassEncoder192.setBindGroup(2, bindGroup81, new Uint32Array(2514), 38, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroupsIndirect(buffer6, 528); };
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer59, 'uint16', 310, 221);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+let computePassEncoder242 = commandEncoder273.beginComputePass({});
+try {
+computePassEncoder118.end();
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup53, new Uint32Array(2746), 589, 0);
+} catch {}
+try {
+commandEncoder271.clearBuffer(buffer57, 1480, 1700);
+} catch {}
+try {
+computePassEncoder174.pushDebugGroup('\u28ec');
+} catch {}
+let buffer177 = device0.createBuffer({size: 5948, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let computePassEncoder243 = commandEncoder109.beginComputePass({});
+let renderPassEncoder64 = commandEncoder272.beginRenderPass({
+  colorAttachments: [{
+  view: textureView224,
+  clearValue: { r: -779.2, g: 795.9, b: 789.6, a: -739.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 300658049,
+});
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup111);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup130, new Uint32Array(2691), 355, 0);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer140, 'uint32', 244, 254);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(7, buffer147, 1_936, 1_948);
+} catch {}
+try {
+commandEncoder271.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2140 */
+  offset: 2140,
+  buffer: buffer18,
+}, {
+  texture: texture161,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder271.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 12, y: 19, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 33, y: 95, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 21, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture246,
+  mipLevel: 0,
+  origin: {x: 31, y: 34, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let computePassEncoder244 = commandEncoder271.beginComputePass({label: '\u0474\uc8c5\u09f5'});
+try {
+computePassEncoder196.setBindGroup(3, bindGroup82, new Uint32Array(1304), 147, 0);
+} catch {}
+try {
+computePassEncoder238.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup130, new Uint32Array(2298), 53, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 6036, new Float32Array(7628), 354, 32);
+} catch {}
+try {
+computePassEncoder183.setBindGroup(1, bindGroup129, new Uint32Array(975), 33, 0);
+} catch {}
+try {
+computePassEncoder244.setPipeline(pipeline1);
+} catch {}
+let sampler157 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.64,
+  lodMaxClamp: 95.71,
+});
+try {
+renderPassEncoder40.setVertexBuffer(0, buffer7, 0, 901);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 17}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 72, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder86.setBindGroup(1, bindGroup93, new Uint32Array(3318), 590, 0);
+} catch {}
+try {
+computePassEncoder242.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup13, new Uint32Array(758), 46, 0);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer85, 0, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7).fill(171), /* required buffer size: 7 */
+{offset: 7, rowsPerImage: 17}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView249 = texture65.createView({aspect: 'all', format: 'r8unorm', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler158 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.79,
+  lodMaxClamp: 78.55,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer18, 'uint16', 300, 2_168);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+try {
+computePassEncoder174.popDebugGroup();
+} catch {}
+try {
+externalTexture10.label = '\uf768\u6e0c\u2543\uf7db';
+} catch {}
+let texture261 = device0.createTexture({
+  size: [20, 24, 11],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup82, new Uint32Array(8), 1, 0);
+} catch {}
+try {
+renderPassEncoder53.setViewport(19.05633357446848, 2.5837632484586344, 0.7395507493871045, 14.03611586893214, 0.7428241512285656, 0.9559410455530133);
+} catch {}
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte170m', transfer: 'hlg'} });
+try {
+computePassEncoder18.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder186.setBindGroup(0, bindGroup20, new Uint32Array(2161), 192, 0);
+} catch {}
+try {
+computePassEncoder243.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer25, 48, 26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer168, 2508, new Float32Array(23863), 2621, 12);
+} catch {}
+try {
+querySet9.label = '\u2ecd\u037f\u2338\u8a95\ud8aa\u{1faa8}';
+} catch {}
+let externalTexture29 = device0.importExternalTexture({source: video5});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 9, depthOrArrayLayers: 17}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 25, y: 12 },
+  flipY: false,
+}, {
+  texture: texture116,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData31 = new ImageData(16, 16);
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout23]});
+let buffer178 = device0.createBuffer({
+  size: 722,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer65, 'uint16', 1_336, 925);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+commandEncoder244.copyBufferToTexture({
+  /* bytesInLastRow: 224 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6784 */
+  offset: 6784,
+  bytesPerRow: 1792,
+  rowsPerImage: 632,
+  buffer: buffer105,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 13, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let texture262 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder65 = commandEncoder244.beginRenderPass({
+  label: '\u055f\u02d8\u0d3b',
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: 111.7, g: -985.7, b: -921.3, a: -173.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder79.end();
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(197);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer77, 'uint16', 454, 35);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(0, undefined, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer179 = device0.createBuffer({size: 6165, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer27, 'uint16', 3_018, 410);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData27,
+  origin: { x: 7, y: 35 },
+  flipY: true,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 1, y: 59, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder245 = commandEncoder20.beginComputePass();
+let sampler159 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.60,
+  lodMaxClamp: 90.14,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder245.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer17, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer105, 4000, new Float32Array(9432), 1418, 552);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture161,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(451).fill(93), /* required buffer size: 451 */
+{offset: 451, bytesPerRow: 56}, {width: 5, height: 46, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise40;
+} catch {}
+let textureView250 = texture248.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler160 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.149,
+  lodMaxClamp: 55.73,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder18.setIndexBuffer(buffer77, 'uint32', 292, 441);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(187).fill(159), /* required buffer size: 187 */
+{offset: 187}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture263 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 77},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder151.pushDebugGroup('\ufe4a');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas1);
+let textureView251 = texture125.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 4});
+let externalTexture30 = device0.importExternalTexture({label: '\u0a15\u{1f6d0}\u{1f88f}\u{1fe04}\u{1fa90}\u056f\u{1f9f7}\u{1f6ad}', source: videoFrame15});
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup108);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder151.popDebugGroup();
+} catch {}
+let buffer180 = device0.createBuffer({
+  size: 15503,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder175.setBindGroup(0, bindGroup35, []);
+} catch {}
+let texture264 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 29},
+  mipLevelCount: 5,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], stencilReadOnly: true});
+let renderBundle27 = renderBundleEncoder27.finish({});
+let sampler161 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.88,
+  lodMaxClamp: 51.81,
+});
+try {
+renderPassEncoder57.executeBundles([renderBundle24, renderBundle2, renderBundle24, renderBundle26, renderBundle2, renderBundle2, renderBundle2, renderBundle24]);
+} catch {}
+try {
+computePassEncoder213.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+externalTexture22.label = '\u79d2\u867e\uf61b\u0090\u0d5f\u0700';
+} catch {}
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 26});
+try {
+computePassEncoder168.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(1, bindGroup43, new Uint32Array(211), 0, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 6, resource: {buffer: buffer138, offset: 2560, size: 1196}},
+    {binding: 54, resource: textureView64},
+    {binding: 200, resource: textureView40},
+    {binding: 434, resource: {buffer: buffer174, offset: 1280}},
+  ],
+});
+let texture265 = device0.createTexture({
+  label: '\u{1f920}\u10f0\u2c5a\u{1f72d}\u0ebb\u0bef\u4d2e\u0293\u0d0a',
+  size: [10, 12, 98],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder217.setBindGroup(1, bindGroup129, new Uint32Array(70), 0, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup53, new Uint32Array(80), 11, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer152, 'uint16', 3_342, 2_801);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer180, 0);
+} catch {}
+try {
+buffer138.unmap();
+} catch {}
+offscreenCanvas4.width = 74;
+let bindGroup144 = device0.createBindGroup({
+  label: '\u{1fa59}\ued3c\u0353',
+  layout: bindGroupLayout23,
+  entries: [{binding: 9, resource: {buffer: buffer139, offset: 512, size: 1715}}],
+});
+let textureView252 = texture142.createView({label: '\uc6a8\u{1f7f0}\u48df\u0fd2\ub1a7\u0845\ud95c\u0b63\u{1fcfc}', dimension: '2d', aspect: 'all'});
+let sampler162 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.76,
+  compare: 'not-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder111); computePassEncoder111.dispatchWorkgroupsIndirect(buffer152, 3_232); };
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -529.2, g: 541.4, b: -753.8, a: -954.7, });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 11}
+*/
+{
+  source: imageData31,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture261,
+  mipLevel: 1,
+  origin: {x: 1, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup145 = device0.createBindGroup({
+  layout: bindGroupLayout12,
+  entries: [{binding: 72, resource: textureView82}, {binding: 159, resource: {buffer: buffer25, offset: 0}}],
+});
+let textureView253 = texture161.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler163 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.44,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder121.setBindGroup(3, bindGroup119, new Uint32Array(996), 134, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder111); computePassEncoder111.dispatchWorkgroupsIndirect(buffer26, 884); };
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer123, 80, new DataView(new ArrayBuffer(10645)), 3667, 52);
+} catch {}
+let sampler164 = device0.createSampler({
+  label: '\u0259\u{1f9ff}\u0049\u7375',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 58.43,
+});
+try {
+computePassEncoder111.end();
+} catch {}
+let imageData32 = new ImageData(36, 36);
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 848});
+let sampler165 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 93.79,
+  lodMaxClamp: 95.99,
+});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup6, new Uint32Array(486), 164, 0);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup141, [0]);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer148, 'uint32', 780, 225);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer125, 1632, new Float32Array(2190), 86, 392);
+} catch {}
+let bindGroup146 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 9, resource: textureView65}]});
+let computePassEncoder246 = commandEncoder115.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup78);
+} catch {}
+try {
+computePassEncoder178.setBindGroup(3, bindGroup118, new Uint32Array(8), 2, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder246.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: img0,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView254 = texture57.createView({baseMipLevel: 0});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup64);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup114, new Uint32Array(3652), 1_836, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle24]);
+} catch {}
+let arrayBuffer28 = buffer32.getMappedRange(3024, 60);
+let textureView255 = texture21.createView({dimension: '2d-array'});
+let sampler166 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 13.56,
+  lodMaxClamp: 56.90,
+});
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'smpte170m'} });
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let bindGroup147 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 244, resource: textureView53}, {binding: 452, resource: textureView224}],
+});
+try {
+computePassEncoder184.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder195.setBindGroup(2, bindGroup87, new Uint32Array(2575), 16, 0);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline9);
+} catch {}
+let buffer181 = device0.createBuffer({size: 317, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView256 = texture263.createView({});
+let sampler167 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.54,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder237.setBindGroup(2, bindGroup127, new Uint32Array(1591), 19, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup139);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup68, new Uint32Array(381), 5, 0);
+} catch {}
+try {
+renderPassEncoder36.setViewport(26.902139423026227, 56.9278553449761, 27.174171133777953, 4.264371950015744, 0.5871551696813799, 0.8130586997487359);
+} catch {}
+try {
+buffer153.unmap();
+} catch {}
+let videoFrame40 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470bg', transfer: 'logSqrt'} });
+await gc();
+let imageData33 = new ImageData(32, 128);
+let shaderModule18 = device0.createShaderModule({
+  label: '\u062f\u{1fc7a}\u8c81\u328f\u0ecc',
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+@group(0) @binding(44) var tex16: texture_1d<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn0() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  out.f0 &= unpack4xU8(bitcast<u32>(override52));
+  out.f0 -= vp23.f0;
+  var vf290: f16 = inverseSqrt(refract(bitcast<vec2h>(override53), vec2h(quantizeToF16(unpack4x8unorm(pack4x8unorm(vec4f(unconst_f32(0.07391), unconst_f32(0.05845), unconst_f32(0.1314), unconst_f32(0.2966))))).zx), tanh(f16(all(bool(atan2(f16(textureNumLevels(tex16)), f16(unconst_f16(6942.0))))))))[1]);
+  let vf291: u32 = pack2x16unorm(vec2f(unconst_f32(0.00786), unconst_f32(0.01836)));
+  out.f0 = unpack4xU8(override53);
+  let vf292: f16 = inverseSqrt(f16(pack2x16unorm(vec2f(firstLeadingBit(vec2i(unconst_i32(146), unconst_i32(338)))))));
+  vf290 *= f16(vf291);
+  vp22 = modf(vec4h(f16(override53)));
+  let ptr162: ptr<private, FragmentOutput10> = &vp23;
+  return out;
+}
+
+@id(58357) override override55 = false;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  f0: array<u32>,
+}
+
+fn fn2() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let ptr166 = &vp22;
+  vp22 = modf(vec4h(override51));
+  fn0();
+  vp23 = FragmentOutput10(vec4u(vp22.fract));
+  return out;
+}
+
+override override56: u32 = 170;
+
+struct T2 {
+  f0: atomic<i32>,
+}
+
+struct FragmentOutput10 {
+  @location(0) @interpolate(flat) f0: vec4u,
+}
+
+var<private> vp23: FragmentOutput10 = FragmentOutput10();
+
+override override53: u32 = 134;
+
+@group(0) @binding(47) var<uniform> buffer182: array<array<f16, 2>, 1>;
+
+struct T0 {
+  @align(1) f0: array<array<f32, 1>>,
+}
+
+var<private> vp22 = modf(vec4h());
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+override override50: f16 = 279.1;
+
+fn fn1(a0: ptr<storage, array<u32>, read>) -> mat3x4h {
+  var out: mat3x4h;
+  var vf293: vec4i = unpack4xI8(u32(unconst_u32(46)));
+  vf293 ^= vec4i(clamp(vec4h(f16(override54)), vec4h(unconst_f16(364.1), unconst_f16(9054.9), unconst_f16(-16930.1), unconst_f16(3993.5)), vec4h(unconst_f16(1699.2), unconst_f16(6942.7), unconst_f16(3142.3), unconst_f16(20306.1))));
+  vf293 &= vec4i(floor(vec4h(unconst_f16(3207.0), unconst_f16(4883.7), unconst_f16(6578.1), unconst_f16(1636.0))));
+  fn0();
+  vp23.f0 ^= unpack4xU8(pack4x8unorm(vec4f(vp23.f0)));
+  var vf294 = fn0();
+  let ptr163: ptr<function, vec4u> = &vf294.f0;
+  let ptr164: ptr<storage, u32, read> = &(*a0)[arrayLength(&(*a0))];
+  vf293 &= vec4i(i32(length(vec3h(unconst_f16(9280.9), unconst_f16(5041.1), unconst_f16(-15315.5)))));
+  vp22 = modf(vec4h(override50));
+  var vf295 = fn0();
+  var vf296 = fn0();
+  vf293 = vf293;
+  vp22 = modf(vec4h(f16(override56)));
+  let vf297: vec4h = floor(vec4h(unconst_f16(-3991.7), unconst_f16(2431.4), unconst_f16(5526.6), unconst_f16(6278.5)));
+  let ptr165: ptr<function, FragmentOutput10> = &vf294;
+  return out;
+}
+
+override override52: i32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(7920) override override54 = -0.1985;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(42712) override override51: f16 = -38540.2;
+
+@vertex
+fn vertex14() -> @builtin(position) vec4f {
+  var out: vec4f;
+  vp23 = FragmentOutput10(vp23.f0);
+  out += vec4f(f32(textureDimensions(tex16)));
+  out -= vec4f(floor(vec2h(unconst_f16(5016.7), unconst_f16(314.3))).rgrr);
+  let ptr167: ptr<private, vec4h> = &vp22.fract;
+  out = vec4f(f32(pack4x8unorm(vec4f(unconst_f32(0.03792), unconst_f32(0.1740), unconst_f32(0.1426), unconst_f32(0.00201)))));
+  var vf298 = fn0();
+  vp22.whole -= vp22.whole;
+  var vf299: vec2h = normalize(vec2h(min(vec4i(unconst_i32(-104), unconst_i32(35), unconst_i32(118), unconst_i32(420)), vec4i(unconst_i32(98), unconst_i32(128), unconst_i32(8), unconst_i32(146))).gg));
+  out += vec4f(f32(vf299[1]));
+  vf299 -= bitcast<vec2h>(textureDimensions(tex16, 0i));
+  let ptr168: ptr<private, FragmentOutput10> = &vp23;
+  let vf300: f16 = override50;
+  var vf301: u32 = textureNumLevels(tex16);
+  let ptr169: ptr<function, vec4u> = &vf298.f0;
+  vf298.f0 *= vec4u(vp22.fract);
+  fn0();
+  vf298 = FragmentOutput10(vec4u(vf301));
+  vf301 += textureNumLevels(tex16);
+  let ptr170: ptr<private, vec4h> = &(*ptr167);
+  var vf302: i32 = dot4I8Packed(u32(unconst_u32(269)), u32(unconst_u32(32)));
+  vp22 = modf(vec4h(textureLoad(tex16, i32(unconst_i32(251)), min(vec4i(unconst_i32(523), unconst_i32(263), unconst_i32(527), unconst_i32(20)), vec4i(unconst_i32(159), unconst_i32(224), unconst_i32(71), unconst_i32(436))).w)));
+  return out;
+}
+
+@fragment
+fn fragment14(@location(11) @interpolate(flat, centroid) a0: vec2u, @builtin(sample_index) a1: u32) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let ptr171: ptr<private, vec4h> = &vp22.fract;
+  let ptr172 = &vp22;
+  out.f0 -= vec4u(u32(inverseSqrt(f16(unconst_f16(3824.0)))));
+  vp22.whole = vec4h((*&buffer182)[0][pack4xU8(vec4u(a0[0]))]);
+  out.f0 = unpack4xU8(override53);
+  let ptr173: ptr<private, vec4u> = &vp23.f0;
+  let ptr174: ptr<private, vec4h> = &(*ptr171);
+  let ptr175: ptr<private, vec4h> = &(*ptr171);
+  let ptr176: ptr<private, vec4u> = &vp23.f0;
+  vp23.f0 &= vec4u((*ptr172).whole);
+  vp22 = modf(vec4h(buffer182[0][1]));
+  out = FragmentOutput10(unpack4xU8(u32(dot(vec4i(i32((*ptr173)[0])), vec4i(unconst_i32(100), unconst_i32(38), unconst_i32(-131), unconst_i32(55))))));
+  out.f0 &= vec4u((*ptr171));
+  vp23 = FragmentOutput10(vec4u(u32((*ptr174)[1])));
+  var vf303: vec4i = abs(vec4i(unconst_i32(74), unconst_i32(200), unconst_i32(93), unconst_i32(194)));
+  var vf304: i32 = override52;
+  vf303 = vec4i(i32((*&buffer182)[0][1]));
+  out = FragmentOutput10(unpack4xU8(u32((*&buffer182)[0][1])));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute20() {
+  vp22.whole = vec4h(f16(textureDimensions(tex16, 0i)));
+  vp23.f0 = vec4u(u32(round(f16(unconst_f16(3732.6)))));
+  vp23.f0 -= unpack4xU8(textureNumLevels(tex16));
+  vp23 = FragmentOutput10(vec4u(vp23.f0[3]));
+  var vf305: f16 = round(f16(unconst_f16(19348.4)));
+}`,
+  hints: {},
+});
+let bindGroup148 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 9, resource: {buffer: buffer164, offset: 512, size: 1372}}],
+});
+let sampler168 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 41.88,
+  lodMaxClamp: 48.86,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer113, 0, 3_114);
+} catch {}
+let bindGroup149 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 337, resource: textureView82},
+    {binding: 321, resource: {buffer: buffer84, offset: 0, size: 548}},
+  ],
+});
+let sampler169 = device0.createSampler({
+  label: '\u3a1e\u{1f9cf}\u{1fabd}\u0c19\u971b\uc4c9\u97f2\u01ff\u359c\u360d\u093e',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.59,
+});
+try {
+computePassEncoder177.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup118);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer140, 'uint16', 2_036, 491);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 11}
+*/
+{
+  source: video6,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture261,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'pq'} });
+let textureView257 = texture102.createView({aspect: 'all'});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder154); computePassEncoder154.dispatchWorkgroupsIndirect(buffer85, 4); };
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup142, new Uint32Array(2894), 657, 1);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer84, 'uint16', 2_122, 3_299);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(4_294_967_295, undefined, 1_309_601, 4_597_121);
+} catch {}
+document.body.append(video3);
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'smpteSt4281'} });
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup82, new Uint32Array(4908), 450, 0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer23, 'uint32', 4_056, 6_275);
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+var<workgroup> vw67: atomic<u32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+var<private> vp24: vec2<bool> = vec2<bool>();
+
+var<workgroup> vw69: T1;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(44) var tex17: texture_1d<i32>;
+
+@group(0) @binding(47) var<uniform> buffer183: vec2h;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @align(4) @size(16) f0: array<array<vec4h, 1>, 1>,
+  @size(8) f1: f16,
+}
+
+struct FragmentOutput11 {
+  @location(0) @interpolate(flat) f0: vec4u,
+}
+
+var<workgroup> vw68: array<array<vec2h, 6>, 3>;
+
+fn fn0(a0: ptr<function, array<array<array<i32, 1>, 1>, 29>>) -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  vp24 = vec2<bool>(bool(textureNumLevels(tex17)));
+  out.f0 = vec4u(degrees(vec3h(unconst_f16(-7737.8), unconst_f16(1452.2), unconst_f16(15833.7))).yxzx);
+  var vf306: u32 = textureDimensions(tex17);
+  let ptr177: ptr<function, array<array<i32, 1>, 1>> = &(*a0)[28];
+  var vf307: vec4i = textureLoad(tex17, i32(unconst_i32(505)), i32(unconst_i32(66)));
+  out.f0 &= vec4u(bitcast<u32>((*a0)[28][u32((*a0)[28][0][0])][0]));
+  return out;
+}
+
+@fragment
+fn fragment15() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  out.f0 <<= unpack4xU8(dot4U8Packed(bitcast<u32>((*&buffer183)), clamp(vec2u(unconst_u32(692), unconst_u32(199)), vec2u(u32(dot4I8Packed(u32(unconst_u32(259)), pack2x16unorm(vec2f(unconst_f32(0.2780), unconst_f32(0.02500)))))), bitcast<vec2u>(transpose(mat4x2h(f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597)))), f16(pack2x16unorm(vec2f(unconst_f32(0.08836), unconst_f32(0.01597))))))[1]))[0]));
+  let vf308: vec3f = saturate(bitcast<vec3f>(sign(vec2i(i32((*&buffer183)[0]))).xxy));
+  vp24 = vec2<bool>(saturate(vec3f(f32(pack4xI8Clamp(vec4i(unconst_i32(152), unconst_i32(192), unconst_i32(-87), unconst_i32(-18)))))).rb);
+  let ptr178: ptr<private, vec2<bool>> = &vp24;
+  vp24 = vec2<bool>(bool(acos(f16(sign(bitcast<vec2i>(clamp(vec2u(unconst_u32(28), unconst_u32(822)), vec2u(u32(any(bool(clamp(bitcast<vec2u>(transpose(mat4x2h(vec2h(extractBits(vec3u(unconst_u32(149), unconst_u32(13), unconst_u32(99)), u32(unconst_u32(213)), u32(unconst_u32(93))).bb), vec2h(extractBits(vec3u(unconst_u32(149), unconst_u32(13), unconst_u32(99)), u32(unconst_u32(213)), u32(unconst_u32(93))).zz), vec2h(extractBits(vec3u(unconst_u32(149), unconst_u32(13), unconst_u32(99)), u32(unconst_u32(213)), u32(unconst_u32(93))).gg), vec2h(extractBits(vec3u(unconst_u32(149), unconst_u32(13), unconst_u32(99)), u32(unconst_u32(213)), u32(unconst_u32(93))).yx)))[1]), vec2u(dot4U8Packed(bitcast<u32>(buffer183), u32(unconst_u32(30)))), vec2u(unconst_u32(20), unconst_u32(169)))[1])))), vec2u(unconst_u32(329), unconst_u32(77))))).g))));
+  vp24 = vec2<bool>(buffer183);
+  var vf309: vec2i = sign(vec2i(unconst_i32(341), unconst_i32(80)));
+  let vf310: mat2x4h = transpose(mat4x2h(unconst_f16(907.3), unconst_f16(7220.6), unconst_f16(5055.5), unconst_f16(6788.5), unconst_f16(26200.9), unconst_f16(26772.5), unconst_f16(8237.8), unconst_f16(4319.3)));
+  vp24 = vec2<bool>(saturate(unpack4x8unorm(u32(dot4I8Packed(u32(vf310[0][1]), extractBits(vec3u(unconst_u32(44), unconst_u32(282), unconst_u32(5)), u32(unconst_u32(133)), pack4xI8Clamp(vec4i(unconst_i32(316), unconst_i32(364), unconst_i32(282), unconst_i32(-54)))).g))).aag).yz);
+  let vf311: vec3f = vf308;
+  var vf312: vec4h = vf310[0];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute21() {
+  let ptr179: ptr<workgroup, array<vec2h, 6>> = &(*&vw68)[atomicExchange(&vw67, bitcast<u32>(vw68[2][5]))];
+  vp24 = vec2<bool>(bool((*&buffer183)[1]));
+  vp24 = vec2<bool>(bool((*ptr179)[5][1]));
+  let vf313: vec2f = unpack2x16unorm(u32((*&vw69).f1));
+  let vf314: bool = any(vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+  vw68[2][u32(unconst_u32(140))] -= (*ptr179)[5];
+  let ptr180: ptr<workgroup, atomic<u32>> = &vw67;
+  atomicMax(&vw67, u32(unconst_u32(31)));
+  vw69 = T1(array<array<vec4h, 1>, 1>(array<vec4h, 1>((*&vw69).f0[0][0])), (*&vw69).f0[0][0].w);
+  let ptr181: ptr<workgroup, vec4h> = &vw69.f0[0][0];
+  var vf315: vec3h = abs(vec3h(f16(dot4U8Packed(u32(unconst_u32(14)), u32(unconst_u32(0))))));
+  let vf316: vec4u = reverseBits(vec4u(u32((*&vw69).f1)));
+  var vf317: bool = vp24[1];
+  let ptr182: ptr<workgroup, vec2h> = &(*ptr179)[5];
+  vf317 = bool((*ptr182)[1]);
+  vf317 = bool((*&vw69).f0[0][0].z);
+  atomicAdd(&vw67, u32(unconst_u32(67)));
+  var vf318: u32 = vf316[1];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let textureView258 = texture6.createView({label: '\u{1f72d}\u0e53\u561f\u0498\u25c4', mipLevelCount: 1});
+let textureView259 = texture158.createView({});
+try {
+renderPassEncoder36.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder50.insertDebugMarker('\u{1fe1f}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer148, 288, new Float32Array(18614), 4629, 132);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageData24);
+let buffer184 = device0.createBuffer({size: 18704, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+try {
+renderPassEncoder24.beginOcclusionQuery(455);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(8, 4, 8, 4);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer167, 'uint16', 78, 716);
+} catch {}
+try {
+computePassEncoder100.insertDebugMarker('\u0f31');
+} catch {}
+video3.width = 4;
+let texture266 = device0.createTexture({
+  size: [256, 256, 24],
+  mipLevelCount: 3,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture176.createView({
+  label: '\u8236\uf84d\u003b\u35d6\u0b44\uf440\uc6d0\uf773\u{1f951}\u25c1',
+  aspect: 'all',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder154); computePassEncoder154.dispatchWorkgroupsIndirect(buffer130, 392); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup58, new Uint32Array(225), 167, 0);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer71, 740, 1_812);
+} catch {}
+try {
+buffer145.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 7, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(58).fill(140), /* required buffer size: 58 */
+{offset: 58, bytesPerRow: 14}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let textureView261 = texture175.createView({format: 'r16uint'});
+let sampler170 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 90.03,
+  lodMaxClamp: 92.31,
+});
+try {
+computePassEncoder222.setBindGroup(0, bindGroup85, new Uint32Array(488), 140, 0);
+} catch {}
+let imageData34 = new ImageData(8, 32);
+try {
+computePassEncoder178.setBindGroup(1, bindGroup63, new Uint32Array(838), 127, 0);
+} catch {}
+try {
+computePassEncoder154.end();
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup78, new Uint32Array(820), 2, 0);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer97, 'uint16', 22_694);
+} catch {}
+try {
+commandEncoder68.copyBufferToBuffer(buffer168, 6452, buffer178, 284, 16);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 1856 widthInBlocks: 116 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2000 */
+  offset: 2000,
+  bytesPerRow: 45824,
+  rowsPerImage: 73,
+  buffer: buffer95,
+}, {
+  texture: texture214,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 116, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder222.insertDebugMarker('\u0449');
+} catch {}
+await gc();
+let textureView262 = texture153.createView({});
+try {
+computePassEncoder227.setBindGroup(1, bindGroup62, new Uint32Array(10000), 1_156, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer14, 'uint32', 124, 396);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+adapter0.label = '\u2fd3\u0d77\u74c7\u0ace\u7441\u4030\ub7b6';
+} catch {}
+let textureView263 = texture39.createView({dimension: '2d-array'});
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup0, new Uint32Array(600), 44, 0);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 636 */
+  offset: 636,
+  bytesPerRow: 30976,
+  buffer: buffer173,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 19, y: 15, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture231,
+  mipLevel: 0,
+  origin: {x: 3, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet5, 65, 54, buffer88, 1536);
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte240m', transfer: 'gamma22curve'} });
+let commandBuffer18 = commandEncoder68.finish({});
+let promise41 = device0.queue.onSubmittedWorkDone();
+let commandEncoder274 = device0.createCommandEncoder({label: '\u4fa6\u{1faa4}\ucc18\u5fb7\ue64e\u0c18'});
+let texture267 = gpuCanvasContext8.getCurrentTexture();
+let textureView264 = texture171.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 4});
+let computePassEncoder247 = commandEncoder274.beginComputePass();
+try {
+computePassEncoder247.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup22, new Uint32Array(441), 69, 0);
+} catch {}
+video5.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup56);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup112, new Uint32Array(1224), 59, 0);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(13, 17, 24, 19);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer148, 'uint16', 72, 621);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(1, buffer106, 100, 640);
+} catch {}
+let bindGroup150 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 47, resource: textureView251}, {binding: 24, resource: textureView76}],
+});
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer185 = device0.createBuffer({
+  label: '\u{1f79b}\ucfc3\u13a4\u01d0',
+  size: 358,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView265 = texture171.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+let sampler171 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 20.86,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup95);
+} catch {}
+let bindGroup151 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 282, resource: sampler62}]});
+try {
+computePassEncoder103.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+computePassEncoder182.setBindGroup(3, bindGroup50, new Uint32Array(421), 2, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 600, new DataView(new ArrayBuffer(13559)), 2267, 1604);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView266 = texture172.createView({});
+try {
+computePassEncoder169.setBindGroup(3, bindGroup69, []);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer71, 0, 668);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView267 = texture214.createView({format: 'rgba32float'});
+let textureView268 = texture253.createView({aspect: 'all', mipLevelCount: 1});
+try {
+device0.queue.writeTexture({
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(133).fill(3), /* required buffer size: 133 */
+{offset: 133, rowsPerImage: 91}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup152 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 168, resource: {buffer: buffer166, offset: 256, size: 357}},
+    {binding: 93, resource: textureView15},
+    {binding: 150, resource: textureView109},
+    {binding: 109, resource: textureView82},
+  ],
+});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 499});
+let sampler172 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 54.89,
+  lodMaxClamp: 66.97,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder35.setIndexBuffer(buffer72, 'uint32', 1_560, 7_008);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+let sampler173 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 49.80,
+});
+try {
+computePassEncoder169.setBindGroup(3, bindGroup129, new Uint32Array(2203), 4, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer135, 884, 11);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData35 = new ImageData(8, 100);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({label: '\u1e18\u0303\ubb64', colorFormats: ['rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder230.setBindGroup(0, bindGroup113, new Uint32Array(853), 61, 0);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup14, new Uint32Array(1559), 164, 0);
+} catch {}
+let bindGroup153 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 54, resource: textureView30},
+    {binding: 200, resource: textureView40},
+    {binding: 434, resource: {buffer: buffer77, offset: 1536}},
+    {binding: 6, resource: {buffer: buffer113, offset: 2304, size: 148}},
+  ],
+});
+let renderBundle28 = renderBundleEncoder28.finish({});
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup62, new Uint32Array(310), 7, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(4, buffer86, 0, 6_414);
+} catch {}
+let texture268 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 11},
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder192.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder82.setBindGroup(2, bindGroup127, new Uint32Array(712), 41, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup138);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle19]);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55); };
+} catch {}
+let bindGroup154 = device0.createBindGroup({
+  label: '\u0fed\u{1ff1c}\u08aa\u{1f8b5}',
+  layout: bindGroupLayout22,
+  entries: [{binding: 81, resource: textureView265}],
+});
+let buffer186 = device0.createBuffer({
+  size: 3683,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture269 = device0.createTexture({
+  size: [40, 48, 77],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: [undefined], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle29 = renderBundleEncoder29.finish();
+let sampler174 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 32.35,
+  lodMaxClamp: 54.67,
+});
+try {
+computePassEncoder137.setBindGroup(3, bindGroup88, new Uint32Array(630), 120, 0);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(3, buffer73, 0);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker('\u{1f9fd}');
+} catch {}
+try {
+computePassEncoder8.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(2);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer66, 1324, new Float32Array(4652), 3094, 160);
+} catch {}
+document.body.append(canvas4);
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let bindGroup155 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 200, resource: textureView86},
+    {binding: 6, resource: {buffer: buffer54, offset: 512}},
+    {binding: 434, resource: {buffer: buffer25, offset: 512}},
+    {binding: 54, resource: textureView30},
+  ],
+});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup141, [0]);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle24, renderBundle24, renderBundle26]);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 6156, new Float32Array(17015), 1391, 28);
+} catch {}
+let buffer187 = device0.createBuffer({
+  size: 1602,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let externalTexture31 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(2, buffer139, 7_128, 3_352);
+} catch {}
+try {
+renderPassEncoder46.pushDebugGroup('\u2378');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture256,
+  mipLevel: 1,
+  origin: {x: 2, y: 4, z: 1},
+  aspect: 'all',
+}, new Uint8Array(380).fill(99), /* required buffer size: 380 */
+{offset: 380, rowsPerImage: 64}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  label: '\u{1f836}\u94eb',
+  layout: bindGroupLayout6,
+  entries: [{binding: 25, resource: {buffer: buffer180, offset: 6400, size: 2220}}],
+});
+let texture270 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder46.popDebugGroup();
+} catch {}
+try {
+computePassEncoder228.insertDebugMarker('\u08b2');
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup157 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 321, resource: {buffer: buffer167, offset: 1024, size: 1000}},
+    {binding: 337, resource: textureView37},
+  ],
+});
+try {
+  await promise41;
+} catch {}
+let imageData36 = new ImageData(16, 4);
+let videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'gamma22curve'} });
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup134);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer175, 'uint32', 8, 4);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer50, 0, 1_319);
+} catch {}
+let buffer188 = device0.createBuffer({size: 36651, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView269 = texture50.createView({dimension: '3d', aspect: 'all', format: 'rgba32uint', arrayLayerCount: 1});
+try {
+computePassEncoder152.setBindGroup(0, bindGroup149);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(3, bindGroup75, new Uint32Array(1509), 158, 0);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup72, new Uint32Array(274), 88, 0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 244, new DataView(new ArrayBuffer(18238)), 659, 3272);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView270 = texture219.createView({dimension: '3d', mipLevelCount: 1});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup112);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup145, new Uint32Array(27), 7, 0);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle26]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 8, y: 4 },
+  flipY: false,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let texture271 = device0.createTexture({
+  size: [80, 75, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder195.setBindGroup(3, bindGroup12, new Uint32Array(3474), 2_173, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle19, renderBundle7, renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4, buffer116, 10_920, 2_330);
+} catch {}
+let promise42 = device0.popErrorScope();
+let buffer189 = device0.createBuffer({size: 4997, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture272 = device0.createTexture({
+  label: '\u376b\uccf6\u{1fe12}\ub214\u{1f6fc}\uf983\u3444\u663b\u5447',
+  size: {width: 20},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder240.setBindGroup(3, bindGroup80, new Uint32Array(4207), 2_887, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer95, 'uint32', 4_256, 436);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule2, constants: {}}});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup95, new Uint32Array(944), 223, 0);
+} catch {}
+let buffer190 = device0.createBuffer({size: 1120, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture273 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture274 = gpuCanvasContext7.getCurrentTexture();
+let sampler175 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.62,
+  lodMaxClamp: 83.37,
+});
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+let bindGroup158 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer62, offset: 0, size: 184}}],
+});
+let textureView271 = texture184.createView({});
+try {
+renderPassEncoder46.setScissorRect(12, 25, 0, 7);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(17);
+} catch {}
+let bindGroup159 = device0.createBindGroup({
+  label: '\u01f7\u06ea\u734f\uef57\u319e\u{1f6f7}',
+  layout: bindGroupLayout22,
+  entries: [{binding: 81, resource: textureView115}],
+});
+let texture275 = device0.createTexture({
+  label: '\u{1f7ec}\u299c\u00df\u24e4\u592d\u72d3',
+  size: {width: 40, height: 37, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView272 = texture159.createView({label: '\u{1f79b}\u0906\ubf6b\u6f62\u0c9b', mipLevelCount: 1, arrayLayerCount: 3});
+try {
+renderPassEncoder46.setBlendConstant({ r: 201.6, g: -716.3, b: -919.2, a: 917.3, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer179, 384, new Int16Array(5168), 690, 376);
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 314, resource: {buffer: buffer54, offset: 1280}},
+    {binding: 56, resource: textureView164},
+    {binding: 429, resource: textureView10},
+    {binding: 315, resource: textureView114},
+    {binding: 224, resource: {buffer: buffer16, offset: 0, size: 292}},
+  ],
+});
+let textureView273 = texture49.createView({baseMipLevel: 0});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup5, new Uint32Array(967), 308, 0);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup96, new Uint32Array(3143), 13, 0);
+} catch {}
+try {
+renderPassEncoder64.setScissorRect(125, 32, 2, 6);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer27);
+} catch {}
+try {
+renderPassEncoder44.insertDebugMarker('\u{1f69f}');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let texture276 = device0.createTexture({
+  size: [20, 24, 1],
+  dimension: '2d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView274 = texture64.createView({dimension: '2d'});
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup118, new Uint32Array(451), 108, 0);
+} catch {}
+let imageData37 = new ImageData(180, 32);
+let buffer191 = device0.createBuffer({size: 23017, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let texture277 = device0.createTexture({
+  size: [320, 300, 1],
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer152, 'uint32', 156, 6_905);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 96, depthOrArrayLayers: 154}
+*/
+{
+  source: videoFrame30,
+  origin: { x: 17, y: 5 },
+  flipY: true,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 3, y: 11, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer192 = device0.createBuffer({size: 3506, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture278 = device0.createTexture({
+  size: {width: 80, height: 96, depthOrArrayLayers: 11},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder208.setBindGroup(2, bindGroup44, new Uint32Array(4823), 246, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup144, new Uint32Array(1833), 151, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer161, 'uint32', 4_244, 269);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(0, buffer25);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+buffer177.unmap();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+  await promise42;
+} catch {}
+let texture279 = device0.createTexture({
+  size: [320, 300, 31],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler176 = device0.createSampler({addressModeV: 'mirror-repeat', lodMinClamp: 32.83, lodMaxClamp: 83.26});
+let externalTexture32 = device0.importExternalTexture({source: video1});
+try {
+computePassEncoder194.setBindGroup(2, bindGroup103, new Uint32Array(1860), 1_395, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup98);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle19, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer17, 0, 246);
+} catch {}
+let buffer193 = device0.createBuffer({size: 16536, usage: GPUBufferUsage.MAP_READ});
+let texture280 = device0.createTexture({
+  size: {width: 10, height: 12, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture281 = gpuCanvasContext6.getCurrentTexture();
+let textureView275 = texture111.createView({mipLevelCount: 1});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer168, 944, 276);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer148, 340, new Float32Array(30850), 830, 36);
+} catch {}
+document.body.append(img6);
+let img8 = await imageWithData(103, 19, '#10101010', '#20202020');
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 373,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer194 = device0.createBuffer({
+  label: '\u{1fcae}\u02b0\u2dc1\uada2',
+  size: 2336,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView276 = texture121.createView({format: 'r8unorm'});
+try {
+computePassEncoder158.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder16.setViewport(177.52985792785762, 54.67864508141488, 113.3306822596189, 121.1636422106579, 0.08353011349764294, 0.1225999067997077);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let buffer195 = device0.createBuffer({size: 9741, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup82);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer121, 'uint32', 4_612, 3_154);
+} catch {}
+try {
+if (!arrayBuffer25.detached) { new Uint8Array(arrayBuffer25).fill(0x55); };
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder192.setBindGroup(0, bindGroup147);
+} catch {}
+try {
+computePassEncoder213.setBindGroup(3, bindGroup41, new Uint32Array(136), 34, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 11});
+let texture282 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView277 = texture120.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({
+  label: '\u{1f8ee}\u{1f7d6}\u0c8b\u0083\ueb3f\uaa6c\uecf5\u{1fdee}\u0d5c\u0bfc\ubef2',
+  bindGroupLayouts: [bindGroupLayout11],
+});
+let textureView278 = texture211.createView({baseArrayLayer: 5, arrayLayerCount: 2});
+try {
+renderPassEncoder54.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder61.setBlendConstant({ r: 518.0, g: -555.7, b: 232.4, a: -631.7, });
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer196 = device0.createBuffer({
+  size: 5609,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView279 = texture33.createView({label: '\u75df\u53d2\u01b6'});
+let sampler177 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.43,
+  lodMaxClamp: 78.84,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup96, new Uint32Array(4120), 1_153, 0);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer134, 120);
+} catch {}
+try {
+  await shaderModule15.getCompilationInfo();
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture283 = device0.createTexture({
+  label: '\u31f2\u66ba\ubf50\u03ae\u0676\u{1fd7a}\u89f1',
+  size: [20, 24, 38],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView280 = texture13.createView({baseMipLevel: 0});
+let sampler178 = device0.createSampler({
+  label: '\u8d1b\u2f66\u3c27\u{1f6c4}\u672f\u0e3b\ue05f\u{1fed2}\u0d09',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 65.83,
+  lodMaxClamp: 84.78,
+});
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup116);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer17, 'uint16', 4_086, 2_889);
+} catch {}
+let textureView281 = texture259.createView({});
+let sampler179 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.46,
+  lodMaxClamp: 91.83,
+});
+try {
+renderPassEncoder37.setBlendConstant({ r: -706.4, g: -486.0, b: 901.9, a: -522.8, });
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer180, 'uint16', 358, 86);
+} catch {}
+document.body.append(img8);
+let bindGroup161 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 244, resource: textureView50}, {binding: 452, resource: textureView252}],
+});
+let texture284 = device0.createTexture({
+  size: {width: 160},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView282 = texture41.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup102, new Uint32Array(5353), 388, 1);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer18, 'uint16', 1_198, 315);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(4, undefined, 950_572_908, 921_772_210);
+} catch {}
+try {
+computePassEncoder110.insertDebugMarker('\u19c5');
+} catch {}
+try {
+computePassEncoder226.setBindGroup(0, bindGroup100);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup125);
+} catch {}
+let buffer197 = device0.createBuffer({size: 16255, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView283 = texture240.createView({});
+let sampler180 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.87,
+  lodMaxClamp: 53.92,
+});
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup91, new Uint32Array(194), 28, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer174, 'uint32', 144, 1_118);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(0, buffer187);
+} catch {}
+let buffer198 = device0.createBuffer({
+  size: 852,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder232.setBindGroup(2, bindGroup41, new Uint32Array(3674), 36, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup126);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(267);
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder90.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup10, new Uint32Array(370), 62, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer187, 0);
+} catch {}
+let bindGroup162 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 67, resource: {buffer: buffer41, offset: 0}}, {binding: 123, resource: textureView10}],
+});
+try {
+renderPassEncoder60.setVertexBuffer(5, buffer104);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap7 = await createImageBitmap(offscreenCanvas0);
+let imageData38 = new ImageData(28, 116);
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 999,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup163 = device0.createBindGroup({
+  label: '\u0939\u0268\u{1faa6}\u0dbe',
+  layout: bindGroupLayout10,
+  entries: [{binding: 65, resource: {buffer: buffer40, offset: 1024}}],
+});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 302});
+let textureView284 = texture73.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder204.setBindGroup(2, bindGroup157);
+} catch {}
+let arrayBuffer29 = buffer28.getMappedRange(12352, 8);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 8, y: 46, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame46 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt2020', transfer: 'smpte240m'} });
+let buffer199 = device0.createBuffer({size: 12057, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler181 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.94,
+  lodMaxClamp: 88.43,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder162.setBindGroup(0, bindGroup49);
+} catch {}
+let bindGroup164 = device0.createBindGroup({layout: bindGroupLayout26, entries: [{binding: 145, resource: textureView264}]});
+let sampler182 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 92.69});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup87, new Uint32Array(4251), 451, 0);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(223).fill(246), /* required buffer size: 223 */
+{offset: 223}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler183 = device0.createSampler({
+  label: '\u4cad\u1aaf\u9ec1\u{1ff03}\u{1fa3c}\u4e54\u0d02',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.15,
+  lodMaxClamp: 78.19,
+  compare: 'always',
+});
+try {
+renderPassEncoder42.beginOcclusionQuery(82);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+let promise43 = device0.queue.onSubmittedWorkDone();
+let texture285 = device0.createTexture({
+  size: {width: 320, height: 300, depthOrArrayLayers: 129},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler184 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.84,
+  compare: 'always',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder162); computePassEncoder162.dispatchWorkgroupsIndirect(buffer34, 828); };
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup118);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer88, 'uint32', 572, 501);
+} catch {}
+let arrayBuffer30 = buffer28.getMappedRange(12624, 84);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView285 = texture140.createView({});
+try {
+computePassEncoder157.setBindGroup(1, bindGroup104, []);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(3, bindGroup152, new Uint32Array(105), 17, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder162); computePassEncoder162.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(611);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline5);
+} catch {}
+let textureView286 = texture20.createView({mipLevelCount: 1});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup162, new Uint32Array(3033), 355, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer78, 'uint16', 1_692, 3_646);
+} catch {}
+try {
+adapter0.label = '\u870a\u{1ff8f}\u6314\u0fd6\u4b42\u{1f838}\u{1f6de}\u0486\ud9e7';
+} catch {}
+let textureView287 = texture116.createView({mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 1});
+try {
+computePassEncoder193.setBindGroup(1, bindGroup78, new Uint32Array(6638), 183, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup102, [512]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 12, depthOrArrayLayers: 19}
+*/
+{
+  source: canvas1,
+  origin: { x: 21, y: 44 },
+  flipY: false,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture286 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame11});
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup158);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup158, new Uint32Array(664), 39, 0);
+} catch {}
+try {
+buffer36.destroy();
+} catch {}
+let video7 = await videoWithData(23);
+try {
+computePassEncoder176.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+computePassEncoder152.setBindGroup(1, bindGroup66, new Uint32Array(4967), 549, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup134);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup120, new Uint32Array(677), 65, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 1832, new BigUint64Array(18237), 2283, 308);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture259,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(79).fill(182), /* required buffer size: 79 */
+{offset: 79, bytesPerRow: 27, rowsPerImage: 28}, {width: 10, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let buffer200 = device0.createBuffer({
+  size: 13094,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 4, y: 53 },
+  flipY: true,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 21, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas3);
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 62, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 111,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup165 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 365, resource: sampler165}]});
+let buffer201 = device0.createBuffer({size: 9279, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let texture287 = device0.createTexture({
+  size: {width: 40, height: 48, depthOrArrayLayers: 77},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView288 = texture7.createView({});
+try {
+computePassEncoder149.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup132, new Uint32Array(1539), 5, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle19]);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(0, bindGroup152, new Uint32Array(1653), 197, 0);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup106);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle26, renderBundle24, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(3, buffer12, 11_624, 2_890);
+} catch {}
+let sampler185 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.263,
+  lodMaxClamp: 42.04,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup109);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(54);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 2768, new DataView(new ArrayBuffer(10576)), 525, 100);
+} catch {}
+let bindGroup166 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 24, resource: textureView264}, {binding: 47, resource: textureView124}],
+});
+let sampler186 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 34.52,
+  lodMaxClamp: 81.40,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup73);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder162); computePassEncoder162.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle26, renderBundle24, renderBundle24]);
+} catch {}
+let buffer202 = device0.createBuffer({
+  size: 7389,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler187 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.637,
+  lodMaxClamp: 74.03,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder233.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder59.setViewport(9.842149294101388, 0.9237638732718295, 46.50634966384206, 48.539723494750085, 0.9614515637876525, 0.9906380374590518);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer1, 'uint32', 0, 36);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup167 = device0.createBindGroup({layout: bindGroupLayout9, entries: [{binding: 382, resource: textureView77}]});
+try {
+computePassEncoder233.setBindGroup(1, bindGroup150);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(0, bindGroup11, new Uint32Array(2060), 74, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder162); computePassEncoder162.dispatchWorkgroupsIndirect(buffer162, 640); };
+} catch {}
+let arrayBuffer31 = buffer44.getMappedRange(0, 8);
+try {
+computePassEncoder173.pushDebugGroup('\u0509');
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u0d0b');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas0);
+let texture288 = device0.createTexture({
+  size: {width: 40, height: 37, depthOrArrayLayers: 118},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint'],
+});
+try {
+computePassEncoder121.setBindGroup(1, bindGroup131);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(1, bindGroup98, new Uint32Array(123), 20, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer27, 'uint16', 398, 4_697);
+} catch {}
+try {
+  await promise43;
+} catch {}
+document.body.append(img7);
+offscreenCanvas4.width = 262;
+let texture289 = device0.createTexture({
+  size: [80, 75, 18],
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder227.setBindGroup(0, bindGroup6, new Uint32Array(1887), 23, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup112);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle16, renderBundle16, renderBundle13]);
+} catch {}
+try {
+computePassEncoder202.pushDebugGroup('\u7099');
+} catch {}
+await gc();
+let textureView289 = texture23.createView({dimension: '1d'});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u57dc\u7aa8\u{1fc9d}\u0ca5\u095d\u1f35\u4716\uf7b4\u{1ffa4}\u00af\u0c5a',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle30 = renderBundleEncoder30.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder227); computePassEncoder227.dispatchWorkgroupsIndirect(buffer178, 32); };
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer23, 0);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -122,7 +122,7 @@ private:
     id<MTLIndirectRenderCommand> currentRenderCommand();
 
     void makeInvalid(NSString* = nil);
-    bool executePreDrawCommands(bool passWasSplit);
+    bool executePreDrawCommands(bool passWasSplit, uint32_t firstInstance = 0, uint32_t instanceCount = 0);
     void endCurrentICB();
     bool addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, ResourceUsageAndRenderStage*);
     bool addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages, const BindGroupEntryUsageData::Resource&);

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -114,7 +114,9 @@ private:
     RenderPassEncoder(CommandEncoder&, Device&, NSString*);
 
     bool validatePopDebugGroup() const;
+    bool executePreDrawCommands(uint32_t firstInstance, uint32_t instanceCount, bool passWasSplit = false);
     bool executePreDrawCommands(bool passWasSplit = false, const Buffer* = nullptr);
+    bool executePreDrawCommands(uint32_t firstInstance, uint32_t instanceCount, bool passWasSplit = false, const Buffer* = nullptr);
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);
     void runVertexBufferValidation(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>);


### PR DESCRIPTION
#### aef268e81760bb14e7b6e6445c57651d9aee9cc1
<pre>
[WebGPU] instance_id should be limited to 2^32 - 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=281272">https://bugs.webkit.org/show_bug.cgi?id=281272</a>
<a href="https://rdar.apple.com/137684526">rdar://137684526</a>

Reviewed by Tadeu Zagallo.

instance_id is uint64 on the Metal framework side, but uint32 in MSL,
so it needs to be limited to uint32

* LayoutTests/fast/webgpu/nocrash/fuzz-281272-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-281272.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::draw):
(WebGPU::RenderBundleEncoder::drawIndexed):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):

Canonical link: <a href="https://commits.webkit.org/285133@main">https://commits.webkit.org/285133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa897a04bb9d9dcfc807c7e289a404e9f82f53fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22404 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56282 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14750 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18822 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63985 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15833 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5750 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46412 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->