### PR TITLE
Use different keychain attribute for passkey credential ID

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -89,6 +89,8 @@ OSStatus SecTrustedApplicationCreateFromPath(const char* path, SecTrustedApplica
 SecSignatureHashAlgorithm SecCertificateGetSignatureHashAlgorithm(SecCertificateRef);
 extern const CFStringRef kSecAttrNoLegacy;
 
+extern const CFStringRef kSecAttrAlias;
+
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -29,6 +29,7 @@
 
 @interface ASCWebKitSPISupport : NSObject
 @property (class, nonatomic) BOOL shouldUseAlternateCredentialStore;
+@property (class, nonatomic, readonly) BOOL shouldUseAlternateKeychainAttribute;
 + (void)getArePasskeysDisallowedForRelyingParty:(nonnull NSString *)relyingParty withCompletionHandler:(void (^ _Nonnull)(BOOL))completionHandler NS_REFINED_FOR_SWIFT;
 + (void)getCanCurrentProcessAccessPasskeysForRelyingParty:(nonnull NSString *)relyingParty withCompletionHandler:(void (^ _Nonnull)(BOOL))completionHandler;
 + (void)getClientCapabilitiesForRelyingParty:(nonnull NSString *)relyingParty withCompletionHandler:(void (^ _Nonnull)(NSDictionary<NSString *, NSNumber *> * _Nonnull))completionHandler;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
@@ -40,6 +40,8 @@ class AuthenticatorAssertionResponse;
 
 namespace WebKit {
 
+BOOL shouldUseAlternateKeychainAttribute();
+
 class LocalAuthenticator final : public Authenticator {
 public:
     // Here is the FSM.

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -86,10 +86,20 @@ using namespace WebCore;
 using namespace WebAuthn;
 using CBOR = cbor::CBORValue;
 
+BOOL shouldUseAlternateKeychainAttribute()
+{
+#if HAVE(UNIFIED_ASC_AUTH_UI)
+    if (![WebKit::getASCWebKitSPISupportClass() respondsToSelector:@selector(shouldUseAlternateKeychainAttribute)])
+        return NO;
+
+    return [WebKit::getASCWebKitSPISupportClass() shouldUseAlternateKeychainAttribute];
+#else
+    return NO;
+#endif
+}
+
 namespace LocalAuthenticatorInternal {
 
-// Credential ID is currently SHA-1 of the corresponding public key.
-constexpr uint16_t credentialIdLength = 20;
 constexpr uint64_t counter = 0;
 // This aaguid is unattested.
 constexpr std::array<uint8_t, 16> aaguid = { 0xFB, 0xFC, 0x30, 0x07, 0x15, 0x4E, 0x4E, 0xCC, 0x8C, 0x0B, 0x6E, 0x02, 0x05, 0x57, 0xD7, 0xBD }; // Randomly generated.
@@ -106,7 +116,7 @@ static inline HashSet<String> produceHashSet(const Vector<PublicKeyCredentialDes
 {
     HashSet<String> result;
     for (auto& credentialDescriptor : credentialDescriptors) {
-        if (emptyTransportsOrContain(credentialDescriptor.transports, AuthenticatorTransport::Internal) && credentialDescriptor.type == PublicKeyCredentialType::PublicKey && BufferSource { credentialDescriptor.id } .length() == credentialIdLength)
+        if (emptyTransportsOrContain(credentialDescriptor.transports, AuthenticatorTransport::Internal) && credentialDescriptor.type == PublicKeyCredentialType::PublicKey)
             result.add(base64EncodeToString(BufferSource { credentialDescriptor.id }.span()));
     }
     return result;
@@ -205,7 +215,15 @@ std::optional<Vector<Ref<AuthenticatorAssertionResponse>>> LocalAuthenticator::g
         }
         auto& username = it->second.getString();
 
-        auto response = AuthenticatorAssertionResponse::create(LocalAuthenticatorInternal::toArrayBuffer(attributes[(id)kSecAttrApplicationLabel]), WTFMove(userHandle), String(username), (__bridge SecAccessControlRef)attributes[(id)kSecAttrAccessControl], AuthenticatorAttachment::Platform);
+        id credentialID;
+        if (shouldUseAlternateKeychainAttribute()) {
+            credentialID = attributes[(id)kSecAttrAlias];
+            if (!credentialID)
+                credentialID = attributes[(id)kSecAttrApplicationLabel];
+        } else
+            credentialID = attributes[(id)kSecAttrApplicationLabel];
+
+        auto response = AuthenticatorAssertionResponse::create(LocalAuthenticatorInternal::toArrayBuffer(credentialID), WTFMove(userHandle), String(username), (__bridge SecAccessControlRef)attributes[(id)kSecAttrAccessControl], AuthenticatorAttachment::Platform);
 
         auto group = groupForAttributes(attributes);
         if (!group.isNull()) {
@@ -355,18 +373,28 @@ std::optional<WebCore::ExceptionData> LocalAuthenticator::processLargeBlobExtens
     // Step 4.
     if (largeBlobInput->write) {
         auto nsCredentialId = toNSData(response->rawId());
-        NSDictionary *fetchQuery = @{
+        BOOL useAlternateKeychainAttribute = shouldUseAlternateKeychainAttribute();
+        auto fetchQuery = adoptNS([[NSMutableDictionary alloc] init]);
+        [fetchQuery setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
             (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
-            (id)kSecAttrApplicationLabel: nsCredentialId.get(),
             (id)kSecUseDataProtectionKeychain: @YES,
             (id)kSecReturnAttributes: @YES,
             (id)kSecReturnPersistentRef: @YES,
-        };
+        }];
+
+        CFStringRef credentialIdKey = useAlternateKeychainAttribute ? kSecAttrAlias : kSecAttrApplicationLabel;
+        [fetchQuery setObject:nsCredentialId.get() forKey:(id)credentialIdKey];
 
         CFTypeRef attributesArrayRef = nullptr;
-        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)fetchQuery, &attributesArrayRef);
+        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)fetchQuery.get(), &attributesArrayRef);
+        if (useAlternateKeychainAttribute && status == errSecItemNotFound) {
+            [fetchQuery removeObjectForKey:(id)kSecAttrAlias];
+            [fetchQuery setObject:nsCredentialId.get() forKey:(id)kSecAttrApplicationLabel];
+            status = SecItemCopyMatching((__bridge CFDictionaryRef)fetchQuery.get(), &attributesArrayRef);
+        }
+
         if (status && status != errSecItemNotFound) {
             ASSERT_NOT_REACHED();
             return WebCore::ExceptionData { ExceptionCode::UnknownError, "Attempted to update unknown credential."_s };
@@ -499,7 +527,6 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         credentialId = digest->computeHash();
         m_provisionalCredentialId = toNSData(credentialId);
 
-#if ASSERT_ENABLED
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
@@ -510,9 +537,15 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         }];
         updateQueryIfNecessary(query.get());
 
+#if ASSERT_ENABLED
         OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), nullptr);
         ASSERT(!status);
