### PR TITLE
Disable iPad Mini UA overrides when Site Specific Hacks are disabled

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -92,6 +92,7 @@ class Preference
   attr_accessor :exposed
   attr_accessor :sharedPreferenceForWebProcess
   attr_accessor :richJavaScript
+  attr_accessor :inspectorOverride
 
   def initialize(name, opts, frontend)
     @name = name
@@ -118,6 +119,7 @@ class Preference
     @exposed = !opts["exposed"] || opts["exposed"].include?(frontend)
     @sharedPreferenceForWebProcess = opts["sharedPreferenceForWebProcess"] || false
     @richJavaScript = opts["richJavaScript"] || false
+    @inspectorOverride = opts["inspectorOverride"]
   end
 
   def nameLower
@@ -172,6 +174,10 @@ class Preference
       else
         "API::FeatureCategory::" + @category.capitalize
       end
+  end
+
+  def hasInspectorOverride?
+    @inspectorOverride == true
   end
 
   # WebKitLegacy specific helpers.
@@ -254,6 +260,7 @@ class Preferences
     @exposedPreferences = @preferences.select { |p| p.exposed }
     @exposedFeatures = @exposedPreferences.select { |p| p.type == "bool" }
     @sharedPreferencesForWebProcess = @exposedFeatures.select { |p| p.type == "bool" && p.sharedPreferenceForWebProcess }
+    @inspectorOverridePreferences = @preferences.select { |p| p.hasInspectorOverride? }
 
     @preferencesBoundToSetting = @preferences.select { |p| !p.webcoreBinding }
     @preferencesBoundToDeprecatedGlobalSettings = @preferences.select { |p| p.webcoreBinding == "DeprecatedGlobalSettings" }

--- a/Source/WebCore/inspector/InspectorClient.h
+++ b/Source/WebCore/inspector/InspectorClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@ enum class InspectorClientDeveloperPreference : uint8_t {
     PrivateClickMeasurementDebugModeEnabled,
     ITPDebugModeEnabled,
     MockCaptureDevicesEnabled,
+    NeedsSiteSpecificQuirks,
 };
 
 class InspectorClient {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -402,6 +402,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
     m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::PrivateClickMeasurementDebugModeEnabled, std::nullopt);
     m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::ITPDebugModeEnabled, std::nullopt);
     m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::MockCaptureDevicesEnabled, std::nullopt);
+    m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::NeedsSiteSpecificQuirks, std::nullopt);
 
     return { };
 }
@@ -486,6 +487,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Ins
 
     case Inspector::Protocol::Page::Setting::NeedsSiteSpecificQuirks:
         inspectedPageSettings.setNeedsSiteSpecificQuirksInspectorOverride(value);
+        m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::NeedsSiteSpecificQuirks, value);
         return { };
 
     case Inspector::Protocol::Page::Setting::ScriptEnabled:

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
@@ -62,6 +62,13 @@
     \
 
 
+#define FOR_EACH_WEBKIT_PREFERENCE_WITH_INSPECTOR_OVERRIDE(macro) \
+<%- for @pref in @inspectorOverridePreferences do -%>
+    macro(<%= @pref.name %>, <%= @pref.nameLower %>, <%= @pref.type %>) \
+<%- end -%>
+    \
+
+
 #define FOR_EACH_PERSISTENT_WEBKIT_PREFERENCE(macro) \
 <%- for @pref in @exposedPreferences.reject(&:ephemeral?) do -%>
     macro(<%= @pref.name %>, <%= @pref.nameLower %>, <%= @pref.typeUpper %>, <%= @pref.type %>, DEFAULT_VALUE_FOR_<%= @pref.name %>, <%= @pref.humanReadableName %>, <%= @pref.humanReadableDescription %>) \

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesGetterSetters.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesGetterSetters.cpp.erb
@@ -42,6 +42,10 @@ void WebPreferences::set<%= @pref.name %>(const <%= @pref.type %>& value)
 
 <%= @pref.type %> WebPreferences::<%= @pref.nameLower %>() const
 {
+<%- if @pref.hasInspectorOverride? -%>
+    if (m_<%= @pref.nameLower %>InspectorOverride)
+        return m_<%= @pref.nameLower %>InspectorOverride.value();
+<%- end -%>
     return m_store.get<%= @pref.typeUpper %>ValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 }
 
@@ -50,6 +54,16 @@ void WebPreferences::delete<%= @pref.name %>()
     deleteKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 }
 
