### PR TITLE
MediaCapability doesn't need to support WeakPtr

### DIFF
--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -36,19 +36,10 @@
 OBJC_CLASS BEMediaEnvironment;
 
 namespace WebKit {
-class MediaCapability;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::MediaCapability> : std::true_type { };
-}
-
-namespace WebKit {
 
 class ExtensionCapabilityGrant;
 
-class MediaCapability final : public ExtensionCapability, public CanMakeWeakPtr<MediaCapability> {
+class MediaCapability final : public ExtensionCapability {
     WTF_MAKE_NONCOPYABLE(MediaCapability);
 public:
     explicit MediaCapability(URL&&);


### PR DESCRIPTION
#### 20bb66605697dc51fdd05b9de1abd2d97dd47fb5
<pre>
MediaCapability doesn&apos;t need to support WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=281367">https://bugs.webkit.org/show_bug.cgi?id=281367</a>

Reviewed by NOBODY (OOPS!).

Remove the capability to create a WeakPtr to MediaCapability since nobody uses it.

* Source/WebKit/Platform/cocoa/MediaCapability.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20bb66605697dc51fdd05b9de1abd2d97dd47fb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71451 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50864 "Hash 20bb6660 for PR 35096 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75562 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22656 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58664 "Hash 20bb6660 for PR 35096 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14896 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74517 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/58664 "Hash 20bb6660 for PR 35096 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36876 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/58664 "Hash 20bb6660 for PR 35096 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20997 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/58664 "Hash 20bb6660 for PR 35096 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77281 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18553 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64138 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5924 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46664 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->