### PR TITLE
Use different keychain attribute for passkey credential ID

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -89,6 +89,8 @@ OSStatus SecTrustedApplicationCreateFromPath(const char* path, SecTrustedApplica
 SecSignatureHashAlgorithm SecCertificateGetSignatureHashAlgorithm(SecCertificateRef);
 extern const CFStringRef kSecAttrNoLegacy;
 
+extern const CFStringRef kSecAttrAlias;
+
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -88,8 +88,6 @@ using CBOR = cbor::CBORValue;
 
 namespace LocalAuthenticatorInternal {
 
-// Credential ID is currently SHA-1 of the corresponding public key.
-constexpr uint16_t credentialIdLength = 20;
 constexpr uint64_t counter = 0;
 // This aaguid is unattested.
 constexpr std::array<uint8_t, 16> aaguid = { 0xFB, 0xFC, 0x30, 0x07, 0x15, 0x4E, 0x4E, 0xCC, 0x8C, 0x0B, 0x6E, 0x02, 0x05, 0x57, 0xD7, 0xBD }; // Randomly generated.
@@ -106,7 +104,7 @@ static inline HashSet<String> produceHashSet(const Vector<PublicKeyCredentialDes
 {
     HashSet<String> result;
     for (auto& credentialDescriptor : credentialDescriptors) {
-        if (emptyTransportsOrContain(credentialDescriptor.transports, AuthenticatorTransport::Internal) && credentialDescriptor.type == PublicKeyCredentialType::PublicKey && BufferSource { credentialDescriptor.id } .length() == credentialIdLength)
+        if (emptyTransportsOrContain(credentialDescriptor.transports, AuthenticatorTransport::Internal) && credentialDescriptor.type == PublicKeyCredentialType::PublicKey)
             result.add(base64EncodeToString(BufferSource { credentialDescriptor.id }.span()));
     }
     return result;
@@ -205,7 +203,11 @@ std::optional<Vector<Ref<AuthenticatorAssertionResponse>>> LocalAuthenticator::g
         }
         auto& username = it->second.getString();
 
-        auto response = AuthenticatorAssertionResponse::create(LocalAuthenticatorInternal::toArrayBuffer(attributes[(id)kSecAttrApplicationLabel]), WTFMove(userHandle), String(username), (__bridge SecAccessControlRef)attributes[(id)kSecAttrAccessControl], AuthenticatorAttachment::Platform);
+        id credentialID = attributes[(id)kSecAttrAlias];
+        if (!credentialID)
+            credentialID = attributes[(id)kSecAttrApplicationLabel];
+
+        auto response = AuthenticatorAssertionResponse::create(LocalAuthenticatorInternal::toArrayBuffer(credentialID), WTFMove(userHandle), String(username), (__bridge SecAccessControlRef)attributes[(id)kSecAttrAccessControl], AuthenticatorAttachment::Platform);
 
         auto group = groupForAttributes(attributes);
         if (!group.isNull()) {
@@ -359,18 +361,25 @@ std::optional<WebCore::ExceptionData> LocalAuthenticator::processLargeBlobExtens
     // Step 4.
     if (largeBlobInput->write) {
         auto nsCredentialId = toNSData(response->rawId());
-        NSDictionary *fetchQuery = @{
+        auto fetchQuery = adoptNS([[NSMutableDictionary alloc] init]);
+        [fetcyQuery setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
             (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
-            (id)kSecAttrApplicationLabel: nsCredentialId.get(),
+            (id)kSecAttrAlias: nsCredentialId.get(),
             (id)kSecUseDataProtectionKeychain: @YES,
             (id)kSecReturnAttributes: @YES,
             (id)kSecReturnPersistentRef: @YES,
-        };
+        }];
 
         CFTypeRef attributesArrayRef = nullptr;
-        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)fetchQuery, &attributesArrayRef);
+        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)fetchQuery.get(), &attributesArrayRef);
+        if (status == errSecItemNotFound) {
+            fetchQuery[(id)kSecAttrAlias] = nil;
+            fetchQuery[(id)kSecAttrApplicationLabel] = nsCredentialId.get();
+            status = SecItemCopyMatching((__bridge CFDictionaryRef)fetchQuery.get(), &attributesArrayRef);
+        }
+
         if (status && status != errSecItemNotFound) {
             ASSERT_NOT_REACHED();
             return WebCore::ExceptionData { ExceptionCode::UnknownError, "Attempted to update unknown credential."_s };
@@ -503,7 +512,6 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         credentialId = digest->computeHash();
         m_provisionalCredentialId = toNSData(credentialId);
 
-#if ASSERT_ENABLED
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
@@ -514,9 +522,15 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         }];
         updateQueryIfNecessary(query.get());
 
