### PR TITLE
[WebGPU] Convert all adds and muls into checked arithmetic - part 1

### DIFF
--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -571,19 +571,24 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         bytesPerRow = std::max<uint32_t>(size.height ? (data.size() / size.height) : data.size(), Texture::bytesPerRow(textureFormat, widthForMetal, texture.sampleCount()));
 
     switch (texture.dimension()) {
-    case WGPUTextureDimension_1D:
-        bytesPerRow = std::min<uint32_t>(bytesPerRow, blockSize * device->limits().maxTextureDimension1D);
-        break;
+    case WGPUTextureDimension_1D: {
+        auto blockSizeTimes1DTextureLimit = checkedProduct<uint32_t>(blockSize, device->limits().maxTextureDimension1D);
+        bytesPerRow = blockSizeTimes1DTextureLimit.hasOverflowed() ? bytesPerRow : std::min<uint32_t>(bytesPerRow, blockSizeTimes1DTextureLimit.value());
+    }break;
     case WGPUTextureDimension_2D:
-    case WGPUTextureDimension_3D:
-        bytesPerRow = std::min<uint32_t>(bytesPerRow, blockSize * device->limits().maxTextureDimension2D);
-        break;
+    case WGPUTextureDimension_3D: {
+        auto blockSizeTimes2DTextureLimit = checkedProduct<uint32_t>(blockSize, device->limits().maxTextureDimension2D);
+        bytesPerRow = blockSizeTimes2DTextureLimit.hasOverflowed() ? bytesPerRow : std::min<uint32_t>(bytesPerRow, blockSizeTimes2DTextureLimit.value());
+    } break;
     case WGPUTextureDimension_Force32:
         break;
     }
 
     NSUInteger rowsPerImage = (dataLayout.rowsPerImage == WGPU_COPY_STRIDE_UNDEFINED) ? size.height : dataLayout.rowsPerImage;
