### PR TITLE
[iOS] Volume of non MediaStreamTrack-based audio reduces when capturing microphone

### DIFF
--- a/LayoutTests/http/tests/webrtc/audioSessionInFrames.html
+++ b/LayoutTests/http/tests/webrtc/audioSessionInFrames.html
@@ -25,11 +25,14 @@ promise_test(async () => {
     const result2 = await new Promise(resolve => window.onmessage = (event) => resolve(event.data));
     frame2.remove();
 
-    assert_equals(result1.type, "auto");
-    assert_equals(result1.state, "inactive");
+    assert_equals(result1.type, "auto", "result1 type");
+    assert_equals(result1.state, "inactive", "result1 state");
 
-    assert_equals(result2.type, "play-and-record");
-    assert_equals(result2.state, "active");
+    assert_equals(result2.type, "auto", "result2 type");
+    assert_equals(result2.state, "inactive", "result2 state");
+
+    assert_equals(navigator.audioSession.type, "play-and-record", "navigator.audioSession type");
+    assert_equals(navigator.audioSession.state, "active", "navigator.audioSession state");
 }, "Allow audioSession in iframes where microphone is allowed");
 </script>
 </body>

--- a/LayoutTests/media/audioSession/audioSessionType-web-audio.html
+++ b/LayoutTests/media/audioSession/audioSessionType-web-audio.html
@@ -17,7 +17,7 @@ promise_test(async (test) => {
         return;
 
     navigator.audioSession.type = "play-and-record";
-    assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
+    assert_equals(internals.audioSessionCategory(), "None");
 
     const audioCtx = new AudioContext();
     const oscillator = audioCtx.createOscillator();
@@ -29,6 +29,7 @@ promise_test(async (test) => {
     await new Promise(resolve => setTimeout(resolve, 50));
 
     assert_equals(navigator.audioSession.type, "play-and-record");
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
 }, "AudioSession type with web audio");
         </script>

--- a/LayoutTests/media/audioSession/audioSessionType.html
+++ b/LayoutTests/media/audioSession/audioSessionType.html
@@ -40,21 +40,27 @@ promise_test(async (test) => {
     assert_equals(await ensureCategory("MediaPlayback"), "", "initial MediaPlayback");
 
     navigator.audioSession.type = "ambient";
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(internals.audioSessionCategory(), "AmbientSound");
 
     navigator.audioSession.type = "playback";
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(internals.audioSessionCategory(), "MediaPlayback");
 
     navigator.audioSession.type = "transient";
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(internals.audioSessionCategory(), "AmbientSound");
 
     navigator.audioSession.type = "play-and-record";
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
 
     navigator.audioSession.type = "transient-solo";
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(internals.audioSessionCategory(), "SoloAmbientSound");
 
     navigator.audioSession.type = "auto";
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert_equals(await ensureCategory("MediaPlayback"), "", "final MediaPlayback");
 }, "AudioSession type");
         </script>

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -31,6 +31,7 @@
 #include "AudioSession.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
+#include "Timer.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -55,6 +56,10 @@ public:
     Type type() const;
     State state() const;
 
+    void update();
+
+    USING_CAN_MAKE_WEAKPTR(AudioSessionInterruptionObserver);
+
 private:
     explicit DOMAudioSession(ScriptExecutionContext*);
 
@@ -74,7 +79,11 @@ private:
     void audioSessionActiveStateChanged() final;
 
     void scheduleStateChangeEvent();
+    bool isTypeBeingApplied() const { return m_applyTypeTimer.isActive(); }
+    void applyType();
 
+    Timer m_applyTypeTimer;
+    DOMAudioSessionType m_typeToApply { DOMAudioSessionType::Auto };
     bool m_hasScheduleStateChangeEvent { false };
     mutable std::optional<State> m_state;
 };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5354,7 +5354,25 @@ void Document::updateIsPlayingMedia()
             controller->checkDocumentForVoiceActivity(this);
     }
 #endif
+
+#if ENABLE(DOM_AUDIO_SESSION)
+    if (RefPtr domAudioSession = m_audioSession.get())
+        domAudioSession->update();
+#endif
 }
+
+#if ENABLE(DOM_AUDIO_SESSION)
+void Document::setDOMAudioSession(DOMAudioSession& session)
+{
+    ASSERT(!m_audioSession);
+    m_audioSession = session;
+}
+
+RefPtr<DOMAudioSession> Document::domAudioSession()
+{
+    return m_audioSession.get();
+}
+#endif
 
 void Document::visibilityAdjustmentStateDidChange()
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -114,6 +114,7 @@ class ContentVisibilityDocumentState;
 class DOMImplementation;
 class DOMSelection;
 class LocalDOMWindow;
+class DOMAudioSession;
 class DOMWrapperWorld;
 class Database;
 class DatabaseThread;
@@ -1976,6 +1977,11 @@ public:
 
     unsigned unloadCounter() const { return m_unloadCounter; }
 
