### PR TITLE
[UnifiedPDF][iOS] PDF sometimes appears zoomed in and at wrong scroll position.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -596,12 +596,8 @@ void PluginView::setParent(ScrollView* scrollView)
 {
     Widget::setParent(scrollView);
 
-    if (scrollView) {
+    if (scrollView)
         initializePlugin();
-#if PLATFORM(IOS_FAMILY)
-        protectedWebPage()->didInitializePlugin();
-#endif
-    }
 }
 
 unsigned PluginView::countFindMatches(const String& target, WebCore::FindOptions options, unsigned maxMatchCount)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -729,7 +729,6 @@ public:
     void setPluginScaleFactor(double scaleFactor, WebCore::IntPoint origin);
 
 #if PLATFORM(IOS_FAMILY)
-    void didInitializePlugin();
     void pluginDidInstallPDFDocument(double initialScale);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4164,12 +4164,6 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
         if (m_isInFullscreenMode == IsInFullscreenMode::Yes)
             return m_viewportConfiguration.nativeWebpageParameters();
 #endif
-
-#if ENABLE(PDF_PLUGIN)
-        if (mainFramePlugIn())
-            return m_viewportConfiguration.pluginDocumentParameters();
-#endif
-
         if (shouldIgnoreMetaViewport())
             return m_viewportConfiguration.nativeWebpageParameters();
         return ViewportConfiguration::webpageParameters();
@@ -4216,6 +4210,10 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
             m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::imageDocumentParameters());
         else if (document->isTextDocument())
             m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::textDocumentParameters());
+#if ENABLE(PDF_PLUGIN)
+        else if (m_page->settings().unifiedPDFEnabled() && document->isPluginDocument())
+            m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::pluginDocumentParameters());
+#endif
         else
             configureWithParametersForStandardFrame = true;
     }
@@ -5655,14 +5653,6 @@ void WebPage::computeSelectionClipRectAndEnclosingScroller(EditorState& state, c
         state.visualData->selectionClipRect = WTFMove(innerScrollingClipRect);
     }
 }
-
-#if ENABLE(PDF_PLUGIN)
-void WebPage::didInitializePlugin()
-{
-    resetViewportDefaultConfiguration(m_mainFrame.ptr());
-    viewportConfigurationChanged();
-}
-#endif
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 8992eaa3fbdf4b0f158c5dfdf114d7437e8cb9a7
<pre>
[UnifiedPDF][iOS] PDF sometimes appears zoomed in and at wrong scroll position.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281352">https://bugs.webkit.org/show_bug.cgi?id=281352</a>
<a href="https://rdar.apple.com/136502394">rdar://136502394</a>

Reviewed by Abrar Rahman Protyasha.

Every now and then when a PDF is loaded, it may appear at the wrong scale (zoomed in) and
also at the wrong scroll position (top left). In 284976@main, we attempted to address this
by creating a plugin-specific viewport configuration as we were supplying incorrect
dimensions to the content, which was causing the plugin to be sized incorrectly. This
solved the problem for the most part, but on occasion, the plugin would still get sized
incorrectly.

This is due to the fact that the following two events could occur in any order under
certain circumstances:

- Setting the viewport configuration to the plugin-specific one
- The PDF being installed in the plugin, which results in us computing an initial scale based off the PDF geometry and plugin size

When the PDF is installed after the viewport configuration is set properly, then the
document loads and appears just fine. However, when the document is first installed, then
we compute a document-fitting scale based off the incorrect plugin size and do not recover
after the viewport configuration changes since we do not automatically adjust the
document-fitting scale by default.

To hopefully set the viewport configuration before the PluginView is created and the plugin
is initialized, let&apos;s make 2 changes:

1.) Stop trying to change the configuration after the plugin has been initialized. It is
possible that the document was installed, and we could have computed a scale using incorrect
geometry, so this is too late.
2.) In WebPage::resetViewportDefaultConfiguration, check to see if the document is a
PluginDocument instead of whether a main frame plugin exists. When the web page is notified
that the load has been committed and it resets the viewport default configuration, we
should be able to take advantage of the fact that we should have a PluginDocument at this
point.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::setParent):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::resetViewportDefaultConfiguration):
(WebKit::WebPage::didInitializePlugin): Deleted.

Canonical link: <a href="https://commits.webkit.org/285273@main">https://commits.webkit.org/285273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/500a4473466ebea8ca8ae75ef8f1cf2d9a0bd16c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22999 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56783 "Found 10 new test failures: media/media-vp8-webm-seek-to-start.html webgl/2.0.y/conformance2/textures/canvas/tex-3d-rg8-rg-unsigned_byte.html webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb16f-rgb-float.html webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb565-rgb-unsigned_byte.html webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb9_e5-rgb-half_float.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r11f_g11f_b10f-rgb-float.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rg16f-rg-float.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rgba4-rgba-unsigned_byte.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15287 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43270 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21524 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64529 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15930 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12709 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6360 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1972 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->