### PR TITLE
[JSC] Limits values for `Intl.DurationFormat` and `Temporal.Duration`

### DIFF
--- a/JSTests/stress/intl-durationformat-limits.js
+++ b/JSTests/stress/intl-durationformat-limits.js
@@ -1,0 +1,40 @@
+function shouldThrow(op, errorConstructor) {
+    try {
+        op();
+    } catch (e) {
+        if (!(e instanceof errorConstructor)) {
+            throw new Error(`threw ${e}, but should have thrown ${errorConstructor.name}`);
+        }
+        return;
+    }
+    throw new Error(`Expected to throw ${errorConstructor.name}, but no exception thrown`);
+}
+
+const df = new Intl.DurationFormat();
+
+{
+    const invalidValues = [
+        2**32,
+        2**32 + 1,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_VALUE,
+    ];
+    for (const v of invalidValues) {
+        shouldThrow(() => { df.format({ years: v }); }, RangeError);
+        shouldThrow(() => { df.format({ months: v }); }, RangeError);
+        shouldThrow(() => { df.format({ weeks: v }); }, RangeError);
+    }
+}
+
+{
+    shouldThrow(() => { df.format({ days: Math.ceil((Number.MAX_SAFE_INTEGER + 1) / 86400) }); }, RangeError)
+    shouldThrow(() => { df.format({ hours: Math.ceil((Number.MAX_SAFE_INTEGER + 1) / 3600) }) }, RangeError);
+    shouldThrow(() => { df.format({ minutes: Math.ceil((Number.MAX_SAFE_INTEGER + 1) / 60) }) }, RangeError);
+    shouldThrow(() => { df.format({ seconds: Number.MAX_SAFE_INTEGER + 1 }) }, RangeError);
+    shouldThrow(() => { df.format({ milliseconds: (Number.MAX_SAFE_INTEGER + 1) * 1e3 }) }, RangeError);
+    shouldThrow(() => { df.format({ milliseconds: 9007199254740992_000 }) }, RangeError);
+    shouldThrow(() => { df.format({ microseconds: (Number.MAX_SAFE_INTEGER + 1) * 1e6 }) }, RangeError);
+    shouldThrow(() => { df.format({ microseconds: 9007199254740992_000_000 }) }, RangeError);
+    shouldThrow(() => { df.format({ nanoseconds: (Number.MAX_SAFE_INTEGER + 1) * 1e9 }) }, RangeError);
+    shouldThrow(() => { df.format({ nanoseconds: 9007199254740992_000_000_000 }) }, RangeError);
+}

--- a/JSTests/stress/temporal-duration-limits.js
+++ b/JSTests/stress/temporal-duration-limits.js
@@ -1,0 +1,40 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(op, errorConstructor) {
+    try {
+        op();
+    } catch (e) {
+        if (!(e instanceof errorConstructor)) {
+            throw new Error(`threw ${e}, but should have thrown ${errorConstructor.name}`);
+        }
+        return;
+    }
+    throw new Error(`Expected to throw ${errorConstructor.name}, but no exception thrown`);
+}
+
+{
+    const invalidValues = [
+        2**32,
+        2**32 + 1,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_VALUE,
+    ];
+    for (const v of invalidValues) {
+        shouldThrow(() => { Temporal.Duration.from({ years: v }); }, RangeError);
+        shouldThrow(() => { Temporal.Duration.from({ months: v }); }, RangeError);
+        shouldThrow(() => { Temporal.Duration.from({ weeks: v }); }, RangeError);
+    }
+}
+
+{
+    shouldThrow(() => { Temporal.Duration.from({ days: Math.ceil((Number.MAX_SAFE_INTEGER + 1) / 86400) }); }, RangeError)
+    shouldThrow(() => { Temporal.Duration.from({ hours: Math.ceil((Number.MAX_SAFE_INTEGER + 1) / 3600) }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ minutes: Math.ceil((Number.MAX_SAFE_INTEGER + 1) / 60) }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ seconds: Number.MAX_SAFE_INTEGER + 1 }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ milliseconds: (Number.MAX_SAFE_INTEGER + 1) * 1e3 }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ milliseconds: 9007199254740992_000 }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ microseconds: (Number.MAX_SAFE_INTEGER + 1) * 1e6 }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ microseconds: 9007199254740992_000_000 }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ nanoseconds: (Number.MAX_SAFE_INTEGER + 1) * 1e9 }) }, RangeError);
+    shouldThrow(() => { Temporal.Duration.from({ nanoseconds: 9007199254740992_000_000_000 }) }, RangeError);
+}

--- a/JSTests/stress/temporal-duration.js
+++ b/JSTests/stress/temporal-duration.js
@@ -94,7 +94,7 @@ shouldThrow(() => Temporal.Duration.from({}), TypeError);
         shouldBe(fromDurationLike[field], pos[field]);
     }
 }
