### PR TITLE
[MediaRecorder/WebM] ASSERT(pts >= m_lastMuxedSampleTime);

### DIFF
--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -117,7 +117,6 @@ private:
     Deque<RetainPtr<CMSampleBufferRef>> m_encodedAudioFrames;
     uint8_t m_audioTrackIndex { 0 };
     int64_t m_audioSamplesCount { 0 };
-    MediaTime m_lastAudioSampleTime;
     MediaTime m_currentAudioSampleTime;
     MediaTime m_resumedAudioTime;
     FourCharCode m_audioCodec { 0 };

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm
@@ -326,9 +326,9 @@ Seconds MediaRecorderPrivateWriterWebM::nextVideoFrameTime() const
     auto frameTime = now - m_resumedVideoTime;
     LOG(MediaStream, "nextVideoFrameTime: frameTime:%f nextVideoFrameTime:%f", frameTime.value(), (frameTime + *m_firstVideoFrameAudioTime).value());
     frameTime = frameTime + *m_firstVideoFrameAudioTime;
-    // Take the max value from m_lastAudioSampleTime to handle the occasional wall clock time drift and ensure muxed frames times
-    // are always monotonically increasing.
-    return std::max(frameTime, Seconds { m_lastAudioSampleTime.toDouble() });
+    // Take the max value from m_lastMuxedSampleTime to handle the occasional wall clock time drift and ensure
+    // muxed frames times are always monotonically increasing.
+    return std::max(frameTime, m_lastMuxedSampleTime);
 }
 
 Seconds MediaRecorderPrivateWriterWebM::resumeVideoTime() const
@@ -375,7 +375,6 @@ void MediaRecorderPrivateWriterWebM::appendAudioSampleBuffer(const PlatformAudio
     if (m_isStopping)
         return;
 
-    m_lastAudioSampleTime = m_currentAudioSampleTime;
     if (auto sampleBuffer = createAudioSampleBuffer(data, description, PAL::toCMTime(m_currentAudioSampleTime), sampleCount))
         RefPtr { m_audioCompressor }->addSampleBuffer(sampleBuffer.get());
     m_audioSamplesCount += sampleCount;
@@ -557,7 +556,7 @@ void MediaRecorderPrivateWriterWebM::resume()
 {
     m_firstVideoFrameAudioTime.reset();
     m_resumedVideoTime = MonotonicTime::now();
-    m_resumedAudioTime = m_lastAudioSampleTime;
+    m_resumedAudioTime = m_currentAudioSampleTime;
     LOG(MediaStream, "MediaRecorderPrivateWriterWebM:resume");
 }
 


### PR DESCRIPTION
#### cd3d290bb0cbc0078f6af58868d427c615ada404
<pre>
[MediaRecorder/WebM] ASSERT(pts &gt;= m_lastMuxedSampleTime);
<a href="https://bugs.webkit.org/show_bug.cgi?id=281396">https://bugs.webkit.org/show_bug.cgi?id=281396</a>
<a href="https://rdar.apple.com/137830389">rdar://137830389</a>

Reviewed by Youenn Fablet and Jer Noble.

We were using the start time of the last received audio sample.
Audio is muxed as quickly as possible and will only ever be delayed if
we know that a video frame is incoming (as we don&apos;t want to enqueue audio until a video frame,
which may never come is finally available).
On an heavily loaded system, audio could have been received and muxed before
the related video frame got received. To ensure the best A/V sync we will
prefer the clock time at which the video frame got received but handle the
case where audio had already been muxed with a later time.

Manually tested, this is highly timing dependent and I could only reproduce while running in a
debugging session and turning on all the logging.

* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm:
(WebCore::MediaRecorderPrivateWriterWebM::nextVideoFrameTime const):
(WebCore::MediaRecorderPrivateWriterWebM::appendAudioSampleBuffer):
(WebCore::MediaRecorderPrivateWriterWebM::resume):

Canonical link: <a href="https://commits.webkit.org/285147@main">https://commits.webkit.org/285147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b05a4ecf84cec3a345b39fdfa64ad859f68e9cba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56525 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14997 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19110 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77398 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6018 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1560 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->