### PR TITLE
text-spacing: text-spacing-trim: implement trim-all for simple path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-spacing-trim-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-spacing-trim-computed-expected.txt
@@ -3,7 +3,7 @@ PASS Property text-spacing-trim value 'auto'
 FAIL Property text-spacing-trim value 'normal' assert_true: 'normal' is a supported value for text-spacing-trim. expected true got false
 PASS Property text-spacing-trim value 'space-all'
 FAIL Property text-spacing-trim value 'trim-both' assert_true: 'trim-both' is a supported value for text-spacing-trim. expected true got false
-FAIL Property text-spacing-trim value 'trim-all' assert_true: 'trim-all' is a supported value for text-spacing-trim. expected true got false
+PASS Property text-spacing-trim value 'trim-all'
 FAIL Property text-spacing-trim value 'trim-start' assert_true: 'trim-start' is a supported value for text-spacing-trim. expected true got false
 FAIL Property text-spacing-trim value 'space-first' assert_true: 'space-first' is a supported value for text-spacing-trim. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-spacing-trim-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-spacing-trim-valid-expected.txt
@@ -3,7 +3,7 @@ FAIL e.style['text-spacing-trim'] = "normal" should set the property value asser
 PASS e.style['text-spacing-trim'] = "auto" should set the property value
 PASS e.style['text-spacing-trim'] = "space-all" should set the property value
 FAIL e.style['text-spacing-trim'] = "trim-both" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['text-spacing-trim'] = "trim-all" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['text-spacing-trim'] = "trim-all" should set the property value
 FAIL e.style['text-spacing-trim'] = "trim-start" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['text-spacing-trim'] = "space-first" should set the property value assert_not_equals: property should be set got disallowed value ""
 

--- a/Source/WTF/wtf/text/CharacterProperties.h
+++ b/Source/WTF/wtf/text/CharacterProperties.h
@@ -156,6 +156,14 @@ inline bool isCJKSymbolOrPunctuation(char32_t character)
     return character >= 0x3000 && character <= 0x303F;
 }
 
+inline bool isFullwidthMiddleDotPunctuation(char32_t character)
+{
+    // U+00B7 MIDDLE DOT
+    // U+2027 HYPHENATION POINT
+    // U+30FB KATAKANA MIDDLE DOT
+    return character == 0x00B7 || character == 0x2027 || character == 0x30FB;
+}
+
 } // namespace WTF
 
 using WTF::isEmojiGroupCandidate;
@@ -174,3 +182,4 @@ using WTF::isClosingPunctuation;
 using WTF::isOfScriptType;
 using WTF::isEastAsianFullWidth;
 using WTF::isCJKSymbolOrPunctuation;
