### PR TITLE
Drop Supplementable::removeSupplement() to simplify Supplement lifetime model

### DIFF
--- a/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.h
+++ b/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.h
@@ -42,4 +42,23 @@ public:
     static TrustedTypePolicyFactory* trustedTypes(WorkerGlobalScope&);
 };
 
+class WorkerGlobalScopeTrustedTypes : public Supplement<WorkerGlobalScope> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WorkerGlobalScopeTrustedTypes);
+public:
+    explicit WorkerGlobalScopeTrustedTypes(WorkerGlobalScope&);
+    virtual ~WorkerGlobalScopeTrustedTypes();
+
+    static WorkerGlobalScopeTrustedTypes* from(WorkerGlobalScope&);
+    TrustedTypePolicyFactory* trustedTypes() const;
+
+    void prepareForDestruction();
+
+    static ASCIILiteral supplementName() { return WindowOrWorkerGlobalScopeTrustedTypes::workerGlobalSupplementName(); }
+
+private:
+    WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
+    mutable RefPtr<TrustedTypePolicyFactory> m_trustedTypes;
+};
+
+
 } // namespace WebCore

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -101,13 +101,7 @@ public:
     {
         ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
         ASSERT(!m_supplements.get(key));
-        m_supplements.set(key, WTFMove(supplement));
-    }
-
-    void removeSupplement(ASCIILiteral key)
-    {
-        ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
-        m_supplements.remove(key);
+        m_supplements.add(key, WTFMove(supplement));
     }
 
     Supplement<T>* requireSupplement(ASCIILiteral key)

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -162,7 +162,8 @@ void WorkerGlobalScope::prepareForDestruction()
 {
     WorkerOrWorkletGlobalScope::prepareForDestruction();
 
-    removeSupplement(WindowOrWorkerGlobalScopeTrustedTypes::workerGlobalSupplementName());
+    if (auto* trustedTypes = static_cast<WorkerGlobalScopeTrustedTypes*>(requireSupplement(WorkerGlobalScopeTrustedTypes::supplementName())))
+        trustedTypes->prepareForDestruction();
 
     if (settingsValues().serviceWorkersEnabled)
         swClientConnection().unregisterServiceWorkerClient(identifier());


### PR DESCRIPTION
#### 47eea119fe9462721e5cc75527a4280c6d5f5214
<pre>
Drop Supplementable::removeSupplement() to simplify Supplement lifetime model
<a href="https://bugs.webkit.org/show_bug.cgi?id=281328">https://bugs.webkit.org/show_bug.cgi?id=281328</a>

Reviewed by Geoffrey Garen and Ryosuke Niwa.

It was only used in one place and wasn&apos;t truly required.

Also call `m_supplements.add()` instead of `m_supplements.set()` to guarantee
we don&apos;t overwrite an existing Supplement and thus destroy it before the
Supplementable gets destroyed.

* Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp:
(WebCore::WorkerGlobalScopeTrustedTypes::prepareForDestruction):
(WebCore::WorkerGlobalScopeTrustedTypes::trustedTypes const):
(WebCore::WorkerGlobalScopeTrustedTypes::supplementName): Deleted.
* Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.h:
(WebCore::WorkerGlobalScopeTrustedTypes::supplementName):
* Source/WebCore/platform/Supplementable.h:
(WebCore::Supplementable::removeSupplement): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::prepareForDestruction):

Canonical link: <a href="https://commits.webkit.org/285049@main">https://commits.webkit.org/285049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29061702bb849535d9b8dfb01fe910a5fcf9cfd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22371 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14850 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20893 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77177 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18489 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64086 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5863 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10940 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46560 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->