### PR TITLE
HashMap::get() / HashMap::take() return invalid ObjectIdentifiers when the key is missing

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -172,7 +172,7 @@ public:
 
     MappedTakeType take(const KeyType&); // efficient combination of get with remove
     MappedTakeType take(iterator);
-    std::optional<MappedTakeType> takeOptional(const KeyType&);
+    std::optional<MappedType> takeOptional(const KeyType&);
     MappedTakeType takeFirst();
 
     // Alternate versions of find() / contains() / get() / remove() that find the object
@@ -573,7 +573,7 @@ auto HashMap<T, U, V, W, MappedTraits, Y>::take(iterator it) -> MappedTakeType
 }
 
 template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
-auto HashMap<T, U, V, W, MappedTraits, Y>::takeOptional(const KeyType& key) -> std::optional<MappedTakeType>
+auto HashMap<T, U, V, W, MappedTraits, Y>::takeOptional(const KeyType& key) -> std::optional<MappedType>
 {
     auto it = find(key);
     if (it == end())

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -227,8 +227,32 @@ struct ObjectIdentifierGenericBaseHash<UUID> {
 };
 
 template<typename T, typename U, typename V, SupportsObjectIdentifierNullState supportsNullState> struct HashTraits<ObjectIdentifierGeneric<T, U, V, supportsNullState>> : SimpleClassHashTraits<ObjectIdentifierGeneric<T, U, V, supportsNullState>> {
-    static ObjectIdentifierGeneric<T, U, V, supportsNullState> emptyValue() { return ObjectIdentifierGeneric<T, U, V, supportsNullState>(ObjectIdentifierGeneric<T, U, V, supportsNullState>::InvalidIdValue); }
-    static bool isEmptyValue(const ObjectIdentifierGeneric<T, U, V, supportsNullState>& value) { return value.isHashTableEmptyValue(); }
+    using ValueType = ObjectIdentifierGeneric<T, U, V, supportsNullState>;
+    static ValueType emptyValue() { return ValueType { ValueType::InvalidIdValue }; }
+    static bool isEmptyValue(ValueType value) { return value.isHashTableEmptyValue(); }
+};
+
+template<typename T, typename U, typename V> struct HashTraits<ObjectIdentifierGeneric<T, U, V, SupportsObjectIdentifierNullState::No>> : SimpleClassHashTraits<ObjectIdentifierGeneric<T, U, V, SupportsObjectIdentifierNullState::No>> {
+    using ValueType = ObjectIdentifierGeneric<T, U, V, SupportsObjectIdentifierNullState::No>;
+    using PeekType = std::optional<ValueType>;
+    using TakeType = std::optional<ValueType>;
+
+    static ValueType emptyValue() { return ValueType { ValueType::InvalidIdValue }; }
+    static bool isEmptyValue(ValueType value) { return value.isHashTableEmptyValue(); }
+
+    static PeekType peek(ValueType identifier)
+    {
+        if (isEmptyValue(identifier))
+            return std::nullopt;
+        return identifier;
+    }
+
+    static TakeType take(ValueType identifier)
+    {
+        if (isEmptyValue(identifier))
+            return std::nullopt;
+        return identifier;
+    }
 };
 
 template<typename T, typename U, typename V, SupportsObjectIdentifierNullState supportsNullState> struct DefaultHash<ObjectIdentifierGeneric<T, U, V, supportsNullState>> : ObjectIdentifierGenericBaseHash<V> { };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -744,7 +744,7 @@ void SWServer::matchAll(SWServerWorker& worker, const ServiceWorkerClientQueryOp
             auto registrationIdentifier = m_clientToControllingRegistration.get(clientData.identifier);
             if (worker.data().registrationIdentifier != registrationIdentifier)
                 return;
-            if (&worker != this->activeWorkerFromRegistrationID(registrationIdentifier))
+            if (&worker != this->activeWorkerFromRegistrationID(worker.data().registrationIdentifier))
                 return;
         }
         if (options.type != ServiceWorkerClientType::All && options.type != clientData.type)


### PR DESCRIPTION
#### 263f7591998f036f63cefd4581e156c809205b0f
<pre>
HashMap::get() / HashMap::take() return invalid ObjectIdentifiers when the key is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=281306">https://bugs.webkit.org/show_bug.cgi?id=281306</a>

Reviewed by Darin Adler.

An ObjectIdentifier cannot be invalid/empty, we normally use `std::optional&lt;ObjectIdentifier&gt;`
or `Markable&lt;ObjectIdentifier&gt;` to represent an invalid/empty identifier. The only way to
construct an &quot;empty&quot; ObjectIdentifier is via `HashTraits&lt;ObjectIdentifier&gt;::emptyValue()`,
which HashMap relies on internally. As long as the HashMap is only using this special value
internally, this is fine. However, HashMap::get() and HashMap::take() will return this
invalid &quot;empty&quot; value if the key is not present. This was very error-prone for
ObjectIdentifier since the client would receive an invalid ObjectIdentifier and have no way
to check if the ObjectIdentifier is valid or not (since we assume an ObjectIdentifier is
always valid).

To address the issue, Update HashMap::get() / HashMap::take() to return a std::optional
when the value type is ObjectIdentifier.

* Source/WTF/wtf/HashMap.h:
(WTF::Y&gt;::takeOptional):
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::matchAll):

Canonical link: <a href="https://commits.webkit.org/285080@main">https://commits.webkit.org/285080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6427d04629fd27569ce99ae0f1ed54b2cd7e557f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22686 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56455 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14926 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19044 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21027 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64606 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77311 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70730 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64166 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12312 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5954 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92516 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10954 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1473 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20397 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47765 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47507 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->