-shouldNotThrow(() => Temporal.Duration.from(`P${Array(308).fill(9).join('')}Y`));
+shouldThrow(() => Temporal.Duration.from(`P${Array(308).fill(9).join('')}Y`), RangeError);
 shouldBe(Temporal.Duration.from('+P1Y2DT3H4.0S').toString(), 'P1Y2DT3H4S');
 shouldBe(Temporal.Duration.from('PT1.03125H').toString(), 'PT1H1M52.5S');
 shouldBe(Temporal.Duration.from('PT1.03125M').toString(), 'PT1M1.875S');

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -118,9 +118,6 @@ test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js:
 test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Duration/compare/argument-duration-out-of-range.js:
-  default: 'Test262Error: string with days > max is out of range (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: string with days > max is out of range (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/compare/exhaustive.js:
   default: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
@@ -139,36 +136,21 @@ test/built-ins/Temporal/Duration/compare/relativeto-string-limits.js:
 test/built-ins/Temporal/Duration/from/argument-duration-max.js:
   default: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«9007199254740994», «9007199254740992») to be true'
   strict mode: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«9007199254740994», «9007199254740992») to be true'
-test/built-ins/Temporal/Duration/from/argument-duration-out-of-range.js:
-  default: 'Test262Error: string with days > max is out of range Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: string with days > max is out of range Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/from/argument-duration-precision-exact-numerical-values.js:
   default: 'Test262Error: case where floating point inaccuracy brings total below limit, positive Expected SameValue(«PT9007199254740992.000424S», «PT9007199254740991.975424S») to be true'
   strict mode: 'Test262Error: case where floating point inaccuracy brings total below limit, positive Expected SameValue(«PT9007199254740992.000424S», «PT9007199254740991.975424S») to be true'
-test/built-ins/Temporal/Duration/out-of-range.js:
-  default: 'Test262Error: years > max Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: years > max Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/add/argument-duration-max.js:
-  default: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«9007199254740994», «9007199254740992») to be true'
-  strict mode: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«9007199254740994», «9007199254740992») to be true'
-test/built-ins/Temporal/Duration/prototype/add/argument-duration-out-of-range.js:
-  default: 'Test262Error: string with days > max is out of range Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: string with days > max is out of range Expected a RangeError to be thrown but no exception was thrown at all'
+  default: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
+  strict mode: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
 test/built-ins/Temporal/Duration/prototype/add/argument-duration-precision-exact-numerical-values.js:
-  default: 'Test262Error: case where floating point inaccuracy brings total below limit, positive: ℝ(𝔽(x)) operation after balancing brings total over limit Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: case where floating point inaccuracy brings total below limit, positive: ℝ(𝔽(x)) operation after balancing brings total over limit Expected a RangeError to be thrown but no exception was thrown at all'
+  default: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
+  strict mode: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
 test/built-ins/Temporal/Duration/prototype/add/precision-exact-mathematical-values.js:
   default: 'Test262Error: duration1.add(duration2): nanoseconds result Expected SameValue(«24», «0») to be true'
   strict mode: 'Test262Error: duration1.add(duration2): nanoseconds result Expected SameValue(«24», «0») to be true'
 test/built-ins/Temporal/Duration/prototype/add/precision-no-floating-point-loss.js:
   default: 'Test262Error: duration1.add(duration2): milliseconds result: Expected SameValue(«926», «999») to be true'
   strict mode: 'Test262Error: duration1.add(duration2): milliseconds result: Expected SameValue(«926», «999») to be true'
-test/built-ins/Temporal/Duration/prototype/add/result-out-of-range-1.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Duration/prototype/add/result-out-of-range-2.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/round/end-of-month-round-up.js:
   default: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
@@ -181,18 +163,12 @@ test/built-ins/Temporal/Duration/prototype/round/largestunit-smallestunit-combin
 test/built-ins/Temporal/Duration/prototype/round/next-day-out-of-range.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(86400_0000_0000_000_000_000n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(86400_0000_0000_000_000_000n, \"UTC\")')"
-test/built-ins/Temporal/Duration/prototype/round/out-of-range-when-converting-from-normalized-duration.js:
-  default: 'Test262Error: nanoseconds component after balancing as a float64-representable integer is out of range Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: nanoseconds component after balancing as a float64-representable integer is out of range Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/round/precision-exact-in-round-duration.js:
   default: 'Test262Error: hours result: Expected SameValue(«100000», «100001») to be true'
   strict mode: 'Test262Error: hours result: Expected SameValue(«100000», «100001») to be true'
 test/built-ins/Temporal/Duration/prototype/round/relativeto-string-limits.js:
   default: 'Test262Error: "-271821-04-19T23:00-01:00[-01:00]" is outside the representable range for a relativeTo parameter Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: "-271821-04-19T23:00-01:00[-01:00]" is outside the representable range for a relativeTo parameter Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Duration/prototype/round/result-out-of-range.js:
-  default: 'Test262Error: result is out of range Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: result is out of range Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/round/round-and-balance-calendar-units-with-increment-disallowed.js:
   default: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
@@ -203,26 +179,17 @@ test/built-ins/Temporal/Duration/prototype/round/rounding-is-noop.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\", \"iso8601\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\", \"iso8601\")')"
 test/built-ins/Temporal/Duration/prototype/subtract/argument-duration-max.js:
-  default: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«-9007199254740994», «-9007199254740992») to be true'
-  strict mode: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«-9007199254740994», «-9007199254740992») to be true'
-test/built-ins/Temporal/Duration/prototype/subtract/argument-duration-out-of-range.js:
-  default: 'Test262Error: string with days > max is out of range Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: string with days > max is out of range Expected a RangeError to be thrown but no exception was thrown at all'
+  default: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
+  strict mode: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
 test/built-ins/Temporal/Duration/prototype/subtract/argument-duration-precision-exact-numerical-values.js:
