### PR TITLE
Fix unexpected smart pointer warnings in WebCore and WebKt

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1026,7 +1026,6 @@ page/OpportunisticTaskScheduler.cpp
 page/Page.cpp
 page/PageColorSampler.cpp
 page/PageConsoleClient.cpp
-page/PageDebuggable.cpp
 page/PageGroup.cpp
 page/PageGroupLoadDeferrer.cpp
 page/PageOverlayController.cpp

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -57,10 +57,11 @@ String PageDebuggable::name() const
 {
     String name;
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &name] {
-        if (!m_page)
+        RefPtr page = m_page.get();
+        if (!page)
             return;
 
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
         if (!localMainFrame)
             return;
 
@@ -76,10 +77,11 @@ String PageDebuggable::url() const
 {
     String url;
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &url] {
-        if (!m_page)
+        RefPtr page = m_page.get();
+        if (!page)
             return;
 
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
         if (!localMainFrame)
             return;
 
@@ -105,32 +107,32 @@ bool PageDebuggable::hasLocalDebugger() const
 void PageDebuggable::connect(FrontendChannel& channel, bool isAutomaticConnection, bool immediatelyPause)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &channel, isAutomaticConnection, immediatelyPause] {
-        if (m_page)
-            m_page->inspectorController().connectFrontend(channel, isAutomaticConnection, immediatelyPause);
+        if (RefPtr page = m_page.get())
+            page->inspectorController().connectFrontend(channel, isAutomaticConnection, immediatelyPause);
     });
 }
 
 void PageDebuggable::disconnect(FrontendChannel& channel)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &channel] {
-        if (m_page)
-            m_page->inspectorController().disconnectFrontend(channel);
+        if (RefPtr page = m_page.get())
+            page->inspectorController().disconnectFrontend(channel);
     });
 }
 
 void PageDebuggable::dispatchMessageFromRemote(String&& message)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, message = WTFMove(message).isolatedCopy()]() mutable {
-        if (m_page)
-            m_page->inspectorController().dispatchMessageFromFrontend(WTFMove(message));
+        if (RefPtr page = m_page.get())
+            page->inspectorController().dispatchMessageFromFrontend(WTFMove(message));
     });
 }
 
 void PageDebuggable::setIndicating(bool indicating)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, indicating] {
-        if (m_page)
-            m_page->inspectorController().setIndicating(indicating);
+        if (RefPtr page = m_page.get())
+            page->inspectorController().setIndicating(indicating);
     });
 }
 

--- a/Source/WebCore/page/PageDebuggable.h
+++ b/Source/WebCore/page/PageDebuggable.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -61,7 +62,7 @@ public:
 private:
     explicit PageDebuggable(Page&);
 