-#endif // NDEBUG
+#endif
+
+        NSDictionary *updateAttributes = @{
+            (id)kSecAttrAlias: m_provisionalCredentialId.get()
+        };
+        SecItemUpdate((__bridge CFDictionaryRef)query.get(), (__bridge CFDictionaryRef)updateAttributes);
     }
 
     // Step 11. https://www.w3.org/TR/webauthn/#attested-credential-data
@@ -683,14 +716,17 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
     RetainPtr<CFDataRef> signature;
     auto nsCredentialId = toNSData(response->rawId());
     {
+        BOOL useAlternateKeychainAttribute = shouldUseAlternateKeychainAttribute();
         NSMutableDictionary *queryDictionary = [@{
             (id)kSecClass: (id)kSecClassKey,
             (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
-            (id)kSecAttrApplicationLabel: nsCredentialId.get(),
             (id)kSecReturnRef: @YES,
             (id)kSecUseDataProtectionKeychain: @YES
         } mutableCopy];
+
+        CFStringRef credentialIdKey = useAlternateKeychainAttribute ? kSecAttrAlias : kSecAttrApplicationLabel;
+        queryDictionary[(id)credentialIdKey] = nsCredentialId.get();
 
         if (context)
             queryDictionary[(id)kSecUseAuthenticationContext] = context;
@@ -699,6 +735,12 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
 
         CFTypeRef privateKeyRef = nullptr;
         OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), &privateKeyRef);
