### PR TITLE
Remove MockAudioSharedUnit::singleton()

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -184,6 +184,9 @@ void BaseAudioSharedUnit::devicesChanged()
 {
     Ref protectedThis { *this };
 
+    if (!hasAudioUnit())
+        return;
+
     auto devices = RealtimeMediaSourceCenter::singleton().audioCaptureFactory().audioCaptureDeviceManager().captureDevices();
     auto persistentID = this->persistentID();
     if (persistentID.isEmpty())

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -81,40 +81,26 @@ static CaptureSourceOrError initializeCoreAudioCaptureSource(Ref<CoreAudioCaptur
 
 CaptureSourceOrError CoreAudioCaptureSource::create(String&& deviceID, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    CoreAudioCaptureSourceFactory::singleton().setOverrideUnit(nullptr);
-
 #if PLATFORM(MAC)
     auto device = CoreAudioCaptureDeviceManager::singleton().coreAudioDeviceWithUID(deviceID);
     if (!device)
         return CaptureSourceOrError({ "No CoreAudioCaptureSource device"_s, MediaAccessDenialReason::PermissionDenied });
 
-    auto source = adoptRef(*new CoreAudioCaptureSource(device.value(), device->deviceID(), WTFMove(hashSalts), nullptr, pageIdentifier));
+    auto source = adoptRef(*new CoreAudioCaptureSource(device.value(), device->deviceID(), WTFMove(hashSalts), pageIdentifier));
 #elif PLATFORM(IOS_FAMILY)
     auto device = AVAudioSessionCaptureDeviceManager::singleton().audioSessionDeviceWithUID(WTFMove(deviceID));
     if (!device)
         return CaptureSourceOrError({ "No AVAudioSessionCaptureDevice device"_s, MediaAccessDenialReason::PermissionDenied });
 
-    auto source = adoptRef(*new CoreAudioCaptureSource(device.value(), 0, WTFMove(hashSalts), nullptr, pageIdentifier));
+    auto source = adoptRef(*new CoreAudioCaptureSource(device.value(), 0, WTFMove(hashSalts), pageIdentifier));
 #endif
     return initializeCoreAudioCaptureSource(WTFMove(source), constraints);
 }
 
-CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, BaseAudioSharedUnit& overrideUnit, std::optional<PageIdentifier> pageIdentifier)
+CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    CoreAudioCaptureSourceFactory::singleton().setOverrideUnit(&overrideUnit);
-
-    auto source = adoptRef(*new CoreAudioCaptureSource(CaptureDevice { WTFMove(deviceID), CaptureDevice::DeviceType::Microphone, WTFMove(label) }, 0, WTFMove(hashSalts), &overrideUnit, pageIdentifier));
+    auto source = adoptRef(*new CoreAudioCaptureSource(CaptureDevice { WTFMove(deviceID), CaptureDevice::DeviceType::Microphone, WTFMove(label) }, 0, WTFMove(hashSalts), pageIdentifier));
     return initializeCoreAudioCaptureSource(WTFMove(source), constraints);
-}
-
-BaseAudioSharedUnit& CoreAudioCaptureSource::unit()
-{
-    return m_overrideUnit ? *m_overrideUnit : CoreAudioSharedUnit::singleton();
-}
-
-const BaseAudioSharedUnit& CoreAudioCaptureSource::unit() const
-{
-    return m_overrideUnit ? *m_overrideUnit : CoreAudioSharedUnit::singleton();
 }
 
 CoreAudioCaptureSourceFactory::CoreAudioCaptureSourceFactory()
@@ -127,22 +113,17 @@ CoreAudioCaptureSourceFactory::~CoreAudioCaptureSourceFactory()
     AudioSession::sharedSession().removeInterruptionObserver(*this);
 }
 
-BaseAudioSharedUnit& CoreAudioCaptureSourceFactory::unit()
-{
-    return m_overrideUnit ? *m_overrideUnit : CoreAudioSharedUnit::singleton();
-}
-
 void CoreAudioCaptureSourceFactory::beginInterruption()
 {
     ensureOnMainThread([] {
-        CoreAudioCaptureSourceFactory::singleton().unit().suspend();
+        CoreAudioSharedUnit::singleton().suspend();
     });
 }
 
 void CoreAudioCaptureSourceFactory::endInterruption()
 {
     ensureOnMainThread([] {
-        CoreAudioCaptureSourceFactory::singleton().unit().resume();
+        CoreAudioSharedUnit::singleton().resume();
     });
 }
 
