### PR TITLE
AX: Remove unnecessary AccessibilityRole::{RubyBase, RubyBlock, RubyRun} and simplify accessibility/mac/ruby-hierarchy-roles.html

### DIFF
--- a/LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt
+++ b/LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt
@@ -1,29 +1,20 @@
 This tests that the ruby containers are exposed with the appropriate hierarchy and roles.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+Testing #ruby
+PASS: axRuby.role === expectedRubyRole
+PASS: axRuby.subrole === expectedRubyInlineSubrole
+Testing #rt
+PASS: axRubyText.role === expectedRubyRole
+PASS: axRubyText.subrole === expectedRubyTextSubrole
+Testing #ruby
+PASS: axRuby.role === expectedRubyRole
+Testing AX element with no ID
+PASS: axRuby.role === expectedRubyRole
+PASS: axRuby.subrole === expectedRubyInlineSubrole
+Testing #rt
+PASS: axRubyText.role === expectedRubyRole
+PASS: axRubyText.subrole === expectedRubyTextSubrole
 
-
-PASS rubyElem != null is true
-PASS axRuby != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyInlineSubrole
-PASS axRubyBase != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyBaseSubrole
-PASS axRubyText != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyTextSubrole
-PASS axRuby != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyBlockSubrole
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyInlineSubrole
-PASS axRubyBase != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyBaseSubrole
-PASS axRubyText != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyTextSubrole
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/ruby-hierarchy-roles.html
+++ b/LayoutTests/accessibility/mac/ruby-hierarchy-roles.html
@@ -1,75 +1,62 @@
-<!-- webkit-test-runner [ CSSBasedRubyEnabled=true ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-    <head>
-        <script src="../../resources/js-test-pre.js"></script>
-    </head>
-    <body>
-        <ruby id="rubyElemId">
-            <rb>basetext</rb>
-            <rp>(</rp>
-            <rt>rubytext</rt>
-            <rp>)</rp>
-        </ruby>
-        
-        <script>
-            if (window.accessibilityController) {
-                description("This tests that the ruby containers are exposed with the appropriate hierarchy and roles.")
-                // At the moment, this is implemented only for OSX.
-                var platform = accessibilityController.platformName;
-                if ("mac" == platform) {
-                    // Expected values for roles and subroles.
-                    var expectedRubyRole = "AXRole: AXGroup"; // all ruby containers have AXGroup role
-                    var expectedRubyInlineSubrole = "AXSubrole: AXRubyInline";
-                    var expectedRubyBlockSubrole = "AXSubrole: AXRubyBlock";
-                    var expectedRubyTextSubrole = "AXSubrole: AXRubyText";
-                    var expectedRubyBaseSubrole = "AXSubrole: AXRubyBase";
-                    
-                    // Try inline style first, block style second
-                    var rubyElem = document.getElementById("rubyElemId");
-                    shouldBeTrue("rubyElem != null");
-                    checkHierarchyAndRoles(rubyElem);
-                    
-                    rubyElem.style.position = "absolute";
-                    checkHierarchyAndRoles(rubyElem);
-                    
-                    function checkHierarchyAndRoles(rubyElem) {
-                        axRuby = window.accessibilityController.accessibleElementById("rubyElemId");
-                        shouldBeTrue("axRuby != null");
-                        role = axRuby.role;
-                        subrole = axRuby.subrole;
-                        shouldBe("role", "expectedRubyRole");
-                        if (rubyElem.style.position != "absolute") {
-                            shouldBe("subrole", "expectedRubyInlineSubrole");
-                        }
-                        else {
-                            shouldBe("subrole", "expectedRubyBlockSubrole");
-                            axRuby = axRuby.childAtIndex(0);
-                            role = axRuby.role;
-                            subrole = axRuby.subrole;
-                            shouldBe("role", "expectedRubyRole");
-                            shouldBe("subrole", "expectedRubyInlineSubrole");
-                        }
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
 
-                        // RubyBase
-                        axRubyBase = axRuby.childAtIndex(0);
-                        shouldBeTrue("axRubyBase != null");
-                        role = axRubyBase.role;
-                        subrole = axRubyBase.subrole;
-                        shouldBe("role", "expectedRubyRole");
-                        shouldBe("subrole", "expectedRubyBaseSubrole");
+<ruby id="ruby">
+    <rb>basetext</rb>
+    <rp>(</rp>
+    <rt id="rt">rubytext</rt>
+    <rp>)</rp>
+</ruby>
 
-                        // RubyText
-                        axRubyText = axRuby.childAtIndex(1);
-                        shouldBeTrue("axRubyText != null");
-                        role = axRubyText.role;
-                        subrole = axRubyText.subrole;
-                        shouldBe("role", "expectedRubyRole");
-                        shouldBe("subrole", "expectedRubyTextSubrole");
-                    }
-                }
-            }
-        </script>
-        <script src="../../resources/js-test-post.js"></script>
-    </body>
+<script>
+var output = "This tests that the ruby containers are exposed with the appropriate hierarchy and roles.\n\n";
+
+function logId(axElement) {
+    const id = axElement.domIdentifier;
+    if (id)
+        output += `Testing #${id}\n`;
+    else
+        output += `Testing AX element with no ID\n`;
+}
+
+if (window.accessibilityController) {
+     // All ruby containers have the AXGroup role.
+    var expectedRubyRole = "AXRole: AXGroup";
+    var expectedRubyInlineSubrole = "AXSubrole: AXRubyInline";
+    var expectedRubyTextSubrole = "AXSubrole: AXRubyText";
+
+    // Try inline style first, block style second.
+    checkHierarchyAndRoles(/* expectInline */ true);
+    document.getElementById("ruby").style.position = "absolute";
+    checkHierarchyAndRoles(/* expectInline */ false);
+
+    function checkHierarchyAndRoles(expectInline) {
+        axRuby = accessibilityController.accessibleElementById("ruby");
+        logId(axRuby);
+        output += expect("axRuby.role", "expectedRubyRole");
+        if (expectInline)
+            output += expect("axRuby.subrole", "expectedRubyInlineSubrole");
+        else {
+            axRuby = axRuby.childAtIndex(0);
+            logId(axRuby);
+            output += expect("axRuby.role", "expectedRubyRole");
+            output += expect("axRuby.subrole", "expectedRubyInlineSubrole");
+        }
+
+        // Test AXRubyText.
+        axRubyText = axRuby.childAtIndex(1);
+        logId(axRubyText);
+        output += expect("axRubyText.role", "expectedRubyRole");
+        output += expect("axRubyText.subrole", "expectedRubyTextSubrole");
+    }
+    debug(output);
+}
+</script>
+</body>
 </html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -213,10 +213,7 @@ enum class AccessibilityRole : uint8_t {
     RowHeader,
     Row,
     RowGroup,
-    RubyBase,
-    RubyBlock,
     RubyInline,
-    RubyRun,
     RubyText,
     ScrollArea,
     ScrollBar,
@@ -454,14 +451,8 @@ ALWAYS_INLINE String accessibilityRoleToString(AccessibilityRole role)
         return "Row"_s;
     case AccessibilityRole::RowGroup:
         return "RowGroup"_s;
-    case AccessibilityRole::RubyBase:
-        return "RubyBase"_s;
-    case AccessibilityRole::RubyBlock:
-        return "RubyBlock"_s;
     case AccessibilityRole::RubyInline:
         return "RubyInline"_s;
-    case AccessibilityRole::RubyRun:
-        return "RubyRun"_s;
     case AccessibilityRole::RubyText:
         return "RubyText"_s;
     case AccessibilityRole::ScrollArea:

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2163,16 +2163,14 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
     if (m_renderer->isRenderOrLegacyRenderSVGRoot())
         return AccessibilityRole::SVGRoot;
     
-    // Check for Ruby elements
     switch (m_renderer->style().display()) {
     case DisplayType::Ruby:
         return AccessibilityRole::RubyInline;
-    case DisplayType::RubyBlock:
-        return AccessibilityRole::RubyBlock;
     case DisplayType::RubyAnnotation:
         return AccessibilityRole::RubyText;
+    case DisplayType::RubyBlock:
     case DisplayType::RubyBase:
-        return AccessibilityRole::RubyBase;
+        return AccessibilityRole::Group;
     default:
         break;
     }

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -359,10 +359,7 @@ static Atspi::Role atspiRole(AccessibilityRole role)
     case AccessibilityRole::Model:
     case AccessibilityRole::Presentational:
     case AccessibilityRole::RowGroup:
-    case AccessibilityRole::RubyBase:
-    case AccessibilityRole::RubyBlock:
     case AccessibilityRole::RubyInline:
-    case AccessibilityRole::RubyRun:
     case AccessibilityRole::RubyText:
     case AccessibilityRole::SliderThumb:
     case AccessibilityRole::SpinButtonPart:

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1024,10 +1024,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     case AccessibilityRole::RowGroup:
     case AccessibilityRole::RowHeader:
     case AccessibilityRole::Row:
-    case AccessibilityRole::RubyBase:
-    case AccessibilityRole::RubyBlock:
     case AccessibilityRole::RubyInline:
-    case AccessibilityRole::RubyRun:
     case AccessibilityRole::RubyText:
     case AccessibilityRole::ScrollArea:
     case AccessibilityRole::ScrollBar:

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -422,14 +422,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return "AXSubscriptStyleGroup"_s;
 
     switch (role) {
-    case AccessibilityRole::RubyBase:
-        return "AXRubyBase"_s;
-    case AccessibilityRole::RubyBlock:
-        return "AXRubyBlock"_s;
     case AccessibilityRole::RubyInline:
         return "AXRubyInline"_s;
-    case AccessibilityRole::RubyRun:
-        return "AXRubyRun"_s;
     case AccessibilityRole::RubyText:
         return "AXRubyText"_s;
     default:
@@ -951,10 +945,7 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::Switch, NSAccessibilityCheckBoxRole },
         { AccessibilityRole::SearchField, NSAccessibilityTextFieldRole },
         { AccessibilityRole::Pre, NSAccessibilityGroupRole },
-        { AccessibilityRole::RubyBase, NSAccessibilityGroupRole },
-        { AccessibilityRole::RubyBlock, NSAccessibilityGroupRole },
         { AccessibilityRole::RubyInline, NSAccessibilityGroupRole },
-        { AccessibilityRole::RubyRun, NSAccessibilityGroupRole },
         { AccessibilityRole::RubyText, NSAccessibilityGroupRole },
         { AccessibilityRole::Details, NSAccessibilityGroupRole },
         { AccessibilityRole::Summary, NSAccessibilityDisclosureTriangleRole },


### PR DESCRIPTION
#### 20ddf93b7b09de3a0852d49dd036ad2da1d19eb7
<pre>
AX: Remove unnecessary AccessibilityRole::{RubyBase, RubyBlock, RubyRun} and simplify accessibility/mac/ruby-hierarchy-roles.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=281356">https://bugs.webkit.org/show_bug.cgi?id=281356</a>
<a href="https://rdar.apple.com/137784243">rdar://137784243</a>

Reviewed by Chris Fleizach.

This patch removes AccessibilityRole::{RubyBase, RubyBlock, RubyRun}, as the subrole they map to is not used by
any Apple assistive technology, and are not mapped in <a href="https://w3c.github.io/html-aam/.">https://w3c.github.io/html-aam/.</a>

AccessibilityRole::RubyInline (mapping to AXSubrole: AXRubyInline) and AccessibilityRole::RubyText (mapping to AXSubrole: AXRubyText)
are present and mapped in <a href="https://w3c.github.io/html-aam">https://w3c.github.io/html-aam</a>, so this patch does not remove them, even though they are also
not actually used by any Apple assistive technology at the time of this writing.

This patch also modernizes accessibility/mac/ruby-hierarchy-roles.html and removes the conditions that tested for the
removed subroles.

* LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt:
* LayoutTests/accessibility/mac/ruby-hierarchy-roles.html:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::accessibilityRoleToString):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):
(WebCore::Accessibility::createPlatformRoleMap):

Canonical link: <a href="https://commits.webkit.org/285072@main">https://commits.webkit.org/285072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f483bf3a6088a4f4d1a14af24fc3bf396a4c8101

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22627 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56416 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36856 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20968 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77252 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64129 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64121 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12271 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1414 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->