+        if (useAlternateKeychainAttribute && status == errSecItemNotFound) {
+            queryDictionary[(id)kSecAttrAlias] = nil;
+            queryDictionary[(id)kSecAttrApplicationLabel] = nsCredentialId.get();
+            status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), &privateKeyRef);
+        }
+
         if (status) {
             receiveException({ ExceptionCode::UnknownError, makeString("Couldn't get the private key reference: "_s, status) });
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't get the private key reference: %d", status);
@@ -722,18 +764,28 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
 
     // Extra step: update the Keychain item with the same value to update its modification date such that LRU can be used
     // for selectAssertionResponse
-    NSDictionary *query = @{
+    BOOL useAlternateKeychainAttribute = shouldUseAlternateKeychainAttribute();
+    auto query = adoptNS([[NSMutableDictionary alloc] init]);
+    [query setDictionary:@{
         (id)kSecClass: (id)kSecClassKey,
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
-        (id)kSecAttrApplicationLabel: nsCredentialId.get(),
         (id)kSecUseDataProtectionKeychain: @YES
-    };
+    }];
+
+    CFStringRef credentialIdKey = useAlternateKeychainAttribute ? kSecAttrAlias : kSecAttrApplicationLabel;
+    [query setObject:nsCredentialId.get() forKey:(id)credentialIdKey];
 
     NSDictionary *updateParams = @{
-        (id)kSecAttrApplicationLabel: nsCredentialId.get(),
+        (id)kSecAttrAlias: nsCredentialId.get(),
     };
-    auto status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)updateParams);
+    auto status = SecItemUpdate((__bridge CFDictionaryRef)query.get(), (__bridge CFDictionaryRef)updateParams);
+    if (useAlternateKeychainAttribute && status == errSecItemNotFound) {
+        [query removeObjectForKey:(id)kSecAttrAlias];
+        [query setObject:nsCredentialId.get() forKey:(id)kSecAttrApplicationLabel];
+        status = SecItemUpdate((__bridge CFDictionaryRef)query.get(), (__bridge CFDictionaryRef)updateParams);
+    }
+
     if (status)
         RELEASE_LOG_ERROR(WebAuthn, "Couldn't update the Keychain item: %d", status);
 
@@ -753,15 +805,24 @@ void LocalAuthenticator::receiveException(ExceptionData&& exception, WebAuthenti
 
     // Roll back the just created credential.
     if (m_provisionalCredentialId) {
+        BOOL useAlternateKeychainAttribute = shouldUseAlternateKeychainAttribute();
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrApplicationLabel: m_provisionalCredentialId.get(),
             (id)kSecUseDataProtectionKeychain: @YES
         }];
         updateQueryIfNecessary(query.get());
 
+        CFStringRef credentialIdKey = useAlternateKeychainAttribute ? kSecAttrAlias : kSecAttrApplicationLabel;
+        [query setObject:m_provisionalCredentialId.get() forKey:(id)credentialIdKey];
+
         OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        if (useAlternateKeychainAttribute && status == errSecItemNotFound) {
+            [query removeObjectForKey:(id)kSecAttrAlias];
+            [query setObject:m_provisionalCredentialId.get() forKey:(id)kSecAttrApplicationLabel];
+            status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        }
+
         if (status)
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't delete provisional credential while handling error: %d", status);
     }
@@ -784,14 +845,25 @@ void LocalAuthenticator::deleteDuplicateCredential() const
         if (!equalSpans(userHandle->span(), BufferSource { creationOptions.user.id } .span()))
             return false;
 
-        NSDictionary *query = @{
+        BOOL useAlternateKeychainAttribute = shouldUseAlternateKeychainAttribute();
+        auto query = adoptNS([[NSMutableDictionary alloc] init]);
+        [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrApplicationLabel: toNSData(credential->rawId()).get(),
+            (id)kSecAttrAlias: toNSData(credential->rawId()).get(),
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
             (id)kSecUseDataProtectionKeychain: @YES
-        };
+        }];
 