-    Page* m_page;
+    WeakPtr<Page> m_page;
     String m_nameOverride;
 };
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
@@ -63,8 +63,9 @@ void ServiceWorkerInspectorProxy::connectToWorker(FrontendChannel& channel)
 {
     m_channel = &channel;
 
-    SWContextManager::singleton().setAsInspected(m_serviceWorkerThreadProxy.identifier(), true);
-    m_serviceWorkerThreadProxy.thread().runLoop().postDebuggerTask([] (ScriptExecutionContext& context) {
+    RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get();
+    SWContextManager::singleton().setAsInspected(serviceWorkerThreadProxy->identifier(), true);
+    serviceWorkerThreadProxy->thread().runLoop().postDebuggerTask([] (ScriptExecutionContext& context) {
         downcast<WorkerGlobalScope>(context).inspectorController().connectFrontend();
     });
 }
@@ -74,8 +75,9 @@ void ServiceWorkerInspectorProxy::disconnectFromWorker(FrontendChannel& channel)
     ASSERT_UNUSED(channel, &channel == m_channel);
     m_channel = nullptr;
 
-    SWContextManager::singleton().setAsInspected(m_serviceWorkerThreadProxy.identifier(), false);
-    m_serviceWorkerThreadProxy.thread().runLoop().postDebuggerTask([] (ScriptExecutionContext& context) {
+    RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get();
+    SWContextManager::singleton().setAsInspected(serviceWorkerThreadProxy->identifier(), false);
+    serviceWorkerThreadProxy->thread().runLoop().postDebuggerTask([] (ScriptExecutionContext& context) {
         downcast<WorkerGlobalScope>(context).inspectorController().disconnectFrontend(DisconnectReason::InspectorDestroyed);
 
         // In case the worker is paused running debugger tasks, ensure we break out of
@@ -86,7 +88,7 @@ void ServiceWorkerInspectorProxy::disconnectFromWorker(FrontendChannel& channel)
 
 void ServiceWorkerInspectorProxy::sendMessageToWorker(String&& message)
 {
-    m_serviceWorkerThreadProxy.thread().runLoop().postDebuggerTask([message = WTFMove(message).isolatedCopy()] (ScriptExecutionContext& context) {
+    m_serviceWorkerThreadProxy.get()->thread().runLoop().postDebuggerTask([message = WTFMove(message).isolatedCopy()] (ScriptExecutionContext& context) {
         downcast<WorkerGlobalScope>(context).inspectorController().dispatchMessageFromFrontend(message);
     });
 }

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h
@@ -28,6 +28,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 // All of these methods should be called on the Main Thread.
 // Used to send messages to the WorkerInspector on the WorkerThread.
@@ -55,7 +56,7 @@ public:
     void sendMessageFromWorkerToFrontend(String&&);
 
 private:
-    ServiceWorkerThreadProxy& m_serviceWorkerThreadProxy;
+    ThreadSafeWeakPtr<ServiceWorkerThreadProxy> m_serviceWorkerThreadProxy;
     Inspector::FrontendChannel* m_channel { nullptr };
 };
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -128,7 +128,7 @@ public:
     private:
         explicit Debuggable(WebAutomationSession&);
 
-        WebAutomationSession* m_session;
+        WeakPtr<WebAutomationSession> m_session;
     };
 #endif // ENABLE(REMOTE_INSPECTOR)
 
@@ -324,6 +324,7 @@ private:
 
     Ref<Inspector::FrontendRouter> protectedFrontendRouter() const;
     Ref<Inspector::BackendDispatcher> protectedBackendDispatcher() const;
+    Ref<Debuggable> protectedDebuggable() const;
 
     WeakPtr<WebProcessPool> m_processPool;
 


### PR DESCRIPTION
#### b09ed0efaa840ee864837b7411c6032c5da901e3
<pre>
Fix unexpected smart pointer warnings in WebCore and WebKt
<a href="https://bugs.webkit.org/show_bug.cgi?id=281395">https://bugs.webkit.org/show_bug.cgi?id=281395</a>

Reviewed by Chris Dumez.

Fixed outstanding clang static analyzer smart pointer warnings.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/PageDebuggable.cpp:
(WebCore::PageDebuggable::name const):
(WebCore::PageDebuggable::url const):
(WebCore::PageDebuggable::connect):
(WebCore::PageDebuggable::disconnect):
(WebCore::PageDebuggable::dispatchMessageFromRemote):
(WebCore::PageDebuggable::setIndicating):
* Source/WebCore/page/PageDebuggable.h:
* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp:
(WebCore::ServiceWorkerInspectorProxy::connectToWorker):
(WebCore::ServiceWorkerInspectorProxy::disconnectFromWorker):
(WebCore::ServiceWorkerInspectorProxy::sendMessageToWorker):
* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::Debuggable::name const):
(WebKit::WebAutomationSession::Debuggable::dispatchMessageFromRemote):
(WebKit::WebAutomationSession::Debuggable::connect):
(WebKit::WebAutomationSession::Debuggable::disconnect):
(WebKit::WebAutomationSession::connect):
(WebKit::WebAutomationSession::init):
(WebKit::WebAutomationSession::terminate):
(WebKit::WebAutomationSession::protectedDebuggable const):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:

Canonical link: <a href="https://commits.webkit.org/285112@main">https://commits.webkit.org/285112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e4f92ec0775197595383c79a3b2b60de90cafc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56502 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14974 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19086 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77372 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5995 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10971 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->