### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from SQLiteStorageArea & StorageAreaBase

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -69,10 +69,12 @@ private:
     void connectionClosedForLocalStorageArea(IPC::Connection::UniqueID);
     void connectionClosedForTransientStorageArea(IPC::Connection::UniqueID);
 
+    RefPtr<StorageAreaBase> protectedLocalStorageArea() const;
+
     String m_path;
     CheckedRef<StorageAreaRegistry> m_registry;
-    std::unique_ptr<MemoryStorageArea> m_transientStorageArea;
-    std::unique_ptr<StorageAreaBase> m_localStorageArea;
+    RefPtr<MemoryStorageArea> m_transientStorageArea;
+    RefPtr<StorageAreaBase> m_localStorageArea;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp
@@ -31,6 +31,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MemoryStorageArea);
 
+Ref<MemoryStorageArea> MemoryStorageArea::create(const WebCore::ClientOrigin& origin, StorageAreaBase::StorageType type)
+{
+    return adoptRef(*new MemoryStorageArea(origin, type));
+}
+
 MemoryStorageArea::MemoryStorageArea(const WebCore::ClientOrigin& origin, StorageAreaBase::StorageType type)
     : StorageAreaBase(WebCore::StorageMap::noQuota, origin)
     , m_map(WebCore::StorageMap(WebCore::StorageMap::noQuota))
@@ -87,11 +92,10 @@ Expected<void, StorageError> MemoryStorageArea::clear(IPC::Connection::UniqueID 
     return { };
 }
 
-std::unique_ptr<MemoryStorageArea> MemoryStorageArea::clone() const
+Ref<MemoryStorageArea> MemoryStorageArea::clone() const
 {
-    auto storageArea = makeUnique<MemoryStorageArea>(origin(), m_storageType);
+    Ref storageArea = MemoryStorageArea::create(origin(), m_storageType);
     storageArea->m_map = m_map;
-
     return storageArea;
 }
 

