### PR TITLE
Deploy downcast<> in CSSFontFeatureValuesRule

### DIFF
--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -82,7 +82,7 @@ String CSSFontFeatureValuesRule::cssText() const
 
 void CSSFontFeatureValuesRule::reattach(StyleRuleBase& rule)
 {
-    m_fontFeatureValuesRule = static_cast<StyleRuleFontFeatureValues&>(rule);
+    m_fontFeatureValuesRule = downcast<StyleRuleFontFeatureValues>(rule);
 }
 
 CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock& block , CSSStyleSheet* parent)
@@ -102,7 +102,7 @@ String CSSFontFeatureValuesBlockRule::cssText() const
 
 void CSSFontFeatureValuesBlockRule::reattach(StyleRuleBase& rule)
 {
-    m_fontFeatureValuesBlockRule = static_cast<StyleRuleFontFeatureValuesBlock&>(rule);
+    m_fontFeatureValuesBlockRule = downcast<StyleRuleFontFeatureValuesBlock>(rule);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 97794de6bffb7c7443331f2f9132a0c7f48ff55f
<pre>
Deploy downcast&lt;&gt; in CSSFontFeatureValuesRule
<a href="https://bugs.webkit.org/show_bug.cgi?id=281410">https://bugs.webkit.org/show_bug.cgi?id=281410</a>

Reviewed by Matthieu Dubet.

Deploy downcast&lt;&gt; in CSSFontFeatureValuesRule

* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
(WebCore::CSSFontFeatureValuesRule::reattach):
(WebCore::CSSFontFeatureValuesBlockRule::reattach):

Canonical link: <a href="https://commits.webkit.org/285165@main">https://commits.webkit.org/285165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9f906a9fd6f68b08cddbfecca43c28d95706aa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56551 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15025 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64264 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15854 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6048 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46812 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1591 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->