### PR TITLE
PaymentAuthorizationPresenter should be ref counted

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -455,7 +455,7 @@ private:
     const String& paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&) final;
     const String& paymentCoordinatorSourceApplicationBundleIdentifier(const WebPaymentCoordinatorProxy&) final;
     const String& paymentCoordinatorSourceApplicationSecondaryIdentifier(const WebPaymentCoordinatorProxy&) final;
-    std::unique_ptr<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) final;
+    Ref<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) final;
     void paymentCoordinatorAddMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName, IPC::MessageReceiver&) final;
     void paymentCoordinatorRemoveMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName) final;
     void getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) final;

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -104,9 +104,9 @@ const String& NetworkConnectionToWebProcess::paymentCoordinatorSourceApplication
     return emptyString();
 }
 
-std::unique_ptr<PaymentAuthorizationPresenter> NetworkConnectionToWebProcess::paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy& coordinator, PKPaymentRequest *request)
+Ref<PaymentAuthorizationPresenter> NetworkConnectionToWebProcess::paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy& coordinator, PKPaymentRequest *request)
 {
-    return makeUnique<PaymentAuthorizationController>(coordinator, request);
+    return PaymentAuthorizationController::create(coordinator, request);
 }
 
 void NetworkConnectionToWebProcess::paymentCoordinatorAddMessageReceiver(WebPaymentCoordinatorProxy&, IPC::ReceiverName, IPC::MessageReceiver&)

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -31,20 +31,12 @@
 #include <WebCore/ApplePaySessionPaymentRequest.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS UIViewController;
 OBJC_CLASS WKPaymentAuthorizationDelegate;
-
-namespace WebKit {
-class PaymentAuthorizationPresenter;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PaymentAuthorizationPresenter> : std::true_type { };
-}
 
 namespace WebCore {
 class Payment;
@@ -62,11 +54,14 @@ struct ApplePayShippingMethodUpdate;
 
 namespace WebKit {
 
-class PaymentAuthorizationPresenter : public CanMakeWeakPtr<PaymentAuthorizationPresenter> {
+class PaymentAuthorizationPresenter : public RefCountedAndCanMakeWeakPtr<PaymentAuthorizationPresenter> {
     WTF_MAKE_TZONE_ALLOCATED(PaymentAuthorizationPresenter);
     WTF_MAKE_NONCOPYABLE(PaymentAuthorizationPresenter);
 public:
-    struct Client {
+    struct Client : public CanMakeWeakPtr<Client>, public CanMakeCheckedPtr<Client> {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
+
         virtual ~Client() = default;
 
         virtual void presenterDidAuthorizePayment(PaymentAuthorizationPresenter&, const WebCore::Payment&) = 0;
@@ -83,7 +78,8 @@ public:
 
     virtual ~PaymentAuthorizationPresenter() = default;
 
-    Client& client() { return m_client; }
+    Client* client() { return m_client.get(); }
+    CheckedPtr<Client> checkedClient() { return m_client.get(); }
 
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&);
     void completePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&&);
@@ -118,7 +114,7 @@ protected:
 #endif
 
 private:
-    Client& m_client;
+    WeakPtr<Client> m_client;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.h
@@ -41,9 +41,11 @@ class WebPaymentCoordinatorProxy;
 
 class PaymentAuthorizationViewController final : public PaymentAuthorizationPresenter {
 public:
-    PaymentAuthorizationViewController(PaymentAuthorizationPresenter::Client&, PKPaymentRequest *, PKPaymentAuthorizationViewController * = nil);
+    static Ref<PaymentAuthorizationViewController> create(PaymentAuthorizationPresenter::Client&, PKPaymentRequest *, PKPaymentAuthorizationViewController * = nil);
 
 private:
+    PaymentAuthorizationViewController(PaymentAuthorizationPresenter::Client&, PKPaymentRequest *, PKPaymentAuthorizationViewController * = nil);
+
     // PaymentAuthorizationPresenter
     WKPaymentAuthorizationDelegate *platformDelegate() final;
     void dismiss() final;

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
@@ -118,6 +118,11 @@ static RetainPtr<PKPaymentAuthorizationViewController> platformViewController(PK
 #endif
 }
 
+Ref<PaymentAuthorizationViewController> PaymentAuthorizationViewController::create(PaymentAuthorizationPresenter::Client& client, PKPaymentRequest *request, PKPaymentAuthorizationViewController *viewController)
+{
+    return adoptRef(*new PaymentAuthorizationViewController(client, request, viewController));
+}
+
 PaymentAuthorizationViewController::PaymentAuthorizationViewController(PaymentAuthorizationPresenter::Client& client, PKPaymentRequest *request, PKPaymentAuthorizationViewController *viewController)
     : PaymentAuthorizationPresenter(client)
     , m_viewController(platformViewController(request, viewController))

--- a/Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm
+++ b/Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm
@@ -205,13 +205,13 @@
     if (!presenter)
         return [self completePaymentSession:PKPaymentAuthorizationStatusFailure errors:@[ ]];
 
-    presenter->client().presenterDidAuthorizePayment(*presenter, WebCore::Payment(payment));
+    presenter->checkedClient()->presenterDidAuthorizePayment(*presenter, WebCore::Payment(payment));
 }
 
 - (void)_didFinish
 {
     if (auto presenter = _presenter.get())
-        presenter->client().presenterDidFinish(*presenter, { std::exchange(_sessionError, nil) });
+        presenter->checkedClient()->presenterDidFinish(*presenter, { std::exchange(_sessionError, nil) });
 }
 
 - (void)_didRequestMerchantSession:(WebKit::DidRequestMerchantSessionCompletion::BlockType)completion
@@ -232,7 +232,7 @@
                 return;
             }
 
-            presenter->client().presenterWillValidateMerchant(*presenter, merchantURL.get());
+            presenter->checkedClient()->presenterWillValidateMerchant(*presenter, merchantURL.get());
         });
     }];
 }
