### PR TITLE
[web-animations] add the notion of an "intrinsic iteration duration" from Web Animations Level 2

### DIFF
--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -55,6 +55,7 @@ struct AnimationEffectTiming {
     Seconds delay { 0_s };
     Seconds endDelay { 0_s };
     CSSNumberishTime iterationDuration { 0_s };
+    CSSNumberishTime intrinsicIterationDuration { 0_s };
     CSSNumberishTime activeDuration { 0_s };
     CSSNumberishTime endTime { 0_s };
 
@@ -66,7 +67,8 @@ struct AnimationEffectTiming {
         double playbackRate { 0 };
     };
 
-    void updateComputedProperties();
+    enum class IsProgressBased : bool { No, Yes };
+    void updateComputedProperties(IsProgressBased);
     BasicEffectTiming getBasicTiming(const ResolutionData&) const;
     ResolvedEffectTiming resolve(const ResolutionData&) const;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6324,6 +6324,7 @@ struct WebCore::AnimationEffectTiming {
     Seconds delay;
     Seconds endDelay;
     WebCore::CSSNumberishTime iterationDuration;
+    WebCore::CSSNumberishTime intrinsicIterationDuration;
     WebCore::CSSNumberishTime activeDuration;
     WebCore::CSSNumberishTime endTime;
 };


### PR DESCRIPTION
#### f735de0e1cf230f4eb43424c95ea58ecbd4099ba
<pre>
[web-animations] add the notion of an &quot;intrinsic iteration duration&quot; from Web Animations Level 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=281419">https://bugs.webkit.org/show_bug.cgi?id=281419</a>
<a href="https://rdar.apple.com/137867467">rdar://137867467</a>

Reviewed by Dean Jackson.

Web Animations Level 2 introduces the notion of an &quot;intrinsic iteration duration&quot;
in <a href="https://drafts.csswg.org/web-animations-2/#intrinsic-iteration-duration.">https://drafts.csswg.org/web-animations-2/#intrinsic-iteration-duration.</a> We
need to introduce this notion in our codebase to support Scroll-driven Animations
since the simple &quot;iteration duration&quot; may use seconds values which would cause problem
since all progress-based values are expected to be percentages.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getComputedTiming const):
(WebCore::AnimationEffect::updateStaticTimingProperties):
(WebCore::AnimationEffect::animationTimelineDidChange):
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::updateComputedProperties):
(WebCore::AnimationEffectTiming::resolve const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/285130@main">https://commits.webkit.org/285130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/082e099c387d1bb285dd817073fb8d8b1d988cb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56571 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15047 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64286 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64282 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6070 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10982 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1614 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49190 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->