### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Make PDFScriptEvaluator ref-counted

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -101,6 +101,9 @@ public:
 
     virtual ~PDFPluginBase();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeThreadSafeCheckedPtr::ptrCount(); }
     uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::ptrCountWithoutThreadCheck(); }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
@@ -32,15 +32,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class PDFScriptEvaluatorClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PDFScriptEvaluatorClient> : std::true_type { };
-}
-
 typedef const struct OpaqueJSContext* JSContextRef;
 typedef struct OpaqueJSValue* JSObjectRef;
 typedef const struct OpaqueJSValue* JSValueRef;
@@ -51,6 +42,9 @@ namespace WebKit {
 class PDFScriptEvaluatorClient : public CanMakeWeakPtr<PDFScriptEvaluatorClient> {
 public:
     virtual ~PDFScriptEvaluatorClient() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual void print() = 0;
 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
@@ -210,9 +210,8 @@ void PDFScriptEvaluator::runScripts(CGPDFDocumentRef document, PDFScriptEvaluato
 
 void PDFScriptEvaluator::print()
 {
-    if (!m_client)
-        return;
-    m_client->print();
+    if (RefPtr client = m_client.get())
+        client->print();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 97eedd83ade0ec09f4f5cf171de111f1761bcee4
<pre>
[IsDeprecatedWeakRefSmartPointerException] Make PDFScriptEvaluator ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281342">https://bugs.webkit.org/show_bug.cgi?id=281342</a>
<a href="https://rdar.apple.com/137773028">rdar://137773028</a>

Reviewed by NOBODY (OOPS!).

Remove IsDeprecatedWeakRefSmartPointerException] by making PDFScriptEvaluator ref-counted.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm:
(WebKit::PDFScriptEvaluator::print):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97eedd83ade0ec09f4f5cf171de111f1761bcee4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71365 "Failed to checkout and rebase branch from PR 35068") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50778 "Failed to checkout and rebase branch from PR 35068") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24138 "Failed to checkout and rebase branch from PR 35068") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58578 "Failed to checkout and rebase branch from PR 35068") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22389 "Failed to checkout and rebase branch from PR 35068") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74431 "Failed to checkout and rebase branch from PR 35068") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/58578 "Failed to checkout and rebase branch from PR 35068") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/24138 "Failed to checkout and rebase branch from PR 35068") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/58578 "Failed to checkout and rebase branch from PR 35068") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/24138 "Failed to checkout and rebase branch from PR 35068") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/58578 "Failed to checkout and rebase branch from PR 35068") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/24138 "Failed to checkout and rebase branch from PR 35068") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/15599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/22389 "Failed to checkout and rebase branch from PR 35068") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/77195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/15642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/24138 "Failed to checkout and rebase branch from PR 35068") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/77195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/24138 "Failed to checkout and rebase branch from PR 35068") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/46578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/47649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->