### PR TITLE
Add some functionality to TiledBackingClient to allow AsyncPDFController to manage tile changes

### DIFF
--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -50,7 +50,7 @@ WEBCORE_EXPORT FloatRect unionRectIgnoringZeroRects(const Vector<FloatRect>&);
 FloatPoint mapPoint(FloatPoint, const FloatRect& srcRect, const FloatRect& destRect);
 
 // Map rect from srcRect to an equivalent rect in destRect.
-FloatRect mapRect(const FloatRect&, const FloatRect& srcRect, const FloatRect& destRect);
+WEBCORE_EXPORT FloatRect mapRect(const FloatRect&, const FloatRect& srcRect, const FloatRect& destRect);
 
 WEBCORE_EXPORT FloatRect largestRectWithAspectRatioInsideRect(float aspectRatio, const FloatRect&);
 WEBCORE_EXPORT FloatRect smallestRectWithAspectRatioAroundRect(float aspectRatio, const FloatRect&);

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -66,6 +66,11 @@ enum class TiledBackingScrollability : uint8_t {
     VerticallyScrollable    = 1 << 1
 };
 
+enum class TileRevalidationType : uint8_t {
+    Partial,
+    Full
+};
+
 using TileIndex = IntPoint;
 class TiledBacking;
 
@@ -78,11 +83,17 @@ public:
     virtual void willRemoveTile(TiledBacking&, TileGridIdentifier, TileIndex) = 0;
     virtual void willRepaintAllTiles(TiledBacking&, TileGridIdentifier) = 0;
 
+    // The client will not receive `willRepaintTile()` for tiles needing display as part of a revalidation.
+    virtual void willRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType) = 0;
+    virtual void didRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType, const HashSet<TileIndex>& tilesNeedingDisplay) = 0;
+
     virtual void didAddGrid(TiledBacking&, TileGridIdentifier) = 0;
     virtual void willRemoveGrid(TiledBacking&, TileGridIdentifier) = 0;
 
     virtual void coverageRectDidChange(TiledBacking&, const FloatRect&) = 0;
-    virtual void tilingScaleFactorDidChange(TiledBacking&, float) = 0;
+
+    virtual void willRepaintTilesAfterScaleFactorChange(TiledBacking&, TileGridIdentifier) = 0;
+    virtual void didRepaintTilesAfterScaleFactorChange(TiledBacking&, TileGridIdentifier) = 0;
 };
 
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -185,10 +185,14 @@ void TileController::setContentsScale(float contentsScale)
     auto oldScale = tileGrid().scale();
     tileGrid().setScale(scale);
 
-    if (m_client && scale != oldScale)
-        m_client->tilingScaleFactorDidChange(*this, scale);
+    bool notifyClient = m_client && scale != oldScale;
+    if (notifyClient)
+        m_client->willRepaintTilesAfterScaleFactorChange(*this, tileGrid().identifier());
 
     tileGrid().setNeedsDisplay();
+
+    if (notifyClient)
+        m_client->didRepaintTilesAfterScaleFactorChange(*this, tileGrid().identifier());
 }
 
 float TileController::contentsScale() const
@@ -696,13 +700,22 @@ void TileController::tileRevalidationTimerFired()
         : OptionSet { TileGrid::UnparentAllTiles });
 }
 
-void TileController::didRevalidateTiles()
+void TileController::willRevalidateTiles(TileGrid& tileGrid, TileRevalidationType revalidationType)
+{
+    if (m_client)
+        m_client->willRevalidateTiles(*this, tileGrid.identifier(), revalidationType);
+}
+
+void TileController::didRevalidateTiles(TileGrid& tileGrid, TileRevalidationType revalidationType, const HashSet<TileIndex>& tilesNeedingDisplay)
 {
     m_boundsAtLastRevalidate = bounds();
 
     LOG_WITH_STREAM(Tiling, stream << "TileController " << this << " (bounds " << bounds() << ") didRevalidateTiles - tileCoverageRect " << tileCoverageRect() << " grid extent " << tileGridExtent() << " memory use " << (retainedTileBackingStoreMemory() / (1024 * 1024)) << "MB");
 
     updateTileCoverageMap();
+
+    if (m_client)
+        m_client->didRevalidateTiles(*this, tileGrid.identifier(), revalidationType, tilesNeedingDisplay);
 }
 
 unsigned TileController::blankPixelCount() const
@@ -888,4 +901,4 @@ void TileController::logFilledVisibleFreshTile(unsigned blankPixelCount)
 
 } // namespace WebCore
 
-#endif
+#endif // USE(CG)

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -135,7 +135,8 @@ public:
 
     IntRect boundsAtLastRevalidate() const { return m_boundsAtLastRevalidate; }
     IntRect boundsAtLastRevalidateWithoutMargin() const;
-    void didRevalidateTiles();
+    void willRevalidateTiles(TileGrid&, TileRevalidationType);
+    void didRevalidateTiles(TileGrid&, TileRevalidationType, const HashSet<TileIndex>& tilesNeedingDisplay);
 
     bool shouldAggressivelyRetainTiles() const;
     bool shouldTemporarilyRetainTileCohorts() const;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -354,8 +354,6 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
     FloatRect coverageRect = m_controller.coverageRect();
     IntRect bounds = m_controller.bounds();
 
