### PR TITLE
Remove BeforeLoad Event from ImageLoader

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -483,8 +483,6 @@ void HTMLImageElement::didAttachRenderers()
     CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer());
     if (!renderImage)
         return;
-    if (m_imageLoader->hasPendingBeforeLoadEvent())
-        return;
 
 #if ENABLE(SERVICE_CONTROLS)
     ImageControlsMac::updateImageControls(*this);

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -143,9 +143,6 @@ void ImageInputType::attach()
     if (!renderer)
         return;
 
-    if (imageLoader.hasPendingBeforeLoadEvent())
-        return;
-
     auto& imageResource = renderer->imageResource();
     imageResource.setCachedImage(imageLoader.protectedImage());
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -133,7 +133,6 @@ static bool canReuseFromListOfAvailableImages(const CachedResourceRequest& reque
 ImageLoader::ImageLoader(Element& element)
     : m_element(element)
     , m_derefElementTimer(*this, &ImageLoader::timerFired)
-    , m_hasPendingBeforeLoadEvent(false)
     , m_hasPendingLoadEvent(false)
     , m_hasPendingErrorEvent(false)
     , m_imageComplete(true)
@@ -168,7 +167,6 @@ void ImageLoader::clearImageWithoutConsideringPendingLoadEvent()
     ASSERT(m_failedLoadURL.isEmpty());
     if (CachedResourceHandle oldImage = m_image) {
         m_image = nullptr;
-        m_hasPendingBeforeLoadEvent = false;
         if (m_hasPendingLoadEvent || m_hasPendingErrorEvent) {
             loadEventSender().cancelEvent(*this);
             m_hasPendingLoadEvent = m_hasPendingErrorEvent = false;
@@ -314,7 +312,6 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
     if (newImage != oldImage || relevantMutation == RelevantMutation::Yes) {
         LOG_WITH_STREAM(LazyLoading, stream << " switching from old image " << oldImage.get() << " to image " << newImage.get() << " " << (newImage ? newImage->url() : URL()));
 
-        m_hasPendingBeforeLoadEvent = false;
         if (m_hasPendingLoadEvent) {
             loadEventSender().cancelEvent(*this, eventNames().loadEvent);
             m_hasPendingLoadEvent = false;
@@ -330,14 +327,11 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
         }
 
         m_image = newImage;
-        m_hasPendingBeforeLoadEvent = !document->isImageDocument() && newImage;
         m_hasPendingLoadEvent = newImage;
         m_imageComplete = !newImage;
 
         if (newImage) {
-            if (!document->isImageDocument())
-                dispatchPendingBeforeLoadEvent();
-            else
+            if (document->isImageDocument())
                 updateRenderer();
 
             if (m_lazyImageLoadState == LazyImageLoadState::Deferred)
@@ -429,8 +423,6 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
     }
 
     m_imageComplete = true;
-    if (!hasPendingBeforeLoadEvent())
-        updateRenderer();
 
     if (!m_hasPendingLoadEvent)
         return;
@@ -607,20 +599,6 @@ void ImageLoader::dispatchPendingEvent(ImageEventSender* eventSender, const Atom
         dispatchPendingLoadEvent();
     if (eventType == eventNames().errorEvent)
         dispatchPendingErrorEvent();
-}
-
-void ImageLoader::dispatchPendingBeforeLoadEvent()
-{
-    if (!m_hasPendingBeforeLoadEvent)
-        return;
-    if (!m_image)
-        return;
-    if (!element().document().hasLivingRenderTree())
-        return;
-    m_hasPendingBeforeLoadEvent = false;
-    if (!element().isConnected())
-        return;
-    updateRenderer();
 }
 
 void ImageLoader::dispatchPendingLoadEvent()

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -88,8 +88,6 @@ public:
 
     void setLoadManually(bool loadManually) { m_loadManually = loadManually; }
 
-    // FIXME: Delete this code. beforeload event no longer exists.
-    bool hasPendingBeforeLoadEvent() const { return m_hasPendingBeforeLoadEvent; }
     bool hasPendingActivity() const;
 
     void dispatchPendingEvent(ImageEventSender*, const AtomString& eventType);
@@ -115,7 +113,6 @@ private:
     void updatedHasPendingEvent();
     void didUpdateCachedImage(RelevantMutation, CachedResourceHandle<CachedImage>&&);
 
-    void dispatchPendingBeforeLoadEvent();
     void dispatchPendingLoadEvent();
     void dispatchPendingErrorEvent();
 
@@ -141,7 +138,6 @@ private:
     AtomString m_failedLoadURL;
     AtomString m_pendingURL;
     Vector<RefPtr<DeferredPromise>> m_decodingPromises;
-    bool m_hasPendingBeforeLoadEvent : 1;
     bool m_hasPendingLoadEvent : 1;
     bool m_hasPendingErrorEvent : 1;
     bool m_imageComplete : 1;


### PR DESCRIPTION
#### 71b13ce03cefa1a406abd0190fc463a2702f3f2c
<pre>
Remove BeforeLoad Event from ImageLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=281364">https://bugs.webkit.org/show_bug.cgi?id=281364</a>

Reviewed by NOBODY (OOPS!).

Remove BeforeLoad Event from ImageLoader

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::didAttachRenderers):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::attach):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::ImageLoader):
(WebCore::ImageLoader::clearImageWithoutConsideringPendingLoadEvent):
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::notifyFinished):
(WebCore::ImageLoader::dispatchPendingBeforeLoadEvent):
* Source/WebCore/loader/ImageLoader.h:
(WebCore::ImageLoader::hasPendingBeforeLoadEvent const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71b13ce03cefa1a406abd0190fc463a2702f3f2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22474 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56432 "Found 39 new test failures: css2.1/20110323/inline-block-replaced-height-008.htm css2.1/t0801-c412-hz-box-00-b-a.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/image-object-hover-inherit.html fast/css/object-fit/object-fit-embed.html fast/css/object-fit/object-fit-object.html fast/css/object-position/object-position-embed.html fast/css/object-position/object-position-object.html fast/history/page-cache-createObjectURL-using-open-panel.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14903 "Found 16 new test failures: fast/css/image-object-hover-inherit.html fast/css/object-fit/object-fit-embed.html fast/css/object-fit/object-fit-object.html fast/css/object-position/object-position-embed.html fast/css/object-position/object-position-object.html fast/css/percent-min-width-img-src-change.html fast/images/animated-gif-no-layout.html fast/images/async-image-src-change.html fast/images/decode-decoding-attribute-async-large-image.html fast/images/exif-orientation-image-object.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74516 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46162 "Found 29 new test failures: css2.1/20110323/inline-block-replaced-height-008.htm css2.1/t0801-c412-hz-box-00-b-a.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/image-object-hover-inherit.html fast/css/object-position/object-position-embed.html fast/css/object-position/object-position-object.html fast/files/apply-blob-url-to-img-using-open-panel.html fast/history/page-cache-createObjectURL-using-open-panel.html fast/images/async-image-src-change.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61546 "8 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36877 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42825 "Found 37 new test failures: imported/w3c/web-platform-tests/FileAPI/url/url_xmlhttprequest_img.html imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-image-load.html imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-auto-margin-and-replaced-item-001.html imported/w3c/web-platform-tests/css/css-grid/img-src-changes.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-001e.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-001o.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-002e.html imported/w3c/web-platform-tests/css/css-images/object-fit-contain-png-002o.html imported/w3c/web-platform-tests/css/css-images/object-fit-cover-png-001e.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19011 "Found 60 new test failures: compositing/hidpi-image-backing-store-scaled.html compositing/tiling/huge-layer-img.html css2.1/20110323/inline-block-replaced-height-008.htm css2.1/t0801-c412-hz-box-00-b-a.html editing/pasteboard/drag-and-drop-objectimage-contenteditable.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/image-object-hover-inherit.html fast/css/object-fit/object-fit-embed.html fast/css/object-fit/object-fit-object.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20996 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64724 "Found 6 new API test failures: TestWebKitAPI.WKAttachmentTests.CopyAndPasteImageBetweenWebViews, TestWebKitAPI.WKAttachmentTests.ChangeFileWrapperForPastedImage, TestWebKitAPI.WKAttachmentTests.ConnectImageWithAttachmentToDocument, TestWebKitAPI.WKAttachmentTests.AddAttachmentToConnectedImageElement, TestWebKitAPI.WKAttachmentTests.SetFileWrapperForPDFImageAttachment, TestWebKitAPI.ImageAnalysisTests.AnalyzeImageAfterChangingSource (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19377 "Found 60 new test failures: compositing/hidpi-image-backing-store-scaled.html compositing/tiling/huge-layer-img.html css2.1/20110323/inline-block-replaced-height-008.htm css2.1/t0801-c412-hz-box-00-b-a.html css3/color-filters/color-filter-current-color.html fast/attachment/mac/wide-attachment-image-controls-basic.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/image-object-hover-inherit.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77280 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15684 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18551 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64143 "Found 41 new test failures: css2.1/20110323/inline-block-replaced-height-008.htm css2.1/t0801-c412-hz-box-00-b-a.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/image-object-hover-inherit.html fast/css/object-fit/object-fit-embed.html fast/css/object-fit/object-fit-object.html fast/css/object-position/object-position-embed.html fast/css/object-position/object-position-object.html fast/files/apply-blob-url-to-img-using-open-panel.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64137 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12289 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5923 "Found 60 new test failures: compositing/hidpi-image-backing-store-scaled.html compositing/tiling/huge-layer-img.html css2.1/20110323/inline-block-replaced-height-008.htm css2.1/t0801-c412-hz-box-00-b-a.html css3/masking/reference-clip-path-animate-transform-repaint.html fast/attachment/mac/wide-attachment-image-controls-basic.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/image-object-hover-inherit.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46663 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1442 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->