@@ -208,29 +189,25 @@ void CoreAudioCaptureSourceFactory::whenAudioCaptureUnitIsNotRunning(Function<vo
 
 bool CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio()
 {
-    auto& unit = CoreAudioSharedUnit::singleton();
 #if PLATFORM(IOS_FAMILY)
-    return unit.isRunning();
+    return CoreAudioSharedUnit::singleton().isRunning();
 #else
-    return unit.isRunning() && unit.isUsingVPIO();
+    return CoreAudioSharedUnit::singleton().isRunning() && CoreAudioSharedUnit::singleton().canRenderAudio();
 #endif // PLATFORM(IOS_FAMILY)
 }
 
-CoreAudioCaptureSource::CoreAudioCaptureSource(const CaptureDevice& device, uint32_t captureDeviceID, MediaDeviceHashSalts&& hashSalts, BaseAudioSharedUnit* overrideUnit, std::optional<PageIdentifier> pageIdentifier)
+CoreAudioCaptureSource::CoreAudioCaptureSource(const CaptureDevice& device, uint32_t captureDeviceID, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
     : RealtimeMediaSource(device, WTFMove(hashSalts), pageIdentifier)
     , m_captureDeviceID(captureDeviceID)
-    , m_overrideUnit(overrideUnit)
 {
-    auto& unit = this->unit();
-
     // We ensure that we unsuspend ourselves on the constructor as a capture source
     // is created when getUserMedia grants access which only happens when the process is foregrounded.
     // We also reset unit capture values to default.
-    unit.prepareForNewCapture();
+    CoreAudioSharedUnit::singleton().prepareForNewCapture();
 
-    initializeEchoCancellation(unit.enableEchoCancellation());
-    initializeSampleRate(unit.sampleRate());
-    initializeVolume(unit.volume());
+    initializeEchoCancellation(CoreAudioSharedUnit::singleton().enableEchoCancellation());
+    initializeSampleRate(CoreAudioSharedUnit::singleton().sampleRate());
+    initializeVolume(CoreAudioSharedUnit::singleton().volume());
 }
 
 void CoreAudioCaptureSource::initializeToStartProducingData()
@@ -241,49 +218,50 @@ void CoreAudioCaptureSource::initializeToStartProducingData()
     ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
     m_isReadyToStart = true;
 
-    auto& unit = this->unit();
-    unit.setCaptureDevice(String { persistentID() }, m_captureDeviceID);
+    CoreAudioSharedUnit::singleton().setCaptureDevice(String { persistentID() }, m_captureDeviceID);
 
-    bool shouldReconfigure = echoCancellation() != unit.enableEchoCancellation() || sampleRate() != unit.sampleRate() || volume() != unit.volume();
-    unit.setEnableEchoCancellation(echoCancellation());
-    unit.setSampleRate(sampleRate());
-    unit.setVolume(volume());
+    bool shouldReconfigure = echoCancellation() != CoreAudioSharedUnit::singleton().enableEchoCancellation() || sampleRate() != CoreAudioSharedUnit::singleton().sampleRate() || volume() != CoreAudioSharedUnit::singleton().volume();
+    CoreAudioSharedUnit::singleton().setEnableEchoCancellation(echoCancellation());
+    CoreAudioSharedUnit::singleton().setSampleRate(sampleRate());
+    CoreAudioSharedUnit::singleton().setVolume(volume());
 
-    unit.addClient(*this);
+    CoreAudioSharedUnit::singleton().addClient(*this);
 
     if (shouldReconfigure)
-        unit.reconfigure();
+        CoreAudioSharedUnit::singleton().reconfigure();
 
     m_currentSettings = std::nullopt;
 }
 
 CoreAudioCaptureSource::~CoreAudioCaptureSource()
 {
-    unit().removeClient(*this);
+    CoreAudioSharedUnit::singleton().removeClient(*this);
 }
 
 void CoreAudioCaptureSource::startProducingData()
 {
     m_canResumeAfterInterruption = true;
     initializeToStartProducingData();
-    unit().startProducingData();
+    CoreAudioSharedUnit::singleton().startProducingData();
     m_currentSettings = { };
 }
 
 void CoreAudioCaptureSource::stopProducingData()
 {
     ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
-    unit().stopProducingData();
+    CoreAudioSharedUnit::singleton().stopProducingData();
 }
 
 const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
 {
     if (!m_capabilities) {
+        BaseAudioSharedUnit& unit = CoreAudioSharedUnit::singleton();
+
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
         capabilities.setDeviceId(hashedId());
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
         capabilities.setVolume({ 0.0, 1.0 });
-        capabilities.setSampleRate(unit().sampleRateCapacities());
+        capabilities.setSampleRate(unit.sampleRateCapacities());
         m_capabilities = WTFMove(capabilities);
     }
     return m_capabilities.value();
@@ -292,9 +270,11 @@ const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
 const RealtimeMediaSourceSettings& CoreAudioCaptureSource::settings()
 {
     if (!m_currentSettings) {
+        BaseAudioSharedUnit& unit = CoreAudioSharedUnit::singleton();
+
         RealtimeMediaSourceSettings settings;
         settings.setVolume(volume());
-        settings.setSampleRate(unit().isRenderingAudio() ? unit().actualSampleRate() : sampleRate());
+        settings.setSampleRate(unit.isRenderingAudio() ? unit.actualSampleRate() : sampleRate());
         settings.setDeviceId(hashedId());
         settings.setGroupId(captureDevice().groupId());
         settings.setLabel(name());
@@ -322,27 +302,28 @@ void CoreAudioCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSett
 
     bool shouldReconfigure = false;
     if (settings.contains(RealtimeMediaSourceSettings::Flag::EchoCancellation)) {
-        unit().setEnableEchoCancellation(echoCancellation());
+        CoreAudioSharedUnit::singleton().setEnableEchoCancellation(echoCancellation());
         shouldReconfigure = true;
     }
     if (settings.contains(RealtimeMediaSourceSettings::Flag::SampleRate)) {
-        unit().setSampleRate(sampleRate());
+        CoreAudioSharedUnit::singleton().setSampleRate(sampleRate());
         shouldReconfigure = true;
     }
     if (shouldReconfigure)
-        unit().reconfigure();
+        CoreAudioSharedUnit::singleton().reconfigure();
 
     m_currentSettings = std::nullopt;
 }
 
 bool CoreAudioCaptureSource::interrupted() const
 {
-    return unit().isSuspended() ? true : RealtimeMediaSource::interrupted();
+    return CoreAudioSharedUnit::singleton().isSuspended() || RealtimeMediaSource::interrupted();
 }
 
 void CoreAudioCaptureSource::delaySamples(Seconds seconds)
 {
-    unit().delaySamples(seconds);
+    BaseAudioSharedUnit& unit = CoreAudioSharedUnit::singleton();
+    unit.delaySamples(seconds);
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -54,7 +54,7 @@ class WebAudioSourceProviderAVFObjC;
 class CoreAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop> {
 public:
     WEBCORE_EXPORT static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
-    static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, BaseAudioSharedUnit& overrideUnit, std::optional<PageIdentifier>);
+    static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
 
     WEBCORE_EXPORT static AudioCaptureFactory& factory();
 
@@ -68,9 +68,7 @@ public:
     virtual ~CoreAudioCaptureSource();
 
 protected:
-    CoreAudioCaptureSource(const CaptureDevice&, uint32_t, MediaDeviceHashSalts&&, BaseAudioSharedUnit*, std::optional<PageIdentifier>);
-    BaseAudioSharedUnit& unit();
-    const BaseAudioSharedUnit& unit() const;
+    CoreAudioCaptureSource(const CaptureDevice&, uint32_t, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
 
     bool canResumeAfterInterruption() const { return m_canResumeAfterInterruption; }
     void setCanResumeAfterInterruption(bool value) { m_canResumeAfterInterruption = value; }
@@ -142,9 +140,6 @@ public:
     WEBCORE_EXPORT void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
     WEBCORE_EXPORT bool shouldAudioCaptureUnitRenderAudio();
 
-    void setOverrideUnit(BaseAudioSharedUnit* unit) { m_overrideUnit = unit; }
-    BaseAudioSharedUnit& unit();
-
 private:
     // AudioSessionInterruptionObserver
     void beginAudioSessionInterruption() final { beginInterruption(); }
@@ -159,8 +154,6 @@ private:
 
     void beginInterruption();
     void endInterruption();
-
-    BaseAudioSharedUnit* m_overrideUnit { nullptr };
 };
 
 inline CaptureSourceOrError CoreAudioCaptureSourceFactory::createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -290,6 +290,7 @@ OSStatus CoreAudioSharedUnit::setupAudioUnit()
         return result.error();
 
     m_ioUnit = WTFMove(result.value()).moveToUniquePtr();
+    m_canRenderAudio = m_ioUnit->canRenderAudio();
 
 #if HAVE(VPIO_DUCKING_LEVEL_API)
     if (m_shouldUseVPIO) {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -85,6 +85,7 @@ public:
         virtual void delaySamples(Seconds) { }
         virtual Seconds verifyCaptureInterval(bool isProducingSamples) const { return isProducingSamples ? 20_s : 2_s; }
         virtual bool setVoiceActivityDetection(bool) = 0;
+        virtual bool canRenderAudio() const { return true; }
     };
 
     WEBCORE_EXPORT static CoreAudioSharedUnit& singleton();
@@ -105,7 +106,7 @@ public:
     void setStatusBarWasTappedCallback(Function<void(CompletionHandler<void()>&&)>&& callback) { m_statusBarWasTappedCallback = WTFMove(callback); }
 #endif
 
-    bool isUsingVPIO() const { return m_shouldUseVPIO; }
+    bool canRenderAudio() const { return m_canRenderAudio; }
 
     struct AudioUnitDeallocator {
         void operator()(AudioUnit) const;
@@ -226,6 +227,7 @@ private:
 #endif
 
     bool m_shouldUseVPIO { true };
+    bool m_canRenderAudio { true };
     bool m_shouldSetVoiceActivityListener { false };
     bool m_voiceActivityDetectionEnabled { false };
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.h
@@ -32,7 +32,8 @@
 namespace WebCore {
 
 namespace MockAudioSharedUnit {
-
+void enable();
+void disable();
 CoreAudioSharedUnit& singleton();
 void increaseBufferSize();
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -194,9 +194,9 @@ void MockRealtimeAudioSource::setIsInterrupted(bool isInterrupted)
     UNUSED_PARAM(isInterrupted);
 #if PLATFORM(COCOA)
     if (isInterrupted)
-        MockAudioSharedUnit::singleton().suspend();
+        CoreAudioSharedUnit::singleton().suspend();
     else
-        MockAudioSharedUnit::singleton().resume();
+        CoreAudioSharedUnit::singleton().resume();
 #elif USE(GSTREAMER)
     for (auto* source : MockRealtimeAudioSourceGStreamer::allMockRealtimeAudioSources())
         source->setInterruptedForTesting(isInterrupted);

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -322,8 +322,8 @@ private:
     const Vector<CaptureDevice>& speakerDevices() const final { return MockRealtimeMediaSourceCenter::speakerDevices(); }
 #if PLATFORM(COCOA)
     void enableMutedSpeechActivityEventListener(Function<void()>&& callback) final {
-MockAudioSharedUnit::singleton().enableMutedSpeechActivityEventListener(WTFMove(callback)); }
-    void disableMutedSpeechActivityEventListener() final { MockAudioSharedUnit::singleton().disableMutedSpeechActivityEventListener(); }
+        CoreAudioSharedUnit::singleton().enableMutedSpeechActivityEventListener(WTFMove(callback)); }
+    void disableMutedSpeechActivityEventListener() final { CoreAudioSharedUnit::singleton().disableMutedSpeechActivityEventListener(); }
 #endif
 };
 
@@ -374,8 +374,12 @@ void MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled(bool
     RealtimeMediaSourceCenter& center = RealtimeMediaSourceCenter::singleton();
 
     if (mock.m_isEnabled) {
-        if (mock.m_isMockAudioCaptureEnabled)
+        if (mock.m_isMockAudioCaptureEnabled) {
+#if PLATFORM(COCOA)
+            MockAudioSharedUnit::enable();
+#endif
             center.setAudioCaptureFactory(mock.audioCaptureFactory());
+        }
         if (mock.m_isMockVideoCaptureEnabled)
             center.setVideoCaptureFactory(mock.videoCaptureFactory());
         if (mock.m_isMockDisplayCaptureEnabled)
@@ -383,8 +387,12 @@ void MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled(bool
         return;
     }
 
-    if (mock.m_isMockAudioCaptureEnabled)
+    if (mock.m_isMockAudioCaptureEnabled) {
+#if PLATFORM(COCOA)
+        MockAudioSharedUnit::disable();
+#endif
         center.unsetAudioCaptureFactory(mock.audioCaptureFactory());
+    }
     if (mock.m_isMockVideoCaptureEnabled)
         center.unsetVideoCaptureFactory(mock.videoCaptureFactory());
     if (mock.m_isMockDisplayCaptureEnabled)
@@ -432,7 +440,7 @@ void MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange(bool f
         auto devices = audioCaptureDeviceManager().captureDevices();
         if (devices.size() > 1) {
             MockAudioSharedUnit::increaseBufferSize();
-            MockAudioSharedUnit::singleton().handleNewCurrentMicrophoneDevice(WTFMove(devices[1]));
+            CoreAudioSharedUnit::singleton().handleNewCurrentMicrophoneDevice(WTFMove(devices[1]));
         }
     }
     if (forDisplay) {


### PR DESCRIPTION
#### 2ec42b771fd5d95a85adec5c28a83e2f24b544be
<pre>
Remove MockAudioSharedUnit::singleton()
<a href="https://rdar.apple.com/137747499">rdar://137747499</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=281299">https://bugs.webkit.org/show_bug.cgi?id=281299</a>

Reviewed by Eric Carlson.

Now that we have a mock audio shared internal unit, it is best to remove MockAudioSharedUnit,
as it makes it hard for code to send signals like testing signals to either the CoreAudioShared unit singleton or the MockAudioSharedUnit singleton.

We update CoreAudioSharedUnit so that we can directly use CoreAudioSharedUnit with a mock audio shared internal unit.

Covered by existing tests.

* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::create):
(WebCore::CoreAudioCaptureSource::createForTesting):
(WebCore::CoreAudioCaptureSourceFactory::beginInterruption):
(WebCore::CoreAudioCaptureSourceFactory::endInterruption):
(WebCore::CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio):
(WebCore::CoreAudioCaptureSource::CoreAudioCaptureSource):
(WebCore::CoreAudioCaptureSource::initializeToStartProducingData):
(WebCore::CoreAudioCaptureSource::~CoreAudioCaptureSource):
(WebCore::CoreAudioCaptureSource::startProducingData):
(WebCore::CoreAudioCaptureSource::stopProducingData):
(WebCore::CoreAudioCaptureSource::capabilities):
(WebCore::CoreAudioCaptureSource::settings):
(WebCore::CoreAudioCaptureSource::settingsDidChange):
(WebCore::CoreAudioCaptureSource::interrupted const):
(WebCore::CoreAudioCaptureSource::delaySamples):
(WebCore::CoreAudioCaptureSource::unit): Deleted.
(WebCore::CoreAudioCaptureSource::unit const): Deleted.
(WebCore::CoreAudioCaptureSourceFactory::unit): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
(WebCore::CoreAudioCaptureSourceFactory::setOverrideUnit): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::setupAudioUnit):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockRealtimeAudioSource::create):
(WebCore::MockAudioSharedUnit::enable):
(WebCore::MockAudioSharedUnit::disable):
(WebCore::MockAudioSharedInternalUnit::voiceDetected):
(WebCore::MockAudioSharedInternalUnit::set):
(WebCore::MockAudioSharedUnit::singleton): Deleted.
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::setIsInterrupted):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled):
(WebCore::MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange):

Canonical link: <a href="https://commits.webkit.org/285115@main">https://commits.webkit.org/285115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5c685149c7b7dfb5f3fb52ac1db15eee32441ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71603 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15029 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19144 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77433 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64269 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64265 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12411 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6052 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->