### PR TITLE
Adjust HTTPSByDefault enums and expose property on WKWebpagePreferences

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2664,9 +2664,9 @@ void DocumentLoader::setHTTPSByDefaultMode(HTTPSByDefaultMode mode)
 {
     if (mode == HTTPSByDefaultMode::Disabled) {
         if (m_advancedPrivacyProtections.contains(AdvancedPrivacyProtections::HTTPSOnly))
-            m_httpsByDefaultMode = HTTPSByDefaultMode::UpgradeAndFailClosed;
+            m_httpsByDefaultMode = HTTPSByDefaultMode::UpgradeWithUserMediatedFallback;
         else if (m_advancedPrivacyProtections.contains(AdvancedPrivacyProtections::HTTPSFirst))
-            m_httpsByDefaultMode = HTTPSByDefaultMode::UpgradeWithHTTPFallback;
+            m_httpsByDefaultMode = HTTPSByDefaultMode::UpgradeWithAutomaticFallback;
     } else
         m_httpsByDefaultMode = mode;
 }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2830,8 +2830,8 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
             isHTTPSByDefaultEnabled = page->protectedSettings()->httpsByDefault();
         }
 
-        bool isHTTPSFirstApplicable = (isHTTPSByDefaultEnabled || provisionalDocumentLoader->httpsByDefaultMode() == HTTPSByDefaultMode::UpgradeWithHTTPFallback)
-            && provisionalDocumentLoader->httpsByDefaultMode() != HTTPSByDefaultMode::UpgradeAndFailClosed
+        bool isHTTPSFirstApplicable = (isHTTPSByDefaultEnabled || provisionalDocumentLoader->httpsByDefaultMode() == HTTPSByDefaultMode::UpgradeWithAutomaticFallback)
+            && provisionalDocumentLoader->httpsByDefaultMode() != HTTPSByDefaultMode::UpgradeWithUserMediatedFallback
             && !isHTTPFallbackInProgress()
             && provisionalDocumentLoader->request().wasSchemeOptimisticallyUpgraded();
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1187,7 +1187,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             }
         }
 #endif
-        bool isHTTPSOnlyActive = m_documentLoader->httpsByDefaultMode() == HTTPSByDefaultMode::UpgradeAndFailClosed
+        // FIXME: Propagate a better error code
+        bool isHTTPSOnlyActive = (m_documentLoader->httpsByDefaultMode() == HTTPSByDefaultMode::UpgradeWithUserMediatedFallback || m_documentLoader->httpsByDefaultMode() == HTTPSByDefaultMode::UpgradeAndNoFallback)
             && !m_documentLoader->advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSOnlyExplicitlyBypassedForDomain)
             && !frame->loader().isHTTPFallbackInProgress()
             && !(committedDocumentURL.protocolIs("http"_s) && request.resourceRequest().isSameSite());

