### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for FileSystemStorageManager

### DIFF
--- a/Source/WebCore/editing/cocoa/TextAttachmentForSerialization.h
+++ b/Source/WebCore/editing/cocoa/TextAttachmentForSerialization.h
@@ -61,7 +61,7 @@ struct MultiRepresentationHEICAttachmentData {
     // Not serialized.
     // FIXME: Remove this once same-process AttributedString to NSAttributeedString conversion
     // is removed. See https://bugs.webkit.org/show_bug.cgi?id=269384.
-    RetainPtr<CFDataRef> data;
+    RetainPtr<CFDataRef> data { };
 };
 
 #endif

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp
@@ -33,6 +33,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FileSystemStorageHandleRegistry);
 
+Ref<FileSystemStorageHandleRegistry> FileSystemStorageHandleRegistry::create()
+{
+    return adoptRef(*new FileSystemStorageHandleRegistry);
+}
+
 FileSystemStorageHandleRegistry::FileSystemStorageHandleRegistry() = default;
 
 void FileSystemStorageHandleRegistry::registerHandle(WebCore::FileSystemHandleIdentifier identifier, FileSystemStorageHandle& handle)
@@ -51,10 +56,7 @@ void FileSystemStorageHandleRegistry::unregisterHandle(WebCore::FileSystemHandle
 
 FileSystemStorageHandle* FileSystemStorageHandleRegistry::getHandle(WebCore::FileSystemHandleIdentifier identifier)
 {
-    if (auto handle = m_handles.get(identifier))
-        return handle.get();
-
-    return nullptr;
+    return m_handles.get(identifier).get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
@@ -27,24 +27,25 @@
 
 #include "Connection.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
-#include <wtf/CheckedPtr.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class FileSystemStorageHandle;
 
-class FileSystemStorageHandleRegistry : public CanMakeThreadSafeCheckedPtr<FileSystemStorageHandleRegistry> {
+class FileSystemStorageHandleRegistry final : public RefCountedAndCanMakeWeakPtr<FileSystemStorageHandleRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(FileSystemStorageHandleRegistry);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileSystemStorageHandleRegistry);
 public:
-    FileSystemStorageHandleRegistry();
+    static Ref<FileSystemStorageHandleRegistry> create();
+
     void registerHandle(WebCore::FileSystemHandleIdentifier, FileSystemStorageHandle&);
     void unregisterHandle(WebCore::FileSystemHandleIdentifier);
     FileSystemStorageHandle* getHandle(WebCore::FileSystemHandleIdentifier);
 
 private:
+    FileSystemStorageHandleRegistry();
+
     HashMap<WebCore::FileSystemHandleIdentifier, WeakPtr<FileSystemStorageHandle>> m_handles;
 };
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -35,6 +35,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FileSystemStorageManager);
 
+Ref<FileSystemStorageManager> FileSystemStorageManager::create(String&& path, FileSystemStorageHandleRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
+{
+    return adoptRef(*new FileSystemStorageManager(WTFMove(path), registry, WTFMove(quotaCheckFunction)));
+}
+
 FileSystemStorageManager::FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
     : m_path(WTFMove(path))
     , m_registry(registry)
@@ -100,7 +105,8 @@ Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystem
     m_handlesByConnection.ensure(connection, [&] {
         return HashSet<WebCore::FileSystemHandleIdentifier> { };
     }).iterator->value.add(newHandleIdentifier);
-    m_registry->registerHandle(newHandleIdentifier, *newHandle);
+    if (RefPtr registry = m_registry.get())
+        registry->registerHandle(newHandleIdentifier, *newHandle);
     m_handles.add(newHandleIdentifier, WTFMove(newHandle));
     return newHandleIdentifier;
 }
@@ -126,7 +132,8 @@ void FileSystemStorageManager::closeHandle(FileSystemStorageHandle& handle)
         if (handles.remove(identifier))
             break;
     }
-    m_registry->unregisterHandle(identifier);
+    if (RefPtr registry = m_registry.get())
+        registry->unregisterHandle(identifier);
 }
 
 void FileSystemStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
