### PR TITLE
Popover non-modal dialog blocks interaction on content behind it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Ensure that popover dialogs do not block mouse events. To test manually, click the red box. The test succeeds if the red box turns green.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Popover dialogs should not block mouse events</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">
+<style>
+    #div {
+        height: 100px;
+        width: 100px;
+        background: red;
+    }
+</style>
+<div id="div"></div>
+<dialog id="dialog" popover="manual"></dialog>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async () => {
+  const dialog = document.getElementById("dialog");
+  dialog.showPopover();
+
+  const div = document.getElementById("div");
+  div.addEventListener("click", function(event) {
+    div.firedOn = true;
+    div.style.backgroundColor = "green";
+  });
+
+  var absoluteTop = 0;
+  var absoluteLeft = 0;
+  for (var parentNode = div; parentNode; parentNode = parentNode.offsetParent) {
+    absoluteLeft += parentNode.offsetLeft;
+    absoluteTop += parentNode.offsetTop;
+  }
+
+  const x = absoluteLeft + div.offsetWidth / 2;
+  const y = absoluteTop + div.offsetHeight / 2;
+  const actions = new test_driver.Actions()
+    .pointerMove(x, y)
+    .pointerDown()
+    .pointerUp()
+    .pointerMove(0, 0);
+  await actions.send();
+  assert_true(div.firedOn, "div should have gotten a click event.");
+}, "Ensure that popover dialogs do not block mouse events. To test manually, click the red box. The test succeeds if the red box turns green.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -24,49 +24,9 @@ PASS Popover focus test: autofocus popover and multiple autofocus children
 PASS Popover button click focus test: autofocus popover and multiple autofocus children
 PASS Popover corner cases test: autofocus popover and multiple autofocus children
 PASS Popover focus test: Opening dialogs as popovers should use dialog initial focus algorithm.
-FAIL Popover button click focus test: Opening dialogs as popovers should use dialog initial focus algorithm. assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <body>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dialog popover="auto" autofocus=...
+PASS Popover button click focus test: Opening dialogs as popovers should use dialog initial focus algorithm.
 PASS Popover corner cases test: Opening dialogs as popovers should use dialog initial focus algorithm.
 PASS Popover focus test: Opening dialogs as popovers which have autofocus should focus the dialog.
-FAIL Popover button click focus test: Opening dialogs as popovers which have autofocus should focus the dialog. assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <body>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<style>
-  [popover] {
-    borde...
+PASS Popover button click focus test: Opening dialogs as popovers which have autofocus should focus the dialog.
 PASS Popover corner cases test: Opening dialogs as popovers which have autofocus should focus the dialog.
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6543,6 +6543,7 @@ webkit.org/b/237358 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-t
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-blocks-mouse-events.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-receives-element-events.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/closed-dialog-does-not-block-mouse-events.html [ Failure ]
+imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-inlines.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-ancestor-is-inert.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/non-modal-dialog-does-not-block-mouse-events.html [ Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -1,3 +1,4 @@
+button
 
 FAIL Popover focus test: default behavior - popover is not focused assert_false: expected false got true
 FAIL Popover button click focus test: default behavior - popover is not focused assert_false: popover should start out hidden expected false got true
@@ -26,7 +27,7 @@ FAIL Popover corner cases test: autofocus popover and multiple autofocus childre
 FAIL Popover focus test: Opening dialogs as popovers should use dialog initial focus algorithm. assert_equals: prior element should get focus after Escape expected Element node <button tabindex="0" id="priorFocus"></button> but got Element node <button class="should-be-focused" tabindex="0">button</bu...
 FAIL Popover button click focus test: Opening dialogs as popovers should use dialog initial focus algorithm. assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: Opening dialogs as popovers should use dialog initial focus algorithm. assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: Opening dialogs as popovers which have autofocus should focus the dialog. assert_equals: expected Element node <button tabindex="0" id="priorFocus"></button> but got Element node <button class="should-be-focused" tabindex="0">button</bu...
-FAIL Popover button click focus test: Opening dialogs as popovers which have autofocus should focus the dialog. assert_equals: expected Element node <button tabindex="0" id="priorFocus"></button> but got Element node <button class="should-be-focused" tabindex="0">button</bu...
-PASS Popover corner cases test: Opening dialogs as popovers which have autofocus should focus the dialog.
+FAIL Popover focus test: Opening dialogs as popovers which have autofocus should focus the dialog. assert_equals: prior element should get focus after Escape expected Element node <button tabindex="0" id="priorFocus"></button> but got Element node <dialog popover="auto" autofocus="" class="should-be-focu...
+FAIL Popover button click focus test: Opening dialogs as popovers which have autofocus should focus the dialog. assert_false: popover should start out hidden expected false got true
+FAIL Popover corner cases test: Opening dialogs as popovers which have autofocus should focus the dialog. assert_false: popover should start out hidden expected false got true
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10066,8 +10066,8 @@ void Document::removeTopLayerElement(Element& element)
 HTMLDialogElement* Document::activeModalDialog() const
 {
     for (auto& element : makeReversedRange(m_topLayerElements)) {
-        if (auto* dialogElement = dynamicDowncast<HTMLDialogElement>(element.get()))
-            return dialogElement;
+        if (RefPtr dialog = dynamicDowncast<HTMLDialogElement>(element.get()); dialog && dialog->isModal())
+            return dialog.get();
     }
 
     return nullptr;


### PR DESCRIPTION
#### 990f8c4b4cc0cef73a7c69c82f4ea59b03e1028f
<pre>
Popover non-modal dialog blocks interaction on content behind it
<a href="https://bugs.webkit.org/show_bug.cgi?id=280940">https://bugs.webkit.org/show_bug.cgi?id=280940</a>
<a href="https://rdar.apple.com/137809195">rdar://137809195</a>

Reviewed by Simon Fraser.

Now that both popovers and dialogs can be in the top layer (and dialogs can also be popovers), `Document::activeModalDialog()` needs to check whether
the dialog is a modal dialog (and not a popover dialog). This function also determines whether the content behind the dialog gets turned inert.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/popover-dialog-does-not-block-mouse-events.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::activeModalDialog const):

Canonical link: <a href="https://commits.webkit.org/285103@main">https://commits.webkit.org/285103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd4576803fbfebc51d7668d0d7d241de5b0d6b00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14987 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19104 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21106 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18644 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15837 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6012 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46773 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->