### PR TITLE
text-spacing: text-spacing-trim: Implement derived half-width font for CoreText platform

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -478,6 +478,15 @@ const Font* Font::smallCapsFont(const FontDescription& fontDescription) const
     return derivedFontData.smallCapsFont.get();
 }
 
+const RefPtr<Font> Font::halfWidthFont() const
+{
+    DerivedFonts& derivedFontData = ensureDerivedFontData();
+    if (!derivedFontData.halfWidthFont)
+        derivedFontData.halfWidthFont = createHalfWidthFont();
+    ASSERT(derivedFontData.halfWidthFont.get() != this);
+    return derivedFontData.halfWidthFont;
+}
+
 const Font& Font::noSynthesizableFeaturesFont() const
 {
 #if PLATFORM(COCOA)
@@ -548,6 +557,11 @@ const OpenTypeMathData* Font::mathData() const
 RefPtr<Font> Font::createScaledFont(const FontDescription& fontDescription, float scaleFactor) const
 {
     return platformCreateScaledFont(fontDescription, scaleFactor);
+}
+
+RefPtr<Font> Font::createHalfWidthFont() const
+{
+    return platformCreateHalfWidthFont();
 }
 
 #if !USE(CORE_TEXT)

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -79,6 +79,7 @@ enum class FontIsOrientationFallback : bool { No, Yes };
 
 #if USE(CORE_TEXT)
 bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
+bool supportsOpenTypeFeature(CTFontRef, CFStringRef featureTag);
 #endif
 
 struct FontInternalAttributes {
@@ -122,6 +123,7 @@ public:
     const Font& noSynthesizableFeaturesFont() const;
     const Font* emphasisMarkFont(const FontDescription&) const;
     const Font& brokenIdeographFont() const;
+    const RefPtr<Font> halfWidthFont() const;
 
     bool isProbablyOnlyUsedToRenderIcons() const;
 
@@ -214,6 +216,7 @@ public:
     bool supportsAllSmallCaps() const;
     bool supportsPetiteCaps() const;
     bool supportsAllPetiteCaps() const;
+    bool supportsOpenTypeAlternateHalfWidths() const;
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     MultiRepresentationHEICMetrics metricsForMultiRepresentationHEIC() const;
 #endif
@@ -252,6 +255,8 @@ private:
     RefPtr<Font> createFontWithoutSynthesizableFeatures() const;
     RefPtr<Font> createScaledFont(const FontDescription&, float scaleFactor) const;
     RefPtr<Font> platformCreateScaledFont(const FontDescription&, float scaleFactor) const;
+    RefPtr<Font> createHalfWidthFont() const;
+    RefPtr<Font> platformCreateHalfWidthFont() const;
 
     struct DerivedFonts;
     DerivedFonts& ensureDerivedFontData() const;
@@ -325,6 +330,7 @@ private:
         RefPtr<Font> verticalRightOrientationFont;
         RefPtr<Font> uprightOrientationFont;
         RefPtr<Font> invisibleFont;
+        RefPtr<Font> halfWidthFont;
     };
 
     mutable std::unique_ptr<DerivedFonts> m_derivedFontData;
@@ -350,6 +356,7 @@ private:
     mutable SupportsFeature m_supportsAllSmallCaps { SupportsFeature::Unknown };
     mutable SupportsFeature m_supportsPetiteCaps { SupportsFeature::Unknown };
     mutable SupportsFeature m_supportsAllPetiteCaps { SupportsFeature::Unknown };
+    mutable SupportsFeature m_supportsOpenTypeAlternateHalfWidths { SupportsFeature::Unknown };
 #endif
 
 #if PLATFORM(WIN)

--- a/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
@@ -40,6 +40,7 @@
 #include "FontCache.h"
 #include "FontDescription.h"
 #include "GlyphBuffer.h"
+#include "NotImplemented.h"
 #include "OpenTypeTypes.h"
 #include "RefPtrCairo.h"
 #include <cairo-ft.h>
@@ -208,6 +209,13 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription& fontDescripti
         fontDescription.orientation(),
         m_platformData.customPlatformData()),
         origin(), IsInterstitial::No);
+}
+
+RefPtr<Font> Font::platformCreateHalfWidthFont() const
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=281333 : implement half width font for this platform.
+    notImplemented();
+    return nullptr;
 }
 
 void Font::determinePitch()

--- a/Source/WebCore/platform/graphics/skia/FontSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontSkia.cpp
@@ -27,6 +27,7 @@
 #include "Font.h"
 
 #include "GlyphBuffer.h"
+#include "NotImplemented.h"
 #include "PathSkia.h"
 #include <skia/core/SkFont.h>
 #include <skia/core/SkFontMetrics.h>
@@ -132,6 +133,13 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
         Vector<hb_feature_t> { m_platformData.features() },
         m_platformData.customPlatformData()),
         origin(), IsInterstitial::No);
+}
+
+RefPtr<Font> Font::platformCreateHalfWidthFont() const
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=281333 : implement half width font for this platform.
+    notImplemented();
+    return nullptr;
 }
 
 void Font::determinePitch()

--- a/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
@@ -33,6 +33,7 @@
 #include "FloatRect.h"
 #include "FontDescription.h"
 #include "HWndDC.h"
+#include "NotImplemented.h"
 #include <mlang.h>
 #include <wtf/MathExtras.h>
 #include <wtf/win/GDIObject.h>
@@ -128,6 +129,13 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     winfont.lfHeight = -lroundf(scaledSize * cWindowsFontScaleFactor);
     auto hfont = adoptGDIObject(::CreateFontIndirect(&winfont));
     return Font::create(FontPlatformData(WTFMove(hfont), scaledSize, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.customPlatformData()), origin());
+}
+
+RefPtr<Font> Font::platformCreateHalfWidthFont() const
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=281333 : implement half width font for this platform.
+    notImplemented();
+    return nullptr;
 }
 
 bool Font::platformSupportsCodePoint(char32_t character, std::optional<char32_t> variation) const


### PR DESCRIPTION
#### 58c01e33d993c0522a6bd711dd21fb105959857d
<pre>
text-spacing: text-spacing-trim: Implement derived half-width font for CoreText platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=281340">https://bugs.webkit.org/show_bug.cgi?id=281340</a>
<a href="https://rdar.apple.com/137770955">rdar://137770955</a>

Reviewed by Sammy Gill.

This is a preparation patch for text-spacing-trim.
According to specification, trimming should be done
by using OpenType &quot;halt&quot; feature.

This patch creates a derived half-width font by
enabling the OpenType &quot;halt&quot; feature of an existent font.

It also implements a way to verify if a given font
supports such feature.

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::halfWidthFont const):
(WebCore::Font::createHalfWidthFont const):
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::supportsOpenTypeAlternateHalfWidths const):
(WebCore::supportsOpenTypeFeature):
(WebCore::Font::platformCreateHalfWidthFont const):
* Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp:
(WebCore::Font::platformCreateHalfWidthFont const):
* Source/WebCore/platform/graphics/skia/FontSkia.cpp:
(WebCore::Font::platformCreateHalfWidthFont const):
* Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp:
(WebCore::Font::platformCreateHalfWidthFont const):

Canonical link: <a href="https://commits.webkit.org/285219@main">https://commits.webkit.org/285219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7366b3985359ba188cbc8595e30749443fe422b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24667 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22911 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61926 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21436 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64475 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12647 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47100 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/48169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/49456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->