### PR TITLE
[MediaRecorder/WebM] Inefficient memory usage driven by libwebm's mkvmuxer

### DIFF
--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -95,13 +95,14 @@ private:
 
     Ref<GenericPromise> flushPendingData();
     void completeFetchData();
-    RefPtr<FragmentedSharedBuffer> takeData();
 
     void maybeStartWriting();
     void maybeForceNewCluster();
 
     friend class MediaRecorderPrivateWriterWebMDelegate;
     void appendData(std::span<const uint8_t>);
+    RefPtr<FragmentedSharedBuffer> takeData();
+    void flushDataBuffer();
 
     bool m_hasStartedWriting { false };
     bool m_isStopped { false };
@@ -109,6 +110,8 @@ private:
 
     Lock m_dataLock;
     SharedBufferBuilder m_data WTF_GUARDED_BY_LOCK(m_dataLock);
+    static constexpr size_t s_dataBufferSize { 1024 };
+    Vector<uint8_t> m_dataBuffer;
     CompletionHandler<void(RefPtr<FragmentedSharedBuffer>&&, double)> m_fetchDataCompletionHandler;
 
     bool m_hasAudio { false };


### PR DESCRIPTION
#### d4723d6d5ac37964b5a9f8ceb9773f45bdee2b58
<pre>
[MediaRecorder/WebM] Inefficient memory usage driven by libwebm&apos;s mkvmuxer
<a href="https://bugs.webkit.org/show_bug.cgi?id=281402">https://bugs.webkit.org/show_bug.cgi?id=281402</a>
<a href="https://rdar.apple.com/137845423">rdar://137845423</a>

Reviewed by Youenn Fablet.

mkvmuxer&apos;s writes are typically one or two bytes long, which aren&apos;t particularly
suited for being stored incrementally into a FragmentedSharedBuffer as each append
requires a new Vector to be created.
Additionally, in a debug build any append to a FragmentedSharedBuffer will cause a consistency check
which becomes very CPU-intensive as it increases in size (profiling shows that over 87% of the web content
time is spent there).
So we write instead to the FragmentedSharedBuffer in block of 1024 bytes, resulting in significant
measured speed and memory gains.

* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm:
(WebCore::MediaRecorderPrivateWriterWebM::MediaRecorderPrivateWriterWebM):
(WebCore::MediaRecorderPrivateWriterWebM::appendData):
(WebCore::MediaRecorderPrivateWriterWebM::flushDataBuffer):
(WebCore::MediaRecorderPrivateWriterWebM::takeData):

Canonical link: <a href="https://commits.webkit.org/285159@main">https://commits.webkit.org/285159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7503d595179f1ccec1e8e5291b877bffba3140f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24502 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22753 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61785 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19252 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77562 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15962 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61818 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12519 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46941 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49296 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/47754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->