### PR TITLE
Port AXID to ObjectIdentifier

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -365,8 +365,8 @@ bool AXCoreObject::isTableCellInSameRowGroup(AXCoreObject* otherTableCell)
     if (!otherTableCell)
         return false;
 
-    AXID ancestorID = rowGroupAncestorID();
-    return ancestorID.isValid() && ancestorID == otherTableCell->rowGroupAncestorID();
+    auto ancestorID = rowGroupAncestorID();
+    return ancestorID && *ancestorID == otherTableCell->rowGroupAncestorID();
 }
 
 bool AXCoreObject::isTableCellInSameColGroup(AXCoreObject* tableCell)

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -64,15 +64,15 @@ std::optional<IntRect> AXGeometryManager::cachedRectForID(AXID axID)
     return std::nullopt;
 }
 
-void AXGeometryManager::cacheRect(AXID axID, IntRect&& rect)
+void AXGeometryManager::cacheRect(std::optional<AXID> axID, IntRect&& rect)
 {
     // We shouldn't call this method on a geometry manager that has no page ID.
     ASSERT(m_cache->pageID());
     ASSERT(AXObjectCache::isIsolatedTreeEnabled());
 
-    if (!axID.isValid())
+    if (!axID)
         return;
-    auto rectIterator = m_cachedRects.find(axID);
+    auto rectIterator = m_cachedRects.find(*axID);
 
     bool rectChanged = false;
     if (rectIterator != m_cachedRects.end()) {
@@ -81,7 +81,7 @@ void AXGeometryManager::cacheRect(AXID axID, IntRect&& rect)
             rectIterator->value = rect;
     } else {
         rectChanged = true;
-        m_cachedRects.set(axID, rect);
+        m_cachedRects.set(*axID, rect);
     }
 
     if (!rectChanged)
@@ -90,7 +90,7 @@ void AXGeometryManager::cacheRect(AXID axID, IntRect&& rect)
     RefPtr tree = AXIsolatedTree::treeForPageID(*m_cache->pageID());
     if (!tree)
         return;
-    tree->updateFrame(axID, WTFMove(rect));
+    tree->updateFrame(*axID, WTFMove(rect));
 }
 
 void AXGeometryManager::scheduleObjectRegionsUpdate(bool scheduleImmediately)

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -51,7 +51,7 @@ public:
     void willUpdateObjectRegions();
     void scheduleObjectRegionsUpdate(bool /* scheduleImmediately */);
 
-    void cacheRect(AXID, IntRect&&);
+    void cacheRect(std::optional<AXID>, IntRect&&);
     // std::nullopt if there is no cached rect for the given ID (i.e. because it hasn't been cached yet via paint or otherwise, or cannot be painted / cached at all).
     std::optional<IntRect> cachedRectForID(AXID);
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -413,7 +413,7 @@ TextStream& operator<<(TextStream& stream, const AccessibilitySearchCriteria& cr
     TextStream::GroupScope groupScope(stream);
     auto streamCriteriaObject = [&stream] (ASCIILiteral objectLabel, auto* axObject) {
         stream.startGroup();
-        stream << objectLabel.characters() << " " << axObject << ", ID " << (axObject ? axObject->objectID() : AXID());
+        stream << objectLabel.characters() << " " << axObject << ", ID " << (axObject && axObject->objectID() ? axObject->objectID()->toUInt64() : 0);
         stream.endGroup();
     };
 
@@ -1302,7 +1302,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
 
     if (options & AXStreamOptions::ParentID) {
         auto* parent = object.parentObjectUnignored();
-        stream.dumpProperty("parentID", parent ? parent->objectID() : AXID());
+        stream.dumpProperty("parentID", parent && parent->objectID()? parent->objectID()->toUInt64() : 0);
     }
 
     auto id = options & AXStreamOptions::IdentifierAttribute ? object.identifierAttribute() : emptyString();

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -322,7 +322,7 @@ public:
     void remove(RenderObject*);
     void remove(Node&);
     void remove(Widget*);
-    void remove(AXID);
+    void remove(std::optional<AXID>);
 
 #if !PLATFORM(COCOA) && !USE(ATSPI)
     void detachWrapper(AXCoreObject*, AccessibilityDetachmentType);
@@ -440,7 +440,7 @@ public:
 
     AccessibilityObject* objectForID(const AXID id) const { return m_objects.get(id); }
     template<typename U> Vector<RefPtr<AXCoreObject>> objectsForIDs(const U&) const;
-    Node* nodeForID(const AXID) const;
+    Node* nodeForID(std::optional<AXID>) const;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void onPaint(const RenderObject&, IntRect&&) const;
@@ -830,7 +830,7 @@ private:
     bool m_deferredRegenerateIsolatedTree { false };
     Ref<AXGeometryManager> m_geometryManager;
     DeferrableOneShotTimer m_selectedTextRangeTimer;
-    AXID m_lastDebouncedTextRangeObject;
+    Markable<AXID> m_lastDebouncedTextRangeObject;
 
     Timer m_updateTreeSnapshotTimer;
 #endif
@@ -851,7 +851,7 @@ private:
 #endif
 
 #if PLATFORM(MAC)
-    AXID m_lastTextFieldAXID;
+    Markable<AXID> m_lastTextFieldAXID;
     VisibleSelection m_lastSelection;
 #endif
 };
@@ -868,12 +868,12 @@ inline Vector<RefPtr<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs)
     });
 }
 
-inline Node* AXObjectCache::nodeForID(const AXID axID) const
+inline Node* AXObjectCache::nodeForID(std::optional<AXID> axID) const
 {
-    if (!axID.isValid())
+    if (!axID)
         return nullptr;
 
-    auto* object = m_objects.get(axID);
+    auto* object = m_objects.get(*axID);
     return object ? object->node() : nullptr;
 }
 

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -126,7 +126,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(RefPtr<AXCoreObject> axObject, co
         auto ranges = axObject->misspellingRanges();
         bool hasMisspelling = !ranges.isEmpty();
         if (hasMisspelling)
-            m_misspellingRanges.set(axObject->objectID(), WTFMove(ranges));
+            m_misspellingRanges.set(*axObject->objectID(), WTFMove(ranges));
         return hasMisspelling;
     }
     case AccessibilitySearchKey::Outline:
