### PR TITLE
[MediaRecorder/WebM] First frames are missed in a recording

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-first-frame-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-first-frame-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Verify MP4 MediaRecorder doesn't drop first frame assert_true: pixel is approximately red expected true got false
+PASS Verify WebM MediaRecorder doesn't drop first frame
+

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-first-frame.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-first-frame.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html>
+<head>
+    <title>MediaRecorder First Frame Check</title>
+    <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#mediarecorder">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../common/canvas-tests.js"></script>
+    <link rel="stylesheet" href="../common/canvas-tests.css">
+</head>
+<body>
+<script>
+    function arraysAreApproximatelyEqual(array, expected, tolerance) {
+        if (array.length != expected.length)
+            return false;
+
+        for (var index in array) {
+            if (Math.abs(array[index] - expected[index]) <= tolerance)
+                continue;
+            return false;
+        }
+        return true;
+    }
+
+    function runTest(t, mimeType) {
+        const video = document.createElement('video');
+        video.playsinline = true;
+        video.muted = true;
+        document.body.appendChild(video);
+
+        const canvas = document.createElement('canvas');
+        canvas.width = 640;
+        canvas.height = 480;
+        let stream = canvas.captureStream(24.0);
+        let context = canvas.getContext("2d");
+
+        let audioContext = new AudioContext({sampleRate: 48000});
+        audioContext.suspend();
+        let destination = audioContext.createMediaStreamDestination();
+        let hum = audioContext.createOscillator();
+        let humGain = audioContext.createGain();
+        hum.connect(humGain);
+        hum.frequency.value = 125.0;
+        humGain.gain.value = 0.10;
+        humGain.connect(destination);
+        humGain.connect(audioContext.destination);
+        hum.start(0);
+        let audioTrack = destination.stream.getTracks()[0];
+        stream.addTrack(audioTrack);
+
+        let doRedImageDraw = () => {
+            context.fillStyle = "#ff0000";
+            context.fillRect(0, 0, 640, 480);
+        }
+
+        let doGreenImageDraw = () => {
+            context.fillStyle = "#00ff00";
+            context.fillRect(0, 0, 640, 480);
+        };
+
+        if (!MediaRecorder.isTypeSupported(mimeType)) {
+            assert_true(false, `MediaRecorder with ${mimeType} is not supported`);
+            t.done();
+            return;
+        }
+
+        const recorder = new MediaRecorder(stream, { mimeType });
+        let blobs;
+        recorder.ondataavailable = t.step_func(blobEvent => {
+            assert_true(blobEvent instanceof BlobEvent, 'the type of event should be BlobEvent');
+            assert_equals(blobEvent.type, 'dataavailable', 'the event type should be dataavailable');
+            assert_true(blobEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
+            assert_true(blobEvent.data instanceof Blob, 'the type of data should be Blob');
+            if (!blobEvent.data.size)
+                return;
+            blobs = new Blob([blobs, event.data]);
+            video.src = URL.createObjectURL(blobEvent.data);
+            video.load();
+        });
+
+        video.onerror = () => {
+            assert_not_reached();
+        };
+
+        video.onloadedmetadata = t.step_func(e => {
+            assert_true(video.readyState >= video.HAVE_METADATA, "we've obtained the video's metadata");
+            assert_equals(video.videoWidth, 640, "video has the right width");
+            assert_equals(video.videoHeight, 480, "video has the right height");
+        });
+
+        video.onloadeddata = t.step_func(e => {
+            var canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            // We leave some time for the first frame to be painted.
+            setTimeout(t.step_func_done(() => {
+                var ctx = canvas.getContext('2d');
+                ctx.drawImage(video, 0, 0);
+                let pixelData = ctx.getImageData(10, 10, 1, 1).data;
+                let redColorTVRange = new Uint8ClampedArray([245, 35, 0, 255]);
+                let redColorFullRange = new Uint8ClampedArray([255, 0, 0, 255]);
+                assert_true(arraysAreApproximatelyEqual(pixelData, redColorTVRange, 10) || arraysAreApproximatelyEqual(pixelData, redColorFullRange, 10), "pixel is approximately red");
+            }), 100);
+        });
+
+        doRedImageDraw();
+        recorder.start();
+        assert_equals(stream.getTracks().length, 2, "MediaStream has two tracks");
+        audioContext.resume();
+        assert_equals(recorder.state, 'recording', 'MediaRecorder has been started successfully');
+        let interval = setInterval(() => {
+            doGreenImageDraw();
+            if (stream.getTracks()[0] instanceof CanvasCaptureMediaStreamTrack)
+                stream.getTracks()[0].requestFrame();
+        }, 41); // wait the duration of one frame before drawing green.
+        setTimeout(() => {
+            recorder.stop();
+            audioContext.suspend();
+            clearInterval(interval);
+        }, 500);
+    }
+
+    async_test(t => runTest(t, "video/mp4"), "Verify MP4 MediaRecorder doesn't drop first frame");
+
+    async_test(t => runTest(t, "video/webm"), "Verify WebM MediaRecorder doesn't drop first frame");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1148,6 +1148,7 @@ webkit.org/b/254522 media/video-volume.html [ Pass Failure ]
 webkit.org/b/254525 http/tests/media/video-throttled-load-metadata.html [ Pass Failure ]
 media/video-seek-to-current-time.html [ Pass Failure ]
 
+webkit.org/b/281489 http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Failure ]
 webkit.org/b/281295 http/wpt/mediarecorder/MediaRecorder-requestData.html [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/mimeType.html [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/mute-tracks.html [ Failure Crash ]

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm
@@ -317,9 +317,6 @@ void MediaRecorderPrivateWriterWebM::appendVideoFrame(Ref<VideoFrame>&& frame)
         });
     }
 
-    if (!m_hasStartedWriting) // We don't record video frames received before the first audio frame.
-        return;
-
     // We take the time before m_firstVideoFrameAudioTime is set so that the first frame will always apepar to have a timestamp of 0 but with a longer duration.
     auto sampleTime = m_firstVideoFrameAudioTime ? nextVideoFrameTime() : resumeVideoTime();
 


### PR DESCRIPTION
#### 2562b4f9c893a95f830c2244efbd9d919109ef88
<pre>
[MediaRecorder/WebM] First frames are missed in a recording
<a href="https://bugs.webkit.org/show_bug.cgi?id=281406">https://bugs.webkit.org/show_bug.cgi?id=281406</a>
<a href="https://rdar.apple.com/137854083">rdar://137854083</a>

Reviewed by Eric Carlson.

Don&apos;t drop video frames received before the first audio frame.
Manual expirementation shows that we don&apos;t need to worry about shifting the timestamp
of the first audio frame by the delay between first video and first audio.

Added test.

* LayoutTests/http/wpt/mediarecorder/MediaRecorder-first-frame-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-first-frame.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.mm:
(WebCore::MediaRecorderPrivateWriterWebM::appendVideoFrame):

Canonical link: <a href="https://commits.webkit.org/285236@main">https://commits.webkit.org/285236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de3b814898acc6c1253f6072404e71dce3f3fdb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22950 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15270 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61956 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/37196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19426 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/21475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/65140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61979 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6313 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1923 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->