### PR TITLE
RemoteLayerBackingStore should support CheckedPtr

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -83,9 +83,10 @@ enum class LayerContentsType : uint8_t {
     CachedIOSurface,
 };
 
-class RemoteLayerBackingStore : public CanMakeWeakPtr<RemoteLayerBackingStore> {
+class RemoteLayerBackingStore : public CanMakeWeakPtr<RemoteLayerBackingStore>, public CanMakeCheckedPtr<RemoteLayerBackingStore> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerBackingStore);
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerBackingStore);
 public:
     RemoteLayerBackingStore(PlatformCALayerRemote&);
     virtual ~RemoteLayerBackingStore();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -66,11 +66,11 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
 
     auto& remoteRenderingBackend = layerTreeContext().ensureRemoteRenderingBackendProxy();
 
-    for (auto& backingStore : m_backingStoresNeedingDisplay) {
-        backingStore.layer().properties().notePropertiesChanged(LayerChange::BackingStoreChanged);
-        transaction.layerPropertiesChanged(backingStore.layer());
+    for (CheckedRef backingStore : m_backingStoresNeedingDisplay) {
+        backingStore->layer().properties().notePropertiesChanged(LayerChange::BackingStoreChanged);
+        transaction.layerPropertiesChanged(backingStore->layer());
 
-        if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
+        if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(backingStore.get())) {
             if (remoteBackingStore->performDelegatedLayerDisplay())
                 continue;
 
@@ -92,7 +92,7 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
             backingStoreList.append(*remoteBackingStore);
         }
 
-        backingStore.prepareToDisplay();
+        backingStore->prepareToDisplay();
     }
 
     if (prepareBuffersData.size()) {
@@ -227,7 +227,7 @@ bool RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayedWithRendering
 
 void RemoteLayerBackingStoreCollection::purgeFrontBufferForTesting(RemoteLayerBackingStore& backingStore)
 {
-    if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
+    if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
         if (RefPtr bufferSet = remoteBackingStore->protectedBufferSet()) {
             Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>> identifiers;
             OptionSet<BufferInSetType> bufferTypes { BufferInSetType::Front };
@@ -235,14 +235,14 @@ void RemoteLayerBackingStoreCollection::purgeFrontBufferForTesting(RemoteLayerBa
             sendMarkBuffersVolatile(WTFMove(identifiers), [](bool) { }, true);
         }
     } else {
-        auto& inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
-        inProcessBackingStore.setBufferVolatile(RemoteLayerBackingStore::BufferType::Front, true);
+        CheckedRef inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
+        inProcessBackingStore->setBufferVolatile(RemoteLayerBackingStore::BufferType::Front, true);
     }
 }
 
 void RemoteLayerBackingStoreCollection::purgeBackBufferForTesting(RemoteLayerBackingStore& backingStore)
 {
-    if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
+    if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
         if (RefPtr bufferSet = remoteBackingStore->protectedBufferSet()) {
             Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>> identifiers;
             OptionSet<BufferInSetType> bufferTypes { BufferInSetType::Back, BufferInSetType::SecondaryBack };
@@ -250,15 +250,15 @@ void RemoteLayerBackingStoreCollection::purgeBackBufferForTesting(RemoteLayerBac
             sendMarkBuffersVolatile(WTFMove(identifiers), [](bool) { }, true);
         }
     } else {
-        auto& inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
-        inProcessBackingStore.setBufferVolatile(RemoteLayerBackingStore::BufferType::Back, true);
-        inProcessBackingStore.setBufferVolatile(RemoteLayerBackingStore::BufferType::SecondaryBack, true);
+        CheckedRef inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
+        inProcessBackingStore->setBufferVolatile(RemoteLayerBackingStore::BufferType::Back, true);
+        inProcessBackingStore->setBufferVolatile(RemoteLayerBackingStore::BufferType::SecondaryBack, true);
     }
 }
 
 void RemoteLayerBackingStoreCollection::markFrontBufferVolatileForTesting(RemoteLayerBackingStore& backingStore)
 {
-    if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
+    if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
         if (RefPtr bufferSet = remoteBackingStore->protectedBufferSet()) {
             Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>> identifiers;
             OptionSet<BufferInSetType> bufferTypes { BufferInSetType::Front };
@@ -266,8 +266,8 @@ void RemoteLayerBackingStoreCollection::markFrontBufferVolatileForTesting(Remote
             sendMarkBuffersVolatile(WTFMove(identifiers), [](bool) { });
         }
     } else {
-        auto& inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
-        inProcessBackingStore.setBufferVolatile(RemoteLayerBackingStore::BufferType::Front, false);
+        CheckedRef inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
+        inProcessBackingStore->setBufferVolatile(RemoteLayerBackingStore::BufferType::Front, false);
     }
 }
 
@@ -317,7 +317,7 @@ void RemoteLayerBackingStoreCollection::backingStoreBecameUnreachable(RemoteLaye
 
 void RemoteLayerBackingStoreCollection::markBackingStoreVolatileAfterReachabilityChange(RemoteLayerBackingStore& backingStore)
 {
-    if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
+    if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
         Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>> identifiers;
         collectRemoteRenderingBackingStoreBufferIdentifiersToMarkVolatile(*remoteBackingStore, { }, { }, identifiers);
 
@@ -329,8 +329,10 @@ void RemoteLayerBackingStoreCollection::markBackingStoreVolatileAfterReachabilit
             if (!succeeded && weakThis)
                 weakThis->scheduleVolatilityTimer();
         });
-    } else
-        markInProcessBackingStoreVolatile(downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore));
+    } else {
+        CheckedRef inProcessBackingStore = downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore);
+        markInProcessBackingStoreVolatile(inProcessBackingStore);
+    }
 }
 
 bool RemoteLayerBackingStoreCollection::markAllBackingStoreVolatile(OptionSet<VolatilityMarkingBehavior> liveBackingStoreMarkingBehavior, OptionSet<VolatilityMarkingBehavior> unparentedBackingStoreMarkingBehavior)