@@ -352,8 +352,8 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
 
     bool forward = criteria.searchDirection == AccessibilitySearchDirection::Next;
     if (match(startObject, criteria)) {
-        ASSERT(m_misspellingRanges.contains(startObject->objectID()));
-        const auto& ranges = m_misspellingRanges.get(startObject->objectID());
+        ASSERT(m_misspellingRanges.contains(*startObject->objectID()));
+        const auto& ranges = m_misspellingRanges.get(*startObject->objectID());
         ASSERT(!ranges.isEmpty());
 
         AXTextMarkerRange startRange { startObject->treeID(), startObject->objectID(), criteria.startRange };
@@ -375,8 +375,8 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     if (!objects.isEmpty() && objects[0]) {
         auto& object = *objects[0];
         AXLOG(object);
-        ASSERT(m_misspellingRanges.contains(object.objectID()));
-        const auto& ranges = m_misspellingRanges.get(object.objectID());
+        ASSERT(m_misspellingRanges.contains(*object.objectID()));
+        const auto& ranges = m_misspellingRanges.get(*object.objectID());
         ASSERT(!ranges.isEmpty());
         return forward ? ranges[0] : ranges.last();
     }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -118,10 +118,10 @@ void AccessibilityObject::init()
     m_role = determineAccessibilityRole();
 }
 
-AXID AccessibilityObject::treeID() const
+std::optional<AXID> AccessibilityObject::treeID() const
 {
     auto* cache = axObjectCache();
-    return cache ? cache->treeID() : AXID();
+    return cache ? std::optional { cache->treeID() } : std::nullopt;
 }
 
 String AccessibilityObject::dbg() const
@@ -134,7 +134,7 @@ String AccessibilityObject::dbg() const
 
     return makeString(
         "{role: "_s, accessibilityRoleToString(roleValue()),
-        ", ID "_s, objectID().loggingString(),
+        ", ID "_s, objectID() ? objectID()->loggingString() : ""_str,
         isIgnored() ? ", ignored"_s : emptyString(),
         backingEntityDescription,
         '}'
@@ -4096,7 +4096,7 @@ bool AccessibilityObject::isIgnored() const
         attributeCache = axObjectCache->computedObjectAttributeCache();
     
     if (attributeCache) {
-        AccessibilityObjectInclusion ignored = attributeCache->getIgnored(objectID());
+        AccessibilityObjectInclusion ignored = attributeCache->getIgnored(*objectID());
         switch (ignored) {
         case AccessibilityObjectInclusion::IgnoreObject:
             return true;
@@ -4111,7 +4111,7 @@ bool AccessibilityObject::isIgnored() const
 
     // Refetch the attribute cache in case it was enabled as part of computing isIgnored.
     if (axObjectCache && (attributeCache = axObjectCache->computedObjectAttributeCache()))
-        attributeCache->setIgnored(objectID(), ignored ? AccessibilityObjectInclusion::IgnoreObject : AccessibilityObjectInclusion::IncludeObject);
+        attributeCache->setIgnored(*objectID(), ignored ? AccessibilityObjectInclusion::IgnoreObject : AccessibilityObjectInclusion::IncludeObject);
 
     return ignored;
 }
@@ -4134,7 +4134,7 @@ bool AccessibilityObject::isIgnoredWithoutCache(AXObjectCache* cache) const
 
 #if !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) && ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         if (becameIgnored)
-            cache->objectBecameIgnored(objectID());
+            cache->objectBecameIgnored(*objectID());
 #endif // !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) && ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         if (becameUnignored || becameIgnored)
             cache->childrenChanged(parentObject());

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -67,7 +67,7 @@ class AccessibilityObject : public AXCoreObject, public CanMakeWeakPtr<Accessibi
 public:
     virtual ~AccessibilityObject();
 
-    AXID treeID() const final;
+    std::optional<AXID> treeID() const final;
     String dbg() const final;
 
     // After constructing an AccessibilityObject, it must be given a
@@ -153,7 +153,7 @@ public:
     AXCoreObject* headerContainer() override { return nullptr; }
     int axColumnCount() const override { return 0; }
     int axRowCount() const override { return 0; }
-    virtual Vector<Vector<AXID>> cellSlots() { return { }; }
+    virtual Vector<Vector<Markable<AXID>>> cellSlots() { return { }; }
 
     // Table cell support.
     bool isTableCell() const override { return false; }

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -413,7 +413,7 @@ void AccessibilityTable::recomputeIsExposable()
     }
 }
 
