### PR TITLE
Prevent use of HashMap::get() / HashMap::take() when the value type is an ObjectIdentifier

### DIFF
--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -386,6 +386,7 @@ inline void HashSet<T, U, V, W>::clear()
 template<typename T, typename U, typename V, typename W>
 inline auto HashSet<T, U, V, W>::take(iterator it) -> TakeType
 {
+    static_assert(!ValueTraits::disablesGetAndTake);
     if (it == end())
         return ValueTraits::take(ValueTraits::emptyValue());
 

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -40,6 +40,12 @@ template<typename T> struct GenericHashTraitsBase<false, T> {
     // The emptyValueIsZero flag is used to optimize allocation of empty hash tables with zeroed memory.
     static constexpr bool emptyValueIsZero = false;
 
+    // HashTable::get() / take() may return the empty value. Setting disablesGetAndTake to true
+    // will disable get() / take(), forcing them to use getOptional() / takeOptional(). This is
+    // useful when one doesn't want to expose the empty value is "invalid" and shouldn't be exposed
+    // to clients.
+    static constexpr bool disablesGetAndTake = false;
+
     // The hasIsEmptyValueFunction flag allows the hash table to automatically generate code to check
     // for the empty value when it can be done with the equality operator, but allows custom functions
     // for cases like String that need them.

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -221,6 +221,7 @@ struct ObjectIdentifierGenericBaseHash<UUID> {
 };
 
 template<typename T, typename U, typename V, SupportsObjectIdentifierNullState supportsNullState> struct HashTraits<ObjectIdentifierGeneric<T, U, V, supportsNullState>> : SimpleClassHashTraits<ObjectIdentifierGeneric<T, U, V, supportsNullState>> {
+    static constexpr bool disablesGetAndTake = supportsNullState == SupportsObjectIdentifierNullState::No;
     static ObjectIdentifierGeneric<T, U, V, supportsNullState> emptyValue() { return ObjectIdentifierGeneric<T, U, V, supportsNullState>(ObjectIdentifierGeneric<T, U, V, supportsNullState>::InvalidIdValue); }
     static bool isEmptyValue(const ObjectIdentifierGeneric<T, U, V, supportsNullState>& value) { return value.isHashTableEmptyValue(); }
 };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -741,10 +741,10 @@ void SWServer::matchAll(SWServerWorker& worker, const ServiceWorkerClientQueryOp
     Vector<ServiceWorkerClientData> matchingClients;
     forEachClientForOrigin(worker.origin(), [&](auto& clientData) {
         if (!options.includeUncontrolled) {
-            auto registrationIdentifier = m_clientToControllingRegistration.get(clientData.identifier);
+            auto registrationIdentifier = m_clientToControllingRegistration.getOptional(clientData.identifier);
             if (worker.data().registrationIdentifier != registrationIdentifier)
                 return;
-            if (&worker != this->activeWorkerFromRegistrationID(registrationIdentifier))
+            if (&worker != this->activeWorkerFromRegistrationID(*registrationIdentifier))
                 return;
         }
         if (options.type != ServiceWorkerClientType::All && options.type != clientData.type)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -168,7 +168,7 @@ bool FileSystemStorageManager::acquireLockForFile(const String& path, WebCore::F
 
 bool FileSystemStorageManager::releaseLockForFile(const String& path, WebCore::FileSystemHandleIdentifier identifier)
 {
-    if (auto lockedByIdentifier = m_lockMap.get(path); lockedByIdentifier == identifier) {
+    if (auto lockedByIdentifier = m_lockMap.getOptional(path); lockedByIdentifier == identifier) {
         m_lockMap.remove(path);
         return true;
     }

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
@@ -49,7 +49,7 @@ StorageAreaBase::~StorageAreaBase() = default;
 
 void StorageAreaBase::addListener(IPC::Connection::UniqueID connection, StorageAreaMapIdentifier identifier)
 {
-    ASSERT(!m_listeners.contains(connection) || m_listeners.get(connection) == identifier);
+    ASSERT(!m_listeners.contains(connection) || m_listeners.getOptional(connection) == identifier);
 
     m_listeners.add(connection, identifier);
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1293,8 +1293,8 @@ void WebProcessPool::pageEndUsingWebsiteDataStore(WebPageProxy& page, WebsiteDat
     RELEASE_ASSERT(iterator != m_sessionToPageIDsMap.end());
 
     auto pageID = page.identifier();
-    auto takenPageID = iterator->value.take(pageID);
-    ASSERT_UNUSED(takenPageID, takenPageID == pageID);
+    ASSERT(iterator->value.contains(pageID));
+    iterator->value.remove(pageID);
 
     if (iterator->value.isEmpty()) {
         m_sessionToPageIDsMap.remove(iterator);


### PR DESCRIPTION
#### 49d143dcba198d9a71a58f3b5287cbae191144eb
<pre>
Prevent use of HashMap::get() / HashMap::take() when the value type is an ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=281306">https://bugs.webkit.org/show_bug.cgi?id=281306</a>

Reviewed by NOBODY (OOPS!).

An ObjectIdentifier cannot be invalid/empty, we normally use `std::optional&lt;ObjectIdentifier&gt;`
or `Markable&lt;ObjectIdentifier&gt;` to represent an invalid/empty identifier. The only way to
construct an &quot;empty&quot; ObjectIdentifier is via `HashTraits&lt;ObjectIdentifier&gt;::emptyValue()`,
which HashMap relies on internally. As long as the HashMap is only using this special value
internally, this is fine. However, HashMap::get() and HashMap::take() will return this
invalid &quot;empty&quot; value if the key is not present. This was very error-prone for
ObjectIdentifier since the client would receive an invalid ObjectIdentifier and have no way
to check if the ObjectIdentifier is valid or not (since we assume an ObjectIdentifier is
always valid).

To address the issue, we now forbid the use of HashMap::get() / HashMap::take() when the
value type is an ObjectIdentifier and force the client to use `HashMap::getOptional()` /
`HashMap::takeOptional()` instead, which returns a std::optional.

* Source/WTF/wtf/HashMap.h:
(WTF::Y&gt;::get const):
(WTF::Y&gt;::inlineGet const):
(WTF::Y&gt;::take):
(WTF::Y&gt;::takeOptional):
* Source/WTF/wtf/HashSet.h:
(WTF::W&gt;::take):
* Source/WTF/wtf/HashTraits.h:
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::matchAll):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::releaseLockForFile):
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp:
(WebKit::StorageAreaBase::addListener):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::pageEndUsingWebsiteDataStore):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d143dcba198d9a71a58f3b5287cbae191144eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14802 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20816 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64395 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77100 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70519 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64052 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64038 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5815 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92305 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1262 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20360 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->