@@ -338,13 +340,13 @@ bool RemoteLayerBackingStoreCollection::markAllBackingStoreVolatile(OptionSet<Vo
     bool successfullyMadeBackingStoreVolatile = true;
     auto now = MonotonicTime::now();
 
-    for (auto& backingStore : m_liveBackingStore) {
-        if (auto* inProcessBackingStore = dynamicDowncast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore))
+    for (CheckedRef backingStore : m_liveBackingStore) {
+        if (CheckedPtr inProcessBackingStore = dynamicDowncast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore.get()))
             successfullyMadeBackingStoreVolatile &= markInProcessBackingStoreVolatile(*inProcessBackingStore, liveBackingStoreMarkingBehavior, now);
     }
 
-    for (auto& backingStore : m_unparentedBackingStore) {
-        if (auto* inProcessBackingStore = dynamicDowncast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore))
+    for (CheckedRef backingStore : m_unparentedBackingStore) {
+        if (CheckedPtr inProcessBackingStore = dynamicDowncast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore.get()))
             successfullyMadeBackingStoreVolatile &= markInProcessBackingStoreVolatile(*inProcessBackingStore, unparentedBackingStoreMarkingBehavior, now);
     }
 
@@ -412,14 +414,14 @@ void RemoteLayerBackingStoreCollection::scheduleVolatilityTimer()
 
 void RemoteLayerBackingStoreCollection::gpuProcessConnectionWasDestroyed()
 {
-    for (auto& backingStore : m_liveBackingStore) {
+    for (CheckedRef backingStore : m_liveBackingStore) {
         if (is<RemoteLayerWithRemoteRenderingBackingStore>(backingStore))
-            backingStore.setNeedsDisplay();
+            backingStore->setNeedsDisplay();
     }
 
-    for (auto& backingStore : m_unparentedBackingStore) {
+    for (CheckedRef backingStore : m_unparentedBackingStore) {
         if (is<RemoteLayerWithRemoteRenderingBackingStore>(backingStore))
-            backingStore.setNeedsDisplay();
+            backingStore->setNeedsDisplay();
     }
 }
 
@@ -455,13 +457,13 @@ bool RemoteLayerBackingStoreCollection::collectAllRemoteRenderingBufferIdentifie
     bool completed = true;
     auto now = MonotonicTime::now();
 
-    for (auto& backingStore : m_liveBackingStore) {
-        if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore))
+    for (CheckedRef backingStore : m_liveBackingStore) {
+        if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(backingStore.get()))
             completed &= collectRemoteRenderingBackingStoreBufferIdentifiersToMarkVolatile(*remoteBackingStore, liveBackingStoreMarkingBehavior, now, identifiers);
     }
 
