### PR TITLE
Writing suggestions show in the wrong place when the text node contains leading non-visible whitespace

### DIFF
--- a/LayoutTests/editing/input/cocoa/inline-predictions-in-text-with-leading-whitespace-expected.html
+++ b/LayoutTests/editing/input/cocoa/inline-predictions-in-text-with-leading-whitespace-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+[contenteditable] {
+    width: 300px;
+    outline: none;
+}
+</style>
+</head>
+<body>
+<div contenteditable>To whom it ma</div>
+<script>
+testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    const editor = document.querySelector("[contenteditable]");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    const text = editor.childNodes[0];
+    getSelection().setPosition(text, text.length);
+
+    await UIHelper.setInlinePrediction("may concern", 2);
+    await UIHelper.ensurePresentationUpdate();
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/input/cocoa/inline-predictions-in-text-with-leading-whitespace.html
+++ b/LayoutTests/editing/input/cocoa/inline-predictions-in-text-with-leading-whitespace.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+[contenteditable] {
+    width: 300px;
+    outline: none;
+}
+</style>
+</head>
+<body>
+<div contenteditable>    To whom it ma</div>
+<script>
+testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    const editor = document.querySelector("[contenteditable]");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    const text = editor.childNodes[0];
+    getSelection().setPosition(text, text.length);
+
+    await UIHelper.setInlinePrediction("may concern", 2);
+    await UIHelper.ensurePresentationUpdate();
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2315,6 +2315,13 @@ void Editor::setWritingSuggestion(const String& fullTextWithPrediction, const Ch
     auto range = document->selection().selection().firstRange();
     if (!range)
         return;
+
+    if (!range->collapsed())
+        return;
+
+    if (!is<Text>(range->startContainer()))
+        return;
+
     range->start.offset = 0;
 
     m_isHandlingAcceptedCandidate = true;
@@ -2327,7 +2334,7 @@ void Editor::setWritingSuggestion(const String& fullTextWithPrediction, const Ch
     ASSERT(newText.isEmpty() || newText.startsWith(currentText));
     auto textDelta = newText.isEmpty() ? emptyString() : newText.substring(currentText.length());
 
-    auto offset = WebCore::characterCount(*range);
+    auto offset = range->endOffset();
     auto offsetWithDelta = currentText.isEmpty() ? offset : offset + textDelta.length();
 
     if (!suggestionText.isEmpty()) {


### PR DESCRIPTION
#### 18268bbc067da5473c03a0896409d1ba1b71f8e0
<pre>
Writing suggestions show in the wrong place when the text node contains leading non-visible whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=281403">https://bugs.webkit.org/show_bug.cgi?id=281403</a>
<a href="https://rdar.apple.com/137237226">rdar://137237226</a>

Reviewed by Richard Robinson.

In the case where writing suggestions are inserted within a text node with leading whitespace, we
end up inserting the generated renderer (representing the suggested text) at the wrong offset within
the text node.

This happens because `WritingSuggestionData::offset()` is incorrect when we set up the suggested
text renderer in `RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer`. This
offset is in turn computed in `Editor::setWritingSuggestion`, where we use `characterCount` to get
the number of characters between the start of the text node and the caret position. The problem with
this approach is that `characterCount` ignores non-rendered whitespace, but the result is then used
to index into the text node&apos;s data, which includes non-rendered whitespace, when determining whether
(or how) to split up the existing text node to insert writing suggestions. As a result, the writing
suggestions renderer is incorrectly offset by an amount equal to the number of non-rendered
whitespace characters at the start of the text node.

To fix this, we use the `endOffset()` of the selection range, after verifying that the selection
range is both (1) collapsed, and (2) an offset within a text node. The current implementation of
writing suggestions doesn&apos;t work properly unless these conditions are met anyways, so it&apos;s safe to
enforce this and simply use the end offset relative to the containing text.

* LayoutTests/editing/input/cocoa/inline-predictions-in-text-with-leading-whitespace-expected.html: Added.
* LayoutTests/editing/input/cocoa/inline-predictions-in-text-with-leading-whitespace.html: Added.

Add a layout test to exercise the change, by verifying that inserting a writing suggestion after the
end of `&lt;div contenteditable&gt;To&amp;nbsp;&lt;/div&gt;` results in the same behavior as inserting the same
suggestion after the end of `&lt;div contenteditable&gt;   To&amp;nbsp;&lt;/div&gt;`.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::setWritingSuggestion):

Canonical link: <a href="https://commits.webkit.org/285107@main">https://commits.webkit.org/285107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f5affdd33793807daffa342a95c106a19110b11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56526 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14999 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15847 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6020 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1562 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->