### PR TITLE
[css-anchor-position-1] Restart anchor resolution if a new anchor reference is discovered after anchor resolution has concluded

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-css-min-max-function-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-css-min-max-function-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+<style>
+.container {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  gap: 10px;
+}
+
+.box {
+  width: 100px;
+  height: 100px;
+}
+
+.green {
+  background-color: green;
+}
+</style>
+
+<p>The test passes if there are three green boxes with no red.</p>
+
+<div class="container">
+  <div class="box green"></div>
+  <div class="box green"></div>
+  <div class="box green"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-css-min-max-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-css-min-max-function.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-pos">
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/anchor-in-css-min-max-function-ref.html">
+
+<style>
+.container {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  gap: 10px;
+}
+
+.box {
+  width: 100px;
+  height: 100px;
+}
+
+.green {
+  background-color: green;
+}
+
+.red {
+  background-color: red;
+}
+
+#anchor1 {
+  anchor-name: --anchor1;
+}
+
+#anchor2 {
+  anchor-name: --anchor2;
+}
+
+#anchor3 {
+  anchor-name: --anchor3;
+}
+
+#target-fail {
+  position: relative;
+  left: 300px;
+}
+
+#target {
+  position: absolute;
+  top: min(anchor(--anchor1 bottom), anchor(--anchor2 bottom), anchor(--anchor3 top));
+  left: max(anchor(--anchor1 left), anchor(--anchor2 left), anchor(--anchor3 left));
+  z-index: 1;
+}
+</style>
+
+<p>The test passes if there are three green boxes with no red.</p>
+
+<div class="container">
+  <!-- These boxes are 100px by 100px and sits next to each other in a row.
+  First two boxes are green and last box is red -->
+  <div class="box green" id="anchor1"></div>
+  <div class="box green" id="anchor2"></div>
+  <div class="box red" id="anchor3"></div>
+</div>
+
+<!-- If min()/max() works correctly, this green box should completely
+cover the red box. -->
+<div class="box green" id="target"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-in-css-min-max-function-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-in-css-min-max-function-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+<style>
+.container {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  gap: 10px;
+}
+
+.box {
+  width: 100px;
+  height: 100px;
+}
+
+.green {
+  background-color: green;
+}
+</style>
+
+<p>The test passes if there are three green boxes with no red.</p>
+
+<div class="container">
+  <div class="box green"></div>
+  <div class="box green"></div>
+  <div class="box green"></div>
+</div>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -420,8 +420,15 @@ std::optional<double> AnchorPositionEvaluator::evaluate(const BuilderState& buil
     if (elementName.isNull())
         elementName = builderState.style().positionAnchor();
 
-    if (!elementName.isNull())
-        anchorPositionedState.anchorNames.add(elementName);
+    if (!elementName.isNull()) {
+        // Collect anchor names that this element refers to in anchor() or anchor-size()
+        bool isNewAnchorName = anchorPositionedState.anchorNames.add(elementName).isNewEntry;
+
+        // If anchor resolution has progressed past Initial, and we pick up a new anchor name, set the
+        // stage back to Initial. This restarts the resolution process to resolve newly added names.
+        if (isNewAnchorName)
+            anchorPositionedState.stage = AnchorPositionResolutionStage::Initial;
+    }
 
     // An anchor() instance will be ready to be resolved when all referenced anchor-names
     // have been mapped to an actual anchor element in the DOM tree. At that point, we


### PR DESCRIPTION
#### 7ea7016e8f1762c542f93faa186a69debb1b81ea
<pre>
[css-anchor-position-1] Restart anchor resolution if a new anchor reference is discovered after anchor resolution has concluded
<a href="https://rdar.apple.com/137628927">rdar://137628927</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=281169">https://bugs.webkit.org/show_bug.cgi?id=281169</a>

Reviewed by Antti Koivisto.

It&apos;s possible for new anchor name references to be picked up after anchor resolution
has completed. Consider this CSS expression:

    top: max(anchor(--a1 top),
             anchor(--a2 top),
             anchor(--a3 top))

min() and max() does short-circuit evaluation: the first argument is always evaluated,
and if any arguments from the second one evaluate to NaN, the overall result is NaN,
and the remaining arguments are not evaluated.

Dring the first pass of style/layout interleaving, only anchor(--a1 top) and
anchor(--a2 top) are evaluated. We learn that resolving this depends on anchor --a1 and
--a2, and we return NaN because there&apos;s no layout information to fully resolve. HOWEVER,
anchor(--a3 top) is not evaluated, and we don&apos;t pick up the dependency on --a3.

On the second pass of style/layout interleaving, anchor(--a1 top) and anchor(--a2 top)
evaluate to non-NaN, and only here is anchor(--a3 top) evaluated. BUT, at this point,
the anchor resolution process has already finished. If we request evaluation of anchor
--a3, it&apos;ll assume it&apos;s an invalid anchor reference, and not a anchor reference that we
have to resolve.

Fix this by setting the anchor resolution stage to the initial stage if we see
a new anchor reference. This forces anchor resolution to rerun and pick up new
references.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-css-min-max-function-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-css-min-max-function.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-in-css-min-max-function-ref.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::evaluate):

Canonical link: <a href="https://commits.webkit.org/285714@main">https://commits.webkit.org/285714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f32e7b4ce18bdaa5cfb8cd5be42b4a017af1b1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57770 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16188 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65424 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16189 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7459 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3515 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->