-    NSUInteger bytesPerImage = bytesPerRow * rowsPerImage;
+    auto checkedBytesPerImage = checkedProduct<uint32_t>(bytesPerRow, rowsPerImage);
+    if (checkedBytesPerImage.hasOverflowed())
+        return;
+    NSUInteger bytesPerImage = checkedBytesPerImage.value();
 
     MTLBlitOption options = MTLBlitOptionNone;
     switch (destination.aspect) {
@@ -606,7 +611,10 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
     uint32_t sliceCount = textureDimension == WGPUTextureDimension_3D ? 1 : size.depthOrArrayLayers;
     bool clearWasNeeded = false;
     for (uint32_t layer = 0; layer < sliceCount; ++layer) {
-        NSUInteger destinationSlice = textureDimension == WGPUTextureDimension_3D ? 0 : (destination.origin.z + layer);
+        auto checkedDestinationSlice = checkedSum<uint32_t>(destination.origin.z, layer);
+        if (checkedDestinationSlice.hasOverflowed())
+            return;
+        NSUInteger destinationSlice = textureDimension == WGPUTextureDimension_3D ? 0 : checkedDestinationSlice.value();
         if (!texture.previouslyCleared(destination.mipLevel, destinationSlice)) {
             if (writeWillCompletelyClear(textureDimension, widthForMetal, logicalSize.width, heightForMetal, logicalSize.height, depthForMetal, logicalSize.depthOrArrayLayers))
                 texture.setPreviouslyCleared(destination.mipLevel, destinationSlice);
@@ -617,7 +625,10 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         }
     }
 
-    NSUInteger maxRowBytes = textureDimension == WGPUTextureDimension_3D ? (2048 * blockSize) : bytesPerRow;
+    auto checkedBlockSizeTimes2048 = checkedProduct<uint32_t>(2048, blockSize);
+    if (checkedBlockSizeTimes2048.hasOverflowed())
+        return;
+    NSUInteger maxRowBytes = textureDimension == WGPUTextureDimension_3D ? checkedBlockSizeTimes2048.value() : bytesPerRow;
     bool isCompressed = Texture::isCompressedFormat(textureFormat);
     auto blockHeight = Texture::texelBlockHeight(textureFormat);
     auto blockWidth = Texture::texelBlockWidth(textureFormat);
@@ -644,21 +655,50 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
             for (uint32_t z = 0, endZ = std::max<uint32_t>(1, depthForMetal); z < endZ; ++z) {
                 WGPUImageCopyTexture newDestination = destination;
-                newDestination.origin.z = destination.origin.z + z;
-                for (uint32_t y = 0, endY = textureDimension == WGPUTextureDimension_1D ? std::max<uint32_t>(1, heightForMetal) : heightForMetal; y < endY; y += newSize.height) {
-                    newDestination.origin.y = destination.origin.y + y;
-                    if (newDestination.origin.y + newSize.height > logicalSize.height)
-                        newSize.height = static_cast<uint32_t>(newDestination.origin.y + newSize.height - logicalSize.height);
+                auto checkedNewDestinationOriginZ = checkedSum<uint32_t>(destination.origin.z, z);
+                if (checkedNewDestinationOriginZ.hasOverflowed())
+                    return;
+                newDestination.origin.z = checkedNewDestinationOriginZ.value();
+                for (uint32_t y = 0, endY = textureDimension == WGPUTextureDimension_1D ? std::max<uint32_t>(1, heightForMetal) : heightForMetal; y < endY; ) {
+                    auto checkedDestinationOriginYPlusY = checkedSum<uint32_t>(destination.origin.y, y);
+                    if (checkedDestinationOriginYPlusY.hasOverflowed())
+                        return;
+                    newDestination.origin.y = checkedDestinationOriginYPlusY.value();
+                    auto checkedNewDestinationOriginYPlusHeight = checkedSum<uint32_t>(newDestination.origin.y, newSize.height);
+                    if (checkedNewDestinationOriginYPlusHeight.value() > logicalSize.height)
+                        newSize.height = static_cast<uint32_t>(checkedNewDestinationOriginYPlusHeight.value() - logicalSize.height);
 
-                    for (uint32_t x = 0; x < widthForMetal; x += maxRowBytes) {
-                        newDestination.origin.x = destination.origin.x + x;
-                        auto offset = x + y * bytesPerRow + z * bytesPerImage;
-                        auto size = (y + 1 == endY) ? bytesInLastRow.value() : (bytesPerRow * newSize.height);
-                        if (offset + size > data.size())
+                    auto checkedBytesPerRowTimesHeight = checkedProduct<uint32_t>(bytesPerRow, newSize.height);
+                    if (checkedBytesPerRowTimesHeight.hasOverflowed())
+                        return;
+                    auto size = (y + 1 == endY) ? bytesInLastRow.value() : checkedBytesPerRowTimesHeight.value();
+                    for (uint32_t x = 0; x < widthForMetal; ) {
+                        auto checkedDestinationOriginXPlusX = checkedSum<uint32_t>(destination.origin.x, x);
+                        if (checkedDestinationOriginXPlusX.hasOverflowed())
+                            return;
+                        newDestination.origin.x = checkedDestinationOriginXPlusX.value();
+                        auto checkedYTimesBytesPerRow = checkedProduct<uint32_t>(y, bytesPerRow);
+                        auto checkedZTimesBytesPerImage = checkedProduct<uint32_t>(z, bytesPerImage);
+                        if (checkedYTimesBytesPerRow.hasOverflowed() || checkedZTimesBytesPerImage.hasOverflowed())
+                            return;
+                        auto checkedXPlusYPlusZ = checkedSum<uint32_t>(x, checkedYTimesBytesPerRow.value(), checkedZTimesBytesPerImage.value());
+                        if (checkedXPlusYPlusZ.hasOverflowed())
+                            return;
+                        auto offset = checkedXPlusYPlusZ.value();
+                        auto checkedOffsetPlusSize = checkedSum<uint32_t>(offset, size);
+                        if (checkedOffsetPlusSize.hasOverflowed() || checkedOffsetPlusSize.value() > data.size())
                             return;
 
                         writeTexture(newDestination, data.subspan(offset, size), newDataLayout, newSize);
+                        auto checkedXPlusMaxRowBytes = checkedSum<uint32_t>(x, maxRowBytes);
+                        if (checkedXPlusMaxRowBytes.hasOverflowed())
+                            return;
+                        x = checkedXPlusMaxRowBytes.value();
                     }
+                    auto checkedYPlusHeight = checkedSum<uint32_t>(y, newSize.height);
+                    if (checkedYPlusHeight.hasOverflowed())
+                        return;
+                    y = checkedYPlusHeight.value();
                 }
             }
             return;
@@ -686,16 +726,25 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
     }
 
     Vector<uint8_t> newData;
-    const auto newBytesPerRow = blockSize * ((widthForMetal / blockWidth) + ((widthForMetal % blockWidth) ? 1 : 0));
+    auto checkedNewBytesPerRow = checkedProduct<uint32_t>(blockSize, ((widthForMetal / blockWidth) + ((widthForMetal % blockWidth) ? 1 : 0)));
+    if (checkedNewBytesPerRow.hasOverflowed())
+        return;
+    const auto newBytesPerRow = checkedNewBytesPerRow.value();
     auto dataLayoutOffset = dataLayout.offset;
     const bool widthMismatch = newBytesPerRow != bytesPerRow && widthForMetal == logicalSize.width && heightForMetal == logicalSize.height;
     const bool multipleOfBlockSize = bytesPerRow % blockSize;
     if (isCompressed && (widthMismatch || multipleOfBlockSize)) {
 
-        auto maxY = std::max<size_t>(blockHeight, heightForMetal) / blockHeight;
-        auto newBytesPerImage = newBytesPerRow * std::max<size_t>(blockHeight, logicalSize.height / blockHeight);
-        auto maxZ = std::max<size_t>(1, size.depthOrArrayLayers);
-        newData.resize(newBytesPerImage * maxZ);
+        const auto maxY = std::max<size_t>(blockHeight, heightForMetal) / blockHeight;
+        auto checkedNewBytesPerImage = checkedProduct<uint32_t>(newBytesPerRow, std::max<size_t>(blockHeight, logicalSize.height / blockHeight));
+        if (checkedNewBytesPerImage.hasOverflowed())
+            return;
+        auto newBytesPerImage = checkedNewBytesPerImage.value();
+        const auto maxZ = std::max<size_t>(1, size.depthOrArrayLayers);
+        auto checkedNewBytesPerImageTimesMaxZ = checkedProduct<uint32_t>(newBytesPerImage, maxZ);
+        if (checkedNewBytesPerImageTimesMaxZ.hasOverflowed())
+            return;
+        newData.resize(checkedNewBytesPerImageTimesMaxZ.value());
         memset(&newData[0], 0, newData.size());
         dataLayoutOffset = 0;
 
@@ -709,11 +758,20 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         }
 
         if (maxY) {
-            if ((maxY - 1) * newBytesPerRow + (maxZ - 1) * newBytesPerImage + newBytesPerRow > newData.size()
-                || (maxY - 1) * bytesPerRow + (maxZ - 1) * bytesPerImage + dataLayout.offset + newBytesPerRow > data.size()) {
+            auto maxYMinus1TimesNewBytesPerRow = checkedProduct<uint32_t>((maxY - 1), newBytesPerRow);
+            auto maxZMinus1TimesNewBytesPerImage = checkedProduct<uint32_t>((maxZ - 1), newBytesPerImage);
+            auto maxYMinus1TimesBytesPerRow = checkedProduct<uint32_t>((maxY - 1), bytesPerRow);
+            auto maxZMinus1TimesBytesPerImage = checkedProduct<uint32_t>((maxZ - 1), bytesPerImage);
+            if (maxYMinus1TimesNewBytesPerRow.hasOverflowed() || maxZMinus1TimesNewBytesPerImage.hasOverflowed() || maxYMinus1TimesBytesPerRow.hasOverflowed() || maxZMinus1TimesBytesPerImage.hasOverflowed())
+                return;
+            auto checkedNewBytesSum = checkedSum<uint32_t>(maxYMinus1TimesNewBytesPerRow.value(), maxZMinus1TimesNewBytesPerImage.value(), newBytesPerRow);
+            auto checkedBytesSum = checkedSum<uint32_t>(maxYMinus1TimesBytesPerRow.value(), maxZMinus1TimesBytesPerImage.value(), dataLayout.offset, newBytesPerRow);
+            if (checkedNewBytesSum.hasOverflowed() || checkedBytesSum.hasOverflowed())
+                return;
+            if (checkedNewBytesSum.value() > newData.size() || checkedBytesSum.value() > data.size()) {
                 auto y = (maxY - 1);
                 auto z = (maxZ - 1);
-                device->generateAValidationError([NSString stringWithFormat:@"y(%zu) * newBytesPerRow(%u) + z(%zu) * newBytesPerImage(%lu) + newBytesPerRow(%u) > newData.size()(%zu) || y(%zu) * bytesPerRow(%lu) + z(%zu) * bytesPerImage(%lu) + newBytesPerRow(%u) > dataSize(%zu), copySize %u, %u, %u, textureSize %u, %u, %u, offset %llu", y, newBytesPerRow, z, newBytesPerImage, newBytesPerRow, newData.size(), y, static_cast<unsigned long>(bytesPerRow), z, static_cast<unsigned long>(bytesPerImage), newBytesPerRow, data.size(), widthForMetal, heightForMetal, depthForMetal, logicalSize.width, logicalSize.height, logicalSize.depthOrArrayLayers, dataLayout.offset]);
+                device->generateAValidationError([NSString stringWithFormat:@"y(%zu) * newBytesPerRow(%u) + z(%zu) * newBytesPerImage(%u) + newBytesPerRow(%u) > newData.size()(%zu) || y(%zu) * bytesPerRow(%lu) + z(%zu) * bytesPerImage(%lu) + newBytesPerRow(%u) > dataSize(%zu), copySize %u, %u, %u, textureSize %u, %u, %u, offset %llu", y, newBytesPerRow, z, newBytesPerImage, newBytesPerRow, newData.size(), y, static_cast<unsigned long>(bytesPerRow), z, static_cast<unsigned long>(bytesPerImage), newBytesPerRow, data.size(), widthForMetal, heightForMetal, depthForMetal, logicalSize.width, logicalSize.height, logicalSize.depthOrArrayLayers, dataLayout.offset]);
                 return;
             }
         }
@@ -721,8 +779,18 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         auto newDataSpan = newData.mutableSpan();
         for (size_t z = 0; z < maxZ; ++z) {
             for (size_t y = 0; y < maxY; ++y) {
-                auto sourceBytesSpan = data.subspan(y * bytesPerRow + z * bytesPerImage + dataLayout.offset, newBytesPerRow);
-                auto destBytesSpan = newDataSpan.subspan(y * newBytesPerRow + z * newBytesPerImage, newBytesPerRow);
+                auto yTimesBytesPerRow = checkedProduct<uint32_t>(y, bytesPerRow);
+                auto yTimesNewBytesPerRow = checkedProduct<uint32_t>(y, newBytesPerRow);
+                auto zTimesBytesPerImage = checkedProduct<uint32_t>(z, bytesPerImage);
+                auto zTimesNewBytesPerImage = checkedProduct<uint32_t>(z, newBytesPerImage);
+                if (yTimesBytesPerRow.hasOverflowed() || yTimesNewBytesPerRow.hasOverflowed() || zTimesBytesPerImage.hasOverflowed() || zTimesNewBytesPerImage.hasOverflowed())
+                    return;
+                auto checkedYPlusZPlusOffset = checkedSum<uint32_t>(yTimesBytesPerRow.value(), zTimesBytesPerImage.value(), dataLayout.offset);
+                auto checkedNewYPlusNewZ = checkedSum<uint32_t>(yTimesNewBytesPerRow.value(), zTimesNewBytesPerImage.value());
+                if (checkedYPlusZPlusOffset.hasOverflowed() || checkedNewYPlusNewZ.hasOverflowed())
+                    return;
+                auto sourceBytesSpan = data.subspan(checkedYPlusZPlusOffset.value(), newBytesPerRow);
+                auto destBytesSpan = newDataSpan.subspan(checkedNewYPlusNewZ.value(), newBytesPerRow);
                 memcpySpan(destBytesSpan, sourceBytesSpan);
             }
         }
@@ -749,15 +817,24 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
                     auto region = MTLRegionMake1D(destination.origin.x, widthForMetal);
                     for (uint32_t layer = 0; layer < size.depthOrArrayLayers; ++layer) {
-                        auto sourceOffset = static_cast<NSUInteger>(dataLayoutOffset + layer * bytesPerImage);
+                        auto checkedLayerTimesBytesPerImage = checkedProduct<uint32_t>(layer, bytesPerImage);
+                        if (checkedLayerTimesBytesPerImage.hasOverflowed())
+                            return;
+                        auto checkedDataLayoutOffsetPlusSum = checkedSum<uint32_t>(dataLayoutOffset, checkedLayerTimesBytesPerImage.value());
+                        if (checkedDataLayoutOffsetPlusSum.hasOverflowed())
+                            return;
+                        auto sourceOffset = static_cast<NSUInteger>(checkedDataLayoutOffsetPlusSum.value());
                         if (sourceOffset % blockSize)
                             continue;
-                        NSUInteger destinationSlice = destination.origin.z + layer;
+                        auto checkedDestinationSlice = checkedSum<NSUInteger>(destination.origin.z, layer);
+                        if (checkedDestinationSlice.hasOverflowed())
+                            return;
+                        NSUInteger destinationSlice = checkedDestinationSlice.value();
                         [mtlTexture
                             replaceRegion:region
                             mipmapLevel:destination.mipLevel
                             slice:destinationSlice
-                            withBytes:byteCast<char>(data.data()) + sourceOffset
+                            withBytes:byteCast<char>(data.subspan(sourceOffset).data())
                             bytesPerRow:0
                             bytesPerImage:0];
                     }
@@ -769,10 +846,20 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
                     auto region = MTLRegionMake2D(destination.origin.x, destination.origin.y, widthForMetal, heightForMetal);
                     for (uint32_t layer = 0; layer < size.depthOrArrayLayers; ++layer) {
-                        auto sourceOffset = static_cast<NSUInteger>(dataLayoutOffset + layer * bytesPerImage);
+                        auto layerTimesBytesPerImage = checkedProduct<uint32_t>(layer, bytesPerImage);
+                        if (layerTimesBytesPerImage.hasOverflowed())
+                            return;
+
+                        auto checkedSourceOffset = checkedSum<NSUInteger>(dataLayoutOffset, layerTimesBytesPerImage.value());
+                        if (checkedSourceOffset.hasOverflowed())
+                            return;
+                        auto sourceOffset = checkedSourceOffset.value();
                         if (sourceOffset % blockSize)
                             continue;
-                        NSUInteger destinationSlice = destination.origin.z + layer;
+                        auto checkedDestinationSlice = checkedSum<NSUInteger>(destination.origin.z, layer);
+                        if (checkedDestinationSlice.hasOverflowed())
+                            return;
+                        NSUInteger destinationSlice = checkedDestinationSlice.value();
                         [mtlTexture
                             replaceRegion:region
                             mipmapLevel:destination.mipLevel
@@ -795,7 +882,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
                         replaceRegion:region
                         mipmapLevel:destination.mipLevel
                         slice:0
-                        withBytes:byteCast<char>(data.data()) + sourceOffset
+                        withBytes:byteCast<char>(data.subspan(sourceOffset).data())
                         bytesPerRow:bytesPerRow
                         bytesPerImage:bytesPerImage];
                     break;
@@ -820,7 +907,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
     // FIXME(PERFORMANCE): Should this temporary buffer really be shared?
     NSUInteger newBufferSize = dataByteSize - dataLayoutOffset;
     bool noCopy = newBufferSize >= largeBufferSize;
-    id<MTLBuffer> temporaryBuffer = noCopy ? device->newBufferWithBytesNoCopy(byteCast<char>(data.data()) + dataLayoutOffset, static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared) : device->newBufferWithBytes(byteCast<char>(data.data()) + dataLayoutOffset, static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared);
+    id<MTLBuffer> temporaryBuffer = noCopy ? device->newBufferWithBytesNoCopy(byteCast<char>(data.subspan(dataLayoutOffset).data()), static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared) : device->newBufferWithBytes(byteCast<char>(data.subspan(dataLayoutOffset).data()), static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared);
     if (!temporaryBuffer)
         return;
 
@@ -835,9 +922,21 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         auto destinationOrigin = MTLOriginMake(destination.origin.x, 0, 0);
 
         for (uint32_t layer = 0; layer < size.depthOrArrayLayers; ++layer) {
-            NSUInteger sourceOffset = layer * bytesPerImage;
-            NSUInteger destinationSlice = destination.origin.z + layer;
-            if (sourceOffset + widthForMetal * blockSize > temporaryBuffer.length)
+            auto checkedSourceOffset = checkedProduct<NSUInteger>(layer, bytesPerImage);
+            if (checkedSourceOffset.hasOverflowed())
+                return;
+            NSUInteger sourceOffset = checkedSourceOffset.value();
+            auto checkedDestinationSlice = checkedSum<NSUInteger>(destination.origin.z, layer);
+            if (checkedDestinationSlice.hasOverflowed())
+                return;
+            NSUInteger destinationSlice = checkedDestinationSlice.value();
+            auto widthTimesBlockSize = checkedProduct<NSUInteger>(widthForMetal, blockSize);
+            if (widthTimesBlockSize.hasOverflowed())
+                return;
+            auto sourceOffsetSum = checkedSum<NSUInteger>(sourceOffset, widthTimesBlockSize.value());
+            if (sourceOffsetSum.hasOverflowed())
+                return;
+            if (sourceOffsetSum.value() > temporaryBuffer.length)
                 continue;
             if (sourceOffset % blockSize)
                 continue;
@@ -865,8 +964,14 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
         auto destinationOrigin = MTLOriginMake(destination.origin.x, destination.origin.y, 0);
         for (uint32_t layer = 0; layer < size.depthOrArrayLayers; ++layer) {
-            NSUInteger sourceOffset = layer * bytesPerImage;
-            NSUInteger destinationSlice = destination.origin.z + layer;
+            auto layerTimesBytesPerImage = checkedProduct<NSUInteger>(layer, bytesPerImage);
+            if (layerTimesBytesPerImage.hasOverflowed())
+                return;
+            NSUInteger sourceOffset = layerTimesBytesPerImage.value();
+            auto checkedDestinationSlice = checkedSum<NSUInteger>(destination.origin.z, layer);
+            if (checkedDestinationSlice.hasOverflowed())
+                return;
+            NSUInteger destinationSlice = checkedDestinationSlice.value();
             if (sourceOffset % blockSize)
                 continue;
             [m_blitCommandEncoder
@@ -935,8 +1040,12 @@ void Queue::clearTextureViewIfNeeded(TextureView& textureView)
     auto& parentTexture = textureView.apiParentTexture();
     for (uint32_t slice = 0; slice < textureView.arrayLayerCount(); ++slice) {
         for (uint32_t mipLevel = 0; mipLevel < textureView.mipLevelCount(); ++mipLevel) {
-            auto parentMipLevel = textureView.baseMipLevel() + mipLevel;
-            auto parentSlice = textureView.baseArrayLayer() + slice;
+            auto checkedParentMipLevel = checkedSum<uint32_t>(textureView.baseMipLevel(), mipLevel);
+            auto checkedParentSlice = checkedSum<uint32_t>(textureView.baseArrayLayer(), slice);
+            if (checkedParentMipLevel.hasOverflowed() || checkedParentSlice.hasOverflowed())
+                return;
+            auto parentMipLevel = checkedParentMipLevel.value();
+            auto parentSlice = checkedParentSlice.value();
             if (parentTexture.previouslyCleared(parentMipLevel, parentSlice))
                 continue;
 

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -72,7 +72,7 @@ public:
 
     // For depth-stencil textures, the input value to texelBlockSize()
     // needs to be the output of aspectSpecificFormat().
-    static uint32_t texelBlockSize(WGPUTextureFormat); // Bytes
+    static Checked<uint32_t> texelBlockSize(WGPUTextureFormat); // Bytes
     static bool containsDepthAspect(WGPUTextureFormat);
     static bool containsStencilAspect(WGPUTextureFormat);
     static bool isDepthOrStencilFormat(WGPUTextureFormat);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2157,10 +2157,11 @@ NSUInteger Texture::bytesPerRow(WGPUTextureFormat format, uint32_t textureWidth,
         return 0;
     }
     NSUInteger blocksInWidth = textureWidth / blockWidth;
-    return Texture::texelBlockSize(format) * blocksInWidth * sampleCount;
+    auto product = checkedProduct<NSUInteger>(Texture::texelBlockSize(format), blocksInWidth, sampleCount);
+    return product.hasOverflowed() ? NSUIntegerMax : product.value();
 }
 
-uint32_t Texture::texelBlockSize(WGPUTextureFormat format) // Bytes
+Checked<uint32_t> Texture::texelBlockSize(WGPUTextureFormat format) // Bytes
 {
     // For depth-stencil textures, the input value to this function
     // needs to be the output of aspectSpecificFormat().


### PR DESCRIPTION
#### be64ae4a8627494d9ea27c261bc09c573f1c2e7d
<pre>
[WebGPU] Convert all adds and muls into checked arithmetic - part 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=281365">https://bugs.webkit.org/show_bug.cgi?id=281365</a>
<a href="https://rdar.apple.com/137793734">rdar://137793734</a>

Reviewed by Geoffrey Garen.

Convert CommandEncoder.mm, Queue.mm, and Texture.mm to
exclusively use checked arithmetic for all values passed
over IPC.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyBufferToTexture):
(WebGPU::CommandEncoder::clearTextureIfNeeded):
(WebGPU::CommandEncoder::copyTextureToBuffer):
(WebGPU::CommandEncoder::copyTextureToTexture):
(WebGPU::validateResolveQuerySet):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
(WebGPU::Queue::clearTextureViewIfNeeded):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::bytesPerRow):

Canonical link: <a href="https://commits.webkit.org/285246@main">https://commits.webkit.org/285246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db380c9ed9b39bcfa13e750bd97d8666936f4664

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56637 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15126 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43060 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77569 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64362 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6164 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46948 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->