### PR TITLE
[web-animations] implement the "auto-align start time" procedure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline generates and resolves finish promises and events assert_true: Animation is finished after passing end expected true got false
+FAIL View timeline generates and resolves finish promises and events assert_false: Animation is not finished while active expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL animation.progress reflects the progress of a scroll animation as a number between 0 and 1 assert_true: Animation is in the pending state. expected true got false
-FAIL animation.progress reflects the overall progress of a scroll animation with multiple iterations. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+PASS animation.progress reflects the progress of a scroll animation as a number between 0 and 1
+FAIL animation.progress reflects the overall progress of a scroll animation with multiple iterations. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
 FAIL animation.progress reflects the overall progress of a scroll animation that uses a view-timeline. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"
 FAIL progresss of a view-timeline is bounded between 0 and 1. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: createViewTimeline"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+Harness Error (TIMEOUT), message = null
+
+PASS animation.progress reflects the progress of a scroll animation as a number between 0 and 1
+TIMEOUT animation.progress reflects the overall progress of a scroll animation with multiple iterations. Test timed out
+NOTRUN animation.progress reflects the overall progress of a scroll animation that uses a view-timeline.
+NOTRUN progresss of a view-timeline is bounded between 0 and 1.
+

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -209,6 +209,7 @@ private:
     void applyPendingPlaybackRate();
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
     CSSNumberishTime timeEpsilon() const;
+    void autoAlignStartTime();
 
     // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;


### PR DESCRIPTION
#### 433599a15892af435851c20280e58a0cc91596cb
<pre>
[web-animations] implement the &quot;auto-align start time&quot; procedure
<a href="https://bugs.webkit.org/show_bug.cgi?id=281420">https://bugs.webkit.org/show_bug.cgi?id=281420</a>
<a href="https://rdar.apple.com/137867653">rdar://137867653</a>

Reviewed by Tim Nguyen.

Web Animations Level 2 introduces an &quot;auto-aligning the start time&quot; procedure for progress-based
animations, such as Scroll-driven Animations. We already added the flag that indicates that an
animation needs to auto-align its start time in 284815@main, and now we implement the procedure
to act on that flag and implement <a href="https://drafts.csswg.org/web-animations-2/#auto-aligning-start-time.">https://drafts.csswg.org/web-animations-2/#auto-aligning-start-time.</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt: Added.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::play):
(WebCore::WebAnimation::autoAlignStartTime):
(WebCore::WebAnimation::tick):
* Source/WebCore/animation/WebAnimation.h:

Canonical link: <a href="https://commits.webkit.org/285176@main">https://commits.webkit.org/285176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d24da197ebda2ef0ac2ad0e020ea365e544308a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24544 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/22975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22795 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/75885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/22975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74836 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/46431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/61824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/75885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/43092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/19291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21316 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/19654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77604 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/18839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/64377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16048 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/61857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/64389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/12556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/6194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11007 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46983 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/1762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->