-    LOG_WITH_STREAM(Tiling, stream << "TileGrid " << this << " (controller " << &m_controller << ") revalidateTiles: bounds " << bounds << " coverageRect" << coverageRect << " validation: " << validationPolicy);
-
     FloatRect scaledRect(coverageRect);
     scaledRect.scale(m_scale);
     IntRect coverageRectInTileCoords(enclosingIntRectPreservingEmptyRects(scaledRect));
@@ -364,13 +362,30 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
     unsigned tilesInCohort = 0;
 
     Seconds minimumRevalidationTimerDuration = Seconds::infinity();
-    bool needsTileRevalidation = false;
-    
+    bool needsDelayedTileRevalidation = false;
+
     auto tileSize = m_controller.computeTileSize();
+
+    LOG_WITH_STREAM(Tiling, stream << "TileGrid " << this << " " << identifier() << " (controller " << &m_controller << ") revalidateTiles: bounds " << bounds << " coverageRect" << coverageRect << " old tile size " << m_tileSize << " new tile size " << tileSize << " validation " << validationPolicy);
+
+    auto revalidationType = [&]() {
+        if (tileSize != m_tileSize)
+            return TileRevalidationType::Full;
+
+        if (!m_scaleAtLastRevalidation || *m_scaleAtLastRevalidation != m_scale)
+            return TileRevalidationType::Full;
+
+        return TileRevalidationType::Partial;
+    }();
+
+    m_controller.willRevalidateTiles(*this, revalidationType);
+
     if (tileSize != m_tileSize) {
         removeAllTiles();
         m_tileSize = tileSize;
     }
+
+    m_scaleAtLastRevalidation = m_scale;
 
     // Move tiles newly outside the coverage rect into the cohort map.
     for (auto& entry : m_tiles) {
@@ -405,7 +420,7 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
                     Seconds timeUntilCohortExpires = cohort.timeUntilExpiration();
                     if (timeUntilCohortExpires > 0_s) {
                         minimumRevalidationTimerDuration = std::min(minimumRevalidationTimerDuration, timeUntilCohortExpires);
-                        needsTileRevalidation = true;
+                        needsDelayedTileRevalidation = true;
                     } else {
                         m_controller.willRemoveTile(*this, tileIndex);
                         tileLayer->removeFromSuperlayer();
@@ -416,7 +431,7 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
         }
     }
 
-    if (needsTileRevalidation)
+    if (needsDelayedTileRevalidation)
         m_controller.scheduleTileRevalidation(minimumRevalidationTimerDuration);
 
     if (!m_controller.shouldAggressivelyRetainTiles()) {
@@ -483,19 +498,20 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
     }
 
     // Ensure primary tile coverage tiles.
-    m_primaryTileCoverageRect = ensureTilesForRect(coverageRect, CoverageType::PrimaryTiles);
+    HashSet<TileIndex> tilesNeedingDisplay;
+    m_primaryTileCoverageRect = ensureTilesForRect(coverageRect, tilesNeedingDisplay, CoverageType::PrimaryTiles);
 
     // Ensure secondary tiles (requested via prepopulateRect).
     if (!(validationPolicy & PruneSecondaryTiles)) {
         for (auto& secondaryCoverageRect : m_secondaryTileCoverageRects) {
             FloatRect secondaryRectInLayerCoordinates(secondaryCoverageRect);
             secondaryRectInLayerCoordinates.scale(1 / m_scale);
-            ensureTilesForRect(secondaryRectInLayerCoordinates, CoverageType::SecondaryTiles);
+            ensureTilesForRect(secondaryRectInLayerCoordinates, tilesNeedingDisplay, CoverageType::SecondaryTiles);
         }
         m_secondaryTileCoverageRects.clear();
     }
 
-    m_controller.didRevalidateTiles();
+    m_controller.didRevalidateTiles(*this, revalidationType, tilesNeedingDisplay);
 }
 
 TileGrid::TileCohort TileGrid::nextTileCohort() const
@@ -556,7 +572,7 @@ void TileGrid::cohortRemovalTimerFired()
     m_controller.updateTileCoverageMap();
 }
 
-IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, CoverageType newTileType)
+IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& tilesNeedingDisplay, CoverageType newTileType)
 {
     if (!m_controller.isInWindow())
         return IntRect();
@@ -607,7 +623,7 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, CoverageType newTile
             }
 
             if (tileInfo.layer->needsDisplay())
-                m_controller.willRepaintTile(*this, tileIndex, tileRect, tileRect);
+                tilesNeedingDisplay.add(tileIndex);
 
             if (!tileInfo.layer->superlayer())
                 m_containerLayer.get().appendSublayer(*tileInfo.layer);
@@ -616,8 +632,6 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, CoverageType newTile
 
     if (tilesInCohort)
         startedNewCohort(currCohort);