-Vector<Vector<AXID>> AccessibilityTable::cellSlots()
+Vector<Vector<Markable<AXID>>> AccessibilityTable::cellSlots()
 {
     updateChildrenIfNecessary();
     return m_cellSlots;
@@ -542,7 +542,7 @@ void AccessibilityTable::addChildren()
 
             // Step 6: While the slot with coordinate (xcurrent, ycurrent) already has a cell assigned to it, increase xcurrent by 1.
             ensureRowAndColumn(yCurrent, xCurrent);
-            while (m_cellSlots[yCurrent][xCurrent].isValid()) {
+            while (m_cellSlots[yCurrent][xCurrent]) {
                 xCurrent += 1;
                 ensureRowAndColumn(yCurrent, xCurrent);
             }
@@ -863,8 +863,8 @@ AccessibilityObject* AccessibilityTable::cellForColumnAndRow(unsigned column, un
     if (row >= m_cellSlots.size() || column >= m_cellSlots[row].size())
         return nullptr;
 
-    if (AXID cellID = m_cellSlots[row][column])
-        return axObjectCache()->objectForID(cellID);
+    if (auto cellID = m_cellSlots[row][column])
+        return axObjectCache()->objectForID(*cellID);
     return nullptr;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -85,7 +85,7 @@ public:
 
     // Cell indexes are assigned during child creation, so make sure children are up-to-date.
     void ensureCellIndexesUpToDate() { updateChildrenIfNecessary(); }
-    Vector<Vector<AXID>> cellSlots() final;
+    Vector<Vector<Markable<AXID>>> cellSlots() final;
     void setCellSlotsDirty();
 
 protected:
@@ -96,7 +96,7 @@ protected:
     AccessibilityChildrenVector m_columns;
     // 2D matrix of the cells assigned to each "slot" in this table.
     // ("Slot" as defined here: https://html.spec.whatwg.org/multipage/tables.html#concept-slots)
-    Vector<Vector<AXID>> m_cellSlots;
+    Vector<Vector<Markable<AXID>>> m_cellSlots;
 
     RefPtr<AccessibilityObject> m_headerContainer;
     bool m_isExposable;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -239,13 +239,13 @@ bool AccessibilityTableCell::isRowHeader() const
     return false;
 }
     
-AXID AccessibilityTableCell::rowGroupAncestorID() const
+std::optional<AXID> AccessibilityTableCell::rowGroupAncestorID() const
 {
     auto* rowGroup = Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (const auto& ancestor) {
         return ancestor.hasTagName(theadTag) || ancestor.hasTagName(tbodyTag) || ancestor.hasTagName(tfootTag);
     });
     if (!rowGroup)
-        return { };
+        return std::nullopt;
 
     return rowGroup->objectID();
 }

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -47,7 +47,7 @@ public:
     bool isColumnHeader() const override;
     bool isRowHeader() const override;
 
-    AXID rowGroupAncestorID() const final;
+    std::optional<AXID> rowGroupAncestorID() const final;
 
     virtual AccessibilityTable* parentTable() const;
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -441,8 +441,10 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_accessibleFunctions = {
             return g_variant_new_string(atspiObject->description().data());
         if (!g_strcmp0(propertyName, "Locale"))
             return g_variant_new_string(atspiObject->locale().utf8().data());
-        if (!g_strcmp0(propertyName, "AccessibleId"))
-            return g_variant_new_string(atspiObject->m_coreObject ? String::number(atspiObject->m_coreObject->objectID().toUInt64()).utf8().data() : "");
+        if (!g_strcmp0(propertyName, "AccessibleId")) {
+            auto objectID = atspiObject->m_coreObject->objectID();
+            return g_variant_new_string(atspiObject->m_coreObject ? String::number(objectID ? objectID->toUInt64() : 0).utf8().data() : "");
+        }
         if (!g_strcmp0(propertyName, "Parent"))
             return atspiObject->parentReference();
         if (!g_strcmp0(propertyName, "ChildCount"))

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -55,7 +55,7 @@ public:
     static Ref<AXIsolatedObject> create(const Ref<AccessibilityObject>&, AXIsolatedTree*);
     ~AXIsolatedObject();
 
-    AXID treeID() const final { return tree()->treeID(); }
+    std::optional<AXID> treeID() const final { return tree()->treeID(); }
     String dbg() const final;
 
     AccessibilityRole roleValue() const final { return static_cast<AccessibilityRole>(intAttributeValue(AXPropertyName::RoleValue)); }
@@ -93,8 +93,8 @@ private:
     void detachRemoteParts(AccessibilityDetachmentType) final;
     void detachPlatformWrapper(AccessibilityDetachmentType) final;
 
-    AXID parent() const { return m_parentID; }
-    void setParent(AXID axID) { m_parentID = axID; }
+    std::optional<AXID> parent() const { return m_parentID; }
+    void setParent(std::optional<AXID> axID) { m_parentID = axID; }
 
     AXIsolatedTree* tree() const { return m_cachedTree.get(); }
 
@@ -198,7 +198,7 @@ private:
     bool isColumnHeader() const final { return boolAttributeValue(AXPropertyName::IsColumnHeader); }
     bool isRowHeader() const final { return boolAttributeValue(AXPropertyName::IsRowHeader); }
     String cellScope() const final { return stringAttributeValue(AXPropertyName::CellScope); }
-    AXID rowGroupAncestorID() const final { return propertyValue<AXID>(AXPropertyName::RowGroupAncestorID); }
+    std::optional<AXID> rowGroupAncestorID() const final { return propertyValue<Markable<AXID>>(AXPropertyName::RowGroupAncestorID); }
 
     // Table column support.
     bool isTableColumn() const final { return boolAttributeValue(AXPropertyName::IsTableColumn); }
@@ -559,7 +559,7 @@ private:
 
     // FIXME: Make this a ThreadSafeWeakPtr<AXIsolatedTree>.
     RefPtr<AXIsolatedTree> m_cachedTree;
-    AXID m_parentID;
+    Markable<AXID> m_parentID;
     bool m_childrenDirty { true };
     Vector<AXID> m_childrenIDs;
     Vector<RefPtr<AXCoreObject>> m_children;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -123,8 +123,8 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     webArea->setProperty(AXPropertyName::ScreenRelativePosition, axWebArea->screenRelativePosition());
     NodeChange webAreaAppend { webArea, axWebArea->wrapper(), AttachWrapper::OnMainThread };
 
-    m_nodeMap.set(root->objectID(), ParentChildrenIDs { { }, { webArea->objectID() } });
-    m_nodeMap.set(webArea->objectID(), ParentChildrenIDs { root->objectID(), { } });
+    m_nodeMap.set(*root->objectID(), ParentChildrenIDs { std::nullopt, { *webArea->objectID() } });
+    m_nodeMap.set(*webArea->objectID(), ParentChildrenIDs { root->objectID(), { } });
 
     {
         Locker locker { m_changeLogLock };
@@ -205,7 +205,7 @@ void AXIsolatedTree::reportLoadingProgress(double processingProgress)
 
     WeakPtr cache = axObjectCache();
     if (RefPtr axWebArea = cache ? cache->rootWebArea() : nullptr) {
-        overrideNodeProperties(axWebArea->objectID(), {
+        overrideNodeProperties(*axWebArea->objectID(), {
             { AXPropertyName::TitleAttributeValue, WTFMove(title) },
         });
         if (cache)
@@ -233,11 +233,11 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::treeForPageID(PageIdentifier pageID)
     return nullptr;
 }
 
-RefPtr<AXIsolatedObject> AXIsolatedTree::objectForID(const AXID axID) const
+RefPtr<AXIsolatedObject> AXIsolatedTree::objectForID(std::optional<AXID> axID) const
 {
     ASSERT(!isMainThread());
 
-    return axID.isValid() ? m_readerThreadNodeMap.get(axID) : nullptr;
+    return axID ? m_readerThreadNodeMap.get(*axID) : nullptr;
 }
 
 void AXIsolatedTree::generateSubtree(AccessibilityObject& axObject)
@@ -261,7 +261,7 @@ bool AXIsolatedTree::shouldCreateNodeChange(AccessibilityObject& axObject)
     return !axObject.isDetached()
         && (axObject.includeIgnoredInCoreTree()
             || !axObject.isIgnored()
-            || m_unconnectedNodes.contains(axObject.objectID()));
+            || m_unconnectedNodes.contains(*axObject.objectID()));
 }
 
 std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Ref<AccessibilityObject> axObject, AttachWrapper attachWrapper)
@@ -276,9 +276,9 @@ std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Re
     ASSERT(axObject->wrapper());
     NodeChange nodeChange { object, axObject->wrapper(), attachWrapper };
 
-    m_nodeMap.set(axObject->objectID(), ParentChildrenIDs { nodeChange.isolatedObject->parent(), axObject->childrenIDs() });
+    m_nodeMap.set(*axObject->objectID(), ParentChildrenIDs { nodeChange.isolatedObject->parent(), axObject->childrenIDs() });
 
-    if (!nodeChange.isolatedObject->parent().isValid() && nodeChange.isolatedObject->isScrollView()) {
+    if (!nodeChange.isolatedObject->parent() && nodeChange.isolatedObject->isScrollView()) {
         Locker locker { m_changeLogLock };
         setRootNode(nodeChange.isolatedObject.ptr());
     }
@@ -293,13 +293,13 @@ void AXIsolatedTree::queueChange(const NodeChange& nodeChange)
 
     m_pendingAppends.append(nodeChange);
 
-    AXID parentID = nodeChange.isolatedObject->parent();
-    if (parentID.isValid()) {
-        auto siblingsIDs = m_nodeMap.get(parentID).childrenIDs;
-        m_pendingChildrenUpdates.append({ parentID, WTFMove(siblingsIDs) });
+    auto parentID = nodeChange.isolatedObject->parent();
+    if (parentID) {
+        auto siblingsIDs = m_nodeMap.get(*parentID).childrenIDs;
+        m_pendingChildrenUpdates.append({ *parentID, WTFMove(siblingsIDs) });
     }
 
-    AXID objectID = nodeChange.isolatedObject->objectID();
+    AXID objectID = *nodeChange.isolatedObject->objectID();
     ASSERT_WITH_MESSAGE(objectID != parentID, "object ID was the same as its parent ID (%s) when queueing a node change", objectID.loggingString().utf8().data());
     ASSERT_WITH_MESSAGE(m_nodeMap.contains(objectID), "node map should've contained objectID: %s", objectID.loggingString().utf8().data());
     auto childrenIDs = m_nodeMap.get(objectID).childrenIDs;
@@ -311,17 +311,18 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     AXTRACE("AXIsolatedTree::addUnconnectedNode"_s);
     ASSERT(isMainThread());
 
-    if (m_unconnectedNodes.contains(axObject->objectID())) {
-        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode exiting because an isolated object for "_s, axObject->objectID().loggingString(), " already exists."_s));
+    auto objectID = *axObject->objectID();
+    if (m_unconnectedNodes.contains(objectID)) {
+        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode exiting because an isolated object for "_s, objectID.loggingString(), " already exists."_s));
         return;
     }
 
     if (axObject->isDetached() || !axObject->wrapper()) {
-        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode bailing because associated live object ID "_s, axObject->objectID().loggingString(), " had no wrapper or is detached. Object is:"_s));
+        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode bailing because associated live object ID "_s, objectID.loggingString(), " had no wrapper or is detached. Object is:"_s));
         AXLOG(axObject.ptr());
         return;
     }
-    AXLOG(makeString("AXIsolatedTree::addUnconnectedNode creating isolated object from live object ID "_s, axObject->objectID().loggingString()));
+    AXLOG(makeString("AXIsolatedTree::addUnconnectedNode creating isolated object from live object ID "_s, objectID.loggingString()));
 
     // Because we are queuing a change for an object not intended to be connected to the rest of the tree,
     // we don't need to update m_nodeMap or m_pendingChildrenUpdates for this object or its parent as is
@@ -336,7 +337,7 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     NodeChange nodeChange { object, nullptr };
     Locker locker { m_changeLogLock };
     m_pendingAppends.append(WTFMove(nodeChange));
-    m_unconnectedNodes.add(axObject->objectID());
+    m_unconnectedNodes.add(objectID);
 }
 
 void AXIsolatedTree::queueRemovals(Vector<AXID>&& subtreeRemovals)
@@ -416,7 +417,7 @@ void AXIsolatedTree::queueAppendsAndRemovals(Vector<NodeChange>&& appends, Vecto
     auto parentUpdateIDs = std::exchange(m_needsParentUpdate, { });
     for (const auto& axID : parentUpdateIDs) {
         ASSERT_WITH_MESSAGE(m_nodeMap.contains(axID), "An object marked as needing a parent update should've had an entry in the node map by now. ID was %s", axID.loggingString().utf8().data());
-        m_pendingParentUpdates.set(axID, m_nodeMap.get(axID).parentID);
+        m_pendingParentUpdates.set(axID, *m_nodeMap.get(axID).parentID);
     }
 
     queueRemovalsLocked(WTFMove(subtreeRemovals));
@@ -438,19 +439,19 @@ void AXIsolatedTree::collectNodeChangesForSubtree(AccessibilityObject& axObject)
         return;
 
     auto* axParent = axObject.parentInCoreTree();
-    auto iterator = m_nodeMap.find(axObject.objectID());
+    auto iterator = m_nodeMap.find(*axObject.objectID());
     if (iterator == m_nodeMap.end())
-        m_unresolvedPendingAppends.set(axObject.objectID(), AttachWrapper::OnMainThread);
+        m_unresolvedPendingAppends.set(*axObject.objectID(), AttachWrapper::OnMainThread);
     else {
         // This object is already in the isolated tree, so there's no need to create full node change for it (doing so is expensive).
         // Protect this object from being deleted. This is important when |axObject| was a child of some other object,
         // but no longer is, and thus the other object will try to queue it for removal. But the fact that we're here
         // indicates this object isn't ready to be removed, just a child of a different parent, so prevent this removal.
-        m_protectedFromDeletionIDs.add(axObject.objectID());
+        m_protectedFromDeletionIDs.add(*axObject.objectID());
         // Update the object's parent if it has changed (but only if we aren't going to create a node change for it,
         // as the act of creating a new node change will correct this as part of creating the new AXIsolatedObject).
-        if (axParent && iterator->value.parentID != axParent->objectID() && !m_unresolvedPendingAppends.contains(axObject.objectID()))
-            m_needsParentUpdate.add(axObject.objectID());
+        if (axParent && iterator->value.parentID != *axParent->objectID() && !m_unresolvedPendingAppends.contains(*axObject.objectID()))
+            m_needsParentUpdate.add(*axObject.objectID());
     }
 
     auto axChildrenCopy = axObject.children();
@@ -462,13 +463,13 @@ void AXIsolatedTree::collectNodeChangesForSubtree(AccessibilityObject& axObject)
             continue;
         }
 
-        axChildrenIDs.append(axChild->objectID());
+        axChildrenIDs.append(*axChild->objectID());
         collectNodeChangesForSubtree(downcast<AccessibilityObject>(*axChild));
     }
     axChildrenIDs.shrinkToFit();
 
     // Update the m_nodeMap.
-    m_nodeMap.set(axObject.objectID(), ParentChildrenIDs { axParent ? axParent->objectID() : AXID(), WTFMove(axChildrenIDs) });
+    m_nodeMap.set(*axObject.objectID(), ParentChildrenIDs { axParent ? axParent->objectID() : std::nullopt, WTFMove(axChildrenIDs) });
 }
 
 void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
@@ -484,7 +485,7 @@ void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
     // AccessibilityRenderObject::updateRoleAfterChildrenCreation), queue the append up to be resolved with the rest
     // of the collected changes. This prevents us from creating two node changes for the same object.
     if (isCollectingNodeChanges() || !m_unresolvedPendingAppends.isEmpty()) {
-        m_unresolvedPendingAppends.ensure(axObject.objectID(), [] {
+        m_unresolvedPendingAppends.ensure(*axObject.objectID(), [] {
             return AttachWrapper::OnAXThread;
         });
         return;
@@ -526,14 +527,14 @@ void AXIsolatedTree::updatePropertiesForSelfAndDescendants(AccessibilityObject& 
         propertySet.add(property);
 
     Accessibility::enumerateUnignoredDescendants<AXCoreObject>(axObject, true, [&propertySet, this] (auto& descendant) {
-        queueNodeUpdate(descendant.objectID(), { propertySet });
+        queueNodeUpdate(*descendant.objectID(), { propertySet });
     });
 }
 
 void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXPropertyNameSet& properties)
 {
     AXTRACE("AXIsolatedTree::updateNodeProperties"_s);
-    AXLOG(makeString("Updating properties for objectID "_s, axObject.objectID().loggingString(), ": "_s));
+    AXLOG(makeString("Updating properties for objectID "_s, axObject.objectID() ? axObject.objectID()->loggingString() : ""_str, ": "_s));
     ASSERT(isMainThread());
 
     if (isUpdatingSubtree())
@@ -606,7 +607,7 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXProper
             break;
         case AXPropertyName::InternalLinkElement: {
             auto* linkElement = axObject.internalLinkElement();
-            propertyMap.set(AXPropertyName::InternalLinkElement, linkElement ? linkElement->objectID() : AXID());
+            propertyMap.set(AXPropertyName::InternalLinkElement, linkElement ? linkElement->objectID() : std::nullopt);
             break;
         }
         case AXPropertyName::IsChecked:
@@ -707,7 +708,7 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXProper
             propertyMap.set(AXPropertyName::SupportsSetSize, axObject.supportsSetSize());
             break;
         case AXPropertyName::TextInputMarkedTextMarkerRange: {
-            std::pair<AXID, CharacterRange> value;
+            std::pair<Markable<AXID>, CharacterRange> value;
             auto range = axObject.textInputMarkedTextMarkerRange();
             if (auto characterRange = range.characterRange(); range && characterRange)
                 value = { range.start().objectID(), *characterRange };
@@ -737,7 +738,7 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXProper
         return;
 
     Locker locker { m_changeLogLock };
-    m_pendingPropertyChanges.append({ axObject.objectID(), propertyMap });
+    m_pendingPropertyChanges.append({ *axObject.objectID(), propertyMap });
 }
 
 void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyMap&& propertyMap)
@@ -758,12 +759,12 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
     auto updateRelatedObjects = [this] (const AccessibilityObject& object) {
         for (const auto& labeledObject : object.labelForObjects()) {
             if (RefPtr axObject = downcast<AccessibilityObject>(labeledObject.get()))
-                queueNodeUpdate(axObject->objectID(), NodeUpdateOptions::nodeUpdate());
+                queueNodeUpdate(*axObject->objectID(), NodeUpdateOptions::nodeUpdate());
         }
 
         for (const auto& describedByObject : object.descriptionForObjects()) {
             if (RefPtr axObject = downcast<AccessibilityObject>(describedByObject.get()))
-                queueNodeUpdate(axObject->objectID(), { { AXPropertyName::AccessibilityText, AXPropertyName::ExtendedDescription } });
+                queueNodeUpdate(*axObject->objectID(), { { AXPropertyName::AccessibilityText, AXPropertyName::ExtendedDescription } });
         }
     };
     updateRelatedObjects(axObject);
@@ -772,7 +773,7 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
     bool updateTableAncestorColumns = is<AccessibilityTableRow>(axObject);
     for (RefPtr ancestor = axObject.parentObject(); ancestor; ancestor = ancestor->parentObject()) {
         if (ancestor->isTree()) {
-            queueNodeUpdate(ancestor->objectID(), { AXPropertyName::ARIATreeRows });
+            queueNodeUpdate(*ancestor->objectID(), { AXPropertyName::ARIATreeRows });
             if (!updateTableAncestorColumns)
                 break;
         }
@@ -782,7 +783,7 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
             if (ancestor->isIgnored())
                 break;
             // Use `NodeUpdateOptions::childrenUpdate()` rather than `updateNodeProperty` because `childrenUpdate()` will ensure the columns (which are children) will have associated isolated objects created.
-            queueNodeUpdate(ancestor->objectID(), NodeUpdateOptions::childrenUpdate());
+            queueNodeUpdate(*ancestor->objectID(), NodeUpdateOptions::childrenUpdate());
             break;
         }
 
@@ -817,7 +818,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
     // has added a new child. So find the closest ancestor of axObject that has
     // an associated isolated object and update its children.
     auto* axAncestor = Accessibility::findAncestor(axObject, true, [this] (auto& ancestor) {
-        return m_nodeMap.find(ancestor.objectID()) != m_nodeMap.end();
+        return m_nodeMap.contains(*ancestor.objectID());
     });
 
     if (!axAncestor || axAncestor->isDetached()) {
@@ -828,7 +829,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
     }
 
     if (axAncestor != &axObject) {
-        AXLOG(makeString("Original object with ID "_s, axObject.objectID().loggingString(), " wasn't in the isolated tree, so instead updating the closest in-isolated-tree ancestor:"_s));
+        AXLOG(makeString("Original object with ID "_s, axObject.objectID() ? axObject.objectID()->loggingString() : ""_str, " wasn't in the isolated tree, so instead updating the closest in-isolated-tree ancestor:"_s));
         AXLOG(axAncestor);
 
         // An explicit copy is necessary here because the nested calls to updateChildren
@@ -839,19 +840,19 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
             if (liveChild->childrenInitialized())
                 continue;
 
-            if (!m_nodeMap.contains(liveChild->objectID())) {
+            if (!m_nodeMap.contains(*liveChild->objectID())) {
                 if (!shouldCreateNodeChange(liveChild))
                     continue;
 
                 // This child should be added to the isolated tree but hasn't been yet.
                 // Add it to the nodemap so the recursive call to updateChildren below properly builds the subtree for this object.
                 auto* parent = axObject.parentInCoreTree();
-                m_nodeMap.set(liveChild->objectID(), ParentChildrenIDs { parent ? parent->objectID() : AXID(), liveChild->childrenIDs() });
-                m_unresolvedPendingAppends.set(liveChild->objectID(), AttachWrapper::OnMainThread);
+                m_nodeMap.set(*liveChild->objectID(), ParentChildrenIDs { parent ? parent->objectID() : std::nullopt, liveChild->childrenIDs() });
+                m_unresolvedPendingAppends.set(*liveChild->objectID(), AttachWrapper::OnMainThread);
             }
 
             AXLOG(makeString(
-                "Child ID "_s, liveChild->objectID().loggingString(), " of original object ID "_s, axObject.objectID().loggingString(), " was found in the isolated tree with uninitialized live children. Updating its isolated children."_s
+                "Child ID "_s, liveChild->objectID() ? liveChild->objectID()->loggingString() : ""_str, " of original object ID "_s, axObject.objectID() ? axObject.objectID()->loggingString() : ""_str, " was found in the isolated tree with uninitialized live children. Updating its isolated children."_s
             ));
             // Don't immediately resolve node changes in these recursive calls to updateChildren. This avoids duplicate node change creation in this scenario:
             //   1. Some subtree is updated in the below call to updateChildren.
@@ -860,7 +861,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         }
     }
 
-    auto oldIDs = m_nodeMap.get(axAncestor->objectID());
+    auto oldIDs = m_nodeMap.get(*axAncestor->objectID());
     auto& oldChildrenIDs = oldIDs.childrenIDs;
 
     const auto& newChildren = axAncestor->children();
@@ -869,7 +870,6 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
     bool childrenChanged = oldChildrenIDs.size() != newChildrenIDs.size();
     for (size_t i = 0; i < newChildren.size(); ++i) {
         ASSERT(newChildren[i]->objectID() == newChildrenIDs[i]);
-        ASSERT(newChildrenIDs[i].isValid());
         size_t index = oldChildrenIDs.find(newChildrenIDs[i]);
         if (index != notFound) {
             // Prevent deletion of this object below by removing it from oldChildrenIDs.
@@ -882,19 +882,19 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         else {
             // This is a new child, add it to the tree.
             childrenChanged = true;
-            AXLOG(makeString("AXID "_s, axAncestor->objectID().loggingString(), " gaining new subtree, starting at ID "_s, newChildren[i]->objectID().loggingString(), ':'));
+            AXLOG(makeString("AXID "_s, axAncestor->objectID() ? axAncestor->objectID()->loggingString() : ""_str, " gaining new subtree, starting at ID "_s, newChildren[i]->objectID() ? newChildren[i]->objectID()->loggingString() : ""_s, ':'));
             AXLOG(newChildren[i]);
             collectNodeChangesForSubtree(downcast<AccessibilityObject>(*newChildren[i]));
         }
     }
-    m_nodeMap.set(axAncestor->objectID(), ParentChildrenIDs { oldIDs.parentID, WTFMove(newChildrenIDs) });
+    m_nodeMap.set(*axAncestor->objectID(), ParentChildrenIDs { oldIDs.parentID, WTFMove(newChildrenIDs) });
     // Since axAncestor is definitively part of the AX tree by way of getting here, protect it from being
     // deleted in case it has been re-parented.
-    m_protectedFromDeletionIDs.add(axAncestor->objectID());
+    m_protectedFromDeletionIDs.add(*axAncestor->objectID());
 
     // What is left in oldChildrenIDs are the IDs that are no longer children of axAncestor.
     // Thus, remove them from m_nodeMap and queue them to be removed from the tree.
-    for (const AXID& axID : oldChildrenIDs)
+    for (auto& axID : oldChildrenIDs)
         removeSubtreeFromNodeMap(axID, axAncestor);
 
     auto unconditionallyUpdate = [] (AccessibilityRole role) {
@@ -965,7 +965,7 @@ OptionSet<ActivityState> AXIsolatedTree::lockedPageActivityState() const
     return m_pageActivityState;
 }
 
-AXID AXIsolatedTree::focusedNodeID()
+std::optional<AXID> AXIsolatedTree::focusedNodeID()
 {
     ASSERT(!isMainThread());
     // applyPendingChanges can destroy `this` tree, so protect it until the end of this method.
@@ -1013,10 +1013,10 @@ void AXIsolatedTree::setRootNode(AXIsolatedObject* root)
     m_rootNode = root;
 }
 
-void AXIsolatedTree::setFocusedNodeID(AXID axID)
+void AXIsolatedTree::setFocusedNodeID(std::optional<AXID> axID)
 {
     AXTRACE("AXIsolatedTree::setFocusedNodeID"_s);
-    AXLOG(makeString("axID "_s, axID.loggingString()));
+    AXLOG(makeString("axID "_s, axID ? axID->loggingString() : ""_str));
     ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
@@ -1089,7 +1089,7 @@ void AXIsolatedTree::updateRootScreenRelativePosition()
 void AXIsolatedTree::removeNode(const AccessibilityObject& axObject)
 {
     AXTRACE("AXIsolatedTree::removeNode"_s);
-    AXLOG(makeString("objectID "_s, axObject.objectID().loggingString()));
+    AXLOG(makeString("objectID "_s, axObject.objectID() ? axObject.objectID()->loggingString() : ""_str));
     ASSERT(isMainThread());
 
     auto labeledObjectIDs = axObjectCache() ? axObjectCache()->relatedObjectIDsFor(axObject, AXRelationType::LabelFor, AXObjectCache::UpdateRelations::No) : std::nullopt;
@@ -1101,52 +1101,53 @@ void AXIsolatedTree::removeNode(const AccessibilityObject& axObject)
         }
     }
 
-    m_unresolvedPendingAppends.remove(axObject.objectID());
+    m_unresolvedPendingAppends.remove(*axObject.objectID());
     removeSubtreeFromNodeMap(axObject.objectID(), axObject.parentInCoreTree());
-    queueRemovals({ axObject.objectID() });
+    queueRemovals({ *axObject.objectID() });
 }
 
-void AXIsolatedTree::removeSubtreeFromNodeMap(AXID objectID, AccessibilityObject* axParent)
+void AXIsolatedTree::removeSubtreeFromNodeMap(std::optional<AXID> objectID, AccessibilityObject* axParent)
 {
     AXTRACE("AXIsolatedTree::removeSubtreeFromNodeMap"_s);
-    AXLOG(makeString("Removing subtree for objectID "_s, objectID.loggingString()));
+    AXLOG(makeString("Removing subtree for objectID "_s,  objectID ? objectID->loggingString() : ""_str));
     ASSERT(isMainThread());
 
-    if (!objectID.isValid())
+    if (!objectID)
         return;
 
-    if (m_unconnectedNodes.remove(objectID))
+    if (m_unconnectedNodes.remove(*objectID))
         return;
 
-    if (!m_nodeMap.contains(objectID)) {
-        AXLOG(makeString("Tried to remove AXID "_s, objectID.loggingString(), " that is no longer in m_nodeMap."_s));
-        return;
-    }
-
-    AXID axParentID = axParent ? axParent->objectID() : AXID();
-    if (axParentID != m_nodeMap.get(objectID).parentID) {
-        AXLOG(makeString("Tried to remove object ID "_s, objectID.loggingString(), " from a different parent "_s, axParentID.loggingString(), ", actual parent "_s, m_nodeMap.get(objectID).parentID.loggingString(), ", bailing out."_s));
+    if (!m_nodeMap.contains(*objectID)) {
+        AXLOG(makeString("Tried to remove AXID "_s, objectID->loggingString(), " that is no longer in m_nodeMap."_s));
         return;
     }
 
-    Vector<AXID> removals = { objectID };
+    auto axParentID = axParent ? axParent->objectID() : std::nullopt;
+    auto actualParentID = m_nodeMap.get(*objectID).parentID;
+    if (axParentID != actualParentID) {
+        AXLOG(makeString("Tried to remove object ID "_s, objectID->loggingString(), " from a different parent "_s, axParentID ? axParentID->loggingString() : ""_str, ", actual parent "_s, actualParentID ? actualParentID->loggingString() : ""_str, ", bailing out."_s));
+        return;
+    }
+
+    Vector<std::optional<AXID>> removals = { *objectID };
     while (removals.size()) {
-        AXID axID = removals.takeLast();
-        if (!axID.isValid() || m_unresolvedPendingAppends.contains(axID) || m_protectedFromDeletionIDs.contains(axID))
+        auto axID = removals.takeLast();
+        if (!axID || m_unresolvedPendingAppends.contains(*axID) || m_protectedFromDeletionIDs.contains(*axID))
             continue;
 
-        auto it = m_nodeMap.find(axID);
+        auto it = m_nodeMap.find(*axID);
         if (it != m_nodeMap.end()) {
             removals.appendVector(it->value.childrenIDs);
-            m_nodeMap.remove(axID);
+            m_nodeMap.remove(*axID);
         }
     }
 
     // Update the childrenIDs of the parent since one of its children has been removed.
     if (axParent) {
-        auto ids = m_nodeMap.get(axParentID);
+        auto ids = m_nodeMap.get(*axParentID);
         ids.childrenIDs = axParent->childrenIDs();
-        m_nodeMap.set(axParentID, WTFMove(ids));
+        m_nodeMap.set(*axParentID, WTFMove(ids));
     }
 }
 
@@ -1155,7 +1156,7 @@ std::optional<ListHashSet<AXID>> AXIsolatedTree::relatedObjectIDsFor(const AXIso
     ASSERT(!isMainThread());
     Locker locker { m_changeLogLock };
 
-    auto relationsIterator = m_relations.find(object.objectID());
+    auto relationsIterator = m_relations.find(*object.objectID());
     if (relationsIterator == m_relations.end())
         return std::nullopt;
 
@@ -1190,7 +1191,7 @@ void AXIsolatedTree::applyPendingChanges()
     }
 
     if (m_pendingFocusedNodeID != m_focusedNodeID) {
-        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID.loggingString(), " pendingFocusedNodeID "_s, m_pendingFocusedNodeID.loggingString()));
+        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID ? m_focusedNodeID->loggingString() : ""_str, " pendingFocusedNodeID "_s, m_pendingFocusedNodeID ? m_pendingFocusedNodeID->loggingString() : ""_str));
         m_focusedNodeID = m_pendingFocusedNodeID;
     }
 
@@ -1210,16 +1211,16 @@ void AXIsolatedTree::applyPendingChanges()
     m_pendingProtectedFromDeletionIDs.clear();
 
     for (const auto& item : m_pendingAppends) {
-        AXID axID = item.isolatedObject->objectID();
-        AXLOG(makeString("appending axID "_s, axID.loggingString()));
-        if (!axID.isValid())
+        auto axID = item.isolatedObject->objectID();
+        AXLOG(makeString("appending axID "_s, axID ? axID->loggingString() : ""_str));
+        if (!axID)
             continue;
 
         auto& wrapper = item.attachWrapper == AttachWrapper::OnAXThread ? item.wrapper : item.isolatedObject->wrapper();
         if (!wrapper)
             continue;
 
-        if (auto existingObject = m_readerThreadNodeMap.get(axID)) {
+        if (auto existingObject = m_readerThreadNodeMap.get(*axID)) {
             if (existingObject != &item.isolatedObject.get()
                 && existingObject->wrapper() == wrapper.get()) {
                 // The new IsolatedObject is a replacement for an existing object
@@ -1228,7 +1229,7 @@ void AXIsolatedTree::applyPendingChanges()
                 existingObject->detach(AccessibilityDetachmentType::ElementChanged);
                 item.isolatedObject->attachPlatformWrapper(wrapper.get());
             }
-            m_readerThreadNodeMap.remove(axID);
+            m_readerThreadNodeMap.remove(*axID);
         }
 
         // If the new object hasn't been attached to a wrapper yet, or if it was detached from
@@ -1236,7 +1237,7 @@ void AXIsolatedTree::applyPendingChanges()
         if (item.isolatedObject->isDetached())
             item.isolatedObject->attachPlatformWrapper(wrapper.get());
 
-        auto addResult = m_readerThreadNodeMap.add(axID, item.isolatedObject.get());
+        auto addResult = m_readerThreadNodeMap.add(*axID, item.isolatedObject.get());
         // The newly added object must have a wrapper.
         ASSERT_UNUSED(addResult, addResult.iterator->value->wrapper());
         // The reference count of the just added IsolatedObject must be 2

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -30,6 +30,7 @@
 #import "FontPlatformData.h"
 #import <CoreGraphics/CoreGraphics.h>
 #import <variant>
+#import <wtf/Markable.h>
 #import <wtf/RefPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -65,7 +66,7 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const Si
     bool m_isolatedObjectInitialized;
 #endif
 
-    WebCore::AXID _identifier;
+    Markable<WebCore::AXID> _identifier;
 }
 
 - (id)initWithAccessibilityObject:(WebCore::AccessibilityObject&)axObject;
@@ -79,7 +80,7 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const Si
 - (void)detachIsolatedObject:(WebCore::AccessibilityDetachmentType)detachmentType;
 #endif
 
-@property (nonatomic, assign) WebCore::AXID identifier;
+@property (nonatomic, assign) Markable<WebCore::AXID> identifier;
 
 // FIXME: unified these two methods into one.
 #if PLATFORM(MAC)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -295,21 +295,21 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (void)attachAXObject:(AccessibilityObject&)axObject
 {
-    ASSERT(!_identifier.isValid() || _identifier == axObject.objectID());
+    ASSERT(!_identifier || *_identifier == axObject.objectID());
     m_axObject = axObject;
-    if (!_identifier.isValid())
+    if (!_identifier)
         _identifier = m_axObject->objectID();
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 - (void)attachIsolatedObject:(AXIsolatedObject*)isolatedObject
 {
-    ASSERT(isolatedObject && (!_identifier.isValid() || _identifier == isolatedObject->objectID()));
+    ASSERT(isolatedObject && (!_identifier || *_identifier == isolatedObject->objectID()));
     m_isolatedObject = isolatedObject;
     if (isMainThread())
         m_isolatedObjectInitialized = true;
 
-    if (!_identifier.isValid())
+    if (!_identifier)
         _identifier = m_isolatedObject.get()->objectID();
 }
 
@@ -322,7 +322,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 - (void)detach
 {
     ASSERT(isMainThread());
-    _identifier = { };
+    _identifier = std::nullopt;
     m_axObject = nullptr;
 }
 

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -118,7 +118,8 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
     ASSERT(object.objectID().toUInt64() >= 1);
     ASSERT(object.objectID().toUInt64() <= std::numeric_limits<LONG>::max());
 
-    NotifyWinEvent(msaaEvent, page->chrome().platformPageClient(), OBJID_CLIENT, -static_cast<LONG>(object.objectID().toUInt64()));
+    auto objectID = object.objectID();
+    NotifyWinEvent(msaaEvent, page->chrome().platformPageClient(), OBJID_CLIENT, -static_cast<LONG>(objectID ? objectID->toUInt64() : 0));
 }
 
 void AXObjectCache::nodeTextChangePlatformNotification(AccessibilityObject*, AXTextChange, unsigned, const String&)

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -59,8 +59,6 @@ header: <wtf/text/AtomString.h>
     [Validator='((static_cast<UInt128>(*high) << 64) | *low) != WTF::UUID::deletedValue'] uint64_t low();
 }
 
-header: <wtf/ObjectIdentifier.h>
-template: enum class WebCore::AXIDType
 template: enum class WebCore::MediaSessionGroupIdentifierType
 template: enum class WebCore::MediaUniqueIdentifierType
 template: enum class WebCore::PushSubscriptionIdentifierType
@@ -75,7 +73,9 @@ template: struct WebCore::PlaybackTargetClientContextIdentifierType
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
 
+header: <wtf/ObjectIdentifier.h>
 template: class WebKit::WebURLSchemeHandler
+template: enum class WebCore::AXIDType
 template: enum class WebCore::BackgroundFetchRecordIdentifierType
 template: enum class WebCore::ElementIdentifierType
 template: enum class WebCore::FetchIdentifierType


### PR DESCRIPTION
#### 42ed41c5d33eca7d0b52ed9aead4c2cdde2880c1
<pre>
Port AXID to ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=281390">https://bugs.webkit.org/show_bug.cgi?id=281390</a>

Reviewed by Darin Adler.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isTableCellInSameRowGroup):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::objectID const):
(WebCore::AXCoreObject::rowGroupAncestorID const):
(WebCore::AXCoreObject::AXCoreObject):
(WebCore::axIDs):
(WebCore::Accessibility::retrieveValueFromMainThread):
* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cacheRect):
* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::streamAXCoreObject):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setIsolatedTreeFocusedObject):
(WebCore::AXObjectCache::get const):
(WebCore::AXObjectCache::cacheAndInitializeWrapper):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::generateNewObjectID const):
(WebCore::AXObjectCache::getAXID):
(WebCore::AXObjectCache::onRendererCreated):
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
(WebCore::AXObjectCache::objectForTextMarkerData):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::updateIsolatedTree const):
(WebCore::AXObjectCache::onPaint const):
(WebCore::AXObjectCache::addRelation):
(WebCore::AXObjectCache::removeRelation):
(WebCore::AXObjectCache::isDescendantOfRelatedNode):
(WebCore::AXObjectCache::relatedObjectIDsFor):
(WebCore::AXObjectCache::selectedTextRangeTimerFired):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXObjectCache::nodeForID const):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
(WebCore::AXSearchManager::findMatchingRange):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::nodeID):
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::operator CharacterOffset const):
(WebCore::AXTextMarker::object const):
(WebCore::AXTextMarker::debugDescription const):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::AXTextMarkerRange::isConfinedTo const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::TextMarkerData::axTreeID const):
(WebCore::TextMarkerData::axObjectID const):
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::treeID const):
(WebCore::AXTextMarker::objectID const):
(WebCore::AXTextMarker::isNull const):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
* Source/WebCore/accessibility/AXTreeStore.h:
(WebCore::AXTreeStore&lt;T&gt;::axObjectCacheForID):
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeForID):
(WebCore::AXTreeStore&lt;T&gt;::generateNewID):
(WebCore::axTreeForID):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::treeID const):
(WebCore::AccessibilityObject::dbg const):
(WebCore::AccessibilityObject::isIgnored const):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::cellSlots):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::cellSlots):
(WebCore::AccessibilityTable::addChildren):
(WebCore::AccessibilityTable::cellForColumnAndRow):
* Source/WebCore/accessibility/AccessibilityTable.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::rowGroupAncestorID const):
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::AXIsolatedObject):
(WebCore::AXIsolatedObject::dbg const):
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::associatedAXObject const):
(WebCore::AXIsolatedObject::setMathscripts):
(WebCore::AXIsolatedObject::setObjectProperty):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::isDetachedFromParent):
(WebCore::AXIsolatedObject::cellForColumnAndRow):
(WebCore::AXIsolatedObject::accessibilityHitTest const):
(WebCore::AXIsolatedObject::objectAttributeValue const):
(WebCore::AXIsolatedObject::textInputMarkedTextMarkerRange const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::reportLoadingProgress):
(WebCore::AXIsolatedTree::objectForID const):
(WebCore::AXIsolatedTree::shouldCreateNodeChange):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::queueChange):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::queueAppendsAndRemovals):
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::updatePropertiesForSelfAndDescendants):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::updateDependentProperties):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::focusedNodeID):
(WebCore::AXIsolatedTree::setFocusedNodeID):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeSubtreeFromNodeMap):
(WebCore::AXIsolatedTree::relatedObjectIDsFor):
(WebCore::AXIsolatedTree::applyPendingChanges):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase attachAXObject:]):
(-[WebAccessibilityObjectWrapperBase attachIsolatedObject:]):
(-[WebAccessibilityObjectWrapperBase detach]):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/285102@main">https://commits.webkit.org/285102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3abc29771a54e54b2d75da7f3fedbc1c2666e6ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56506 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14978 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19091 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64221 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64216 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5999 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10967 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1538 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->