### PR TITLE
Annotate RTCDataChannelRemoteManagerProxy endpoints with feature flags

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -400,6 +400,10 @@ void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier ident
 
 void NetworkProcess::sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier identifier, SharedPreferencesForWebProcess&& sharedPreferences, CompletionHandler<void()>&& completionHandler)
 {
+#if ENABLE(WEB_RTC)
+    m_rtcDataChannelProxy->updateSharedPreferencesForWebProcess(sharedPreferences);
+#endif
+
     if (RefPtr connection = m_webProcessConnections.get(identifier))
         connection->updateSharedPreferencesForWebProcess(WTFMove(sharedPreferences));
     completionHandler();

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
@@ -97,6 +97,13 @@ void RTCDataChannelRemoteManagerProxy::bufferedAmountIsDecreasing(WebCore::RTCDa
         IPC::Connection::send(*connectionID, Messages::RTCDataChannelRemoteManager::BufferedAmountIsDecreasing { identifier, amount }, 0);
 }
 
+void RTCDataChannelRemoteManagerProxy::updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess)
+{
+    protectedQueue()->dispatch([this, protectedThis = Ref { *this }, sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess)] {
+        m_sharedPreferencesForWebProcess = sharedPreferencesForWebProcess;
+    });
+}
+
 }
 
 #endif

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -27,6 +27,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "Connection.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/RTCDataChannelRemoteHandlerConnection.h>
 #include <WebCore/RTCDataChannelRemoteSourceConnection.h>
@@ -42,6 +43,9 @@ public:
 
     void registerConnectionToWebProcess(NetworkConnectionToWebProcess&);
     void unregisterConnectionToWebProcess(NetworkConnectionToWebProcess&);
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
+    void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess);
+
 
 private:
     RTCDataChannelRemoteManagerProxy();
@@ -63,6 +67,7 @@ private:
 
     Ref<WorkQueue> m_queue;
     HashMap<WebCore::ProcessIdentifier, IPC::Connection::UniqueID> m_webProcessConnections;
+    SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
@@ -23,9 +23,9 @@
 #if ENABLE(WEB_RTC)
 
 [
-    ExceptionForEnabledBy,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    EnabledBy=PeerConnectionEnabled
 ]
 messages -> RTCDataChannelRemoteManagerProxy {
     // To source


### PR DESCRIPTION
#### 09cb3cd57825d2d042d053e7deed9790d355a726
<pre>
Annotate RTCDataChannelRemoteManagerProxy endpoints with feature flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=281427">https://bugs.webkit.org/show_bug.cgi?id=281427</a>
<a href="https://rdar.apple.com/137875225">rdar://137875225</a>

Reviewed by NOBODY (OOPS!).

Annotate RTCDataChannelRemoteManagerProxy endpoints with feature flags

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::sharedPreferencesForWebProcessDidChange):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp:
(WebKit::RTCDataChannelRemoteManagerProxy::updateSharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09cb3cd57825d2d042d053e7deed9790d355a726

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35424 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86010 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32475 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8825 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/86010 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21340 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84550 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/726 "Found 30 new test failures: editing/pasteboard/copy-paste-attachment.html fast/attachment/attachment-dom.html fast/attachment/attachment-folder-icon.html fast/attachment/attachment-icon-from-file-extension.html fast/attachment/attachment-label-highlight.html fast/attachment/attachment-progress.html fast/attachment/attachment-select-on-click-inside-user-select-all.html fast/attachment/attachment-select-on-click.html fast/attachment/attachment-subtitle.html fast/attachment/attachment-title.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75571 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/86010 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/615 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30925 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72075 "Found 1 new API test failure: TestWebKitAPI.WebKit2.RTCDataChannelPostMessage (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28923 "Found 1 new test failure: http/wpt/webrtc/transfer-datachannel-service-worker.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87445 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8711 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6190 "Found 1 new test failure: http/wpt/webrtc/transfer-datachannel-service-worker.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71923 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71154 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15214 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14131 "Found 1 new test failure: http/wpt/webrtc/transfer-datachannel-service-worker.https.html (failure)") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14202 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8509 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->