### PR TITLE
Use RetainPtr in a few places for extra safety

### DIFF
--- a/Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm
@@ -55,10 +55,10 @@ static ApplePayPayment::Token convert(PKPaymentToken *paymentToken)
 
     result.paymentMethod = PaymentMethod(paymentToken.paymentMethod).toApplePayPaymentMethod();
 
-    if (NSString *transactionIdentifier = paymentToken.transactionIdentifier)
-        result.transactionIdentifier = transactionIdentifier;
-    if (NSData *paymentData = paymentToken.paymentData)
-        result.paymentData = String::fromUTF8(span(paymentData));
+    if (RetainPtr<NSString> transactionIdentifier = paymentToken.transactionIdentifier)
+        result.transactionIdentifier = transactionIdentifier.get();
+    if (RetainPtr<NSData> paymentData = paymentToken.paymentData)
+        result.paymentData = String::fromUTF8(span(paymentData.get()));
 
     return result;
 }

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -212,15 +212,15 @@ void ResourceRequest::doUpdateResourceRequest()
 
 void ResourceRequest::doUpdateResourceHTTPBody()
 {
-    if (NSData* bodyData = [m_nsRequest HTTPBody])
-        m_httpBody = FormData::create(span(bodyData));
-    else if (NSInputStream* bodyStream = [m_nsRequest HTTPBodyStream]) {
-        FormData* formData = httpBodyFromStream(bodyStream);
+    if (RetainPtr bodyData = [m_nsRequest HTTPBody])
+        m_httpBody = FormData::create(span(bodyData.get()));
+    else if (RetainPtr bodyStream = [m_nsRequest HTTPBodyStream]) {
+        RefPtr formData = httpBodyFromStream(bodyStream.get());
         // There is no FormData object if a client provided a custom data stream.
         // We shouldn't be looking at http body after client callbacks.
         ASSERT(formData);
         if (formData)
-            m_httpBody = formData;
+            m_httpBody = WTFMove(formData);
     }
 }
 


### PR DESCRIPTION
#### 71376288420b34ea37e78d34ef5538482c9cef86
<pre>
Use RetainPtr in a few places for extra safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=281337">https://bugs.webkit.org/show_bug.cgi?id=281337</a>

Reviewed by Abrar Rahman Protyasha and Timothy Hatcher.

* Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm:
(WebCore::convert):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceHTTPBody):

Canonical link: <a href="https://commits.webkit.org/285057@main">https://commits.webkit.org/285057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7821b46ac2c0bfbd6b9c1c0996aa5418d42106d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18988 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20960 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18529 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61563 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64114 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5901 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10945 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46627 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->