### PR TITLE
[IsDeprecatedWeakRefSmartPointerException] Remove exception from ProcessStateMonitor

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -89,7 +89,7 @@ static bool processHasActiveRunTimeLimitation()
     std::atomic<bool> _backgroundTaskWasInvalidated;
     ThreadSafeWeakHashSet<ProcessAndUIAssertion> _assertionsNeedingBackgroundTask;
     dispatch_block_t _pendingTaskReleaseTask;
-    std::unique_ptr<WebKit::ProcessStateMonitor> m_processStateMonitor;
+    RefPtr<WebKit::ProcessStateMonitor> m_processStateMonitor;
 }
 
 + (WKProcessAssertionBackgroundTaskManager *)shared
@@ -257,8 +257,8 @@ static bool processHasActiveRunTimeLimitation()
 #if PLATFORM(IOS_FAMILY)
         WebKit::WebProcessPool::notifyProcessPoolsApplicationIsAboutToSuspend();
 #endif
-        if (m_processStateMonitor)
-            m_processStateMonitor->processWillBeSuspendedImmediately();
+        if (RefPtr processStateMonitor = m_processStateMonitor)
+            processStateMonitor->processWillBeSuspendedImmediately();
     }
 
     [_backgroundTask removeObserver:self];
@@ -274,7 +274,7 @@ static bool processHasActiveRunTimeLimitation()
     }
 
     if (!m_processStateMonitor) {
-        m_processStateMonitor = makeUnique<WebKit::ProcessStateMonitor>([](bool suspended) {
+        m_processStateMonitor = WebKit::ProcessStateMonitor::create([](bool suspended) {
             for (auto& processPool : WebKit::WebProcessPool::allProcessPools())
                 processPool->setProcessesShouldSuspend(suspended);
         });

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMalloc.h>
@@ -44,14 +45,20 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ProcessStateM
 
 namespace WebKit {
 
-class ProcessStateMonitor : public CanMakeWeakPtr<ProcessStateMonitor> {
+class ProcessStateMonitor : public RefCountedAndCanMakeWeakPtr<ProcessStateMonitor> {
     WTF_MAKE_TZONE_ALLOCATED(ProcessStateMonitor);
 public:
-    ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler);
+    static Ref<ProcessStateMonitor> create(Function<void(bool)>&& becomeSuspendedHandler)
+    {
+        return adoptRef(*new ProcessStateMonitor(WTFMove(becomeSuspendedHandler)));
+    }
+
     ~ProcessStateMonitor();
     void processWillBeSuspendedImmediately();
 
 private:
+    ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler);
+
     void processDidBecomeRunning();
     void processWillBeSuspended(Seconds timeout);
     void suspendTimerFired();


### PR DESCRIPTION
#### 882c85a823c9d74a342a951da9cf1df88df7596b
<pre>
[IsDeprecatedWeakRefSmartPointerException] Remove exception from ProcessStateMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=281350">https://bugs.webkit.org/show_bug.cgi?id=281350</a>
<a href="https://rdar.apple.com/137778725">rdar://137778725</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

Remove IsDeprecatedWeakRefSmartPointerException] by making ProcessStateMonitor ref-counted.

* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(-[WKProcessAssertionBackgroundTaskManager _releaseBackgroundTask]):
(-[WKProcessAssertionBackgroundTaskManager setProcessStateMonitorEnabled:]):
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.h:
(WebKit::ProcessStateMonitor::create):

Canonical link: <a href="https://commits.webkit.org/285088@main">https://commits.webkit.org/285088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38faacbe43d2260d20c469c5920c2070e6ab2b39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22620 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56411 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14876 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42803 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77245 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64115 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5899 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10960 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->