### PR TITLE
REGRESSION(284461@main?) [ iPad ] 4x TestWebKitAPI.DocumentEditingContext.CharacterRectConsistency* (api-tests) are constant timeouts

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -91,14 +91,16 @@
 - (UITextSelectionDisplayInteraction *)textSelectionDisplayInteraction
 {
 #if USE(BROWSERENGINEKIT)
-    return [_asyncTextInteraction textSelectionDisplayInteraction];
-#else
+    if (_asyncTextInteraction)
+        return [_asyncTextInteraction textSelectionDisplayInteraction];
+#endif
+
     for (id<UIInteraction> interaction in _view.interactions) {
         if (RetainPtr selectionInteraction = dynamic_objc_cast<UITextSelectionDisplayInteraction>(interaction))
             return selectionInteraction.get();
     }
+
     return nil;
-#endif
 }
 
 #endif // HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)


### PR DESCRIPTION
#### e1526704268bbe8bc3050402e9a1f9d800167e81
<pre>
REGRESSION(284461@main?) [ iPad ] 4x TestWebKitAPI.DocumentEditingContext.CharacterRectConsistency* (api-tests) are constant timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=281332">https://bugs.webkit.org/show_bug.cgi?id=281332</a>
<a href="https://rdar.apple.com/137769684">rdar://137769684</a>

Reviewed by Abrar Rahman Protyasha.

These API tests began to fail on iPadOS after the changes in 284461@main; this is because in the
case where `USE(BROWSERENGINEKIT)` is enabled but the runtime flag for async text input on iPad is
*disabled*, the newly introduced `-[WKTextInteractionWrapper textSelectionDisplayInteraction]`
helper method returns `nil`. This in turn causes `-activateSelection` and `-deactivateSelection` to
become no-ops.

Fix this by preserving the old codepath in the case where `USE(BROWSERENGINEKIT)` is enabled but
`_asyncTextInteraction` is `nil`, by falling back to iterating over the content view&apos;s interactions
until we find an instance of `UITextSelectionDisplayInteraction`.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper textSelectionDisplayInteraction]):

Canonical link: <a href="https://commits.webkit.org/285060@main">https://commits.webkit.org/285060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4290f0aacc5b4aa1328898c4ce0e8363ec5bd90e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22421 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14869 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61511 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36845 "Found 1 new API test failure: /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42792 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20943 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18517 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5890 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1389 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->