### PR TITLE
Deploy smart pointers in WorkerThreadableLoader

### DIFF
--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -58,13 +58,15 @@ namespace WebCore {
 
 WorkerThreadableLoader::WorkerThreadableLoader(WorkerOrWorkletGlobalScope& workerOrWorkletGlobalScope, ThreadableLoaderClient& client, const String& taskMode, ResourceRequest&& request, const ThreadableLoaderOptions& options, const String& referrer)
     : m_workerClientWrapper(ThreadableLoaderClientWrapper::create(client, options.initiatorType))
-    , m_bridge(*new MainThreadBridge(m_workerClientWrapper.get(), workerOrWorkletGlobalScope.workerOrWorkletThread()->workerLoaderProxy(), workerOrWorkletGlobalScope.identifier(), taskMode, WTFMove(request), options, referrer.isEmpty() ? workerOrWorkletGlobalScope.url().strippedForUseAsReferrer().string : referrer, workerOrWorkletGlobalScope))
+    , m_bridge(adoptRef(*new MainThreadBridge(m_workerClientWrapper.get(), workerOrWorkletGlobalScope.workerOrWorkletThread()->workerLoaderProxy(), workerOrWorkletGlobalScope.identifier(), taskMode, WTFMove(request), options, referrer.isEmpty() ? workerOrWorkletGlobalScope.url().strippedForUseAsReferrer().string : referrer, workerOrWorkletGlobalScope)))
 {
 }
 
-WorkerThreadableLoader::~WorkerThreadableLoader()
+WorkerThreadableLoader::~WorkerThreadableLoader() = default;
+
+WorkerThreadableLoader::MainThreadBridge& WorkerThreadableLoader::bridge()
 {
-    m_bridge.destroy();
+    return m_bridge;
 }
 
 void WorkerThreadableLoader::loadResourceSynchronously(WorkerOrWorkletGlobalScope& workerOrWorkletGlobalScope, ResourceRequest&& request, ThreadableLoaderClient& client, const ThreadableLoaderOptions& options)
@@ -85,12 +87,12 @@ void WorkerThreadableLoader::loadResourceSynchronously(WorkerOrWorkletGlobalScop
 
 void WorkerThreadableLoader::cancel()
 {
-    m_bridge.cancel();
+    bridge().cancel();
 }
 
 void WorkerThreadableLoader::computeIsDone()
 {
-    m_bridge.computeIsDone();
+    bridge().computeIsDone();
 }
 
 struct LoaderTaskOptions {

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -91,7 +91,7 @@ private:
     //    go through it. All tasks posted from the worker object's thread to the worker context's
     //    thread contain the RefPtr<ThreadableLoaderClientWrapper> object, so the
     //    ThreadableLoaderClientWrapper instance is there until all tasks are executed.
-    class MainThreadBridge final : public ThreadableLoaderClient {
+    class MainThreadBridge final : public RefCounted<MainThreadBridge>, public ThreadableLoaderClient {
         WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MainThreadBridge);
     public:
@@ -138,9 +138,10 @@ private:
     WorkerThreadableLoader(WorkerOrWorkletGlobalScope&, ThreadableLoaderClient&, const String& taskMode, ResourceRequest&&, const ThreadableLoaderOptions&, const String& referrer);
 
     void computeIsDone() final;
+    WorkerThreadableLoader::MainThreadBridge& bridge();
 
     Ref<ThreadableLoaderClientWrapper> m_workerClientWrapper;
-    MainThreadBridge& m_bridge; // FIXME: Use a smart pointer.
+    Ref<MainThreadBridge> m_bridge;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 5108dfdca1e5cc3775152b75af4b27883b7ceb20
<pre>
Deploy smart pointers in WorkerThreadableLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=281359">https://bugs.webkit.org/show_bug.cgi?id=281359</a>

Reviewed by NOBODY (OOPS!).

Deploy smart pointers in WorkerThreadableLoader

* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::bridge):
(WebCore::WorkerThreadableLoader::cancel):
(WebCore::WorkerThreadableLoader::computeIsDone):
(WebCore::m_contextIdentifier):
(WebCore::WorkerThreadableLoader::MainThreadBridge::destroy):
(WebCore::WorkerThreadableLoader::MainThreadBridge::cancel):
(WebCore::WorkerThreadableLoader::MainThreadBridge::computeIsDone):
* Source/WebCore/loader/WorkerThreadableLoader.h:
(WebCore::WorkerThreadableLoader::WorkerThreadableLoader):
(WebCore::WorkerThreadableLoader::~WorkerThreadableLoader): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5108dfdca1e5cc3775152b75af4b27883b7ceb20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7487 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62680 "Failure limit exceed. At least found 426 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html crypto/workers/subtle/aes-ctr-import-key-decrypt.html crypto/workers/subtle/aes-ctr-import-key-encrypt.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20496 "Found 60 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html fast/workers/atob-btoa.html fast/workers/worker-xhr-setRequestHeader.html http/tests/fetch/bodyUsed-worker.html http/tests/fetch/fetch-in-worker-crash.html http/tests/inspector/network/resource-response-service-worker.html http/tests/inspector/worker/blob-script-with-cross-domain-imported-scripts.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83255 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52752 "Found 60 new test failures: compositing/contents-format/deep-color-backing-store.html compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73025 "Found 8 new API test failures: TestWebKitAPI.WKWebExtensionAPIDevTools.InspectedWindowEval, TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker, TestWebKitAPI.ServiceWorkers.ServerTrust, TestWebKitAPI.ServiceWorkers.ContentRuleList, TestWebKitAPI.ServiceWorker.FocusNotYetLoadedClient, TestWebKitAPI.ServiceWorkers.ThirdPartyRestoredFromDisk, TestWebKitAPI.AdvancedPrivacyProtections.AddNoiseToWebAudioAPIs, TestWebKitAPI.AdvancedPrivacyProtections.AddNoiseToWebAudioAPIsAfterMultiplePSON (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42986 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50082 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-in-worker.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice-overflow.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-text.any.worker.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27180 "Found 60 new test failures: compositing/repaint/iframes/compositing-iframe-scroll-repaint.html crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html crypto/workers/subtle/aes-cfb-import-key-decrypt.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29623 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71211 "Found 8 new API test failures: TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker, TestWebKitAPI.ServiceWorkers.ServerTrust, TestWebKitAPI.AppPrivacyReport.AppInitiatedRequestWithServiceWorker, TestWebKitAPI.AppPrivacyReport.MultipleWebViewsWithSharedServiceWorker, TestWebKitAPI.AppPrivacyReport.NonAppInitiatedRequestWithServiceWorker, TestWebKitAPI.AdvancedPrivacyProtections.AddNoiseToWebAudioAPIs, TestWebKitAPI.AdvancedPrivacyProtections.AddNoiseToWebAudioAPIsAfterMultiplePSON, TestWebKitAPI.WKNavigation.FrameNavigationWithPrivateTokenPermissionAndAllowOriginsAndWithServiceWorker (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27688 "Found 60 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html crypto/workers/subtle/aes-cfb-import-key-decrypt.html crypto/workers/subtle/aes-cfb-import-key-encrypt.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86135 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7406 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5242 "Found 60 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html crypto/workers/subtle/aes-cfb-import-key-decrypt.html crypto/workers/subtle/aes-cfb-import-key-encrypt.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70956 "Failure limit exceed. At least found 402 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html crypto/workers/subtle/aes-ctr-import-key-decrypt.html crypto/workers/subtle/aes-ctr-import-key-encrypt.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70196 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14188 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13139 "Found 60 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/crypto-random-values-limits-worker.html crypto/workers/crypto-random-values-types-worker.html crypto/workers/crypto-random-values-worker.html crypto/workers/subtle/aes-cbc-import-key-decrypt.html crypto/workers/subtle/aes-cbc-import-key-encrypt.html crypto/workers/subtle/aes-cbc-import-key-unwrap-key.html crypto/workers/subtle/aes-cbc-import-key-wrap-key.html crypto/workers/subtle/aes-cfb-import-key-decrypt.html crypto/workers/subtle/aes-cfb-import-key-encrypt.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12887 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7209 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->