+<%- end -%>
+
+<%- for @pref in @inspectorOverridePreferences do -%>
+void WebPreferences::set<%= @pref.name %>InspectorOverride(std::optional<<%= @pref.type %>> <%= @pref.nameLower %>InspectorOverride)
+{
+    if (m_<%= @pref.nameLower %>InspectorOverride == <%= @pref.nameLower %>InspectorOverride)
+        return;
+    m_<%= @pref.nameLower %>InspectorOverride = <%= @pref.nameLower %>InspectorOverride;
+    update();
+}
 <%- end -%>
 
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7584,6 +7584,7 @@ enum class WebCore::InspectorClientDeveloperPreference : uint8_t {
     PrivateClickMeasurementDebugModeEnabled,
     ITPDebugModeEnabled,
     MockCaptureDevicesEnabled,
+    NeedsSiteSpecificQuirks,
 };
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::SystemImage subclasses {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  * Portions Copyright (c) 2011 Motorola Mobility, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -758,6 +758,11 @@ void WebInspectorUIProxy::setDeveloperPreferenceOverride(WebCore::InspectorClien
         if (RefPtr inspectedPage = m_inspectedPage.get())
             inspectedPage->setMockCaptureDevicesEnabledOverride(overrideValue);
 #endif // ENABLE(MEDIA_STREAM)
+        return;
+
+    case InspectorClient::DeveloperPreference::NeedsSiteSpecificQuirks:
+        if (RefPtr inspectedPage = m_inspectedPage.get())
+            inspectedPage->protectedPreferences()->setNeedsSiteSpecificQuirksInspectorOverride(overrideValue);
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -37,6 +37,13 @@
     void delete##KeyUpper(); \
     Type KeyLower() const;
 
+#define DECLARE_INSPECTOR_OVERRIDE_SETTERS(KeyUpper, KeyLower, Type) \
+    void set##KeyUpper##InspectorOverride(std::optional<Type> inspectorOverride);
+
+#define DECLARE_INSPECTOR_OVERRIDE_STORE(KeyUpper, KeyLower, Type) \
+    std::optional<Type> m_##KeyLower##InspectorOverride;
+
+
 namespace WebKit {
 
 class WebPageProxy;
@@ -60,6 +67,7 @@ public:
 
     // Implemented in generated file WebPreferencesGetterSetters.cpp.
     FOR_EACH_WEBKIT_PREFERENCE(DECLARE_PREFERENCE_GETTER_AND_SETTERS)
+    FOR_EACH_WEBKIT_PREFERENCE_WITH_INSPECTOR_OVERRIDE(DECLARE_INSPECTOR_OVERRIDE_SETTERS)
 
     static const Vector<RefPtr<API::Object>>& features();
     static const Vector<RefPtr<API::Object>>& experimentalFeatures();
@@ -137,6 +145,8 @@ private:
     WeakHashSet<WebPageProxy> m_pages;
     unsigned m_updateBatchCount { 0 };
     bool m_needUpdateAfterBatch { false };
+
+    FOR_EACH_WEBKIT_PREFERENCE_WITH_INSPECTOR_OVERRIDE(DECLARE_INSPECTOR_OVERRIDE_STORE)
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1422,7 +1422,7 @@ static RecommendDesktopClassBrowsingForRequest desktopClassBrowsingRecommendedFo
 
 bool WebPageProxy::isDesktopClassBrowsingRecommended(const WebCore::ResourceRequest& request) const
 {
-    auto desktopClassBrowsingRecommendation = desktopClassBrowsingRecommendedForRequest(request);
+    auto desktopClassBrowsingRecommendation = m_preferences->needsSiteSpecificQuirks() ? desktopClassBrowsingRecommendedForRequest(request) : RecommendDesktopClassBrowsingForRequest::Auto;
     if (desktopClassBrowsingRecommendation == RecommendDesktopClassBrowsingForRequest::Yes)
         return true;
 


### PR DESCRIPTION
#### d146f360321a12c140eb7278b3d173900d44fcb8
<pre>
Disable iPad Mini UA overrides when Site Specific Hacks are disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=281212">https://bugs.webkit.org/show_bug.cgi?id=281212</a>
<a href="https://rdar.apple.com/50035167">rdar://50035167</a>

Reviewed by Devin Rousso and Patrick Angle.

iPad Mini UA overrides needs to be disabled when Site Specific Hacks
are disabled.

Karl&apos;s work on that issue revealed that changing the Site Specific Quirks
state through the WebInspector did not trigger a notification in the UIProcess.
Since the UIProcess governs the load, quirks about using Desktop versus
Mobile state were not disabled.

This patch fixes both issues.

It also updates the generated preferences to use an optional override value
when appropriate, similar to how the WebCore&apos;s Settings overrides work. This
will allow the page to snap back to default behavior when the WebInspector
is disconnected.

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WebCore/inspector/InspectorClient.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::overrideSetting):
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb:
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesGetterSetters.cpp.erb:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::setDeveloperPreferenceOverride):
* Source/WebKit/UIProcess/WebPreferences.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::isDesktopClassBrowsingRecommended const):

Canonical link: <a href="https://commits.webkit.org/285166@main">https://commits.webkit.org/285166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9bf4f3ba9e48a860797f0aee185a48d0ceaf6bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56543 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15017 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36992 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/71096 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19129 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21134 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64713 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77418 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70837 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64256 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64252 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6037 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92623 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11001 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1580 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20415 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->