-    for (auto& backingStore : m_unparentedBackingStore) {
-        if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore))
+    for (CheckedRef backingStore : m_unparentedBackingStore) {
+        if (CheckedPtr remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(backingStore.get()))
             completed &= collectRemoteRenderingBackingStoreBufferIdentifiersToMarkVolatile(*remoteBackingStore, unparentedBackingStoreMarkingBehavior, now, identifiers);
     }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -32,8 +32,9 @@
 
 namespace WebKit {
 
-class RemoteLayerWithInProcessRenderingBackingStore : public RemoteLayerBackingStore {
+class RemoteLayerWithInProcessRenderingBackingStore final : public RemoteLayerBackingStore {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerWithInProcessRenderingBackingStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerWithInProcessRenderingBackingStore);
 public:
     using RemoteLayerBackingStore::RemoteLayerBackingStore;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -29,21 +29,13 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
-class RemoteLayerWithRemoteRenderingBackingStore;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::RemoteLayerWithRemoteRenderingBackingStore> : std::true_type { };
-}
-
-namespace WebKit {
 
 class RemoteDisplayListRecorderProxy;
 class RemoteImageBufferSetProxy;
 
-class RemoteLayerWithRemoteRenderingBackingStore : public RemoteLayerBackingStore {
+class RemoteLayerWithRemoteRenderingBackingStore final : public RemoteLayerBackingStore {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerWithRemoteRenderingBackingStore);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerWithRemoteRenderingBackingStore);
 public:
     RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote&);
     ~RemoteLayerWithRemoteRenderingBackingStore();


### PR DESCRIPTION
#### 4d7301d7383873869ab6cf36f046cc1bd1881820
<pre>
RemoteLayerBackingStore should support CheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=281374">https://bugs.webkit.org/show_bug.cgi?id=281374</a>

Reviewed by Chris Dumez.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay):
(WebKit::RemoteLayerBackingStoreCollection::purgeFrontBufferForTesting):
(WebKit::RemoteLayerBackingStoreCollection::purgeBackBufferForTesting):
(WebKit::RemoteLayerBackingStoreCollection::markFrontBufferVolatileForTesting):
(WebKit::RemoteLayerBackingStoreCollection::markBackingStoreVolatileAfterReachabilityChange):
(WebKit::RemoteLayerBackingStoreCollection::markAllBackingStoreVolatile):
(WebKit::RemoteLayerBackingStoreCollection::gpuProcessConnectionWasDestroyed):
(WebKit::RemoteLayerBackingStoreCollection::collectAllRemoteRenderingBufferIdentifiersToMarkVolatile):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::Buffer::operator bool const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::protectedBufferSet): Deleted.
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::setBufferCacheIdentifiers): Deleted.
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::setBackendHandle): Deleted.

Canonical link: <a href="https://commits.webkit.org/285081@main">https://commits.webkit.org/285081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efd5ff00895fdf88f9b786db26706f912ca0666b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22671 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56440 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14912 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42834 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21012 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77296 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64153 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64148 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5935 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1458 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->