--- a/Source/WebCore/platform/network/HTTPSByDefaultMode.h
+++ b/Source/WebCore/platform/network/HTTPSByDefaultMode.h
@@ -27,6 +27,6 @@
 
 namespace WebCore {
 
-enum class HTTPSByDefaultMode : uint8_t { Disabled, UpgradeWithHTTPFallback, UpgradeAndFailClosed };
+enum class HTTPSByDefaultMode : uint8_t { Disabled, UpgradeWithAutomaticFallback, UpgradeWithUserMediatedFallback, UpgradeAndNoFallback };
 
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -392,8 +392,9 @@ enum class WebCore::StorageBlockingPolicy : uint8_t {
 
 enum class WebCore::HTTPSByDefaultMode : uint8_t {
     Disabled,
-    UpgradeWithHTTPFallback,
-    UpgradeAndFailClosed
+    UpgradeWithAutomaticFallback,
+    UpgradeWithUserMediatedFallback
+    UpgradeAndNoFallback
 };
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -134,6 +134,8 @@ public:
 
     WebCore::HTTPSByDefaultMode httpsByDefaultMode() const { return m_data.httpsByDefaultMode; }
     void setHTTPSByDefault(WebCore::HTTPSByDefaultMode mode) { m_data.httpsByDefaultMode = mode; }
+    bool isUpgradeWithUserMediatedFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSOnly) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback; }
+    bool isUpgradeWithAutomaticFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSFirst) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback; }
 
     const Vector<Vector<HashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
     void setVisibilityAdjustmentSelectors(Vector<Vector<HashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -42,6 +42,22 @@ typedef NS_ENUM(NSInteger, WKContentMode) {
     WKContentModeDesktop
 } WK_API_AVAILABLE(ios(13.0));
 
+/*! @enum WKWebpagePreferencesUpgradeToHTTPSPolicy
+ @abstract A secure navigation policy represents whether or not there is a
+ preference for loading a webpage with https, and how failures should be
+ handled.
+ @constant WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested             Maintains the current behavior without preferring https
+ @constant WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP     Upgrades http requests to https, and re-attempts the request with http on failure
+ @constant WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP  Upgrades http requests to https, and shows a warning page on failure
+ @constant WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure              Upgrades http requests to https, and returns an error on failure
+ */
+typedef NS_ENUM(NSInteger, WKWebpagePreferencesUpgradeToHTTPSPolicy) {
+    WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested,
+    WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP,
+    WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP,
+    WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure
+} NS_SWIFT_NAME(WKWebpagePreferences.UpgradeToHTTPSPolicy) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 /*! A WKWebpagePreferences object is a collection of properties that
  determine the preferences to use when loading and rendering a page.
  @discussion Contains properties used to determine webpage preferences.
@@ -77,5 +93,14 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  The default value depends on the system setting.
  */
 @property (nonatomic, getter=isLockdownModeEnabled) BOOL lockdownModeEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
+/*! @abstract A WKWebpagePreferencesUpgradeToHTTPSPolicy indicating the desired mode
+ used when performing a top-level navigation to a webpage.
+ @discussion The default value is WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested.
+ The stated preference is ignored on subframe navigation, and it may be ignored based on
+ system configuration. The upgradeKnownHostsToHTTPS property on WKWebViewConfiguration
+ supercedes this policy for known hosts.
+ */
+@property (nonatomic) WKWebpagePreferencesUpgradeToHTTPSPolicy preferredHTTPSNavigationPolicy WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -77,6 +77,39 @@ WebKit::WebContentMode webContentMode(WKContentMode contentMode)
 
 #endif // PLATFORM(IOS_FAMILY)
 
+WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy(WebCore::HTTPSByDefaultMode httpsByDefault)
+{
+    switch (httpsByDefault) {
+    case WebCore::HTTPSByDefaultMode::Disabled:
+        return WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested;
+    case WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback:
+        return WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
+    case WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback:
+        return WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP;
+    case WebCore::HTTPSByDefaultMode::UpgradeAndNoFallback:
+        return WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure;
+    }
+    ASSERT_NOT_REACHED();
+    return WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested;
+}
+
+WebCore::HTTPSByDefaultMode httpsByDefaultMode(WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy)
+{
+    switch (upgradeToHTTPSPolicy) {
+    case WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested:
+        return WebCore::HTTPSByDefaultMode::Disabled;
+    case WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP:
+        return WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback;
+    case WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP:
+        return WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback;
+    case WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure:
+        return WebCore::HTTPSByDefaultMode::UpgradeAndNoFallback;
+    }
+
+    ASSERT_NOT_REACHED();
+    return WebCore::HTTPSByDefaultMode::Disabled;
+}
+
 static _WKWebsiteMouseEventPolicy mouseEventPolicy(WebCore::MouseEventPolicy policy)
 {
     switch (policy) {
@@ -566,6 +599,16 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
     _websitePolicies->setLockdownModeEnabled(!!lockdownModeEnabled);
 #endif
+}
+
+- (void)setPreferredHTTPSNavigationPolicy:(WKWebpagePreferencesUpgradeToHTTPSPolicy)upgradeToHTTPSPolicy
+{
+    _websitePolicies->setHTTPSByDefault(WebKit::httpsByDefaultMode(upgradeToHTTPSPolicy));
+}
+
+- (WKWebpagePreferencesUpgradeToHTTPSPolicy)preferredHTTPSNavigationPolicy
+{
+    return WebKit::upgradeToHTTPSPolicy(_websitePolicies->httpsByDefaultMode());
 }
 
 - (BOOL)_networkConnectionIntegrityEnabled

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesInternal.h
@@ -38,6 +38,8 @@ WKContentMode contentMode(WebContentMode);
 WebContentMode webContentMode(WKContentMode);
 #endif
 
+WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy(WebCore::HTTPSByDefaultMode);
+WebCore::HTTPSByDefaultMode httpsByDefaultMode(WKWebpagePreferencesUpgradeToHTTPSPolicy);
 }
 
 @interface WKWebpagePreferences () <WKObject> {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6677,7 +6677,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
         URL failedURL { provisionalURL };
         bool canFallbackToHTTP = frame.isMainFrame() && error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && failedURL.protocolIs("https"_s);
         if (auto* websitePolicies = navigation ? navigation->websitePolicies() : nullptr; websitePolicies
-            && websitePolicies->advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSOnly)
+            && websitePolicies->isUpgradeWithUserMediatedFallbackEnabled()
             && !websitePolicies->advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSOnlyExplicitlyBypassedForDomain)
             && !internals().pageLoadState.httpFallbackInProgress()
             && canFallbackToHTTP) {
@@ -6711,7 +6711,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
             callClientFunctions();
     } else {
         if (RefPtr websitePolicies = navigation ? navigation->websitePolicies() : nullptr; websitePolicies
-            && (websitePolicies->advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSFirst) || m_preferences->httpSByDefaultEnabled())) {
+            && (websitePolicies->isUpgradeWithAutomaticFallbackEnabled() || m_preferences->httpSByDefaultEnabled())) {
             URL failedURL { provisionalURL };
             if (frame.isMainFrame() && error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && failedURL.protocolIs("https"_s)) {
                 failedURL.setProtocol("http"_s);


### PR DESCRIPTION
#### 46ae6dc7269a175e7d878f962c220b24236cd85b
<pre>
Adjust HTTPSByDefault enums and expose property on WKWebpagePreferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=281399">https://bugs.webkit.org/show_bug.cgi?id=281399</a>
<a href="https://rdar.apple.com/137835292">rdar://137835292</a>

Reviewed by Alex Christensen.

This patch renames two enum values and adds a fourth value. The new names are
more descriptive. The newly introduced value provides a mechanism to upgrade
navigations but fail with an error instead of showing an interstitial. I&apos;ll
rename HTTPSByDefault to something like PreferredHTTPSNavigationPolicy in
another patch.

This patch also adds a new property and enum on WKWebpagePreferences.

I duplicated and adjusted the relevant existing tests that cover SPI for this
behavior so they exercise the new API. I also added a couple new tests for the
NoFallback (ErrorOnFailure) case.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setHTTPSByDefaultMode):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/platform/network/HTTPSByDefaultMode.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(WebKit::upgradeToHTTPSPolicy):
(WebKit::httpsByDefaultMode):
(-[WKWebpagePreferences setPreferredHTTPSNavigationPolicy:]):
(-[WKWebpagePreferences preferredHTTPSNavigationPolicy]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesInternal.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngrade)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeAfterPSON)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeAndSameSiteNavigation)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackRedirectNoHTTPDowngradeRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackLocalHostIPAddress)):
(TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackInitialLoad)):
(TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackHTTPFallbackGoBack)):
(TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackHTTPFallbackContinue)):
(TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackWithHTTPRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackRedirectNoHTTPDowngradeRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackInitialLoad)):
(TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackOnCertificateError)):

Canonical link: <a href="https://commits.webkit.org/285300@main">https://commits.webkit.org/285300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0933a18e019467d294026eaf952031534db40a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56497 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19080 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77366 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64207 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5990 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11078 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1528 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47820 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->