+using WTF::isFullwidthMiddleDotPunctuation;

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1182,7 +1182,8 @@
             "inherited": true,
             "values": [
                 "auto",
-                "space-all"
+                "space-all",
+                "trim-all"
             ],
             "codegen-properties": {
                 "settings-flag": "cssTextSpacingTrimEnabled",
@@ -1190,9 +1191,7 @@
                 "high-priority": true,
                 "sink-priority": true,
                 "converter": "TextSpacingTrim",
-                "parser-function": "consumeTextSpacingTrim",
-                "parser-grammar-unused": "auto | space-all | trim-all | [ allow-end || space-first ]",
-                "parser-grammar-unused-reason": "Needs support for '||' groups."
+                "parser-grammar": "space-all | trim-all | auto"
             },
             "status": "in development",
             "specification": {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1775,6 +1775,7 @@ false
 
 // text-spacing-trim
 space-all
+trim-all
 // text-autospace
 // normal
 no-autospace

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -386,9 +386,17 @@ static Ref<CSSPrimitiveValue> textSpacingTrimFromStyle(const RenderStyle& style)
 {
     // FIXME: add support for remaining values once spec is stable and we are parsing them.
     auto textSpacingTrim = style.textSpacingTrim();
-    if (textSpacingTrim.isAuto())
+    switch (textSpacingTrim.type()) {
+    case TextSpacingTrim::TrimType::SpaceAll:
+        return CSSPrimitiveValue::create(CSSValueSpaceAll);
+    case TextSpacingTrim::TrimType::Auto:
         return CSSPrimitiveValue::create(CSSValueAuto);
-
+    case TextSpacingTrim::TrimType::TrimAll:
+        return CSSPrimitiveValue::create(CSSValueTrimAll);
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
     return CSSPrimitiveValue::create(CSSValueSpaceAll);
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -2377,18 +2377,6 @@ RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange& range, const CSSPa
     return CSSVariableParser::parseDeclarationValue(nullAtom(), range.consumeAll(), context);
 }
 
-RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange& range, const CSSParserContext&)
-{
-    // auto | space-all |  trim-all | [ allow-end || space-first ]
-    // FIXME: add remaining values;
-    if (auto value = consumeIdent<CSSValueAuto, CSSValueSpaceAll>(range)) {
-        if (!range.atEnd())
-            return nullptr;
-        return value;
-    }
-    return nullptr;
-}
-
 RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange& range, const CSSParserContext&)
 {
     //  normal | auto | no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -117,7 +117,6 @@ RefPtr<CSSValue> consumeTextEmphasisPosition(CSSParserTokenRange&, const CSSPars
 RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&, const CSSParserContext&);
 #endif
 RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeTextUnderlinePosition(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeWebKitRubyPosition(CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -390,6 +390,16 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         return;
 
     auto glyphData = m_font->glyphDataForCharacter(character, false, FontVariant::NormalVariant);
+
+    auto getHalfWidthFontAndSetGlyphDataIfNeeded = [&](GlyphData& glyphData, const TextSpacing::CharactersData& charactersData) {
+        auto halfWidthFont = fontDescription.textSpacingTrim().shouldTrimSpacing(charactersData) ? glyphData.font->halfWidthFont() : nullptr;
+        if (halfWidthFont)
+            glyphData.font = halfWidthFont.get();
+        return halfWidthFont;
+    };
+    TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
+    auto halfWidthFont = getHalfWidthFontAndSetGlyphDataIfNeeded(glyphData, charactersData);
+
     advanceInternalState.updateFont(glyphData.font ? glyphData.font.get() : primaryFont.ptr());
     auto capitalizedCharacter = capitalized(character);
     if (shouldSynthesizeSmallCaps(smallCapsState.dontSynthesizeSmallCaps, advanceInternalState.font.get(), character, capitalizedCharacter, smallCapsState.fontVariantCaps, smallCapsState.engageAllSmallCapsProcessing))
@@ -419,6 +429,10 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         }
 #endif
         auto glyphData = m_font->glyphDataForCharacter(character, false, FontVariant::NormalVariant);
+
+        TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
+        halfWidthFont = getHalfWidthFontAndSetGlyphDataIfNeeded(glyphData, charactersData);
+
         advanceInternalState.updateFont(glyphData.font ? glyphData.font.get() : primaryFont.ptr());
         smallCapsState.shouldSynthesizeCharacter = shouldSynthesizeSmallCaps(smallCapsState.dontSynthesizeSmallCaps, advanceInternalState.font.get(), character, capitalizedCharacter, smallCapsState.fontVariantCaps, smallCapsState.engageAllSmallCapsProcessing);
         updateCharacterAndSmallCapsIfNeeded(smallCapsState, capitalizedCharacter, characterToWrite);

--- a/Source/WebCore/platform/text/TextSpacing.cpp
+++ b/Source/WebCore/platform/text/TextSpacing.cpp
@@ -32,6 +32,20 @@ namespace WebCore {
 
 using namespace TextSpacing;
 
+bool TextSpacingTrim::shouldTrimSpacing(const CharactersData& charactersData) const
+{
+    switch (m_trim) {
+    case TrimType::SpaceAll:
+        return false;
+    case TrimType::Auto:
+        return false;
+    case TrimType::TrimAll:
+        return charactersData.currentCharacterClass == CharacterClass::FullWidthOpeningPunctuation || charactersData.currentCharacterClass == CharacterClass::FullWidthClosingPunctuation || charactersData.currentCharacterClass == CharacterClass::FullWidthMiddleDotPunctuation;
+    default:
+        return false;
+    }
+}
+
 bool TextAutospace::shouldApplySpacing(CharacterClass firstCharacterClass, CharacterClass secondCharacterClass) const
 {
     constexpr uint8_t ideographAlphaMask = static_cast<uint8_t>(CharacterClass::Ideograph) | static_cast<uint8_t>(CharacterClass::NonIdeographLetter);
@@ -117,6 +131,9 @@ CharacterClass characterClass(char32_t character)
         if (character == rightSingleQuotationMark || character == rightDoubleQuotationMark)
             return CharacterClass::FullWidthClosingPunctuation;
     }
+
+    if (isFullwidthMiddleDotPunctuation(character))
+        return CharacterClass::FullWidthMiddleDotPunctuation;
     // FIXME: implement remaining classes for text-autospace: punctuation
     return CharacterClass::Undefined;
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -272,7 +272,7 @@ struct ViewTimelineInsets;
 struct TabSize;
 class TextAutospace;
 struct TextEdge;
-struct TextSpacingTrim;
+class TextSpacingTrim;
 struct TransformOperationData;
 
 template<typename> class FontTaggedSettings;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1931,8 +1931,17 @@ inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(const Build
 inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(const BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->valueID() == CSSValueAuto)
-            return { .m_trim = TextSpacingTrim::TrimType::Auto };
+        switch (primitiveValue->valueID()) {
+        case CSSValueSpaceAll:
+            return TextSpacingTrim::TrimType::SpaceAll;
+        case CSSValueTrimAll:
+            return TextSpacingTrim::TrimType::TrimAll;
+        case CSSValueAuto:
+            return TextSpacingTrim::TrimType::Auto;
+        default:
+            ASSERT_NOT_REACHED();
+            break;
+        }
     }
     return { };
 }


### PR DESCRIPTION
#### 43585a41ba1389bb588e1b6d5346f5318ba15486
<pre>
text-spacing: text-spacing-trim: implement trim-all for simple path
<a href="https://bugs.webkit.org/show_bug.cgi?id=281371">https://bugs.webkit.org/show_bug.cgi?id=281371</a>
<a href="https://rdar.apple.com/137795775">rdar://137795775</a>

Reviewed by Brent Fulgham.

Implementing text-spacing: trim-all for the simple path (WidthIterator).

* Source/WTF/wtf/text/CharacterProperties.h:
(WTF::isFullwidthMiddleDotPunctuation):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTextSpacingTrim): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advanceInternal):
* Source/WebCore/platform/text/TextSpacing.cpp:
(WebCore::TextSpacingTrim::shouldTrimSpacing const):
(WebCore::TextSpacing::characterClass):
* Source/WebCore/platform/text/TextSpacing.h:
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextSpacingTrim):

Canonical link: <a href="https://commits.webkit.org/285287@main">https://commits.webkit.org/285287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddb25f542bdd3302d93197c4ba368e6fb92ee827

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24903 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23324 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23146 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/76280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/15388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62122 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21674 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/65244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/65282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77960 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/71369 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/19118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62145 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12817 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/93150 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47334 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/2118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20512 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->