### PR TITLE
REGRESSION (284573@main): [ macOS wk1 ] imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html is a consistent failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -414,7 +414,6 @@ PASS -webkit-mask-position-x
 PASS -webkit-mask-position-y
 PASS -webkit-nbsp-mode
 PASS -webkit-rtl-ordering
-PASS -webkit-ruby-position
 PASS -webkit-text-fill-color
 PASS -webkit-text-security
 PASS -webkit-text-stroke-color

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -256,7 +256,7 @@ PASS right
 PASS rotate
 PASS row-gap
 PASS ruby-align
-FAIL ruby-position assert_not_equals: Should get a different computed value. got disallowed value "over"
+PASS ruby-position
 PASS rx
 PASS ry
 PASS scale

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-position.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 
-<p><ruby id="o1" style="-webkit-ruby-position: over">base<rt>annotation</rt></ruby></p>
-<p><ruby id="o2" style="-webkit-ruby-position: over">base<rt style="-webkit-ruby-position: under">annotation</rt></ruby></p>
-<p><ruby id="o3" style="-webkit-ruby-position: under">base<rtc style="-webkit-ruby-position: over"><rt style="-webkit-ruby-position: under">annotation</rt></rtc></ruby></p>
+<p><ruby id="o1" style="ruby-position: over">base<rt>annotation</rt></ruby></p>
+<p><ruby id="o2" style="ruby-position: over">base<rt style="ruby-position: under">annotation</rt></ruby></p>
+<p><ruby id="o3" style="ruby-position: under">base<rtc style="ruby-position: over"><rt style="ruby-position: under">annotation</rt></rtc></ruby></p>
 
-<p><ruby id="u1" style="-webkit-ruby-position: under">base<rt>annotation</rt></ruby></p>
-<p><ruby id="u2" style="-webkit-ruby-position: under">base<rt style="-webkit-ruby-position: over">annotation</rt></ruby></p>
-<p><ruby id="u3" style="-webkit-ruby-position: over">base<rtc style="-webkit-ruby-position: under"><rt style="-webkit-ruby-position: over">annotation</rt></rtc></ruby></p>
+<p><ruby id="u1" style="ruby-position: under">base<rt>annotation</rt></ruby></p>
+<p><ruby id="u2" style="ruby-position: under">base<rt style="ruby-position: over">annotation</rt></ruby></p>
+<p><ruby id="u3" style="ruby-position: over">base<rtc style="ruby-position: under"><rt style="ruby-position: over">annotation</rt></rtc></ruby></p>
 
 <script>
 test(() => {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1349,8 +1349,8 @@
                 "inter-character"
             ],
             "codegen-properties": {
-                "top-priority": true,
-                "comment": "This is a top priority property to ensure that its value can be checked when determining a smart default font size', (<https://trac.webkit.org/browser/trunk/Source/WebCore/ChangeLog?rev=172861>).",
+                "cascade-alias": "ruby-position",
+                "skip-builder": true,
                 "name-for-methods": "RubyPosition",
                 "parser-function": "consumeWebKitRubyPosition",
                 "parser-grammar-unused": "before | after | inter-character",

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1167,10 +1167,10 @@ RefPtr<CSSValue> consumeTextBoxEdge(CSSParserTokenRange& range, const CSSParserC
 RefPtr<CSSValue> consumeWebKitRubyPosition(CSSParserTokenRange& range, const CSSParserContext&)
 {
     if (range.peek().id() == CSSValueInterCharacter) {
-        consumeIdent(range);
+        range.consumeIncludingWhitespace();
         return CSSPrimitiveValue::create(CSSValueLegacyInterCharacter);
     }
-    return consumeIdent(range);
+    return consumeIdent<CSSValueBefore, CSSValueAfter>(range);
 }
 
 RefPtr<CSSValue> consumeBorderRadiusCorner(CSSParserTokenRange& range, const CSSParserContext& context)


### PR DESCRIPTION
#### dab4f5183e767b32aff634617b460514161222fd
<pre>
REGRESSION (284573@main): [ macOS wk1 ] imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=281157">https://bugs.webkit.org/show_bug.cgi?id=281157</a>
<a href="https://rdar.apple.com/137614049">rdar://137614049</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/ruby-position.html:

Revert a test importer fixup to use -webkit-ruby-position instead of ruby-position.

* Source/WebCore/css/CSSProperties.json:

Mark -webkit-ruby-position as a cascade-alias for ruby-position. This ensures it doesn&apos;t show up
in computed style enumeration.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeWebKitRubyPosition):

Also limit parser-allowed values of -webkit-ruby-position.

Canonical link: <a href="https://commits.webkit.org/285015@main">https://commits.webkit.org/285015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/029ff769caf15f10283d824b073e14968d2e2011

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22283 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/14792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61412 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/36762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20805 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64024 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12172 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5801 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1251 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47543 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->