### PR TITLE
Annotate NetworkTransportSession endpoints with feature flags

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -130,4 +130,12 @@ void NetworkTransportSession::receiveBidirectionalStream()
     // FIXME: Implement and send Messages::WebTransportSession::ReceiveBidirectionalStream.
 }
 
+std::optional<SharedPreferencesForWebProcess> NetworkTransportSession::sharedPreferencesForWebProcess() const
+{
+    if (auto connectionToWebProcess = m_connectionToWebProcess.get())
+        return connectionToWebProcess->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
+}
+
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -44,6 +44,7 @@ class NetworkTransportBidirectionalStream;
 class NetworkTransportReceiveStream;
 class NetworkTransportSendStream;
 
+struct SharedPreferencesForWebProcess;
 struct WebTransportSessionIdentifierType;
 struct WebTransportStreamIdentifierType;
 
@@ -72,6 +73,7 @@ public:
     void receiveBidirectionalStream();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 private:
     template<typename... Args> static Ref<NetworkTransportSession> create(Args&&... args) { return adoptRef(*new NetworkTransportSession(std::forward<Args>(args)...)); }
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[EnabledBy=WebTransportEnabled]
 messages -> NetworkTransportSession NotRefCounted {
     SendDatagram(std::span<const uint8_t> datagram) -> ()
     CreateOutgoingUnidirectionalStream() -> (std::optional<WebKit::WebTransportStreamIdentifier> identifier)


### PR DESCRIPTION
#### 6f44aa3747961e2b8af1cea9c756e0331a1e7e2d
<pre>
Annotate NetworkTransportSession endpoints with feature flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=281301">https://bugs.webkit.org/show_bug.cgi?id=281301</a>
<a href="https://rdar.apple.com/137748494">rdar://137748494</a>

Reviewed by Sihui Liu.

Annotate NetworkTransportSession endpoints with feature flags

* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:

Canonical link: <a href="https://commits.webkit.org/285047@main">https://commits.webkit.org/285047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47dcb94caae74e9ccc66eb65627f6dc06d35b214

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22465 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56328 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14789 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42709 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64039 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64025 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5799 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1252 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47544 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->