### PR TITLE
CacheStorageManager should be ref counted

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
@@ -35,6 +35,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CacheStorageRegistry);
 
 CacheStorageRegistry::CacheStorageRegistry() = default;
 
+Ref<CacheStorageRegistry> CacheStorageRegistry::create()
+{
+    return adoptRef(*new CacheStorageRegistry());
+}
+
 void CacheStorageRegistry::registerCache(WebCore::DOMCacheIdentifier identifier, CacheStorageCache& cache)
 {
     ASSERT(!m_caches.contains(identifier));

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -28,22 +28,24 @@
 #include <WebCore/DOMCacheIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class CacheStorageCache;
 
-class CacheStorageRegistry : public CanMakeThreadSafeCheckedPtr<CacheStorageRegistry> {
+class CacheStorageRegistry : public ThreadSafeRefCounted<CacheStorageRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(CacheStorageRegistry);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CacheStorageRegistry);
 public:
-    CacheStorageRegistry();
+    static Ref<CacheStorageRegistry> create();
+
     void registerCache(WebCore::DOMCacheIdentifier, CacheStorageCache&);
     void unregisterCache(WebCore::DOMCacheIdentifier);
     CacheStorageCache* cache(WebCore::DOMCacheIdentifier);
 
 private:
+    CacheStorageRegistry();
     HashMap<WebCore::DOMCacheIdentifier, WeakPtr<CacheStorageCache>> m_caches;
 };
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -264,6 +264,7 @@ private:
     void setStorageSiteValidationEnabledInternal(bool);
     void addAllowedSitesForConnectionInternal(IPC::Connection::UniqueID, const Vector<WebCore::RegistrableDomain>&);
     bool isSiteAllowedForConnection(IPC::Connection::UniqueID, const WebCore::RegistrableDomain&) const;
+    RefPtr<CacheStorageRegistry> protectedCacheStorageRegistry();
 
     WeakPtr<NetworkProcess> m_process;
     PAL::SessionID m_sessionID;
@@ -277,7 +278,7 @@ private:
     RefPtr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;
     std::unique_ptr<IDBStorageRegistry> m_idbStorageRegistry;
-    std::unique_ptr<CacheStorageRegistry> m_cacheStorageRegistry;
+    RefPtr<CacheStorageRegistry> m_cacheStorageRegistry;
     String m_customLocalStoragePath;
     String m_customIDBStoragePath;
     String m_customIDBStoragePathNormalizedMainThread;


### PR DESCRIPTION
#### 1a842f16a74442ab4564a1e47f6fe2553b53eff7
<pre>
CacheStorageManager should be ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281363">https://bugs.webkit.org/show_bug.cgi?id=281363</a>

Reviewed by Chris Dumez and Sihui Liu.

Made CacheStorageManager as well as CacheStorageRegistry ref counted.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::removeRecords):
(WebKit::CacheStorageCache::putRecords):
(WebKit::CacheStorageCache::putRecordsInStore):
(WebKit::CacheStorageCache::removeAllRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::create):
(WebKit::CacheStorageManager::reset):
(WebKit::CacheStorageManager::initializeCaches):
(WebKit::CacheStorageManager::openCache):
(WebKit::CacheStorageManager::removeUnusedCache):
(WebKit::CacheStorageManager::protectedRegistry):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp:
(WebKit::CacheStorageRegistry::create):
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::cacheStorageOpenCache):
(WebKit::NetworkStorageManager::cacheStorageRemoveCache):
(WebKit::NetworkStorageManager::cacheStorageAllCaches):
(WebKit::NetworkStorageManager::cacheStorageReference):
(WebKit::NetworkStorageManager::cacheStorageDereference):
(WebKit::NetworkStorageManager::lockCacheStorage):
(WebKit::NetworkStorageManager::cacheStorageRetrieveRecords):
(WebKit::NetworkStorageManager::cacheStorageRemoveRecords):
(WebKit::NetworkStorageManager::cacheStoragePutRecords):
(WebKit::NetworkStorageManager::cacheStorageRepresentation):
(WebKit::NetworkStorageManager::protectedCacheStorageRegistry):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::connectionClosed):
(WebKit::OriginStorageManager::StorageBucket::cacheStorageManager):
(WebKit::OriginStorageManager::StorageBucket::deleteCacheStorageData):

Canonical link: <a href="https://commits.webkit.org/285174@main">https://commits.webkit.org/285174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5930583c174d80ad5f106e4c7fee32a41702967f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22896 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56617 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15104 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43028 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21237 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64333 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6131 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11005 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1683 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->