--- a/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h
@@ -35,18 +35,22 @@ class StorageMap;
 
 namespace WebKit {
 
-class MemoryStorageArea final : public StorageAreaBase {
+class MemoryStorageArea final : public StorageAreaBase, public RefCounted<MemoryStorageArea> {
     WTF_MAKE_TZONE_ALLOCATED(MemoryStorageArea);
 public:
-    explicit MemoryStorageArea(const WebCore::ClientOrigin&, StorageAreaBase::StorageType = StorageAreaBase::StorageType::Session);
+    static Ref<MemoryStorageArea> create(const WebCore::ClientOrigin&, StorageAreaBase::StorageType = StorageAreaBase::StorageType::Session);
 
-    StorageAreaBase::Type type() const final { return StorageAreaBase::Type::Memory; };
+    StorageAreaBase::Type type() const final { return StorageAreaBase::Type::Memory; }
     bool isEmpty() final;
     void clear() final;
-    std::unique_ptr<MemoryStorageArea> clone() const;
+    Ref<MemoryStorageArea> clone() const;
     
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
+    explicit MemoryStorageArea(const WebCore::ClientOrigin&, StorageAreaBase::StorageType);
+
     // StorageAreaBase
     StorageAreaBase::StorageType storageType() const final { return m_storageType; }
     HashMap<String, String> allItems() final;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1427,9 +1427,9 @@ void NetworkStorageManager::connectToStorageArea(IPC::Connection& connection, We
     if (!resultIdentifier)
         return completionHandler(std::nullopt, HashMap<String, String> { }, StorageAreaBase::nextMessageIdentifier());
 
-    if (auto storageArea = m_storageAreaRegistry->getStorageArea(*resultIdentifier)) {
+    if (RefPtr storageArea = m_storageAreaRegistry->getStorageArea(*resultIdentifier)) {
         completionHandler(*resultIdentifier, storageArea->allItems(), StorageAreaBase::nextMessageIdentifier());
-        writeOriginToFileIfNecessary(origin, storageArea);
+        writeOriginToFileIfNecessary(origin, storageArea.get());
         return;
     }
 
@@ -1473,7 +1473,7 @@ void NetworkStorageManager::disconnectFromStorageArea(IPC::Connection& connectio
 {
     ASSERT(!RunLoop::isMain());
 
-    auto storageArea = m_storageAreaRegistry->getStorageArea(identifier);
+    RefPtr storageArea = m_storageAreaRegistry->getStorageArea(identifier);
     if (!storageArea)
         return;
 
@@ -1491,7 +1491,7 @@ void NetworkStorageManager::setItem(IPC::Connection& connection, StorageAreaIden
 
     bool hasError = false;
     HashMap<String, String> allItems;
-    auto storageArea = m_storageAreaRegistry->getStorageArea(identifier);
+    RefPtr storageArea = m_storageAreaRegistry->getStorageArea(identifier);
     if (!storageArea)
         return completionHandler(hasError, WTFMove(allItems));
 
@@ -1505,7 +1505,7 @@ void NetworkStorageManager::setItem(IPC::Connection& connection, StorageAreaIden
         allItems = storageArea->allItems();
     completionHandler(hasError, WTFMove(allItems));
 
-    writeOriginToFileIfNecessary(storageArea->origin(), storageArea);
+    writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());
 }
 
 void NetworkStorageManager::removeItem(IPC::Connection& connection, StorageAreaIdentifier identifier, StorageAreaImplIdentifier implIdentifier, String&& key, String&& urlString, CompletionHandler<void(bool, HashMap<String, String>&&)>&& completionHandler)
@@ -1514,7 +1514,7 @@ void NetworkStorageManager::removeItem(IPC::Connection& connection, StorageAreaI
 
     bool hasError = false;
     HashMap<String, String> allItems;
-    auto storageArea = m_storageAreaRegistry->getStorageArea(identifier);
+    RefPtr storageArea = m_storageAreaRegistry->getStorageArea(identifier);
     if (!storageArea)
         return completionHandler(hasError, WTFMove(allItems));
 
@@ -1526,14 +1526,14 @@ void NetworkStorageManager::removeItem(IPC::Connection& connection, StorageAreaI
         allItems = storageArea->allItems();
     completionHandler(hasError, WTFMove(allItems));
 
-    writeOriginToFileIfNecessary(storageArea->origin(), storageArea);
+    writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());
 }
 
 void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdentifier identifier, StorageAreaImplIdentifier implIdentifier, String&& urlString, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
 
-    auto storageArea = m_storageAreaRegistry->getStorageArea(identifier);
+    RefPtr storageArea = m_storageAreaRegistry->getStorageArea(identifier);
     if (!storageArea)
         return completionHandler();
 
@@ -1542,7 +1542,7 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
     storageArea->clear(connection.uniqueID(), implIdentifier, WTFMove(urlString));
     completionHandler();
 
-    writeOriginToFileIfNecessary(storageArea->origin(), storageArea);
+    writeOriginToFileIfNecessary(storageArea->origin(), storageArea.get());
 }
 
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -68,6 +68,11 @@ ASCIILiteral SQLiteStorageArea::statementString(StatementType type) const
     return ""_s;
 }
 
+Ref<SQLiteStorageArea> SQLiteStorageArea::create(unsigned quota, const WebCore::ClientOrigin& origin, const String& path, Ref<WorkQueue>&& workQueue)
+{
+    return adoptRef(*new SQLiteStorageArea(quota, origin, path, WTFMove(workQueue)));
+}
+
 SQLiteStorageArea::SQLiteStorageArea(unsigned quota, const WebCore::ClientOrigin& origin, const String& path, Ref<WorkQueue>&& workQueue)
     : StorageAreaBase(quota, origin)
     , m_path(path)

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -36,32 +36,28 @@ class SQLiteTransaction;
 }
 
 namespace WebKit {
-class SQLiteStorageArea;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::SQLiteStorageArea> : std::true_type { };
-}
-
-namespace WebKit {
-
-class SQLiteStorageArea final : public StorageAreaBase {
+class SQLiteStorageArea final : public StorageAreaBase, public RefCounted<SQLiteStorageArea> {
     WTF_MAKE_TZONE_ALLOCATED(SQLiteStorageArea);
 public:
-    SQLiteStorageArea(unsigned quota, const WebCore::ClientOrigin&, const String& path, Ref<WorkQueue>&&);
+    static Ref<SQLiteStorageArea> create(unsigned quota, const WebCore::ClientOrigin&, const String& path, Ref<WorkQueue>&&);
     ~SQLiteStorageArea();
 
     void close();
     void handleLowMemoryWarning();
     void commitTransactionIfNecessary();
+    void clear() final;
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
+    SQLiteStorageArea(unsigned quota, const WebCore::ClientOrigin&, const String& path, Ref<WorkQueue>&&);
+
     // StorageAreaBase
     Type type() const final { return StorageAreaBase::Type::SQLite; };
     StorageType storageType() const final { return StorageAreaBase::StorageType::Local; };
     bool isEmpty() final;
-    void clear() final;
     HashMap<String, String> allItems() final;
     Expected<void, StorageError> setItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, String&& key, String&& value, const String& urlString) final;
     Expected<void, StorageError> removeItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& urlString) final;

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
@@ -56,10 +56,10 @@ public:
     void cloneStorageArea(StorageNamespaceIdentifier, StorageNamespaceIdentifier);
 
 private:
-    StorageAreaIdentifier addStorageArea(std::unique_ptr<MemoryStorageArea>, StorageNamespaceIdentifier);
+    StorageAreaIdentifier addStorageArea(Ref<MemoryStorageArea>&&, StorageNamespaceIdentifier);
 
     CheckedRef<StorageAreaRegistry> m_registry;
-    HashMap<StorageAreaIdentifier, std::unique_ptr<MemoryStorageArea>> m_storageAreas;
+    HashMap<StorageAreaIdentifier, Ref<MemoryStorageArea>> m_storageAreas;
     HashMap<StorageNamespaceIdentifier, StorageAreaIdentifier> m_storageAreasByNamespace;
 };
 

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
@@ -59,11 +59,6 @@ void StorageAreaBase::removeListener(IPC::Connection::UniqueID connection)
     m_listeners.remove(connection);
 }
 
-bool StorageAreaBase::hasListeners() const
-{
-    return !m_listeners.isEmpty();
-}
-
 void StorageAreaBase::notifyListenersAboutClear()
 {
     for (auto& [connection, identifier] : m_listeners)

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
@@ -30,18 +30,10 @@
 #include "StorageAreaImplIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
 #include <WebCore/ClientOrigin.h>
+#include <wtf/HashMap.h>
 #include <wtf/Identified.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebKit {
-class StorageAreaBase;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::StorageAreaBase> : std::true_type { };
-}
 
 namespace WebCore {
 struct ClientOrigin;
@@ -73,13 +65,16 @@ public:
     unsigned quota() const { return m_quota; }
     void addListener(IPC::Connection::UniqueID, StorageAreaMapIdentifier);
     void removeListener(IPC::Connection::UniqueID);
-    bool hasListeners() const;
+    bool hasListeners() const { return !m_listeners.isEmpty(); }
     void notifyListenersAboutClear();
 
     virtual HashMap<String, String> allItems() = 0;
     virtual Expected<void, StorageError> setItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, String&& key, String&& value, const String& urlString) = 0;
     virtual Expected<void, StorageError> removeItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& urlString) = 0;
     virtual Expected<void, StorageError> clear(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& urlString) = 0;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
 protected:
     StorageAreaBase(unsigned quota, const WebCore::ClientOrigin&);


### PR DESCRIPTION
#### f1f97ea13f5c953bd909ce22ae07a87bf331da1e
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from SQLiteStorageArea &amp; StorageAreaBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=281393">https://bugs.webkit.org/show_bug.cgi?id=281393</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
(WebKit::LocalStorageManager::hasDataInMemory const):
(WebKit::LocalStorageManager::clearDataInMemory):
(WebKit::LocalStorageManager::clearDataOnDisk):
(WebKit::LocalStorageManager::close):
(WebKit::LocalStorageManager::handleLowMemoryWarning):
(WebKit::LocalStorageManager::syncLocalStorage):
(WebKit::LocalStorageManager::connectionClosedForLocalStorageArea):
(WebKit::LocalStorageManager::connectionClosedForTransientStorageArea):
(WebKit::LocalStorageManager::connectToLocalStorageArea):
(WebKit::LocalStorageManager::protectedLocalStorageArea const):
(WebKit::LocalStorageManager::connectToTransientLocalStorageArea):
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp:
(WebKit::MemoryStorageArea::create):
(WebKit::MemoryStorageArea::clone const):
* Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h:
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::create):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp:
(WebKit::SessionStorageManager::clearData):
(WebKit::SessionStorageManager::connectionClosed):
(WebKit::SessionStorageManager::addStorageArea):
(WebKit::SessionStorageManager::connectToSessionStorageArea):
(WebKit::SessionStorageManager::cancelConnectToSessionStorageArea):
(WebKit::SessionStorageManager::disconnectFromStorageArea):
(WebKit::SessionStorageManager::cloneStorageArea):
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp:
(WebKit::StorageAreaBase::hasListeners const): Deleted.
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.h:
(WebKit::StorageAreaBase::hasListeners const):

Canonical link: <a href="https://commits.webkit.org/285106@main">https://commits.webkit.org/285106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9845132c41533e65095ab7fcfb9879ffc6dac35a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56528 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15001 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42920 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21119 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18656 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15850 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64239 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12384 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6023 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10968 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46786 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->