@@ -242,11 +242,11 @@
     ASSERT(!_didSelectPaymentMethodCompletion);
     _didSelectPaymentMethodCompletion = completion;
 
-    auto presenter = _presenter.get();
+    RefPtr presenter = _presenter.get();
     if (!presenter)
         return [self completePaymentMethodSelection:nil];
 
-    presenter->client().presenterDidSelectPaymentMethod(*presenter, WebCore::PaymentMethod(paymentMethod));
+    presenter->checkedClient()->presenterDidSelectPaymentMethod(*presenter, WebCore::PaymentMethod(paymentMethod));
 }
 
 - (void)_didSelectShippingContact:(PKContact *)contact completion:(WebKit::DidSelectShippingContactCompletion::BlockType)completion
@@ -254,11 +254,11 @@
     ASSERT(!_didSelectShippingContactCompletion);
     _didSelectShippingContactCompletion = completion;
 
-    auto presenter = _presenter.get();
+    RefPtr presenter = _presenter.get();
     if (!presenter)
         return [self completeShippingContactSelection:nil];
 
-    presenter->client().presenterDidSelectShippingContact(*presenter, WebCore::PaymentContact(contact));
+    presenter->checkedClient()->presenterDidSelectShippingContact(*presenter, WebCore::PaymentContact(contact));
 }
 
 #if HAVE(PASSKIT_SHIPPING_METHOD_DATE_COMPONENTS_RANGE)
@@ -313,11 +313,11 @@ static WebCore::ApplePayShippingMethod toShippingMethod(PKShippingMethod *shippi
     ASSERT(!_didSelectShippingMethodCompletion);
     _didSelectShippingMethodCompletion = completion;
 
-    auto presenter = _presenter.get();
+    RefPtr presenter = _presenter.get();
     if (!presenter)
         return [self completeShippingMethodSelection:nil];
 
-    presenter->client().presenterDidSelectShippingMethod(*presenter, toShippingMethod(shippingMethod, true));
+    presenter->checkedClient()->presenterDidSelectShippingMethod(*presenter, toShippingMethod(shippingMethod, true));
 }
 
 #if HAVE(PASSKIT_COUPON_CODE)
@@ -327,11 +327,11 @@ static WebCore::ApplePayShippingMethod toShippingMethod(PKShippingMethod *shippi
     ASSERT(!_didChangeCouponCodeCompletion);
     _didChangeCouponCodeCompletion = completion;
 
-    auto presenter = _presenter.get();
+    RefPtr presenter = _presenter.get();
     if (!presenter)
         return [self completeCouponCodeChange:nil];
 
-    presenter->client().presenterDidChangeCouponCode(*presenter, couponCode);
+    presenter->checkedClient()->presenterDidChangeCouponCode(*presenter, couponCode);
 }
 
 #endif // HAVE(PASSKIT_COUPON_CODE)

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.h
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.h
@@ -39,9 +39,11 @@ namespace WebKit {
 
 class PaymentAuthorizationController final : public PaymentAuthorizationPresenter {
 public:
-    PaymentAuthorizationController(PaymentAuthorizationPresenter::Client&, PKPaymentRequest *);
+    static Ref<PaymentAuthorizationController> create(PaymentAuthorizationPresenter::Client&, PKPaymentRequest *);
 
 private:
+    PaymentAuthorizationController(PaymentAuthorizationPresenter::Client&, PKPaymentRequest *);
+
     // PaymentAuthorizationPresenter
     WKPaymentAuthorizationDelegate *platformDelegate() final;
     void dismiss() final;

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -49,7 +49,7 @@
     if (!(self = [super _initWithRequest:request presenter:presenter]))
         return nil;
 
-    _presentingWindow = presenter.client().presentingWindowForPaymentAuthorization(presenter);
+    _presentingWindow = presenter.checkedClient()->presentingWindowForPaymentAuthorization(presenter);
     return self;
 }
 
@@ -134,6 +134,11 @@
 @end
 
 namespace WebKit {
+
+Ref<PaymentAuthorizationController> PaymentAuthorizationController::create(PaymentAuthorizationPresenter::Client& client, PKPaymentRequest *request)
+{
+    return adoptRef(*new PaymentAuthorizationController(client, request));
+}
 
 PaymentAuthorizationController::PaymentAuthorizationController(PaymentAuthorizationPresenter::Client& client, PKPaymentRequest *request)
     : PaymentAuthorizationPresenter(client)

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -85,7 +85,10 @@ class WebPaymentCoordinatorProxy final
     , public PaymentAuthorizationPresenter::Client
     , public RefCounted<WebPaymentCoordinatorProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WebPaymentCoordinatorProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPaymentCoordinatorProxy);
 public:
+    USING_CAN_MAKE_WEAKPTR(MessageReceiver);
+
     struct Client : public CanMakeWeakPtr<Client>, public CanMakeCheckedPtr<Client> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
@@ -104,7 +107,7 @@ public:
         virtual void getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&&) = 0;
 #endif
         virtual const String& paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&) = 0;