+#if ASSERT_ENABLED
         OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), nullptr);
         ASSERT(!status);
-#endif // NDEBUG
+#endif
+
+        NSDictionary *updateAttributes = @{
+            (id)kSecAttrAlias: m_provisionalCredentialId.get()
+        };
+        SecItemUpdate((__bridge CFDictionaryRef)query.get(), (__bridge CFDictionaryRef)updateAttributes);
     }
 
     // Step 11. https://www.w3.org/TR/webauthn/#attested-credential-data
@@ -695,7 +709,7 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
             (id)kSecClass: (id)kSecClassKey,
             (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
-            (id)kSecAttrApplicationLabel: nsCredentialId.get(),
+            (id)kSecAttrAlias: nsCredentialId.get(),
             (id)kSecReturnRef: @YES,
             (id)kSecUseDataProtectionKeychain: @YES
         } mutableCopy];
@@ -707,6 +721,12 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
 
         CFTypeRef privateKeyRef = nullptr;
         OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), &privateKeyRef);
+        if (status == errSecItemNotFound) {
+            queryDictionary[(id)kSecAttrAlias] = nil;
+            queryDictionary[(id)kSecAttrApplicationLabel] = nsCredentialId.get();
+            status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), &privateKeyRef);
+        }
+
         if (status) {
             receiveException({ ExceptionCode::UnknownError, makeString("Couldn't get the private key reference: "_s, status) });
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't get the private key reference: %d", status);
@@ -730,18 +750,25 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
 
     // Extra step: update the Keychain item with the same value to update its modification date such that LRU can be used
     // for selectAssertionResponse
-    NSDictionary *query = @{
+    auto query = adoptNS([[NSMutableDictionary alloc] init]);
+    [query setDictionary:@{
         (id)kSecClass: (id)kSecClassKey,
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
-        (id)kSecAttrApplicationLabel: nsCredentialId.get(),
+        (id)kSecAttrAlias: nsCredentialId.get(),
         (id)kSecUseDataProtectionKeychain: @YES
-    };
+    }];
 
     NSDictionary *updateParams = @{
-        (id)kSecAttrApplicationLabel: nsCredentialId.get(),
+        (id)kSecAttrAlias: nsCredentialId.get(),
     };
-    auto status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)updateParams);
+    auto status = SecItemUpdate((__bridge CFDictionaryRef)query.get(), (__bridge CFDictionaryRef)updateParams);
+    if (status == errSecItemNotFound) {
+        [query removeObjectForKey:(id)kSecAttrAlias];
+        [query setObject:nsCredentialId.get() forKey:(id)kSecAttrApplicationLabel];
+        status = SecItemUpdate((__bridge CFDictionaryRef)query.get(), (__bridge CFDictionaryRef)updateParams);
+    }
+
     if (status)
         RELEASE_LOG_ERROR(WebAuthn, "Couldn't update the Keychain item: %d", status);
 
@@ -764,12 +791,18 @@ void LocalAuthenticator::receiveException(ExceptionData&& exception, WebAuthenti
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrApplicationLabel: m_provisionalCredentialId.get(),
+            (id)kSecAttrAlias: m_provisionalCredentialId.get(),
             (id)kSecUseDataProtectionKeychain: @YES
         }];
         updateQueryIfNecessary(query.get());
 
         OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        if (status == errSecItemNotFound) {
+            [query removeObjectForKey:(id)kSecAttrAlias];
+            [query setObject:m_provisionalCredentialId.get() forKey:(id)kSecAttrApplicationLabel];
+            status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        }
+
         if (status)
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't delete provisional credential while handling error: %d", status);
     }
@@ -792,14 +825,21 @@ void LocalAuthenticator::deleteDuplicateCredential() const
         if (!equalSpans(userHandle->span(), BufferSource { creationOptions.user.id } .span()))
             return false;
 
-        NSDictionary *query = @{
+        auto query = adoptNS([[NSMutableDictionary alloc] init]);
+        [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrApplicationLabel: toNSData(credential->rawId()).get(),
+            (id)kSecAttrAlias: toNSData(credential->rawId()).get(),
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
             (id)kSecUseDataProtectionKeychain: @YES
-        };
+        }];
 
