### PR TITLE
Deploy more smart pointers in PDFDocument and FullScreenManager

### DIFF
--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -70,7 +70,7 @@ FullscreenManager::~FullscreenManager() = default;
 
 Element* FullscreenManager::fullscreenElement() const
 {
-    for (auto& element : makeReversedRange(document().topLayerElements())) {
+    for (Ref element : makeReversedRange(document().topLayerElements())) {
         if (element->hasFullscreenFlag())
             return element.ptr();
     }
@@ -423,18 +423,18 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
 
     auto unfullscreenDocument = [](const Ref<Document>& document) {
         Vector<Ref<Element>> toRemove;
-        for (auto& element : document->topLayerElements()) {
+        for (Ref element : document->topLayerElements()) {
             if (!element->hasFullscreenFlag())
                 continue;
             clearFullscreenFlags(element);
             toRemove.append(element);
         }
-        for (auto& element : toRemove)
+        for (Ref element : toRemove)
             element->removeFromTopLayer();
     };
 
     auto exitDocuments = documentsToUnfullscreen(currentDocument);
-    for (auto& exitDocument : exitDocuments) {
+    for (Ref exitDocument : exitDocuments) {
         addDocumentToFullscreenChangeEventQueue(exitDocument);
         if (mode == ExitMode::Resize)
             unfullscreenDocument(exitDocument);
@@ -756,7 +756,7 @@ void FullscreenManager::addDocumentToFullscreenChangeEventQueue(Document& docume
 bool FullscreenManager::isSimpleFullscreenDocument() const
 {
     bool foundFullscreenFlag = false;
-    for (auto& element : document().topLayerElements()) {
+    for (Ref element : document().topLayerElements()) {
         if (element->hasFullscreenFlag()) {
             if (foundFullscreenFlag)
                 return false;

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -148,12 +148,12 @@ void PDFDocument::createDocumentStructure()
     // Description of parameters:
     // - Empty `?file=` parameter prevents default pdf from loading.
     auto viewerURL = "webkit-pdfjs-viewer://pdfjs/web/viewer.html?file="_s;
-    auto rootElement = HTMLHtmlElement::create(*this);
+    Ref rootElement = HTMLHtmlElement::create(*this);
     appendChild(rootElement);
 
     frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 
-    auto body = HTMLBodyElement::create(*this);
+    Ref body = HTMLBodyElement::create(*this);
     body->setAttribute(styleAttr, "margin: 0px;height: 100vh;"_s);
     rootElement->appendChild(body);
 
@@ -239,7 +239,7 @@ void PDFDocument::injectStyleAndContentScript()
 
     auto* contentDocument = m_iframe->contentDocument();
     ASSERT(contentDocument->head());
-    auto link = HTMLLinkElement::create(HTMLNames::linkTag, *contentDocument, false);
+    Ref link = HTMLLinkElement::create(HTMLNames::linkTag, *contentDocument, false);
     link->setAttribute(relAttr, "stylesheet"_s);
 #if PLATFORM(COCOA)
     link->setAttribute(hrefAttr, "webkit-pdfjs-viewer://pdfjs/extras/cocoa/style.css"_s);


### PR DESCRIPTION
#### cb96f3f7d04f0a68c6e3bd29c1074b7c3315070e
<pre>
Deploy more smart pointers in PDFDocument and FullScreenManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=281409">https://bugs.webkit.org/show_bug.cgi?id=281409</a>

Reviewed by Tim Nguyen.

Deploy more smart pointers in PDFDocument and FullScreenManager

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::fullscreenElement const):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::isSimpleFullscreenDocument const):
* Source/WebCore/html/PDFDocument.cpp:
(WebCore::PDFDocument::createDocumentStructure):
(WebCore::PDFDocument::injectStyleAndContentScript):

Canonical link: <a href="https://commits.webkit.org/285308@main">https://commits.webkit.org/285308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/735681fa246561108887009feff44d9cfc313d8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56550 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15028 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19138 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21143 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64263 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12405 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6046 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1589 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->