### PR TITLE
[RISCV] Fix typo about GPRReg def

### DIFF
--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -779,16 +779,16 @@ public:
     static constexpr GPRReg wasmBaseMemoryPointer = regCS3;
     static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS4;
 
-    static constexpr GPRReg regWS0 = RICSV64Registers::x6;
-    static constexpr GPRReg regWS1 = RICSV64Registers::x7;
-    static constexpr GPRReg regWA0 = RICSV64Registers::x10;
-    static constexpr GPRReg regWA1 = RICSV64Registers::x11;
-    static constexpr GPRReg regWA2 = RICSV64Registers::x12;
-    static constexpr GPRReg regWA3 = RICSV64Registers::x13;
-    static constexpr GPRReg regWA4 = RICSV64Registers::x14;
-    static constexpr GPRReg regWA5 = RICSV64Registers::x15;
-    static constexpr GPRReg regWA6 = RICSV64Registers::x16;
-    static constexpr GPRReg regWA7 = RICSV64Registers::x17;
+    static constexpr GPRReg regWS0 = RISCV64Registers::x6;
+    static constexpr GPRReg regWS1 = RISCV64Registers::x7;
+    static constexpr GPRReg regWA0 = RISCV64Registers::x10;
+    static constexpr GPRReg regWA1 = RISCV64Registers::x11;
+    static constexpr GPRReg regWA2 = RISCV64Registers::x12;
+    static constexpr GPRReg regWA3 = RISCV64Registers::x13;
+    static constexpr GPRReg regWA4 = RISCV64Registers::x14;
+    static constexpr GPRReg regWA5 = RISCV64Registers::x15;
+    static constexpr GPRReg regWA6 = RISCV64Registers::x16;
+    static constexpr GPRReg regWA7 = RISCV64Registers::x17;
 
     static constexpr GPRReg patchpointScratchRegister = RISCV64Registers::x30; // Should match dataTempRegister
 


### PR DESCRIPTION
#### 78dc48740b53b279b10501cca36aae44591061ac
<pre>
[RISCV] Fix typo about GPRReg def
<a href="https://bugs.webkit.org/show_bug.cgi?id=281380">https://bugs.webkit.org/show_bug.cgi?id=281380</a>

Reviewed by Yijia Huang.

* Source/JavaScriptCore/jit/GPRInfo.h:

Canonical link: <a href="https://commits.webkit.org/285359@main">https://commits.webkit.org/285359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5cb2b1c5dcbc29441167ecc3fa271c4a5f334b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22951 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56647 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15134 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21292 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/64871 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77580 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70996 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64365 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64371 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6173 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/92781 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11109 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46959 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20451 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->