-        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
+        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        if (status == errSecItemNotFound) {
+            [query removeObjectForKey:(id)kSecAttrAlias];
+            [query setObject:toNSData(credential->rawId()).get() forKey:(id)kSecAttrApplicationLabel];
+            status = SecItemDelete((__bridge CFDictionaryRef)query.get());
+        }
+
         if (status && status != errSecItemNotFound)
             RELEASE_LOG_ERROR(WebAuthn, "Couldn't delete older credential: %d", status);
         return true;

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -608,22 +608,37 @@ void TestController::cleanUpKeychain(const String& attrLabel, const String& appl
     [deleteQuery setObject:(id)kSecClassKey forKey:(id)kSecClass];
     [deleteQuery setObject:attrLabel forKey:(id)kSecAttrLabel];
     [deleteQuery setObject:@YES forKey:(id)kSecUseDataProtectionKeychain];
-    if (!!applicationLabelBase64)
-        [deleteQuery setObject:adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]).get() forKey:(id)kSecAttrApplicationLabel];
 
-    SecItemDelete((__bridge CFDictionaryRef)deleteQuery.get());
+    auto credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    if (!!applicationLabelBase64)
+        [deleteQuery setObject:credentialID.get() forKey:(id)kSecAttrAlias];
+
+    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)deleteQuery.get());
+    if (status == errSecItemNotFound) {
+        [deleteQuery removeObjectForKey:(id)kSecAttrAlias];
+        [deleteQuery setObject:credentialID.get() forKey:(id)kSecAttrApplicationLabel];
+        SecItemDelete((__bridge CFDictionaryRef)deleteQuery.get());
+    }
 }
 
 bool TestController::keyExistsInKeychain(const String& attrLabel, const String& applicationLabelBase64)
 {
-    NSDictionary *query = @{
+    auto credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    auto query = adoptNS([[NSMutableDictionary alloc] init]);
+    [query setDictionary:@{
         (id)kSecClass: (id)kSecClassKey,
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrLabel: attrLabel,
-        (id)kSecAttrApplicationLabel: adoptNS([[NSData alloc] initWithBase64EncodedString:applicationLabelBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters]).get(),
+        (id)kSecAttrAlias: credentialID.get(),
         (id)kSecUseDataProtectionKeychain: @YES
-    };
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
+    }];
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), NULL);
+    if (status == errSecItemNotFound) {
+        [query removeObjectForKey:(id)kSecAttrAlias];
+        [query setObject:credentialID.get() forKey:(id)kSecAttrApplicationLabel];
+        status = SecItemCopyMatching((__bridge CFDictionaryRef)query.get(), NULL);
+    }
+
     if (!status)
         return true;
     ASSERT(status == errSecItemNotFound);


### PR DESCRIPTION
#### b1a6c4a1dc46f17d2767104119ad0963f34925bb
<pre>
Use different keychain attribute for passkey credential ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=281344">https://bugs.webkit.org/show_bug.cgi?id=281344</a>
<a href="https://rdar.apple.com/137771569">rdar://137771569</a>

Reviewed by NOBODY (OOPS!).

Use kSecAttrAlias going forward, and if a query using this field fails then fall
back to kSecAttrApplicationLabel

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel deleteLocalAuthenticatorCredentialWithGroupAndID:credential:]):
(+[_WKWebAuthenticationPanel setDisplayNameForLocalCredentialWithGroupAndID:credential:displayName:]):
(+[_WKWebAuthenticationPanel setNameForLocalCredentialWithGroupAndID:credential:name:]):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
(+[_WKWebAuthenticationPanel exportLocalAuthenticatorCredentialWithGroupAndID:credential:error:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::produceHashSet):
(WebKit::LocalAuthenticator::getExistingCredentials):
(WebKit::LocalAuthenticator::processLargeBlobExtension):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):
(WebKit::LocalAuthenticator::receiveException const):
(WebKit::LocalAuthenticator::deleteDuplicateCredential const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cleanUpKeychain):
(WTR::TestController::keyExistsInKeychain):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a6c4a1dc46f17d2767104119ad0963f34925bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71534 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50947 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24308 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73649 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58747 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22559 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74600 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/58747 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/24308 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36942 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/58747 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/24308 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21080 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64659 "Built successfully and passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/58747 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/24308 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77364 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70783 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15768 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/22559 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64207 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15811 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/24308 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64203 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/24308 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92569 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46747 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1526 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20411 "Found 3 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/verbose-failure-dont-graph-dump-availability-already-freed.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47818 "Hash b1a6c4a1 for PR 35070 does not build (failure)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->