-  default: 'Test262Error: case where floating point inaccuracy brings total below limit, positive: ℝ(𝔽(x)) operation after balancing brings total over limit Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: case where floating point inaccuracy brings total below limit, positive: ℝ(𝔽(x)) operation after balancing brings total over limit Expected a RangeError to be thrown but no exception was thrown at all'
+  default: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
+  strict mode: 'RangeError: Temporal.Duration properties must be finite and of consistent sign'
 test/built-ins/Temporal/Duration/prototype/subtract/precision-exact-mathematical-values.js:
   default: 'Test262Error: duration1.subtract(duration2): nanoseconds result Expected SameValue(«24», «0») to be true'
   strict mode: 'Test262Error: duration1.subtract(duration2): nanoseconds result Expected SameValue(«24», «0») to be true'
 test/built-ins/Temporal/Duration/prototype/subtract/precision-no-floating-point-loss.js:
   default: 'Test262Error: duration1.subtract(duration2): milliseconds result: Expected SameValue(«926», «999») to be true'
   strict mode: 'Test262Error: duration1.subtract(duration2): milliseconds result: Expected SameValue(«926», «999») to be true'
-test/built-ins/Temporal/Duration/prototype/subtract/result-out-of-range-1.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Duration/prototype/subtract/result-out-of-range-2.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/toString/max-value.js:
   default: 'Test262Error: values do not lose precision intermediately Expected SameValue(«PT9007199254740.992S», «PT9007199254740.993S») to be true'
   strict mode: 'Test262Error: values do not lose precision intermediately Expected SameValue(«PT9007199254740.992S», «PT9007199254740.993S») to be true'
@@ -1084,15 +1051,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
   strict mode: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
-test/intl402/DurationFormat/prototype/format/duration-out-of-range-1.js:
-  default: 'Test262Error: Duration "years" throws when value is 4294967296 Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Duration "years" throws when value is 4294967296 Expected a RangeError to be thrown but no exception was thrown at all'
-test/intl402/DurationFormat/prototype/format/duration-out-of-range-2.js:
-  default: 'Test262Error: Duration "days" throws when value is 104249991375 Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Duration "days" throws when value is 104249991375 Expected a RangeError to be thrown but no exception was thrown at all'
-test/intl402/DurationFormat/prototype/format/duration-out-of-range-3.js:
-  default: 'Test262Error: Duration "{"days":104249991374,"hours":7,"minutes":36,"seconds":31,"milliseconds":999,"microseconds":999,"nanoseconds":1000}" throws Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Duration "{"days":104249991374,"hours":7,"minutes":36,"seconds":31,"milliseconds":999,"microseconds":999,"nanoseconds":1000}" throws Expected a RangeError to be thrown but no exception was thrown at all'
 test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
   default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
   strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -69,6 +69,8 @@ public:
     const_iterator end() const { return m_data.end(); }
     void clear() { m_data.fill(0); }
 
+    std::optional<Int128> totalNanoseconds() const;
+
     Duration operator-() const
     {
         Duration result(*this);


### PR DESCRIPTION
#### 67e4f629c1ce19663e4d945d35def83e5ab1f5e8
<pre>
[JSC] Limits values for `Intl.DurationFormat` and `Temporal.Duration`
<a href="https://bugs.webkit.org/show_bug.cgi?id=281394">https://bugs.webkit.org/show_bug.cgi?id=281394</a>

Reviewed by Yusuke Suzuki.

To align with the behavior of `Temporal.Duration`, a value limit has been added to
`Intl.DurationFormat`[1]. The current JSC doesn&apos;t implement the limits for both
`Intl.DurationFormat` and `Temporal.Duration`.

This patch implements that specifications.

In the spec, this limit is represented as a double based on seconds. However, to avoid rounding
errors, we represent it as an `Int128` based on nanoseconds.

[1]: <a href="https://github.com/tc39/proposal-intl-duration-format/pull/173">https://github.com/tc39/proposal-intl-duration-format/pull/173</a>

(shouldThrow):
(const.df.new.Intl.DurationFormat):
(RangeError.shouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::Duration::normalizedNanoseconds const):
(JSC::ISO8601::absInt128):
(JSC::ISO8601::isValidDuration):
* Source/JavaScriptCore/runtime/ISO8601.h:

Canonical link: <a href="https://commits.webkit.org/285131@main">https://commits.webkit.org/285131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f073185f1587050e2cc94651792371f421e73e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22805 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56552 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15026 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21146 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64725 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77430 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70849 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64265 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64261 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6045 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92635 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46813 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20418 "Found 3 jsc stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/verbose-failure-dont-graph-dump-availability-already-freed.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->