+#if ENABLE(DOM_AUDIO_SESSION)
+    void setDOMAudioSession(DOMAudioSession&);
+    RefPtr<DOMAudioSession> domAudioSession();
+#endif
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,
@@ -2538,6 +2544,7 @@ private:
 
 #if ENABLE(DOM_AUDIO_SESSION)
     DOMAudioSessionType m_audioSessionType { };
+    WeakPtr<DOMAudioSession> m_audioSession;
 #endif
 
     OptionSet<ContentRelevancy> m_contentRelevancyUpdate;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -35,6 +35,8 @@
 #include "CoreAudioCaptureDeviceManager.h"
 #include "CoreAudioSharedUnit.h"
 #include "Logging.h"
+#include "MockAudioSharedUnit.h"
+#include "MockRealtimeMediaSourceCenter.h"
 #include "PlatformMediaSessionManager.h"
 #include "Timer.h"
 #include "WebAudioSourceProviderCocoa.h"

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -139,6 +139,8 @@ public:
     WEBCORE_EXPORT bool isAudioCaptureUnitRunning();
     WEBCORE_EXPORT bool shouldAudioCaptureUnitRenderAudio();
 
+    void movingOutOfPlayAndRecord() { beginInterruption(); }
+
 private:
     // AudioSessionInterruptionObserver
     void beginAudioSessionInterruption() final { beginInterruption(); }
@@ -151,7 +153,7 @@ private:
     void enableMutedSpeechActivityEventListener(Function<void()>&&) final;
     void disableMutedSpeechActivityEventListener() final;
 
-    void beginInterruption();
+    WEBCORE_EXPORT void beginInterruption();
     void endInterruption();
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -119,7 +119,12 @@ void RemoteAudioSessionProxyManager::updateCategory()
     else if (policyCounts.contains(RouteSharingPolicy::Independent))
         ASSERT_NOT_REACHED();
 
-    AudioSession::protectedSharedSession()->setCategory(category, mode, policy);
+    Ref sharedSession = AudioSession::protectedSharedSession();
+#if ENABLE(MEDIA_STREAM)
+    if (sharedSession->category() == AudioSession::CategoryType::PlayAndRecord && category != AudioSession::CategoryType::PlayAndRecord && CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning())
+        CoreAudioCaptureSourceFactory::singleton().movingOutOfPlayAndRecord();
+#endif
+    sharedSession->setCategory(category, mode, policy);
 }
 
 void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()


### PR DESCRIPTION
#### e58f0b060ebf4563380e2ffb0189ff4ccecc28c3
<pre>
[iOS] Volume of non MediaStreamTrack-based audio reduces when capturing microphone
<a href="https://rdar.apple.com/88670586">rdar://88670586</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=236219">https://bugs.webkit.org/show_bug.cgi?id=236219</a>

Reviewed by NOBODY (OOPS!).

Update DOMAudioSession implementation so that it stores its own type per document.
Update the computation of the audio session category override by looking at the audible document DOMAudioSession types.

Make sure to suspend the capture audio unit when category moves out of PlayAndRecord.

This allows a web page to do the following:
- Have one document whose type is PlayAndRecord to capture and do a recording.
- Have another document whose type is Playback to play the recording.

Whenever capture starts, the AudioSession category is set to PlayAndRecord.
Whenever the recording starts, the AudioSession category is set to Playback.
This is inline with the principle discussed for W3C AudioSession API so that an AudioSession may inactivate another one in the same document.

That way, the audio level will be the playback audio level.
The capture will be muted after playback starts.
Capture can be unmuted using navigator.mediaSession.setMicrophoneActive(true), which should happen without a prompt.

* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::create):
(WebCore::DOMAudioSession::DOMAudioSession):
(WebCore::shouldUseDocumentType):
(WebCore::DOMAudioSession::setType):
(WebCore::DOMAudioSession::applyType):
(WebCore::DOMAudioSession::update):
(WebCore::DOMAudioSession::type const):
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIsPlayingMedia):
(WebCore::Document::setDOMAudioSession):
* Source/WebCore/dom/Document.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
(WebCore::CoreAudioCaptureSourceFactory::movingOutOfPlayAndRecord):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateCategory):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4137a6bcc43d0608aff204052f38837e5af751a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79341 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49708 "Found 1 new test failure: http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25868 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68233 "Found 2 new API test failures: TestWebKitAPI.WebKit2.CrashGPUProcessAfterApplyingConstraints, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturing (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23325 "Found 2 new test failures: http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html media/audioSession/audioSessionState.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3646 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2378 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/fetch.any.serviceworker.html imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.https.any.serviceworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68029 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67341 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11307 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9407 "Found 2 new test failures: http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html media/audioSession/audioSessionState.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3594 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6401 "Found 1 new failure in Modules/audiosession/DOMAudioSession.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->