### PR TITLE
[buildbot] Add de-duper script for results

### DIFF
--- a/Tools/CISupport/Shared/de-duper
+++ b/Tools/CISupport/Shared/de-duper
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import hashlib
+import os
+import sys
+
+CHUNK_SIZE = 8192
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(
+        description='Program which de-duplicates PNG files in a directory using hard links'
+    )
+    parser.add_argument(
+        'root', nargs='?',
+        help='Path to root of directory to de-duplicate PNG files in',
+        type=str, default='.',
+    )
+    parser.add_argument(
+        '-s', '--storage',
+        help='Directory to store images the program is linking to',
+        type=str,
+        default='storage',
+    )
+    parser.add_argument(
+        '-d', '--dry-run',
+        action='store_true',
+        dest='dry_run',
+        default=False,
+    )
+    return parser.parse_args(args)
+
+
+def sha1(path):
+    try:
+        with open(path, 'rb') as file:
+            hsh = hashlib.sha1()
+            chunk = file.read(CHUNK_SIZE)
+            while chunk:
+                hsh.update(chunk)
+                chunk = file.read(CHUNK_SIZE)
+        return hsh.hexdigest()
+    except OSError:
+        return None
+
+
+def main(args):
+    args = parse_args(args)
+
+    args.root = os.path.abspath(args.root)
+    args.storage = os.path.join(args.root, args.storage)
+    if not os.path.isdir(args.root):
+        print(f"'{args.root}' is a path which does not exist\n", file=sys.stderr)
+        return 1
+    storage_parent = os.path.dirname(args.storage)
+    if not os.path.isdir(storage_parent):
+        print(f"'{storage_parent}' is a path which does not exist\n", file=sys.stderr)
+        return 1
+
+    if not os.path.isdir(args.storage):
+        os.mkdir(args.storage)
+
+    cleaned_up = 0
+    de_duped = 0
+    processed = 0
+
+    existing_links = set()
+    with os.scandir(args.storage) as existing_files:
+        for existing_file in existing_files:
+            if not existing_file.name.startswith('.') and existing_file.is_file():
+                continue
+            if '.' not in existing_file.name:
+                continue
+            sha_value, extension = existing_file.name.split('.', 1)
+            if extension != 'png':
+                continue
+            if not existing_file.inode() <= 1:
+                if args.dry_run:
+                    print(f'[dry-run] Removing {existing_file.path}')
+                else:
+                    os.remove(existing_file.path)
+                cleaned_up += 1
+            else:
+                existing_links.add(sha_value)
+
+    for root, _, files in os.walk(args.root, topdown=False):
+        for file in files:
+            if not file.endswith('.png'):
+                continue
+            processed += 1
+            full_path = os.path.join(root, file)
+            if os.stat(full_path).st_nlink > 1:
+                continue
+            sha_value = sha1(full_path)
+            if sha_value in existing_links:
+                if args.dry_run:
+                    print(f'[dry-run] Linking {full_path} to {sha_value}.png')
+                else:
+                    os.remove(full_path)
+                    os.link(os.path.join(args.storage, f'{sha_value}.png'), full_path)
+                de_duped += 1
+            elif not sha_value:
+                print(f"Failed to compute SHA for '{full_path}'\n", file=sys.stderr)
+            else:
+                if args.dry_run:
+                    print(f'[dry-run] Storing and linking {full_path} to {sha_value}.png')
+                else:
+                    os.link(full_path, os.path.join(args.storage, f'{sha_value}.png'))
+                existing_links.add(sha_value)
+
+    print(f'{len(existing_links)} unique png files in storage of {processed} processed')
+    print(f'{cleaned_up} files removed, {de_duped} de-duped')
+
+    return 0
+
+if '__main__' == __name__:
+     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
#### f07efecdac0917ed92543b28e9af8c2e0305ba10
<pre>
[buildbot] Add de-duper script for results
<a href="https://bugs.webkit.org/show_bug.cgi?id=281334">https://bugs.webkit.org/show_bug.cgi?id=281334</a>
<a href="https://rdar.apple.com/137770187">rdar://137770187</a>

Reviewed by Sam Sneddon.

Attempt to hard-link identical PNG files to a shared &quot;storage&quot; directory.

* Tools/CISupport/Shared/de-duper: Added.
(parse_args): Caller can specify root directory and storage directory.
(sha1): Compute the sha1 hash of the specified file.
(main): Iterate through all PNG files in the root directory, if those files
are already hard-links, skip them. Otherwise, compute the sha1 hash of the source
PNG files and move the file content to the storage directory and hard-link to that.

Canonical link: <a href="https://commits.webkit.org/285362@main">https://commits.webkit.org/285362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a231377e06fc207b9cb88cf0356598b43dedb9b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25207 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/23628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23450 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/23628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75486 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/62366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/20191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/16660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/78267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/72094 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/16708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/62379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/78267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11112 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47638 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/48450 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->