@@ -140,7 +147,8 @@ void FileSystemStorageManager::connectionClosed(IPC::Connection::UniqueID connec
     auto identifiers = connectionHandles->value;
     for (auto identifier : identifiers) {
         m_handles.remove(identifier);
-        m_registry->unregisterHandle(identifier);
+        if (RefPtr registry = m_registry.get())
+            registry->unregisterHandle(identifier);
     }
 
     m_lockMap.removeIf([&identifiers](auto& entry) {
@@ -183,7 +191,8 @@ void FileSystemStorageManager::close()
     for (auto& [connectionID, identifiers] : m_handlesByConnection) {
         for (auto identifier : identifiers) {
             auto takenHandle = m_handles.take(identifier);
-            m_registry->unregisterHandle(identifier);
+            if (RefPtr registry = m_registry.get())
+                registry->unregisterHandle(identifier);
 
             // Send message to web process to invalidate active sync access handle.
             if (auto accessHandleIdentifier = takenHandle->activeSyncAccessHandle())

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -27,27 +27,19 @@
 
 #include "FileSystemStorageHandle.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebKit {
-class FileSystemStorageManager;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::FileSystemStorageManager> : std::true_type { };
-}
 
 namespace WebKit {
 
 class FileSystemStorageHandle;
 class FileSystemStorageHandleRegistry;
 
-class FileSystemStorageManager : public CanMakeWeakPtr<FileSystemStorageManager> {
+class FileSystemStorageManager final : public RefCountedAndCanMakeWeakPtr<FileSystemStorageManager> {
     WTF_MAKE_TZONE_ALLOCATED(FileSystemStorageManager);
 public:
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
-    FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);
+    static Ref<FileSystemStorageManager> create(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);
     ~FileSystemStorageManager();
 
     bool isActive() const;
@@ -63,10 +55,12 @@ public:
     void requestSpace(uint64_t spaceRequested, CompletionHandler<void(bool)>&&);
 
 private:
+    FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);
+
     void close();
 
     String m_path;
-    CheckedRef<FileSystemStorageHandleRegistry> m_registry;
+    WeakPtr<FileSystemStorageHandleRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;
     HashMap<IPC::Connection::UniqueID, HashSet<WebCore::FileSystemHandleIdentifier>> m_handlesByConnection;
     HashMap<WebCore::FileSystemHandleIdentifier, RefPtr<FileSystemStorageHandle>> m_handles;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -202,7 +202,7 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
         m_backupExclusionPeriod = defaultBackupExclusionPeriod;
 #endif
         setStorageSiteValidationEnabledInternal(storageSiteValidationEnabled);
-        m_fileSystemStorageHandleRegistry = makeUnique<FileSystemStorageHandleRegistry>();
+        m_fileSystemStorageHandleRegistry = FileSystemStorageHandleRegistry::create();
         m_storageAreaRegistry = makeUnique<StorageAreaRegistry>();
         m_idbStorageRegistry = makeUnique<IDBStorageRegistry>();
         m_cacheStorageRegistry = makeUnique<CacheStorageRegistry>();

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -274,7 +274,7 @@ private:
     bool m_closed { false };
     HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers WTF_GUARDED_BY_CAPABILITY(workQueue());
     ThreadSafeWeakHashSet<IPC::Connection> m_connections;
-    std::unique_ptr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
+    RefPtr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;
     std::unique_ptr<IDBStorageRegistry> m_idbStorageRegistry;
     std::unique_ptr<CacheStorageRegistry> m_cacheStorageRegistry;


### PR DESCRIPTION
#### 79e73b46003e5070f11863b9653e8d5be4f123dd
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for FileSystemStorageManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=281362">https://bugs.webkit.org/show_bug.cgi?id=281362</a>

Reviewed by Darin Adler.

* Source/WebCore/editing/cocoa/TextAttachmentForSerialization.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::close):
(WebKit::FileSystemStorageHandle::isSameEntry):
(WebKit::FileSystemStorageHandle::requestCreateHandle):
(WebKit::FileSystemStorageHandle::resolve):
(WebKit::FileSystemStorageHandle::createSyncAccessHandle):
(WebKit::FileSystemStorageHandle::closeSyncAccessHandle):
(WebKit::FileSystemStorageHandle::getHandle):
(WebKit::FileSystemStorageHandle::move):
(WebKit::FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp:
(WebKit::FileSystemStorageHandleRegistry::create):
(WebKit::FileSystemStorageHandleRegistry::getHandle):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::create):
(WebKit::FileSystemStorageManager::createHandle):
(WebKit::FileSystemStorageManager::closeHandle):
(WebKit::FileSystemStorageManager::connectionClosed):
(WebKit::FileSystemStorageManager::close):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::connectionClosed):
(WebKit::OriginStorageManager::StorageBucket::fileSystemStorageManager):
(WebKit::OriginStorageManager::StorageBucket::isActive const):

Canonical link: <a href="https://commits.webkit.org/285079@main">https://commits.webkit.org/285079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d80aeebe27b1b734309d3a9149e8087e8c1f70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56422 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14892 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64128 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5915 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10953 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->