### PR TITLE
[build.webkit.org] Switch GTK and WPE nightly packaging bots to generate universal bundles.

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -106,7 +106,6 @@
                   { "name": "gtk-linux-bot-20", "platform": "gtk" },
                   { "name": "gtk-linux-bot-21", "platform": "gtk" },
                   { "name": "gtk-linux-bot-22", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-23", "platform": "gtk" },
                   { "name": "gtk-linux-bot-24", "platform": "gtk" },
 
                   { "name": "jsconly-linux-igalia-bot-1", "platform": "jsc-only" },
@@ -149,7 +148,6 @@
                   { "name": "wpe-linux-bot-33", "platform": "wpe" },
                   { "name": "wpe-linux-bot-34", "platform": "wpe" },
                   { "name": "wpe-linux-bot-35", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-36", "platform": "wpe" },
                   { "name": "wpe-linux-bot-37", "platform": "wpe" }
                 ],
 
@@ -538,16 +536,10 @@
                     "workernames": ["gtk-linux-bot-21"]
                   },
                   {
-                    "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
+                    "name": "GTK-Linux-64bit-Release-Packaging-Nightly", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-bubblewrap-sandbox"],
                     "workernames": ["gtk-linux-bot-17"]
-                  },
-                  {
-                    "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
-                    "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
-                    "additionalArguments": ["--no-bubblewrap-sandbox"],
-                    "workernames": ["gtk-linux-bot-23"]
                   },
                   {
                     "name": "GTK-Linux-64-bit-Release-GTK3-Tests", "factory": "BuildAndTestAndArchiveAllButJSCFactory",
@@ -645,16 +637,10 @@
                     "workernames": ["wpe-linux-bot-6"]
                   },
                   {
-                    "name": "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
+                    "name": "WPE-Linux-64bit-Release-Packaging-Nightly", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
-                    "additionalArguments": ["--no-bubblewrap-sandbox", "--cmakeargs=-DENABLE_WPE_QT_API=OFF"],
+                    "additionalArguments": ["--no-bubblewrap-sandbox"],
                     "workernames": ["wpe-linux-bot-8"]
-                  },
-                  {
-                    "name": "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
-                    "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
-                    "additionalArguments": ["--no-bubblewrap-sandbox", "--cmakeargs=-DENABLE_WPE_QT_API=OFF"],
-                    "workernames": ["wpe-linux-bot-36"]
                   },
                   {
                     "name": "WPE-Linux-64-bit-Release-Non-Unified-Build", "factory": "BuildFactory",
@@ -970,10 +956,8 @@
                   },
                   { "type": "Nightly", "name": "NightlyScheduler", "change_filter": "main_filter",
                     "branch": "main", "hour": 22, "minute": 0,
-                    "builderNames": ["GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004",
-                                     "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204",
-                                     "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004",
-                                     "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204"]
+                    "builderNames": ["GTK-Linux-64bit-Release-Packaging-Nightly",
+                                     "WPE-Linux-64bit-Release-Packaging-Nightly"]
                   }
                 ]
 }

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1396,7 +1396,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
-        'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
+        'GTK-Linux-64bit-Release-Packaging-Nightly': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -1409,7 +1409,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'generate-minibrowser-bundle'
         ],
-        'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204': [
+        'GTK-Linux-64bit-Release-Packaging-Nightly': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -1740,20 +1740,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'webdriver-test'
         ],
-        'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'generate-minibrowser-bundle'
-        ],
-        'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204': [
+        'WPE-Linux-64bit-Release-Packaging-Nightly': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',


### PR DESCRIPTION
#### 6c794791a3396581d1b8184920f8694c23a55612
<pre>
[build.webkit.org] Switch GTK and WPE nightly packaging bots to generate universal bundles.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281305">https://bugs.webkit.org/show_bug.cgi?id=281305</a>

Reviewed by Carlos Garcia Campos.

The GTK and WPE nightly packaging bots are producing MiniBrowser bundles for Ubuntu-22.04
and Ubuntu-24.04, but the Ubuntu-22.04 bundles have been broken for a while.

So the idea is to remove the bots generating bundles for a specific distro (like Ubuntu)
and instead have just one bot generating universal bundles that can work on any distro.

An extra test step is added that validates the generated bundle before uploading it
(by running several WebDriver tests on very different distros with Docker).

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/steps.py:
(GenerateMiniBrowserBundle):
(GenerateMiniBrowserBundle.run):
(TestMiniBrowserBundle):
(TestMiniBrowserBundle.run):
* Tools/CISupport/build-webkit-org/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/285255@main">https://commits.webkit.org/285255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/613c61d06380324f7c5649fbc8433a6e219966a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56361 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36789 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77107 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64053 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/70953 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64039 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5821 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11051 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46490 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48844 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->