### PR TITLE
Port WebExtensions Manifest Sidebar to C++

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -104,14 +104,6 @@ static NSString * const declarativeNetRequestRulesetIDManifestKey = @"id";
 static NSString * const declarativeNetRequestRuleEnabledManifestKey = @"enabled";
 static NSString * const declarativeNetRequestRulePathManifestKey = @"path";
 
-#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-static NSString * const sidebarActionManifestKey = @"sidebar_action";
-static NSString * const sidePanelManifestKey = @"side_panel";
-static NSString * const sidebarActionTitleManifestKey = @"default_title";
-static NSString * const sidebarActionPathManifestKey = @"default_panel";
-static NSString * const sidePanelPathManifestKey = @"default_path";
-#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-
 static const size_t maximumNumberOfShortcutCommands = 4;
 
 WebExtension::WebExtension(NSBundle *appExtensionBundle, NSURL *resourceBaseURL, RefPtr<API::Error>& outError)
@@ -537,75 +529,6 @@ void WebExtension::populateActionPropertiesIfNeeded()
     m_displayActionLabel = objectForKey<NSString>(m_actionDictionary, defaultTitleManifestKey);
     m_actionPopupPath = objectForKey<NSString>(m_actionDictionary, defaultPopupManifestKey);
 }
-
-#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-bool WebExtension::hasSidebarAction()
-{
-    return objectForKey<NSDictionary>(m_manifest, sidebarActionManifestKey);
-}
-
-bool WebExtension::hasAnySidebar()
-{
-    return hasSidebarAction() || hasSidePanel();
-}
-
-CocoaImage *WebExtension::sidebarIcon(CGSize idealSize)
-{
-    // FIXME: <https://webkit.org/b/276833> implement this
-    return nil;
-}
-
-NSString *WebExtension::sidebarDocumentPath()
-{
-    populateSidebarPropertiesIfNeeded();
-    return m_sidebarDocumentPath.get();
-}
-
-NSString *WebExtension::sidebarTitle()
-{
-    populateSidebarPropertiesIfNeeded();
-    return m_sidebarTitle.get();
-}
-
-void WebExtension::populateSidebarPropertiesIfNeeded()
-{
-    if (!manifestParsedSuccessfully())
-        return;
-
-    if (m_parsedManifestSidebarProperties)
-        return;
-
-    // sidePanel documentation: https://developer.chrome.com/docs/extensions/reference/manifest#side-panel
-    // see "Examples" header -> "Side Panel" tab (doesn't mention `default_path` key elsewhere)
-    // sidebarAction documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
-
-    auto sidebarActionDictionary = objectForKey<NSDictionary>(m_manifest, sidebarActionManifestKey);
-    if (sidebarActionDictionary) {
-        populateSidebarActionProperties(sidebarActionDictionary);
-        return;
-    }
-
-    auto sidePanelDictionary = objectForKey<NSDictionary>(m_manifest, sidePanelManifestKey);
-    if (sidePanelDictionary)
-        populateSidePanelProperties(sidePanelDictionary);
-}
-
-void WebExtension::populateSidebarActionProperties(RetainPtr<NSDictionary> sidebarActionDictionary)
-{
-    // FIXME: <https://webkit.org/b/276833> implement sidebar icon parsing
-    m_sidebarIconsCache = nil;
-    m_sidebarTitle = objectForKey<NSString>(sidebarActionDictionary, sidebarActionTitleManifestKey);
-    m_sidebarDocumentPath = objectForKey<NSString>(sidebarActionDictionary, sidebarActionPathManifestKey);
-}
-
-void WebExtension::populateSidePanelProperties(RetainPtr<NSDictionary> sidePanelDictionary)
-{
-    // Since sidePanel cannot set a default title or icon from the manifest, setting these nil here is intentional.
-    m_sidebarIconsCache = nil;
-    m_sidebarTitle = nil;
-    m_sidebarDocumentPath = objectForKey<NSString>(sidePanelDictionary, sidePanelPathManifestKey);
-}
-#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 CocoaImage *WebExtension::imageForPath(NSString *imagePath, RefPtr<API::Error>& outError, CGSize sizeForResizing)
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -254,9 +254,9 @@ public:
     bool hasSidebarAction();
     bool hasSidePanel();
     bool hasAnySidebar();
-    CocoaImage *sidebarIcon(CGSize idealSize);
-    NSString *sidebarDocumentPath();
-    NSString *sidebarTitle();
+    RefPtr<WebCore::Icon> sidebarIcon(WebCore::FloatSize idealSize);
+    const Sring& sidebarDocumentPath();
+    const String& sidebarTitle();
 #endif
 
     CocoaImage *imageForPath(NSString *, RefPtr<API::Error>&, CGSize sizeForResizing = CGSizeZero);
@@ -402,9 +402,9 @@ private:
     RetainPtr<NSString> m_actionPopupPath;
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-    RetainPtr<NSMutableDictionary> m_sidebarIconsCache;
-    RetainPtr<NSString> m_sidebarDocumentPath;
-    RetainPtr<NSString> m_sidebarTitle;
+    HashMap<String, Ref<WebCore::Icon>> m_sidebarIconsCache;
+    String m_sidebarDocumentPath;
+    String m_sidebarTitle;
 #endif
 
     String m_contentSecurityPolicy;


### PR DESCRIPTION
#### fc144a33c0b528043d513f36e53d22aebb9c944c
<pre>
Port WebExtensions Manifest Sidebar to C++
<a href="https://webkit.org/b/281391">https://webkit.org/b/281391</a>

Reviewed by Timothy Hatcher.

Ports the WebExtension Manifest sidebar code to C++ for use in other ports.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::hasSidePanel):
(WebKit::WebExtension::hasSidebarAction): Deleted.
(WebKit::WebExtension::hasAnySidebar): Deleted.
(WebKit::WebExtension::sidebarIcon): Deleted.
(WebKit::WebExtension::sidebarDocumentPath): Deleted.
(WebKit::WebExtension::sidebarTitle): Deleted.
(WebKit::WebExtension::populateSidebarPropertiesIfNeeded): Deleted.
(WebKit::WebExtension::populateSidebarActionProperties): Deleted.
(WebKit::WebExtension::populateSidePanelProperties): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::hasSidebarAction):
(WebKit::WebExtension::hasAnySidebar):
(WebKit::WebExtension::sidebarIcon):
(WebKit::WebExtension::sidebarDocumentPath):
(WebKit::WebExtension::sidebarTitle):
(WebKit::WebExtension::populateSidebarPropertiesIfNeeded):
(WebKit::WebExtension::populateSidebarActionProperties):
(WebKit::WebExtension::populateSidePanelProperties):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:

Canonical link: <a href="https://commits.webkit.org/285091@main">https://commits.webkit.org/285091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deda1652c41f4b65940368796eb229e9576cc2c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22723 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56482 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42877 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21064 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77348 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18610 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64196 "Found 26 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-left-001.xht imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-right-001.xht imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64192 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5978 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10962 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1510 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->