-        virtual std::unique_ptr<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) = 0;
+        virtual Ref<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) = 0;
 #endif
         virtual CocoaWindow *paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) const = 0;
         virtual void getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) = 0;
@@ -244,7 +247,7 @@ private:
         ValidationComplete
     } m_merchantValidationState { MerchantValidationState::Idle };
 
-    std::unique_ptr<PaymentAuthorizationPresenter> m_authorizationPresenter;
+    RefPtr<PaymentAuthorizationPresenter> m_authorizationPresenter;
     Ref<WorkQueue> m_canMakePaymentsQueue;
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -105,7 +105,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 
             ASSERT(viewController);
 
-            paymentCoordinatorProxy->m_authorizationPresenter = makeUnique<PaymentAuthorizationViewController>(*paymentCoordinatorProxy, paymentRequest.get(), viewController);
+            paymentCoordinatorProxy->m_authorizationPresenter = PaymentAuthorizationViewController::create(*paymentCoordinatorProxy, paymentRequest.get(), viewController);
 
             ASSERT(!paymentCoordinatorProxy->m_sheetWindow);
             paymentCoordinatorProxy->m_sheetWindow = [NSWindow windowWithContentViewController:viewController];

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -467,7 +467,7 @@ public:
 #if ENABLE(APPLE_PAY) && PLATFORM(IOS_FAMILY)
     UIViewController *paymentCoordinatorPresentingViewController(const WebPaymentCoordinatorProxy&) final;
     const String& paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&) final;
-    std::unique_ptr<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) final;
+    Ref<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) final;
 #endif
 #if ENABLE(APPLE_PAY) && PLATFORM(IOS_FAMILY) && ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
     void getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&&) final;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1353,9 +1353,9 @@ void WebPageProxy::requestPasswordForQuickLookDocumentInMainFrameShared(const St
 
 #if ENABLE(APPLE_PAY)
 
-std::unique_ptr<PaymentAuthorizationPresenter> WebPageProxy::Internals::paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy& paymentCoordinatorProxy, PKPaymentRequest *paymentRequest)
+Ref<PaymentAuthorizationPresenter> WebPageProxy::Internals::paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy& paymentCoordinatorProxy, PKPaymentRequest *paymentRequest)
 {
-    return makeUnique<PaymentAuthorizationController>(paymentCoordinatorProxy, paymentRequest);
+    return PaymentAuthorizationController::create(paymentCoordinatorProxy, paymentRequest);
 }
 
 UIViewController *WebPageProxy::Internals::paymentCoordinatorPresentingViewController(const WebPaymentCoordinatorProxy&)


### PR DESCRIPTION
#### 88b3dbd8492d899763808fa4b3928ffb7d8ab9cf
<pre>
PaymentAuthorizationPresenter should be ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=281368">https://bugs.webkit.org/show_bug.cgi?id=281368</a>

Reviewed by Chris Dumez.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm:
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorAuthorizationPresenter):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
(WebKit::PaymentAuthorizationPresenter::client):
(WebKit::PaymentAuthorizationPresenter::checkedClient):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm:
(WebKit::PaymentAuthorizationViewController::create):
* Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm:
(-[WKPaymentAuthorizationDelegate _didAuthorizePayment:completion:]):
(-[WKPaymentAuthorizationDelegate _didFinish]):
(-[WKPaymentAuthorizationDelegate _didRequestMerchantSession:]):
(-[WKPaymentAuthorizationDelegate _didSelectPaymentMethod:completion:]):
(-[WKPaymentAuthorizationDelegate _didSelectShippingContact:completion:]):
(-[WKPaymentAuthorizationDelegate _didSelectShippingMethod:completion:]):
(-[WKPaymentAuthorizationDelegate _didChangeCouponCode:completion:]):
* Source/WebKit/Platform/ios/PaymentAuthorizationController.h:
* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(-[WKPaymentAuthorizationControllerDelegate initWithRequest:presenter:]):
(WebKit::PaymentAuthorizationController::create):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::Internals::paymentCoordinatorAuthorizationPresenter):

Canonical link: <a href="https://commits.webkit.org/285181@main">https://commits.webkit.org/285181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ab0746a5268b0a565ec034f721ec53ba0ad3f12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22922 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43049 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21263 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77551 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18794 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12510 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6151 "Found 2 new test failures: pageoverlay/overlay-small-frame-mouse-events.html pageoverlay/overlay-small-frame-paints.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1709 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->