-
-    LOG_WITH_STREAM(Tiling, stream << "TileGrid " << this << " (bounds " << m_controller.bounds() << ") ensureTilesForRect: " << rect << " covered " << coverageRect);
 
     return coverageRect;
 }

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -116,7 +116,7 @@ private:
     bool getTileIndexRangeForRect(const IntRect&, TileIndex& topLeft, TileIndex& bottomRight) const;
 
     enum class CoverageType { PrimaryTiles, SecondaryTiles };
-    IntRect ensureTilesForRect(const FloatRect&, CoverageType);
+    IntRect ensureTilesForRect(const FloatRect&, HashSet<TileIndex>& tilesNeedingDisplay, CoverageType);
 
     struct TileCohortInfo {
         TileCohort cohort;
@@ -175,6 +175,7 @@ private:
     IntSize m_tileSize;
 
     float m_scale { 1 };
+    std::optional<float> m_scaleAtLastRevalidation;
 };
 
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -148,7 +148,12 @@ private:
     void willRepaintAllTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
 
     void coverageRectDidChange(WebCore::TiledBacking&, const WebCore::FloatRect&) final;
-    void tilingScaleFactorDidChange(WebCore::TiledBacking&, float) final;
+
+    void willRevalidateTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileRevalidationType) final;
+    void didRevalidateTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileRevalidationType, const HashSet<WebCore::TileIndex>& tilesNeedingDisplay) final;
+
+    void willRepaintTilesAfterScaleFactorChange(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
+    void didRepaintTilesAfterScaleFactorChange(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
 
     void didAddGrid(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
     void willRemoveGrid(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -199,12 +199,12 @@ void AsyncPDFRenderer::didCompletePagePreviewRender(RefPtr<ImageBuffer>&& imageB
     presentationController->didGeneratePreviewForPage(pageIndex);
 }
 
-RefPtr<WebCore::ImageBuffer> AsyncPDFRenderer::previewImageForPage(PDFDocumentLayout::PageIndex pageIndex) const
+RefPtr<ImageBuffer> AsyncPDFRenderer::previewImageForPage(PDFDocumentLayout::PageIndex pageIndex) const
 {
     return m_pagePreviews.get(pageIndex);
 }
 
-bool AsyncPDFRenderer::renderInfoIsValidForTile(WebCore::TiledBacking& tiledBacking, const TileForGrid& tileInfo, const TileRenderInfo& renderInfo) const
+bool AsyncPDFRenderer::renderInfoIsValidForTile(TiledBacking& tiledBacking, const TileForGrid& tileInfo, const TileRenderInfo& renderInfo) const
 {
     ASSERT(isMainRunLoop());
 
@@ -315,7 +315,19 @@ void AsyncPDFRenderer::removePagePreviewsOutsideCoverageRect(const FloatRect& co
         removePreviewForPage(pageIndex);
 }
 
-void AsyncPDFRenderer::tilingScaleFactorDidChange(TiledBacking&, float)
+void AsyncPDFRenderer::willRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType)
+{
+}
+
+void AsyncPDFRenderer::didRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType, const HashSet<TileIndex>& tilesNeedingDisplay)
+{
+}
+
+void AsyncPDFRenderer::willRepaintTilesAfterScaleFactorChange(TiledBacking&, TileGridIdentifier)
+{
+}
+
+void AsyncPDFRenderer::didRepaintTilesAfterScaleFactorChange(TiledBacking&, TileGridIdentifier)
 {
 }
 


### PR DESCRIPTION
#### 73d0f1af1e0fb82c72d830f7f58b1271555f96fe
<pre>
Add some functionality to TiledBackingClient to allow AsyncPDFController to manage tile changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=281384">https://bugs.webkit.org/show_bug.cgi?id=281384</a>
<a href="https://rdar.apple.com/137810931">rdar://137810931</a>

Reviewed by Abrar Rahman Protyasha.

A future change will have AsyncPDFRenderer stash old tiles until it knows that new tiles are available.

To support this, TiledBackingClient needs to expose more information about tile invalidation. Specifically,
the client needs to know when we&apos;re doing repaints because the scale change, or when we add/remove tiles
in the middle of a tile revalidation, and whether it&apos;s a partial or full revalidation. Full revalidations
happen for scale change, and tile size change.

* Source/WebCore/platform/graphics/GeometryUtilities.h:
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setContentsScale):
(WebCore::TileController::willRevalidateTiles):
(WebCore::TileController::didRevalidateTiles):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::revalidateTiles):
(WebCore::TileGrid::ensureTilesForRect):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::previewImageForPage const):
(WebKit::AsyncPDFRenderer::renderInfoIsValidForTile const):
(WebKit::AsyncPDFRenderer::willRevalidateTiles):
(WebKit::AsyncPDFRenderer::didRevalidateTiles):
(WebKit::AsyncPDFRenderer::willRepaintTilesAfterScaleFactorChange):
(WebKit::AsyncPDFRenderer::didRepaintTilesAfterScaleFactorChange):
(WebKit::AsyncPDFRenderer::tilingScaleFactorDidChange): Deleted.

Canonical link: <a href="https://commits.webkit.org/285124@main">https://commits.webkit.org/285124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37af292b200a265f19cccf78f93eeebd67874f5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14927 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19042 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21033 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5952 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1479 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->