-        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
+        CFStringRef credentialIdKey = useAlternateKeychainAttribute ? kSecAttrAlias : kSecAttrApplicationLabel;
+        [query setObject:toNSData(credential->rawId()).get() forKey:(id)credentialIdKey];
+
+        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        if (useAlternateKeychainAttribute && status == errSecItemNotFound) {
+            [query removeObjectForKey:(id)kSecAttrAlias];
+            [query setObject:toNSData(credential->rawId()).get() forKey:(id)kSecAttrApplicationLabel];
+            status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        }
+
         if (status && status != errSecItemNotFound)
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't delete older credential: %d", status);
         return true;

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -608,22 +608,37 @@ void TestController::cleanUpKeychain(const String& attrLabel, const String& appl
     [deleteQuery setObject:(id)kSecClassKey forKey:(id)kSecClass];
     [deleteQuery setObject:attrLabel forKey:(id)kSecAttrLabel];
     [deleteQuery setObject:@YES forKey:(id)kSecUseDataProtectionKeychain];
-    if (!!applicationLabelBase64)
-        [deleteQuery setObject:adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]).get() forKey:(id)kSecAttrApplicationLabel];
 
-    SecItemDelete((__bridge CFDictionaryRef)deleteQuery.get());
+    auto credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    if (!!applicationLabelBase64)
+        [deleteQuery setObject:credentialID.get() forKey:(id)kSecAttrAlias];
+
+    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)deleteQuery.get());
+    if (status == errSecItemNotFound) {
+        [deleteQuery removeObjectForKey:(id)kSecAttrAlias];
+        [deleteQuery setObject:credentialID.get() forKey:(id)kSecAttrApplicationLabel];
+        SecItemDelete((__bridge CFDictionaryRef)deleteQuery.get());
+    }
 }
 
 bool TestController::keyExistsInKeychain(const String& attrLabel, const String& applicationLabelBase64)
 {
-    NSDictionary *query = @{
+    auto credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    auto query = adoptNS([[NSMutableDictionary alloc] init]);
+    [query setDictionary:@{
         (id)kSecClass: (id)kSecClassKey,
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrLabel: attrLabel,
-        (id)kSecAttrApplicationLabel: adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]).get(),
+        (id)kSecAttrAlias: credentialID.get(),
         (id)kSecUseDataProtectionKeychain: @YES
-    };
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
+    }];
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), NULL);
+    if (status == errSecItemNotFound) {
+        [query removeObjectForKey:(id)kSecAttrAlias];
+        [query setObject:credentialID.get() forKey:(id)kSecAttrApplicationLabel];
+        status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), NULL);
+    }
+
     if (!status)
         return true;
     ASSERT(status == errSecItemNotFound);


### PR DESCRIPTION
#### 1dc9ae6c18649e69843343042de19d3042e64d2e
<pre>
Use different keychain attribute for passkey credential ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=281344">https://bugs.webkit.org/show_bug.cgi?id=281344</a>
<a href="https://rdar.apple.com/137771569">rdar://137771569</a>

Reviewed by Brent Fulgham.

Use kSecAttrAlias going forward, and if a query using this field fails then fall
back to kSecAttrApplicationLabel

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel deleteLocalAuthenticatorCredentialWithGroupAndID:credential:]):
(+[_WKWebAuthenticationPanel setDisplayNameForLocalCredentialWithGroupAndID:credential:displayName:]):
(+[_WKWebAuthenticationPanel setNameForLocalCredentialWithGroupAndID:credential:name:]):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
(+[_WKWebAuthenticationPanel exportLocalAuthenticatorCredentialWithGroupAndID:credential:error:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::produceHashSet):
(WebKit::LocalAuthenticator::getExistingCredentials):
(WebKit::LocalAuthenticator::processLargeBlobExtension):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):
(WebKit::LocalAuthenticator::receiveException const):
(WebKit::LocalAuthenticator::deleteDuplicateCredential const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cleanUpKeychain):
(WTR::TestController::keyExistsInKeychain):

Canonical link: <a href="https://commits.webkit.org/285575@main">https://commits.webkit.org/285575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afd314606349cf5522c1aa9e0f656d88376999b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24316 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57434 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15916 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22645 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/66213 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78957 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/72335 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65870 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65147 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7143 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/94114 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11258 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/3094 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20700 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->