### PR TITLE
[WPE] REGRESSION(284269@main): Inspector crashes due to missing GRefPtr specialization for GResource

### DIFF
--- a/Source/WTF/wtf/glib/GRefPtr.cpp
+++ b/Source/WTF/wtf/glib/GRefPtr.cpp
@@ -21,8 +21,7 @@
 
 #if USE(GLIB)
 
-#include <glib-object.h>
-#include <glib.h>
+#include <gio/gio.h>
 
 namespace WTF {
 
@@ -237,6 +236,21 @@ void derefGPtr(GArray* ptr)
 {
     if (ptr)
         g_array_unref(ptr);
+}
+
+template <>
+GResource* refGPtr(GResource* ptr)
+{
+    if (ptr)
+        g_resource_ref(ptr);
+    return ptr;
+}
+
+template <>
+void derefGPtr(GResource* ptr)
+{
+    if (ptr)
+        g_resource_unref(ptr);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -253,6 +253,8 @@ template <> WTF_EXPORT_PRIVATE GDBusNodeInfo* refGPtr(GDBusNodeInfo* ptr);
 template <> WTF_EXPORT_PRIVATE void derefGPtr(GDBusNodeInfo* ptr);
 template <> WTF_EXPORT_PRIVATE GArray* refGPtr(GArray*);
 template <> WTF_EXPORT_PRIVATE void derefGPtr(GArray*);
+template <> WTF_EXPORT_PRIVATE GResource* refGPtr(GResource*);
+template <> WTF_EXPORT_PRIVATE void derefGPtr(GResource*);
 
 #if HAVE(GURI)
 template <> WTF_EXPORT_PRIVATE GUri* refGPtr(GUri*);

--- a/Source/WTF/wtf/glib/GTypedefs.h
+++ b/Source/WTF/wtf/glib/GTypedefs.h
@@ -55,6 +55,7 @@ typedef struct _GMainContext GMainContext;
 typedef struct _GMainLoop GMainLoop;
 typedef struct _GPatternSpec GPatternSpec;
 typedef struct _GPollableOutputStream GPollableOutputStream;
+typedef struct _GResource GResource;
 typedef struct _GSList GSList;
 typedef struct _GSocketClient GSocketClient;
 typedef struct _GSocketConnection GSocketConnection;


### PR DESCRIPTION
#### b076eff3f70e46ae846783f7f0dc9d3bf598a763
<pre>
[WPE] REGRESSION(284269@main): Inspector crashes due to missing GRefPtr specialization for GResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=281298">https://bugs.webkit.org/show_bug.cgi?id=281298</a>

Reviewed by Michael Catanzaro.

Add template specializations to make GRefPtr&lt;GResource&gt; use g_resource_{ref,unref}.
This is needed because GResource is not a GObject subclass, therefore using the
generic implementation of the template picked g_object_{ref,unref} instead and
the internal GLib sanity checks failed.

* Source/WTF/wtf/glib/GRefPtr.cpp:
(WTF::refGPtr): Added specialization for GResource.
(WTF::derefGPtr): Ditto.
* Source/WTF/wtf/glib/GRefPtr.h: Add template specialization declarations.
* Source/WTF/wtf/glib/GTypedefs.h: Add forward-declaration for GResource.

Canonical link: <a href="https://commits.webkit.org/285035@main">https://commits.webkit.org/285035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b488fc420fcdd9d3bf9aaf89ecb737b82b27b367

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22463 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56327 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18870 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20804 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77088 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70507 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64042 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64028 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5798 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92293 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10933 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46471 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20355 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->