### PR TITLE
MediaRecorderPrivateWriterWebM should be running in the content process.

### DIFF
--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<WebCore::MediaRecorderPrivate> MediaRecorderProvider::createMedi
 {
 #if ENABLE(GPU_PROCESS) && ENABLE(WEB_RTC)
     RefPtr page = m_webPage->corePage();
-    if (page && page->settings().webRTCPlatformCodecsInGPUProcessEnabled())
+    if (page && page->settings().webRTCPlatformCodecsInGPUProcessEnabled() && !isWebMAndSupported(options.mimeType))
         return makeUnique<MediaRecorderPrivate>(stream, options);
 #endif
     return WebCore::MediaRecorderProvider::createMediaRecorderPrivate(stream, options);


### PR DESCRIPTION
#### f447304fe0efb069b90eeec9d0940ac05f661792
<pre>
MediaRecorderPrivateWriterWebM should be running in the content process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281370">https://bugs.webkit.org/show_bug.cgi?id=281370</a>
<a href="https://rdar.apple.com/137795763">rdar://137795763</a>

Reviewed by Youenn Fablet.

We create the MediaRecorderPrivate in the content process if webm was requested.
When running in the content process, MediaRecorderPrivateWriterWebM::appendAudioSampleBuffer
will be called on the audio thread and MediaRecorderPrivateWriterWebM::appendVideoFrame will
be called on the video capture thread. So we have to make those both methods thread-safe.

To achieve this goal we now run the MediaRecorderPrivateWriterWebM on its own work queue.
Using the main thread was no longer suitable as we want the writer to operate even when
the main thread is blocked to avoid losing data.
We could have made the threading management controlled by the MediaRecorderPrivate instead
but it would have required more extensive changes, so we limit it to WebM only for now.

For appendVideoFrame we simply forward the video frame to this WorkQueue,
for appendAudioSampleBuffer the data structure received isn&apos;t ref-counted
we must as such create the CMSampleBuffer on the audio thread and then forward it to the workqueue.

This is similar to what the WebKit::MediaRecorderPrivate is doing before sending the data to
the GPU process.

* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm:
(WebCore::MediaRecorderPrivateWriterWebM::MediaRecorderPrivateWriterWebM):
(WebCore::MediaRecorderPrivateWriterWebM::close):
(WebCore::MediaRecorderPrivateWriterWebM::compressedAudioOutputBufferCallback):
(WebCore::MediaRecorderPrivateWriterWebM::initialize):
(WebCore::MediaRecorderPrivateWriterWebM::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateWriterWebM::maybeStartWriting):
(WebCore::MediaRecorderPrivateWriterWebM::appendVideoFrame):
(WebCore::MediaRecorderPrivateWriterWebM::nextVideoFrameTime const):
(WebCore::MediaRecorderPrivateWriterWebM::resumeVideoTime const):
(WebCore::MediaRecorderPrivateWriterWebM::encodePendingVideoFrames):
(WebCore::MediaRecorderPrivateWriterWebM::appendAudioSampleBuffer):
(WebCore::MediaRecorderPrivateWriterWebM::flushEncodedQueues):
(WebCore::MediaRecorderPrivateWriterWebM::partiallyFlushEncodedQueues):
(WebCore::MediaRecorderPrivateWriterWebM::muxNextFrame):
(WebCore::MediaRecorderPrivateWriterWebM::stopRecording):
(WebCore::MediaRecorderPrivateWriterWebM::fetchData):
(WebCore::MediaRecorderPrivateWriterWebM::flushPendingData):
(WebCore::MediaRecorderPrivateWriterWebM::appendData):
(WebCore::MediaRecorderPrivateWriterWebM::flushDataBuffer):
(WebCore::MediaRecorderPrivateWriterWebM::takeData):
(WebCore::MediaRecorderPrivateWriterWebM::pause):
(WebCore::MediaRecorderPrivateWriterWebM::resume):
(WebCore::MediaRecorderPrivateWriterWebM::mimeType const):
(WebCore::MediaRecorderPrivateWriterWebM::audioBitRate const):
(WebCore::MediaRecorderPrivateWriterWebM::videoBitRate const):
(WebCore::MediaRecorderPrivateWriterWebM::maybeForceNewCluster):
(WebCore::MediaRecorderPrivateWriterWebM::workQueue const):
(WebCore::MediaRecorderPrivateWriterWebM::completeFetchData): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp:
(WebKit::MediaRecorderProvider::createMediaRecorderPrivate):

Canonical link: <a href="https://commits.webkit.org/285227@main">https://commits.webkit.org/285227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad732b78e7913cbe689d3997c02999cd69261c86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24593 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/76053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22844 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56717 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64425 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6234 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47032 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1811 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->